### PR TITLE
Deprecated DYNAMIC splitter due to license issue

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -33,6 +33,7 @@ var (
 	blockCommands      = app.Command("block", "Commands to manipulate virtual blocks in repository.").Alias("blk").Hidden()
 	storageCommands    = app.Command("storage", "Commands to manipulate raw storage blocks.").Hidden()
 	blockIndexCommands = app.Command("blockindex", "Commands to manipulate block index.").Hidden()
+	benchmarkCommands  = app.Command("benchmark", "Commands to test performance of algorithms.").Hidden()
 )
 
 func helpFullAction(ctx *kingpin.ParseContext) error {

--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -11,26 +11,26 @@ import (
 )
 
 var (
-	blockCryptoBenchmarkCommand    = blockCommands.Command("cryptobenchmark", "Run hash and encryption benchmarks")
-	blockCryptoBenchmarkBlockSize  = blockCryptoBenchmarkCommand.Flag("block-size", "Size of a block to encrypt").Default("1MB").Bytes()
-	blockCryptoBenchmarkEncryption = blockCryptoBenchmarkCommand.Flag("encryption", "Test encrypted formats").Default("true").Bool()
-	blockCryptoBenchmarkRepeat     = blockCryptoBenchmarkCommand.Flag("repeat", "Number of repetitions").Default("100").Int()
+	benchmarkCryptoCommand    = benchmarkCommands.Command("crypto", "Run hash and encryption benchmarks")
+	benchmarkCryptoBlockSize  = benchmarkCryptoCommand.Flag("block-size", "Size of a block to encrypt").Default("1MB").Bytes()
+	benchmarkCryptoEncryption = benchmarkCryptoCommand.Flag("encryption", "Test encrypted formats").Default("true").Bool()
+	benchmarkCryptoRepeat     = benchmarkCryptoCommand.Flag("repeat", "Number of repetitions").Default("100").Int()
 )
 
-type benchResult struct {
-	hash       string
-	encryption string
-	throughput float64
-}
+func runBenchmarkCryptoAction(ctx *kingpin.ParseContext) error {
 
-func runBlockCryptoBenchmarkAction(ctx *kingpin.ParseContext) error {
+	type benchResult struct {
+		hash       string
+		encryption string
+		throughput float64
+	}
 	var results []benchResult
 
-	data := make([]byte, *blockCryptoBenchmarkBlockSize)
+	data := make([]byte, *benchmarkCryptoBlockSize)
 	for _, ha := range block.SupportedHashAlgorithms() {
 		for _, ea := range block.SupportedEncryptionAlgorithms() {
 			isEncrypted := ea != "NONE"
-			if *blockCryptoBenchmarkEncryption != isEncrypted {
+			if *benchmarkCryptoEncryption != isEncrypted {
 				continue
 			}
 
@@ -44,9 +44,9 @@ func runBlockCryptoBenchmarkAction(ctx *kingpin.ParseContext) error {
 				continue
 			}
 
-			log.Infof("Benchmarking hash '%v' and encryption '%v'... (%v x %v bytes)", ha, ea, *blockCryptoBenchmarkRepeat, len(data))
+			log.Infof("Benchmarking hash '%v' and encryption '%v'... (%v x %v bytes)", ha, ea, *benchmarkCryptoRepeat, len(data))
 			t0 := time.Now()
-			hashCount := *blockCryptoBenchmarkRepeat
+			hashCount := *benchmarkCryptoRepeat
 			for i := 0; i < hashCount; i++ {
 				blockID := h(data)
 				if _, encerr := e.Encrypt(data, blockID); encerr != nil {
@@ -74,5 +74,5 @@ func runBlockCryptoBenchmarkAction(ctx *kingpin.ParseContext) error {
 }
 
 func init() {
-	blockCryptoBenchmarkCommand.Action(runBlockCryptoBenchmarkAction)
+	benchmarkCryptoCommand.Action(runBenchmarkCryptoAction)
 }

--- a/cli/command_benchmark_splitters.go
+++ b/cli/command_benchmark_splitters.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"math/rand"
+	"sort"
+	"time"
+
+	"github.com/kopia/kopia/repo/object"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	benchmarkSplitterCommand    = benchmarkCommands.Command("splitter", "Run splitter benchmarks")
+	benchmarkSplitterRandSeed   = benchmarkSplitterCommand.Flag("rand-seed", "Random seed").Default("42").Int64()
+	benchmarkSplitterBlockSize  = benchmarkSplitterCommand.Flag("data-size", "Size of a data to split").Default("32MB").Bytes()
+	benchmarkSplitterBlockCount = benchmarkSplitterCommand.Flag("block-count", "Number of data blocks to split").Default("16").Int()
+)
+
+func runBenchmarkSplitterAction(ctx *kingpin.ParseContext) error {
+	type benchResult struct {
+		splitter     string
+		duration     time.Duration
+		segmentCount int
+		min          int
+		p10          int
+		p25          int
+		p50          int
+		p75          int
+		p90          int
+		max          int
+	}
+
+	var results []benchResult
+
+	// generate data blocks
+	var dataBlocks [][]byte
+	rnd := rand.New(rand.NewSource(*benchmarkSplitterRandSeed))
+
+	for i := 0; i < *benchmarkSplitterBlockCount; i++ {
+		b := make([]byte, *benchmarkSplitterBlockSize)
+		rnd.Read(b)
+		dataBlocks = append(dataBlocks, b)
+	}
+
+	log.Infof("splitting %v blocks of %v each", *benchmarkSplitterBlockCount, *benchmarkSplitterBlockSize)
+
+	for _, sp := range object.SupportedSplitters {
+		fact := object.GetSplitterFactory(sp)
+		var segmentLengths []int
+
+		t0 := time.Now()
+		for _, data := range dataBlocks {
+			s := fact()
+			l := 0
+			for _, d := range data {
+				l++
+				if s.ShouldSplit(d) {
+					segmentLengths = append(segmentLengths, l)
+					l = 0
+				}
+			}
+			if l > 0 {
+				segmentLengths = append(segmentLengths, l)
+			}
+		}
+		dur := time.Since(t0)
+		sort.Ints(segmentLengths)
+
+		r := benchResult{
+			sp,
+			dur,
+			len(segmentLengths),
+			segmentLengths[0],
+			segmentLengths[len(segmentLengths)*10/100],
+			segmentLengths[len(segmentLengths)*25/100],
+			segmentLengths[len(segmentLengths)*50/100],
+			segmentLengths[len(segmentLengths)*75/100],
+			segmentLengths[len(segmentLengths)*90/100],
+			segmentLengths[len(segmentLengths)-1],
+		}
+
+		printStdout("%-25v %6v ms count:%v min:%v 10th:%v 25th:%v 50th:%v 75th:%v 90th:%v max:%v\n",
+			r.splitter,
+			r.duration.Nanoseconds()/1e6,
+			r.segmentCount,
+			r.min, r.p10, r.p25, r.p50, r.p75, r.p90, r.max)
+
+		results = append(results, r)
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].duration < results[j].duration
+	})
+	printStdout("-----------------------------------------------------------------\n")
+	for ndx, r := range results {
+		printStdout("%3v. %-25v %6v ms count:%v min:%v 10th:%v 25th:%v 50th:%v 75th:%v 90th:%v max:%v\n",
+			ndx,
+			r.splitter,
+			r.duration.Nanoseconds()/1e6,
+			r.segmentCount,
+			r.min, r.p10, r.p25, r.p50, r.p75, r.p90, r.max)
+
+	}
+	return nil
+}
+
+func init() {
+	benchmarkSplitterCommand.Action(runBenchmarkSplitterAction)
+}

--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -35,27 +35,13 @@ func runStatusCommand(ctx context.Context, rep *repo.Repository) error {
 	}
 	fmt.Println()
 
-	var splitterExtraInfo string
-
-	switch rep.Objects.Format.Splitter {
-	case "DYNAMIC":
-		splitterExtraInfo = fmt.Sprintf(
-			" (min: %v; avg: %v; max: %v)",
-			units.BytesStringBase2(int64(rep.Objects.Format.MinBlockSize)),
-			units.BytesStringBase2(int64(rep.Objects.Format.AvgBlockSize)),
-			units.BytesStringBase2(int64(rep.Objects.Format.MaxBlockSize)))
-	case "":
-	case "FIXED":
-		splitterExtraInfo = fmt.Sprintf(" %v", units.BytesStringBase2(int64(rep.Objects.Format.MaxBlockSize)))
-	}
-
 	fmt.Println()
 	fmt.Printf("Unique ID:           %x\n", rep.UniqueID)
 	fmt.Println()
 	fmt.Printf("Block hash:          %v\n", rep.Blocks.Format.Hash)
 	fmt.Printf("Block encryption:    %v\n", rep.Blocks.Format.Encryption)
 	fmt.Printf("Max pack length:     %v\n", units.BytesStringBase2(int64(rep.Blocks.Format.MaxPackSize)))
-	fmt.Printf("Splitter:            %v%v\n", rep.Objects.Format.Splitter, splitterExtraInfo)
+	fmt.Printf("Splitter:            %v\n", rep.Objects.Format.Splitter)
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/bgentry/speakeasy v0.1.0
 	github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40
+	github.com/chmduquesne/rollinghash v4.0.0+incompatible
 	github.com/danieljoos/wincred v1.0.2 // indirect
 	github.com/efarrer/iothrottler v0.0.0-20141121142253-60e7e547c7fe
 	github.com/go-ini/ini v1.42.0 // indirect
@@ -18,7 +19,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/pkg/errors v0.8.1
-	github.com/silvasur/buzhash v0.0.0-20160816060738-9bdec3dec7c6
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
 	github.com/studio-b12/gowebdav v0.0.0-20190103184047-38f79aeaf1ac
 	github.com/zalando/go-keyring v0.0.0-20190208082241-fbe81aec3a07
@@ -27,5 +27,6 @@ require (
 	golang.org/x/net v0.0.0-20190328230028-74de082e2cca
 	golang.org/x/oauth2 v0.0.0-20190523182746-aaccbc9213b0
 	google.golang.org/api v0.5.0
+	google.golang.org/appengine v1.4.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 h1:y4B3+GPxKlrigF1ha5FFErxK+sr6sWxQovRMzwMhejo=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/chmduquesne/rollinghash v4.0.0+incompatible h1:hnREQO+DXjqIw3rUTzWN7/+Dpw+N5Um8zpKV0JOEgbo=
+github.com/chmduquesne/rollinghash v4.0.0+incompatible/go.mod h1:Uc2I36RRfTAf7Dge82bi3RU0OQUmXT9iweIcPqvr8A0=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/danieljoos/wincred v1.0.1 h1:fcRTaj17zzROVqni2FiToKUVg3MmJ4NtMSGCySPIr/g=
 github.com/danieljoos/wincred v1.0.1/go.mod h1:SnuYRW9lp1oJrZX/dXJqr0cPK5gYXqx3EJbmjhLdK9U=
@@ -154,6 +156,7 @@ google.golang.org/api v0.0.0-20181229000844-f26a60c56f14/go.mod h1:4mhQ8q/RsB7i+
 google.golang.org/api v0.5.0 h1:lj9SyhMzyoa38fgFF0oO2T6pjs5IzkLPKfVtxpyCRMM=
 google.golang.org/api v0.5.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -48,8 +48,7 @@ func (e *Environment) Setup(t *testing.T, opts ...func(*repo.NewRepositoryOption
 			Encryption: "NONE",
 		},
 		ObjectFormat: object.Format{
-			Splitter:     "FIXED",
-			MaxBlockSize: 400,
+			Splitter: "FIXED-1M",
 		},
 	}
 

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -84,13 +84,10 @@ func repositoryObjectFormatFromOptions(opt *NewRepositoryOptions) *repositoryObj
 			Encryption:  applyDefaultString(opt.BlockFormat.Encryption, block.DefaultEncryption),
 			HMACSecret:  applyDefaultRandomBytes(opt.BlockFormat.HMACSecret, 32),
 			MasterKey:   applyDefaultRandomBytes(opt.BlockFormat.MasterKey, 32),
-			MaxPackSize: applyDefaultInt(opt.BlockFormat.MaxPackSize, applyDefaultInt(opt.ObjectFormat.MaxBlockSize, 20<<20)), // 20 MB
+			MaxPackSize: applyDefaultInt(opt.BlockFormat.MaxPackSize, 20<<20), // 20 MB
 		},
 		Format: object.Format{
-			Splitter:     applyDefaultString(opt.ObjectFormat.Splitter, object.DefaultSplitter),
-			MaxBlockSize: applyDefaultInt(opt.ObjectFormat.MaxBlockSize, 20<<20), // 20MiB
-			MinBlockSize: applyDefaultInt(opt.ObjectFormat.MinBlockSize, 10<<20), // 10MiB
-			AvgBlockSize: applyDefaultInt(opt.ObjectFormat.AvgBlockSize, 16<<20), // 16MiB
+			Splitter: applyDefaultString(opt.ObjectFormat.Splitter, object.DefaultSplitter),
 		},
 	}
 

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -58,7 +58,7 @@ type objectWriter struct {
 
 	description string
 
-	splitter objectSplitter
+	splitter Splitter
 }
 
 func (w *objectWriter) Close() error {
@@ -72,7 +72,7 @@ func (w *objectWriter) Write(data []byte) (n int, err error) {
 	for _, d := range data {
 		w.buffer.WriteByte(d)
 
-		if w.splitter.add(d) {
+		if w.splitter.ShouldSplit(d) {
 			if err := w.flushBuffer(); err != nil {
 				return 0, err
 			}

--- a/repo/object/splitter_buzhash32.go
+++ b/repo/object/splitter_buzhash32.go
@@ -1,0 +1,47 @@
+package object
+
+import (
+	"github.com/chmduquesne/rollinghash/buzhash32"
+)
+
+type buzhash32Splitter struct {
+	// we're intentionally not using rollinghash.Hash32 interface because doing this in a tight loop
+	// is 40% slower because compiler can't inline the call.
+	rh      *buzhash32.Buzhash32
+	mask    uint32
+	count   int
+	minSize int
+	maxSize int
+}
+
+func (rs *buzhash32Splitter) ShouldSplit(b byte) bool {
+	rs.rh.Roll(b)
+	rs.count++
+	if rs.rh.Sum32()&rs.mask == 0 && rs.count >= rs.minSize {
+		rs.count = 0
+		return true
+	}
+
+	if rs.count >= rs.maxSize {
+		rs.count = 0
+		return true
+	}
+
+	return false
+}
+
+func newBuzHash32SplitterFactory(avgSize int) SplitterFactory {
+	// avgSize must be a power of two, so 0b000001000...0000
+	// it just so happens that mask is avgSize-1 :)
+	mask := uint32(avgSize - 1)
+	maxSize := avgSize * 2
+	minSize := avgSize / 2
+
+	// log.Printf("Setting up buzhash with avg size: %v mask: %v %032b", avgSize, avgSize-1, mask)
+
+	return func() Splitter {
+		s := buzhash32.New()
+		s.Write(make([]byte, splitterSlidingWindowSize)) //nolint:errcheck
+		return &buzhash32Splitter{s, mask, 0, minSize, maxSize}
+	}
+}

--- a/repo/object/splitter_fixed.go
+++ b/repo/object/splitter_fixed.go
@@ -1,0 +1,22 @@
+package object
+
+type fixedSplitter struct {
+	cur         int
+	chunkLength int
+}
+
+func (s *fixedSplitter) ShouldSplit(b byte) bool {
+	s.cur++
+	if s.cur >= s.chunkLength {
+		s.cur = 0
+		return true
+	}
+
+	return false
+}
+
+func newFixedSplitterFactory(length int) SplitterFactory {
+	return func() Splitter {
+		return &fixedSplitter{chunkLength: length}
+	}
+}

--- a/repo/object/splitter_rabinkarp64.go
+++ b/repo/object/splitter_rabinkarp64.go
@@ -1,0 +1,40 @@
+package object
+
+import "github.com/chmduquesne/rollinghash/rabinkarp64"
+
+type rabinKarp64Splitter struct {
+	// we're intentionally not using rollinghash.Hash32 interface because doing this in a tight loop
+	// is 40% slower because compiler can't inline the call.
+	rh      *rabinkarp64.RabinKarp64
+	mask    uint64
+	count   int
+	minSize int
+	maxSize int
+}
+
+func (rs *rabinKarp64Splitter) ShouldSplit(b byte) bool {
+	rs.rh.Roll(b)
+	rs.count++
+	if rs.rh.Sum64()&rs.mask == 0 && rs.count >= rs.minSize {
+		rs.count = 0
+		return true
+	}
+	if rs.count >= rs.maxSize {
+		rs.count = 0
+		return true
+	}
+
+	return false
+}
+
+func newRabinKarp64SplitterFactory(avgSize int) SplitterFactory {
+	mask := uint64(avgSize - 1)
+	maxSize := avgSize * 2
+	minSize := avgSize / 2
+
+	return func() Splitter {
+		s := rabinkarp64.New()
+		s.Write(make([]byte, splitterSlidingWindowSize)) //nolint:errcheck
+		return &rabinKarp64Splitter{s, mask, 0, minSize, maxSize}
+	}
+}

--- a/repo/open.go
+++ b/repo/open.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/kopia/kopia/repo/block"
 	"github.com/kopia/kopia/internal/repologging"
+	"github.com/kopia/kopia/repo/block"
 	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/repo/storage"
@@ -107,7 +107,7 @@ func OpenWithConfig(ctx context.Context, st storage.Storage, lc *LocalConfig, pa
 
 	fo := repoConfig.FormattingOptions
 	if fo.MaxPackSize == 0 {
-		fo.MaxPackSize = repoConfig.MaxBlockSize
+		fo.MaxPackSize = 20 << 20 // 20 MB
 	}
 
 	log.Debugf("initializing block manager")

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -11,9 +11,9 @@ import (
 	"runtime/debug"
 	"testing"
 
+	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/block"
-	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/repo/storage"
 )
@@ -263,8 +263,7 @@ func TestFormats(t *testing.T) {
 			n.BlockFormat.Hash = hash
 			n.BlockFormat.Encryption = encryption
 			n.BlockFormat.HMACSecret = []byte("key")
-			n.ObjectFormat.MaxBlockSize = 10000
-			n.ObjectFormat.Splitter = "FIXED"
+			n.ObjectFormat.Splitter = "FIXED-1M"
 		}
 	}
 
@@ -274,7 +273,6 @@ func TestFormats(t *testing.T) {
 	}{
 		{
 			format: func(n *repo.NewRepositoryOptions) {
-				n.ObjectFormat.MaxBlockSize = 10000
 			},
 			oids: map[string]object.ID{
 				"": "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad",


### PR DESCRIPTION
The splitter in question was depending on
github.com/silvasur/buzhash which is not licensed according to FOSSA bot

Switched to new faster implementation of buzhash, which is
unfortunately incompatible and will split the objects in different
places.

This change is be semi-breaking - old repositories can be read, but
when uploading large objects they will be re-uploaded where previously
they would be de-duped.

Also added 'benchmark splitters' subcommand and moved 'block cryptobenchmark'
subcommand to 'benchmark crypto'.