### PR TITLE
Added separate cache for metadata.

### DIFF
--- a/cli/command_cache_info.go
+++ b/cli/command_cache_info.go
@@ -20,12 +20,19 @@ func runCacheInfoCommand(ctx context.Context, rep *repo.Repository) error {
 		return nil
 	}
 
-	log.Debugf("scanning cache...")
+	log.Debugf("scanning contents cache...")
 	fileCount, totalFileSize, err := scanCacheDir(filepath.Join(rep.CacheDirectory, "contents"))
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Usage: %v files %v\n", fileCount, units.BytesStringBase2(totalFileSize))
+	fmt.Printf("Content usage: %v files %v\n", fileCount, units.BytesStringBase2(totalFileSize))
+
+	log.Debugf("scanning metadata cache...")
+	metadataFileCount, totalMetadataFileSize, err := scanCacheDir(filepath.Join(rep.CacheDirectory, "metadata"))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Metadata usage: %v files %v\n", metadataFileCount, units.BytesStringBase2(totalMetadataFileSize))
 	return nil
 }
 

--- a/cli/command_cache_set.go
+++ b/cli/command_cache_set.go
@@ -10,16 +10,18 @@ import (
 var (
 	cacheSetParamsCommand = cacheCommands.Command("set", "Sets parameters local caching of repository data")
 
-	cacheSetDirectory            = cacheSetParamsCommand.Flag("cache-directory", "Directory where to store cache files").String()
-	cacheSetMaxCacheSizeMB       = cacheSetParamsCommand.Flag("cache-size-mb", "Size of local cache (0 disables caching)").PlaceHolder("MB").Int64()
-	cacheSetMaxListCacheDuration = cacheSetParamsCommand.Flag("max-list-cache-duration", "Duration of index cache").Default("600s").Duration()
+	cacheSetDirectory              = cacheSetParamsCommand.Flag("cache-directory", "Directory where to store cache files").String()
+	cacheSetMaxCacheSizeMB         = cacheSetParamsCommand.Flag("cache-size-mb", "Size of local content cache (0 disables caching)").PlaceHolder("MB").Int64()
+	cacheSetMaxMetadataCacheSizeMB = cacheSetParamsCommand.Flag("metadata-cache-size-mb", "Size of local metadata cache (0 disables caching)").PlaceHolder("MB").Int64()
+	cacheSetMaxListCacheDuration   = cacheSetParamsCommand.Flag("max-list-cache-duration", "Duration of index cache").Default("600s").Duration()
 )
 
 func runCacheSetCommand(ctx context.Context, rep *repo.Repository) error {
 	opts := content.CachingOptions{
-		CacheDirectory:          *cacheSetDirectory,
-		MaxCacheSizeBytes:       *cacheSetMaxCacheSizeMB << 20,
-		MaxListCacheDurationSec: int(cacheSetMaxListCacheDuration.Seconds()),
+		CacheDirectory:            *cacheSetDirectory,
+		MaxCacheSizeBytes:         *cacheSetMaxCacheSizeMB << 20,
+		MaxMetadataCacheSizeBytes: *cacheSetMaxMetadataCacheSizeMB << 20,
+		MaxListCacheDurationSec:   int(cacheSetMaxListCacheDuration.Seconds()),
 	}
 
 	return repo.SetCachingConfig(ctx, repositoryConfigFileName(), opts)

--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -14,11 +14,12 @@ import (
 )
 
 var (
-	connectCommand              = repositoryCommands.Command("connect", "Connect to a repository.")
-	connectPersistCredentials   bool
-	connectCacheDirectory       string
-	connectMaxCacheSizeMB       int64
-	connectMaxListCacheDuration time.Duration
+	connectCommand                = repositoryCommands.Command("connect", "Connect to a repository.")
+	connectPersistCredentials     bool
+	connectCacheDirectory         string
+	connectMaxCacheSizeMB         int64
+	connectMaxMetadataCacheSizeMB int64
+	connectMaxListCacheDuration   time.Duration
 )
 
 func setupConnectOptions(cmd *kingpin.CmdClause) {
@@ -27,6 +28,7 @@ func setupConnectOptions(cmd *kingpin.CmdClause) {
 	cmd.Flag("persist-credentials", "Persist credentials").Default("true").BoolVar(&connectPersistCredentials)
 	cmd.Flag("cache-directory", "Cache directory").PlaceHolder("PATH").StringVar(&connectCacheDirectory)
 	cmd.Flag("cache-size-mb", "Size of local cache").PlaceHolder("MB").Default("500").Int64Var(&connectMaxCacheSizeMB)
+	cmd.Flag("metadata-cache-size-mb", "Size of local metadata cache").PlaceHolder("MB").Default("100").Int64Var(&connectMaxMetadataCacheSizeMB)
 	cmd.Flag("max-list-cache-duration", "Duration of index cache").Default("600s").Hidden().DurationVar(&connectMaxListCacheDuration)
 }
 

--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -50,7 +50,7 @@ func runStatusCommand(ctx context.Context, rep *repo.Repository) error {
 func scanCacheDir(dirname string) (fileCount int, totalFileLength int64, err error) {
 	entries, err := ioutil.ReadDir(dirname)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, nil
 	}
 
 	for _, e := range entries {

--- a/repo/connect.go
+++ b/repo/connect.go
@@ -86,6 +86,7 @@ func setupCaching(configPath string, lc *LocalConfig, opt content.CachingOptions
 		lc.Caching.CacheDirectory = absCacheDir
 	}
 	lc.Caching.MaxCacheSizeBytes = opt.MaxCacheSizeBytes
+	lc.Caching.MaxMetadataCacheSizeBytes = opt.MaxMetadataCacheSizeBytes
 	lc.Caching.MaxListCacheDurationSec = opt.MaxListCacheDurationSec
 
 	log.Debugf("Creating cache directory '%v' with max size %v", lc.Caching.CacheDirectory, lc.Caching.MaxCacheSizeBytes)

--- a/repo/content/caching_options.go
+++ b/repo/content/caching_options.go
@@ -2,9 +2,10 @@ package content
 
 // CachingOptions specifies configuration of local cache.
 type CachingOptions struct {
-	CacheDirectory          string `json:"cacheDirectory,omitempty"`
-	MaxCacheSizeBytes       int64  `json:"maxCacheSize,omitempty"`
-	MaxListCacheDurationSec int    `json:"maxListCacheDuration,omitempty"`
-	IgnoreListCache         bool   `json:"-"`
-	HMACSecret              []byte `json:"-"`
+	CacheDirectory            string `json:"cacheDirectory,omitempty"`
+	MaxCacheSizeBytes         int64  `json:"maxCacheSize,omitempty"`
+	MaxMetadataCacheSizeBytes int64  `json:"maxMetadataCacheSize,omitempty"`
+	MaxListCacheDurationSec   int    `json:"maxListCacheDuration,omitempty"`
+	IgnoreListCache           bool   `json:"-"`
+	HMACSecret                []byte `json:"-"`
 }

--- a/repo/content/info.go
+++ b/repo/content/info.go
@@ -9,6 +9,20 @@ import (
 // ID is an identifier of content in content-addressable storage.
 type ID string
 
+// Prefix returns a one-character prefix of a content ID or an empty string.
+func (i ID) Prefix() ID {
+	if i.HasPrefix() {
+		return i[0:1]
+	}
+
+	return ""
+}
+
+// HasPrefix determines if the given ID has a non-empty prefix.
+func (i ID) HasPrefix() bool {
+	return len(i)%2 == 1
+}
+
 // Info is an information about a single piece of content managed by Manager.
 type Info struct {
 	ID               ID      `json:"contentID"`


### PR DESCRIPTION
All blocks with a non-empty prefix land in that cache which has its own
size and expires independently from content cache.