### PR TITLE
minor testability tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 COVERAGE_PACKAGES=./repo/...,./fs/...,./snapshot/...
 LINTER_TOOL=.tools/bin/golangci-lint
 GOVERALLS_TOOL=.tools/bin/goveralls
+GO_TEST=go test
 
 -include ./Makefile.local.mk
 
@@ -70,26 +71,26 @@ dev-deps:
 	GO111MODULE=off go get -u github.com/sqs/goreturns
 	
 test-with-coverage:
-	go test -count=1 -coverprofile=tmp.cov --coverpkg $(COVERAGE_PACKAGES) -timeout 90s github.com/kopia/kopia/...
+	$(GO_TEST) -count=1 -coverprofile=tmp.cov --coverpkg $(COVERAGE_PACKAGES) -timeout 90s github.com/kopia/kopia/...
 
 test-with-coverage-pkgonly:
-	go test -count=1 -coverprofile=tmp.cov -timeout 90s github.com/kopia/kopia/...
+	$(GO_TEST) -count=1 -coverprofile=tmp.cov -timeout 90s github.com/kopia/kopia/...
 
 test:
-	go test -count=1 -timeout 90s github.com/kopia/kopia/...
+	$(GO_TEST) -count=1 -timeout 90s github.com/kopia/kopia/...
 
 vtest:
-	go test -count=1 -short -v -timeout 90s github.com/kopia/kopia/...
+	$(GO_TEST) -count=1 -short -v -timeout 90s github.com/kopia/kopia/...
 
 dist-binary:
 	go build -o dist/integration/kopia github.com/kopia/kopia
 
 integration-tests: dist-binary
-	KOPIA_EXE=$(CURDIR)/dist/integration/kopia go test -count=1 -timeout 90s github.com/kopia/kopia/tests/end_to_end_test
+	KOPIA_EXE=$(CURDIR)/dist/integration/kopia $(GO_TEST) -v -count=1 -timeout 90s github.com/kopia/kopia/tests/end_to_end_test
 
 stress-test:
-	KOPIA_LONG_STRESS_TEST=1 go test -count=1 -timeout 200s github.com/kopia/kopia/tests/stress_test
-	go test -count=1 -timeout 200s github.com/kopia/kopia/tests/repository_stress_test
+	KOPIA_LONG_STRESS_TEST=1 $(GO_TEST) -count=1 -timeout 200s github.com/kopia/kopia/tests/stress_test
+	$(GO_TEST) -count=1 -timeout 200s github.com/kopia/kopia/tests/repository_stress_test
 
 godoc:
 	godoc -http=:33333

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -215,7 +215,7 @@ func TestEndToEnd(t *testing.T) {
 		e.runAndExpectFailure(t, "repo", "connect", "filesystem", "--path", e.repoDir)
 
 		// now run repair, which will recover the format blob from one of the pack blobs.
-		e.runAndExpectSuccess(t, "repo", "repair", "filesystem", "--path", e.repoDir)
+		e.runAndExpectSuccess(t, "repo", "repair", "--log-level=debug", "--trace-storage", "filesystem", "--path", e.repoDir)
 
 		// now connect can succeed
 		e.runAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", e.repoDir)
@@ -281,6 +281,7 @@ canary
 }
 
 func (e *testenv) runAndExpectSuccess(t *testing.T, args ...string) []string {
+	t.Helper()
 	stdout, err := e.run(t, args...)
 	if err != nil {
 		t.Fatalf("'kopia %v' failed with %v", strings.Join(args, " "), err)
@@ -289,6 +290,7 @@ func (e *testenv) runAndExpectSuccess(t *testing.T, args ...string) []string {
 }
 
 func (e *testenv) runAndExpectFailure(t *testing.T, args ...string) []string {
+	t.Helper()
 	stdout, err := e.run(t, args...)
 	if err == nil {
 		t.Fatalf("'kopia %v' succeeded, but expected failure", strings.Join(args, " "))
@@ -306,6 +308,7 @@ func (e *testenv) runAndVerifyOutputLineCount(t *testing.T, wantLines int, args 
 }
 
 func (e *testenv) run(t *testing.T, args ...string) ([]string, error) {
+	t.Helper()
 	t.Logf("running 'kopia %v'", strings.Join(args, " "))
 	cmdArgs := append(append([]string(nil), e.fixedArgs...), args...)
 	c := exec.Command(e.exe, cmdArgs...)


### PR DESCRIPTION
This allows overriding 'go test' command with a wrapper that provides coloring (https://stackoverflow.com/questions/27242652/colorizing-golang-test-run-output)