### PR TITLE
Added support for separate packs for metadata

### DIFF
--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -142,9 +142,11 @@ func TestManifestInitCorruptedBlock(t *testing.T) {
 
 	// corrupt data at the storage level.
 	for blobID, v := range data {
-		if strings.HasPrefix(string(blobID), "p") {
-			for i := 0; i < len(v); i++ {
-				v[i] ^= 1
+		for _, prefix := range content.PackBlobIDPrefixes {
+			if strings.HasPrefix(string(blobID), string(prefix)) {
+				for i := 0; i < len(v); i++ {
+					v[i] ^= 1
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This puts all content blocks with non-empty prefix into starting with
`q` instead of `p`. This neatly separates all data (p) from metadata
(q) at the storage level and allows different storage policies, since
most data is not going to be ever accessed ever, but metadata is going
to be read a lot..

We can more aggressively cache contents from `q`.