### PR TITLE
added 'rewrite --prefixed' flag to only rewrite prefixed content IDs …

### DIFF
--- a/cli/command_content_rewrite.go
+++ b/cli/command_content_rewrite.go
@@ -16,6 +16,7 @@ import (
 var (
 	contentRewriteCommand     = contentCommands.Command("rewrite", "Rewrite content using most recent format")
 	contentRewriteIDs         = contentRewriteCommand.Arg("contentID", "Identifiers of contents to rewrite").Strings()
+	contentRewritePrefixed    = contentRewriteCommand.Flag("prefixed", "Rewrite contents with a non-empty prefix").Bool()
 	contentRewriteParallelism = contentRewriteCommand.Flag("parallelism", "Number of parallel workers").Default("16").Int()
 
 	contentRewriteShortPacks    = contentRewriteCommand.Flag("short", "Rewrite contents from short packs").Bool()
@@ -160,7 +161,9 @@ func findContentInShortPacks(rep *repo.Repository, ch chan contentInfoOrError, t
 	} else {
 		for _, b := range infos {
 			if shortPackBlocks[b.PackBlobID] && strings.HasPrefix(string(b.PackBlobID), *contentRewritePackPrefix) {
-				ch <- contentInfoOrError{Info: b}
+				if b.ID.HasPrefix() == *contentRewritePrefixed {
+					ch <- contentInfoOrError{Info: b}
+				}
 			}
 		}
 	}

--- a/cli/command_repository_repair.go
+++ b/cli/command_repository_repair.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	repairCommand = repositoryCommands.Command("repair", "Repairs respository.")
+	repairCommand = repositoryCommands.Command("repair", "Repairs repository.")
 
 	repairCommandRecoverFormatBlob         = repairCommand.Flag("recover-format", "Recover format blob from a copy").Default("auto").Enum("auto", "yes", "no")
 	repairCommandRecoverFormatBlobPrefixes = repairCommand.Flag("recover-format-block-prefixes", "Prefixes of file names").Strings()

--- a/cli/command_snapshot_migrate.go
+++ b/cli/command_snapshot_migrate.go
@@ -55,7 +55,7 @@ func runMigrateCommand(ctx context.Context, destRepo *repo.Repository) error {
 		if !canceled {
 			canceled = true
 			for s, u := range activeUploaders {
-				log.Warningf("cancelling active uploader for %v", s)
+				log.Warningf("canceling active uploader for %v", s)
 				u.Cancel()
 			}
 		}


### PR DESCRIPTION
…(by default only rewrites non-prefixed IDs)