### PR TITLE
added content.Manager Iterate()

### DIFF
--- a/repo/content/builder.go
+++ b/repo/content/builder.go
@@ -14,6 +14,20 @@ import (
 // packIndexBuilder prepares and writes content index.
 type packIndexBuilder map[ID]*Info
 
+// clone returns a deep clone of packIndexBuilder
+func (b packIndexBuilder) clone() packIndexBuilder {
+	if b == nil {
+		return nil
+	}
+
+	r := packIndexBuilder{}
+	for k, v := range r {
+		i2 := *v
+		r[k] = &i2
+	}
+	return r
+}
+
 // Add adds a new entry to the builder or conditionally replaces it if the timestamp is greater.
 // nolint:gocritic
 func (b packIndexBuilder) Add(i Info) {

--- a/repo/content/merged.go
+++ b/repo/content/merged.go
@@ -69,7 +69,7 @@ func (h *nextInfoHeap) Pop() interface{} {
 }
 
 func iterateChan(prefix ID, ndx packIndex, done chan bool) <-chan Info {
-	ch := make(chan Info)
+	ch := make(chan Info, 16)
 	go func() {
 		defer close(ch)
 


### PR DESCRIPTION
This uses callbacks avoids having to buffer
all content infos in memory and does not require holding a lock.