### PR TITLE
removed content.Manager.ListContents*() API

### DIFF
--- a/cli/command_content_gc.go
+++ b/cli/command_content_gc.go
@@ -2,20 +2,30 @@ package cli
 
 import (
 	"context"
+	"sync"
 
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/blob"
 )
 
 var (
 	contentGarbageCollectCommand       = contentCommands.Command("gc", "Garbage-collect unused blobs")
 	contentGarbageCollectCommandDelete = contentGarbageCollectCommand.Flag("delete", "Whether to delete unused blobs").String()
+	contentGarbageCollectParallel      = contentGarbageCollectCommand.Flag("parallel", "Number of parallel blob scans").Int()
 )
 
 func runContentGarbageCollectCommand(ctx context.Context, rep *repo.Repository) error {
-	unused, err := rep.Content.FindUnreferencedBlobs(ctx)
-	if err != nil {
+	var mu sync.Mutex
+	var unused []blob.Metadata
+
+	if err := rep.Content.IterateUnreferencedBlobs(ctx, *contentGarbageCollectParallel, func(bm blob.Metadata) error {
+		mu.Lock()
+		unused = append(unused, bm)
+		mu.Unlock()
+		return nil
+	}); err != nil {
 		return errors.Wrap(err, "error looking for unreferenced blobs")
 	}
 
@@ -27,7 +37,6 @@ func runContentGarbageCollectCommand(ctx context.Context, rep *repo.Repository) 
 	if *contentGarbageCollectCommandDelete != "yes" {
 		var totalBytes int64
 		for _, u := range unused {
-			printStderr("unused %v (%v bytes)\n", u.BlobID, u.Length)
 			totalBytes += u.Length
 		}
 		printStderr("Would delete %v unused blobs (%v bytes), pass '--delete=yes' to actually delete.\n", len(unused), totalBytes)

--- a/examples/upload_download/main.go
+++ b/examples/upload_download/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/content"
 )
 
 func main() {
@@ -29,12 +30,12 @@ func main() {
 	uploadAndDownloadObjects(ctx, r)
 
 	// Now list contents found in the repository.
-	cnts, err := r.Content.ListContents("")
-	if err != nil {
+	if err := r.Content.IterateContents(
+		content.IterateOptions{},
+		func(ci content.Info) error {
+			log.Printf("found content %v", ci)
+			return nil
+		}); err != nil {
 		log.Printf("err: %v", err)
-	}
-
-	for _, c := range cnts {
-		log.Printf("found content %v", c)
 	}
 }

--- a/repo/content/builder.go
+++ b/repo/content/builder.go
@@ -21,7 +21,7 @@ func (b packIndexBuilder) clone() packIndexBuilder {
 	}
 
 	r := packIndexBuilder{}
-	for k, v := range r {
+	for k, v := range b {
 		i2 := *v
 		r[k] = &i2
 	}

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -96,11 +96,16 @@ func TestManifest(t *testing.T) {
 		t.Errorf("can't compact: %v", err)
 	}
 
-	blks, err := mgr.b.ListContents(manifestContentPrefix)
-	if err != nil {
-		t.Errorf("unable to list manifest blocks: %v", err)
+	foundContents := 0
+	if err := mgr.b.IterateContents(
+		content.IterateOptions{Prefix: manifestContentPrefix},
+		func(ci content.Info) error {
+			foundContents++
+			return nil
+		}); err != nil {
+		t.Errorf("unable to list manifest content: %v", err)
 	}
-	if got, want := len(blks), 1; got != want {
+	if got, want := foundContents, 1; got != want {
 		t.Errorf("unexpected number of blocks: %v, want %v", got, want)
 	}
 


### PR DESCRIPTION
This was previously forcing allocation of the slice for all contents in the repository (unbounded). Replaced with much more memory-efficient iteration.

Note that still in order to list packs we need to keep them in memory, but that can be further optimized when needed, for example by using sharding and repeated iteration of contents.