### PR TITLE
travis: generate repository snapshot for long-term storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .release/
 .releases/
+compat-test/
 playground/
 kopia-*.tar.gz
 kopia-*.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install: make travis-setup
 script: make travis-release
 deploy:
 - provider: script
-  script: curl -sL https://git.io/goreleaser | bash /dev/stdin --rm-dist
+  script: make tagged-release
   skip_cleanup: true
   on:
     tags: true

--- a/tests/compat_test/gen-compat-repo.sh
+++ b/tests/compat_test/gen-compat-repo.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+if [[ $TRAVIS_TAG == "" ]]; then
+    echo TRAVIS_TAG must be set.
+    exit 0
+fi
+
+if [[ $KOPIA_EXE == "" ]]; then
+    echo KOPIA_EXE must be set.
+    exit 0
+fi
+
+OUTPUT_DIR="compat-test/$TRAVIS_TAG"
+rm -rf "$OUTPUT_DIR"
+
+mkdir -pv "$OUTPUT_DIR"
+TMP_DIR=$(mktemp -d)
+mkdir -pv $TMP_DIR/{config,repo}
+export KOPIA_PASSWORD=long-term-test 
+KOPIA_ARGS="--analytics-consent=disagree --config-file=$TMP_DIR/config/kopia.config"
+$KOPIA_EXE $KOPIA_ARGS repository create filesystem --path "$TMP_DIR/repo"
+
+$KOPIA_EXE $KOPIA_ARGS snap create repo
+$KOPIA_EXE $KOPIA_ARGS snap create cli
+$KOPIA_EXE $KOPIA_ARGS snap create site
+
+$KOPIA_EXE $KOPIA_ARGS snap create repo
+$KOPIA_EXE $KOPIA_ARGS snap create cli
+$KOPIA_EXE $KOPIA_ARGS snap create site
+(cd $TMP_DIR && tar cf - "repo/") > "$OUTPUT_DIR/repo.tar"
+cp dist/*.tar.gz "$OUTPUT_DIR"
+rm -rf "$TMP_DIR"
+gsutil cp -rv $OUTPUT_DIR gs://kopia-compat-test/


### PR DESCRIPTION
This is triggered for tagged releases and will be used later for
long-term repository compatibility testing.