### PR TITLE
webdav: improved error handling

### DIFF
--- a/cli/password.go
+++ b/cli/password.go
@@ -94,7 +94,7 @@ func getPersistedPassword(configFile, username string) (string, bool) {
 	if *keyringEnabled {
 		kr, err := keyring.Get(getKeyringItemID(configFile), username)
 		if err == nil {
-			log.Debugf("password for %v retrieved from OS keyring")
+			log.Debugf("password for %v retrieved from OS keyring", configFile)
 			return kr, true
 		}
 	}

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -109,7 +109,6 @@ func sweepLogDir(dirname string, maxCount int, maxAge time.Duration) {
 	if maxCount == 0 {
 		maxCount = math.MaxInt32
 	}
-	log.Debugf("log file time cut-off: %v max count: %v", timeCutoff, maxCount)
 
 	entries, err := ioutil.ReadDir(dirname)
 	if err != nil {

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -43,3 +43,12 @@ func WithExponentialBackoff(desc string, attempt AttemptFunc, isRetriableError I
 
 	return nil, errors.Errorf("unable to complete %v despite %v retries", desc, maxAttempts)
 }
+
+// WithExponentialBackoffNoValue is a shorthand for WithExponentialBackoff except the
+// attempt function does not return any value.
+func WithExponentialBackoffNoValue(desc string, attempt func() error, isRetriableError IsRetriableFunc) error {
+	_, err := WithExponentialBackoff(desc, func() (interface{}, error) {
+		return nil, attempt()
+	}, isRetriableError)
+	return err
+}

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -2,6 +2,7 @@ package blob
 
 import (
 	"context"
+	"log"
 	"sync"
 	"time"
 
@@ -135,16 +136,25 @@ func ListAllBlobsConsistent(ctx context.Context, st Storage, prefix ID, maxAttem
 // sameBlobs returns true if b1 & b2 contain the same blobs (ignoring order).
 func sameBlobs(b1, b2 []Metadata) bool {
 	if len(b1) != len(b2) {
+		log.Printf("a")
 		return false
 	}
 	m := map[ID]Metadata{}
 	for _, b := range b1 {
-		m[b.BlobID] = b
+		m[b.BlobID] = normalizeMetadata(b)
 	}
 	for _, b := range b2 {
-		if m[b.BlobID] != b {
+		if r := m[b.BlobID]; r != normalizeMetadata(b) {
 			return false
 		}
 	}
 	return true
+}
+
+func normalizeMetadata(m Metadata) Metadata {
+	return Metadata{m.BlobID, m.Length, normalizeTimestamp(m.Timestamp)}
+}
+
+func normalizeTimestamp(t time.Time) time.Time {
+	return time.Unix(0, t.UnixNano())
 }

--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -5,11 +5,15 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/studio-b12/gowebdav"
 
+	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/sharded"
 )
@@ -41,10 +45,13 @@ type davStorageImpl struct {
 }
 
 func (d *davStorageImpl) GetBlobFromPath(ctx context.Context, dirPath, path string, offset, length int64) ([]byte, error) {
-	data, err := d.cli.Read(path)
+	v, err := retry.WithExponentialBackoff("GetBlobFromPath", func() (interface{}, error) {
+		return d.cli.Read(path)
+	}, isRetriable)
 	if err != nil {
 		return nil, d.translateError(err)
 	}
+	data := v.([]byte)
 	if length < 0 {
 		return data, nil
 	}
@@ -61,11 +68,22 @@ func (d *davStorageImpl) GetBlobFromPath(ctx context.Context, dirPath, path stri
 	return data[0:length], nil
 }
 
+func httpErrorCode(err error) int {
+	if err, ok := err.(*os.PathError); ok {
+		code, err := strconv.Atoi(strings.Split(err.Err.Error(), " ")[0])
+		if err == nil {
+			return code
+		}
+	}
+
+	return 0
+}
+
 func (d *davStorageImpl) translateError(err error) error {
 	switch err := err.(type) {
 	case *os.PathError:
-		switch err.Err.Error() {
-		case "404":
+		switch httpErrorCode(err) {
+		case http.StatusNotFound:
 			return blob.ErrBlobNotFound
 		default:
 			return err
@@ -76,18 +94,32 @@ func (d *davStorageImpl) translateError(err error) error {
 }
 
 func (d *davStorageImpl) ReadDir(ctx context.Context, dir string) ([]os.FileInfo, error) {
-	return d.cli.ReadDir(gowebdav.FixSlash(dir))
+	v, err := retry.WithExponentialBackoff("ReadDir("+dir+")", func() (interface{}, error) {
+		return d.cli.ReadDir(gowebdav.FixSlash(dir))
+	}, isRetriable)
+	if err == nil {
+		return v.([]os.FileInfo), nil
+	}
+
+	return nil, err
 }
 
 func (d *davStorageImpl) PutBlobInPath(ctx context.Context, dirPath, filePath string, data []byte) error {
 	tmpPath := fmt.Sprintf("%v-%v", filePath, rand.Int63())
-	if err := d.translateError(d.cli.Write(tmpPath, data, defaultFilePerm)); err != nil {
+	if err := d.translateError(retry.WithExponentialBackoffNoValue("Write", func() error {
+		return d.cli.Write(tmpPath, data, defaultFilePerm)
+	}, isRetriable)); err != nil {
 		if err != blob.ErrBlobNotFound {
 			return err
 		}
 
-		d.cli.MkdirAll(dirPath, defaultDirPerm) //nolint:errcheck
-		if err := d.translateError(d.cli.Write(tmpPath, data, defaultFilePerm)); err != nil {
+		_ = retry.WithExponentialBackoffNoValue("MkdirAll", func() error {
+			return d.cli.MkdirAll(dirPath, defaultDirPerm)
+		}, isRetriable)
+
+		if err := d.translateError(retry.WithExponentialBackoffNoValue("Write", func() error {
+			return d.cli.Write(tmpPath, data, defaultFilePerm)
+		}, isRetriable)); err != nil {
 			return err
 		}
 	}
@@ -96,7 +128,9 @@ func (d *davStorageImpl) PutBlobInPath(ctx context.Context, dirPath, filePath st
 }
 
 func (d *davStorageImpl) DeleteBlobInPath(ctx context.Context, dirPath, filePath string) error {
-	return d.translateError(d.cli.Remove(filePath))
+	return d.translateError(retry.WithExponentialBackoffNoValue("DeleteBlobInPath", func() error {
+		return d.cli.Remove(filePath)
+	}, isRetriable))
 }
 
 func (d *davStorage) ConnectionInfo() blob.ConnectionInfo {
@@ -108,6 +142,20 @@ func (d *davStorage) ConnectionInfo() blob.ConnectionInfo {
 
 func (d *davStorage) Close(ctx context.Context) error {
 	return nil
+}
+
+func isRetriable(err error) bool {
+	switch err := err.(type) {
+	case nil:
+		return false
+
+	case *os.PathError:
+		httpCode := httpErrorCode(err)
+		return httpCode == 429 || httpCode >= 500
+
+	default:
+		return true
+	}
 }
 
 // New creates new WebDAV-backed storage in a specified URL.

--- a/repo/blob/webdav/webdav_storage_test.go
+++ b/repo/blob/webdav/webdav_storage_test.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/net/webdav"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/logging"
 )
 
 func basicAuth(h http.Handler) http.HandlerFunc {
@@ -31,11 +33,29 @@ func basicAuth(h http.Handler) http.HandlerFunc {
 	}
 }
 
-func TestWebDAVStorage(t *testing.T) {
+func TestWebDAVStorageExternalServer(t *testing.T) {
+	t.Parallel()
+	testURL := os.Getenv("KOPIA_WEBDAV_TEST_URL")
+	if testURL == "" {
+		t.Skip("KOPIA_WEBDAV_TEST_URL not provided")
+	}
+
+	testUsername := os.Getenv("KOPIA_WEBDAV_TEST_USERNAME")
+	if testUsername == "" {
+		t.Skip("KOPIA_WEBDAV_TEST_USERNAME not provided")
+	}
+
+	testPassword := os.Getenv("KOPIA_WEBDAV_TEST_PASSWORD")
+	if testPassword == "" {
+		t.Skip("KOPIA_WEBDAV_TEST_PASSWORD not provided")
+	}
+
+	verifyWebDAVStorage(t, testURL, testUsername, testPassword, nil)
+}
+
+func TestWebDAVStorageBuiltInServer(t *testing.T) {
 	tmpDir, _ := ioutil.TempDir("", "webdav")
 	defer os.RemoveAll(tmpDir)
-
-	t.Logf("tmpDir: %v", tmpDir)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", basicAuth(&webdav.Handler{
@@ -45,8 +65,6 @@ func TestWebDAVStorage(t *testing.T) {
 
 	server := httptest.NewServer(mux)
 	defer server.Close()
-
-	ctx := context.Background()
 
 	// Test varioush shard configurations.
 	for _, shardSpec := range [][]int{
@@ -64,22 +82,36 @@ func TestWebDAVStorage(t *testing.T) {
 			}
 			os.MkdirAll(tmpDir, 0700) //nolint:errcheck
 
-			r, err := New(context.Background(), &Options{
-				URL:             server.URL,
-				DirectoryShards: shardSpec,
-				Username:        "user",
-				Password:        "password",
-			})
-
-			if r == nil || err != nil {
-				t.Errorf("unexpected result: %v %v", r, err)
-			}
-
-			blobtesting.VerifyStorage(ctx, t, r)
-			blobtesting.AssertConnectionInfoRoundTrips(ctx, t, r)
-			if err := r.Close(ctx); err != nil {
-				t.Fatalf("err: %v", err)
-			}
+			verifyWebDAVStorage(t, server.URL, "user", "password", shardSpec)
 		})
+	}
+}
+
+func verifyWebDAVStorage(t *testing.T, url, username, password string, shardSpec []int) {
+	ctx := context.Background()
+
+	st, err := New(context.Background(), &Options{
+		URL:             url,
+		DirectoryShards: shardSpec,
+		Username:        username,
+		Password:        password,
+	})
+
+	if st == nil || err != nil {
+		t.Errorf("unexpected result: %v %v", st, err)
+	}
+
+	st = logging.NewWrapper(st)
+
+	if err := st.ListBlobs(ctx, "", func(bm blob.Metadata) error {
+		return st.DeleteBlob(ctx, bm.BlobID)
+	}); err != nil {
+		t.Fatalf("unable to clear webdav storage: %v", err)
+	}
+
+	blobtesting.VerifyStorage(ctx, t, st)
+	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
+	if err := st.Close(ctx); err != nil {
+		t.Fatalf("err: %v", err)
 	}
 }


### PR DESCRIPTION
- improved HTTP error handling
- added exponential back-off around gowebdav calls
- fixed blob.ListAllBlobsConsistent which was never finishing for WebDAV

Fixes #88 - 429 Too Many Requests - PROPFIND /n0a #88
Fixex #89 - Debug log clashes with interactive repo password request