### PR TITLE
localfs: improved performance and memory usage when scanning large directories

### DIFF
--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -24,17 +26,58 @@ func (e sortedEntries) Less(i, j int) bool {
 }
 
 type filesystemEntry struct {
-	os.FileInfo
+	name       string
+	size       int64
+	mtimeNanos int64
+	mode       os.FileMode
+	owner      fs.OwnerInfo
 
-	path string
+	parentDir string
 }
 
-func (e filesystemEntry) Owner() fs.OwnerInfo {
-	return platformSpecificOwnerInfo(e)
+func (e *filesystemEntry) Name() string {
+	return e.name
 }
 
-func newEntry(md os.FileInfo, path string) filesystemEntry {
-	return filesystemEntry{md, path}
+func (e *filesystemEntry) IsDir() bool {
+	return e.mode.IsDir()
+}
+
+func (e *filesystemEntry) Mode() os.FileMode {
+	return e.mode
+}
+
+func (e *filesystemEntry) Size() int64 {
+	return e.size
+}
+
+func (e *filesystemEntry) ModTime() time.Time {
+	return time.Unix(0, e.mtimeNanos)
+}
+
+func (e *filesystemEntry) Sys() interface{} {
+	return nil
+}
+
+func (e *filesystemEntry) fullPath() string {
+	return filepath.Join(e.parentDir, e.Name())
+}
+
+func (e *filesystemEntry) Owner() fs.OwnerInfo {
+	return e.owner
+}
+
+var _ os.FileInfo = (*filesystemEntry)(nil)
+
+func newEntry(fi os.FileInfo, parentDir string) filesystemEntry {
+	return filesystemEntry{
+		fi.Name(),
+		fi.Size(),
+		fi.ModTime().UnixNano(),
+		fi.Mode(),
+		platformSpecificOwnerInfo(fi),
+		parentDir,
+	}
 }
 
 type filesystemDirectory struct {
@@ -59,36 +102,79 @@ func (fsd *filesystemDirectory) Summary() *fs.DirectorySummary {
 }
 
 func (fsd *filesystemDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
-	f, direrr := os.Open(fsd.path)
+	fullPath := fsd.fullPath()
+	f, direrr := os.Open(fullPath)
 	if direrr != nil {
 		return nil, direrr
 	}
 	defer f.Close() //nolint:errcheck
 
-	var entries fs.Entries
-
-	for {
-		fileInfos, err := f.Readdir(16)
-		for _, fi := range fileInfos {
-			e, fierr := entryFromFileInfo(fi, filepath.Join(fsd.path, fi.Name()))
-			if fierr != nil {
-				log.Warningf("unable to create directory entry %q: %v", fi.Name(), fierr)
+	// start feeding directory entry names to namesCh
+	namesCh := make(chan string, 200)
+	var namesErr error
+	var namesWG sync.WaitGroup
+	namesWG.Add(1)
+	go func() {
+		defer namesWG.Done()
+		defer close(namesCh)
+		for {
+			names, err := f.Readdirnames(100)
+			for _, name := range names {
+				namesCh <- name
+			}
+			if err == nil {
 				continue
 			}
-			entries = append(entries, e)
-		}
-		if err == nil {
-			continue
-		}
-		if err == io.EOF {
+			if err == io.EOF {
+				break
+			}
+			namesErr = err
 			break
 		}
-		return nil, err
+	}()
+
+	entriesCh := make(chan fs.Entry, 200)
+
+	// launch N workers to os.Lstat() each name in parallel and push to entriesCh
+	workers := 16
+	var workersWG sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		workersWG.Add(1)
+		go func() {
+			defer workersWG.Done()
+
+			for n := range namesCh {
+				fi, staterr := os.Lstat(fullPath + "/" + n)
+				if os.IsNotExist(staterr) {
+					// lost the race - ignore.
+					continue
+				}
+				e, fierr := entryFromChildFileInfo(fi, fullPath)
+				if fierr != nil {
+					log.Warningf("unable to create directory entry %q: %v", fi.Name(), fierr)
+					continue
+				}
+				entriesCh <- e
+			}
+		}()
+	}
+
+	// close entriesCh channel when all workers terminate
+	go func() {
+		workersWG.Wait()
+		close(entriesCh)
+	}()
+
+	// drain the entriesCh into a slice and sort it
+	var entries fs.Entries
+	for e := range entriesCh {
+		entries = append(entries, e)
 	}
 
 	sort.Sort(sortedEntries(entries))
 
-	return entries, nil
+	// return any error encountered when listing the directory
+	return entries, namesErr
 }
 
 type fileWithMetadata struct {
@@ -100,11 +186,11 @@ func (f *fileWithMetadata) Entry() (fs.Entry, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &filesystemFile{newEntry(fi, f.Name())}, nil
+	return &filesystemFile{newEntry(fi, filepath.Dir(f.Name()))}, nil
 }
 
 func (fsf *filesystemFile) Open(ctx context.Context) (fs.Reader, error) {
-	f, err := os.Open(fsf.path)
+	f, err := os.Open(fsf.fullPath())
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +199,7 @@ func (fsf *filesystemFile) Open(ctx context.Context) (fs.Reader, error) {
 }
 
 func (fsl *filesystemSymlink) Readlink(ctx context.Context) (string, error) {
-	return os.Readlink(fsl.path)
+	return os.Readlink(fsl.fullPath())
 }
 
 // NewEntry returns fs.Entry for the specified path, the result will be one of supported entry types: fs.File, fs.Directory, fs.Symlink.
@@ -123,7 +209,19 @@ func NewEntry(path string) (fs.Entry, error) {
 		return nil, err
 	}
 
-	return entryFromFileInfo(fi, path)
+	switch fi.Mode() & os.ModeType {
+	case os.ModeDir:
+		return &filesystemDirectory{newEntry(fi, filepath.Dir(path))}, nil
+
+	case os.ModeSymlink:
+		return &filesystemSymlink{newEntry(fi, filepath.Dir(path))}, nil
+
+	case 0:
+		return &filesystemFile{newEntry(fi, filepath.Dir(path))}, nil
+
+	default:
+		return nil, errors.Errorf("unsupported filesystem entry: %v", fi)
+	}
 }
 
 // Directory returns fs.Directory for the specified path.
@@ -142,19 +240,19 @@ func Directory(path string) (fs.Directory, error) {
 	}
 }
 
-func entryFromFileInfo(fi os.FileInfo, path string) (fs.Entry, error) {
+func entryFromChildFileInfo(fi os.FileInfo, parentDir string) (fs.Entry, error) {
 	switch fi.Mode() & os.ModeType {
 	case os.ModeDir:
-		return &filesystemDirectory{newEntry(fi, path)}, nil
+		return &filesystemDirectory{newEntry(fi, parentDir)}, nil
 
 	case os.ModeSymlink:
-		return &filesystemSymlink{newEntry(fi, path)}, nil
+		return &filesystemSymlink{newEntry(fi, parentDir)}, nil
 
 	case 0:
-		return &filesystemFile{newEntry(fi, path)}, nil
+		return &filesystemFile{newEntry(fi, parentDir)}, nil
 
 	default:
-		return nil, errors.Errorf("unsupported filesystem entry: %v", path)
+		return nil, errors.Errorf("unsupported filesystem entry: %v", fi)
 	}
 }
 


### PR DESCRIPTION
- parallelized os.Lstat() x 16 (dramatically improves speed)
- discarded unused portions of os.FileInfo (uses 60% less RAM on macOS)

BEFORE:
10:47:03.670 [kopia/localfs] listed 200000 entries in 43.871211686s using 79126528 bytes of heap

After:
10:49:12.439 [kopia/localfs] listed 200000 entries in 1.953018184s using 30515200 bytes of heap