### PR TITLE
Switch file log level to info

### DIFF
--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -34,7 +34,7 @@ var (
 	logDirMaxFiles = cli.App().Flag("log-dir-max-files", "Maximum number of log files to retain").Envar("KOPIA_LOG_DIR_MAX_FILES").Default("1000").Hidden().Int()
 	logDirMaxAge   = cli.App().Flag("log-dir-max-age", "Maximum age of log files to retain").Envar("KOPIA_LOG_DIR_MAX_AGE").Hidden().Duration()
 	logLevel       = cli.App().Flag("log-level", "Console log level").Default("info").Enum(logLevels...)
-	fileLogLevel   = cli.App().Flag("file-log-level", "File log level").Default("debug").Enum(logLevels...)
+	fileLogLevel   = cli.App().Flag("file-log-level", "File log level").Default("info").Enum(logLevels...)
 )
 
 var log = kopialogging.Logger("kopia")


### PR DESCRIPTION
Reduces multi-GB log files. Main culprits were:

- [upload.go:385] could not find cache entry for...
- [content_manager.go:790] WriteContent("...") - new
- [content_manager.go:396] adding ... length=... deleted=false