### PR TITLE
content: fixed content.Manager.Flush() race

### DIFF
--- a/internal/blobtesting/faulty.go
+++ b/internal/blobtesting/faulty.go
@@ -102,6 +102,7 @@ func (s *FaultyStorage) getNextFault(method string, args ...interface{}) error {
 	}
 	if f.Sleep > 0 {
 		log.Debugf("sleeping for %v in %v %v", f.Sleep, method, args)
+		time.Sleep(f.Sleep)
 	}
 	if f.ErrCallback != nil {
 		err := f.ErrCallback()

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -148,6 +148,7 @@ func (bm *Manager) addToPackUnlocked(ctx context.Context, contentID ID, data []b
 
 	// do not start new uploads while flushing
 	for bm.flushing {
+		formatLog.Debugf("waiting before flush completes")
 		bm.cond.Wait()
 	}
 

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -31,7 +31,7 @@ func (r *Repository) Close(ctx context.Context) error {
 	if err := r.Manifests.Flush(ctx); err != nil {
 		return errors.Wrap(err, "error flushing manifests")
 	}
-	if err := r.Content.Flush(ctx); err != nil {
+	if err := r.Content.Close(ctx); err != nil {
 		return errors.Wrap(err, "error closing content-addressable storage manager")
 	}
 	if err := r.Blobs.Close(ctx); err != nil {

--- a/tests/repository_stress_test/repository_stress_test.go
+++ b/tests/repository_stress_test/repository_stress_test.go
@@ -173,7 +173,6 @@ func repositoryTest(ctx context.Context, t *testing.T, cancel chan struct{}, rep
 	for {
 		select {
 		case <-cancel:
-			rep.Close(ctx)
 			return
 		default:
 		}


### PR DESCRIPTION
Previously, it was possible for Flush() to miss in-flight writes,
but only when using repository manually since Uploader guarantees
there are no in-flight writes when it completes.

With this change Flush() will guarantee that any pending writes
completed before Flush() has started are guaranteed to be committed
to the repository before Flush() returns.

This was actually a regression introduced in #105.
Added regression test to prevent it from reoccurring.