### PR TITLE
Add .gitattributes with settings for Go

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.go	whitespace=trailing-space,space-before-tab,indent-with-non-tab
+go.mod	whitespace=trailing-space,space-before-tab,indent-with-non-tab


### PR DESCRIPTION
Removes git warnings about tabs in indentation for Go files.