### PR TITLE
Fix double unlock in Cache.getEntries

### DIFF
--- a/fs/cachefs/cache.go
+++ b/fs/cachefs/cache.go
@@ -89,7 +89,7 @@ func (c *Cache) Readdir(ctx context.Context, d fs.Directory) (fs.Entries, error)
 	return d.Readdir(ctx)
 }
 
-func (c *Cache) getEntriesFromCache(id string) fs.Entries {
+func (c *Cache) getEntriesFromCacheLocked(id string) fs.Entries {
 	if v, ok := c.data[id]; id != "" && ok {
 		if time.Now().Before(v.expireAfter) {
 			c.moveToHead(v)
@@ -118,7 +118,7 @@ func (c *Cache) getEntries(ctx context.Context, id string, expirationTime time.D
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if entries := c.getEntriesFromCache(id); entries != nil {
+	if entries := c.getEntriesFromCacheLocked(id); entries != nil {
 		return entries, nil
 	}
 

--- a/fs/cachefs/cache.go
+++ b/fs/cachefs/cache.go
@@ -93,7 +93,6 @@ func (c *Cache) getEntriesFromCache(id string) fs.Entries {
 	if v, ok := c.data[id]; id != "" && ok {
 		if time.Now().Before(v.expireAfter) {
 			c.moveToHead(v)
-			c.mu.Unlock()
 			if c.debug {
 				log.Debugf("cache hit for %q (valid until %v)", id, v.expireAfter)
 			}


### PR DESCRIPTION
# Motivation:

- Consistent locking/unlocking of `c.mu` in `Cache.getEntries`
- Fix CI failure

`Cache.getEntriesFromCache()` was releasing `c.mu` when returning an entry and not releasing it when returning nil. Previously, the caller (`Cache.getEntries`) was accordingly not releasing `c.mu` when `getEntriesFromCache()` was returning an entry, and unlocking `c.mu` otherwise.

`Cache.getEntries` is the only caller for `getEntriesFromCache`.

After this change c.mu is consistently locked and unlocked in `getEntries`

Also rename function to `Cache.c.getEntriesFromCacheLocked`

# Test Plan

```
go test -count=1 -timeout 90s github.com/kopia/kopia/...
?   	github.com/kopia/kopia	[no test files]
?   	github.com/kopia/kopia/cli	[no test files]
?   	github.com/kopia/kopia/examples/upload_download	[no test files]
?   	github.com/kopia/kopia/fs	[no test files]
ok  	github.com/kopia/kopia/fs/cachefs	0.021s
ok  	github.com/kopia/kopia/fs/ignorefs	0.022s
ok  	github.com/kopia/kopia/fs/localfs	0.020s
?   	github.com/kopia/kopia/fs/loggingfs	[no test files]
ok  	github.com/kopia/kopia/internal/blobtesting	0.016s
?   	github.com/kopia/kopia/internal/diff	[no test files]
?   	github.com/kopia/kopia/internal/editor	[no test files]
?   	github.com/kopia/kopia/internal/fusemount	[no test files]
ok  	github.com/kopia/kopia/internal/ignore	0.014s
?   	github.com/kopia/kopia/internal/kopialogging	[no test files]
?   	github.com/kopia/kopia/internal/logfile	[no test files]
?   	github.com/kopia/kopia/internal/mockfs	[no test files]
?   	github.com/kopia/kopia/internal/ospath	[no test files]
?   	github.com/kopia/kopia/internal/parallelwork	[no test files]
?   	github.com/kopia/kopia/internal/repologging	[no test files]
?   	github.com/kopia/kopia/internal/repotesting	[no test files]
ok  	github.com/kopia/kopia/internal/retry	0.069s
?   	github.com/kopia/kopia/internal/scrubber	[no test files]
?   	github.com/kopia/kopia/internal/server	[no test files]
?   	github.com/kopia/kopia/internal/serverapi	[no test files]
ok  	github.com/kopia/kopia/internal/throttle	0.019s
ok  	github.com/kopia/kopia/internal/units	0.010s
?   	github.com/kopia/kopia/internal/webdavmount	[no test files]
ok  	github.com/kopia/kopia/repo	12.865s
ok  	github.com/kopia/kopia/repo/blob	0.014s
ok  	github.com/kopia/kopia/repo/blob/filesystem	4.027s
ok  	github.com/kopia/kopia/repo/blob/gcs	0.025s
ok  	github.com/kopia/kopia/repo/blob/logging	0.015s
?   	github.com/kopia/kopia/repo/blob/providers	[no test files]
ok  	github.com/kopia/kopia/repo/blob/s3	5.542s
ok  	github.com/kopia/kopia/repo/blob/sftp	0.025s
?   	github.com/kopia/kopia/repo/blob/sharded	[no test files]
ok  	github.com/kopia/kopia/repo/blob/webdav	0.349s
ok  	github.com/kopia/kopia/repo/content	24.025s
ok  	github.com/kopia/kopia/repo/manifest	1.067s
ok  	github.com/kopia/kopia/repo/object	11.992s
?   	github.com/kopia/kopia/site/cli2md	[no test files]
ok  	github.com/kopia/kopia/snapshot	0.825s
?   	github.com/kopia/kopia/snapshot/gc	[no test files]
?   	github.com/kopia/kopia/snapshot/policy	[no test files]
ok  	github.com/kopia/kopia/snapshot/snapshotfs	4.911s
ok  	github.com/kopia/kopia/tests/end_to_end_test	0.008s
ok  	github.com/kopia/kopia/tests/repository_stress_test	7.792s
ok  	github.com/kopia/kopia/tests/stress_test	3.042s
```
