### PR TITLE
Simple test for Cache.getEntries() locking/unlocking

### DIFF
--- a/fs/cachefs/cache.go
+++ b/fs/cachefs/cache.go
@@ -23,7 +23,7 @@ type cacheEntry struct {
 
 // Cache maintains in-memory cache of recently-read data to speed up filesystem operations.
 type Cache struct {
-	mu sync.Mutex
+	mu sync.Locker
 
 	totalDirectoryEntries int
 	maxDirectories        int
@@ -175,6 +175,7 @@ func NewCache(options *Options) *Cache {
 	}
 
 	return &Cache{
+		mu:                  &sync.Mutex{},
 		data:                make(map[string]*cacheEntry),
 		maxDirectories:      options.MaxCachedDirectories,
 		maxDirectoryEntries: options.MaxCachedEntries,


### PR DESCRIPTION
See #130 and #132

# Test Plan

```
go test -timeout 30s github.com/kopia/kopia/fs/cachefs -run ^(TestCacheGetEntriesLocking)$

ok  	github.com/kopia/kopia/fs/cachefs	0.006s
Success: Tests passed.
```