### PR TITLE
Minor cleanups

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,8 @@ linters-settings:
       - experimental
     disabled-checks:
       - wrapperFunc
+  whitespace:
+    multi-func: true
 
 linters:
   enable-all: true

--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -18,7 +18,6 @@ var (
 )
 
 func runBenchmarkCryptoAction(ctx *kingpin.ParseContext) error {
-
 	type benchResult struct {
 		hash       string
 		encryption string

--- a/cli/command_snapshot_estimate.go
+++ b/cli/command_snapshot_estimate.go
@@ -130,6 +130,7 @@ func showBuckets(b buckets) {
 		}
 	}
 }
+
 func estimate(ctx context.Context, relativePath string, entry fs.Entry, stats *snapshot.Stats, ib, eb buckets) error {
 	switch entry := entry.(type) {
 	case fs.Directory:

--- a/cli/memory_tracking.go
+++ b/cli/memory_tracking.go
@@ -38,7 +38,6 @@ func dumpMemoryUsage() {
 
 func startMemoryTracking() {
 	if *trackMemoryUsage > 0 {
-
 		go func() {
 			for {
 				dumpMemoryUsage()

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -189,7 +189,6 @@ func (imf *File) SetContents(b []byte) {
 	imf.source = func() (ReaderSeekerCloser, error) {
 		return readerSeekerCloser{bytes.NewReader(b)}, nil
 	}
-
 }
 
 type fileReader struct {

--- a/repo/blob/s3/s3_options.go
+++ b/repo/blob/s3/s3_options.go
@@ -9,7 +9,7 @@ type Options struct {
 	Prefix string `json:"prefix,omitempty"`
 
 	Endpoint    string `json:"endpoint"`
-	DoNotUseTLS bool   `json:"doNotUseTLS,omitempyy"`
+	DoNotUseTLS bool   `json:"doNotUseTLS,omitempty"`
 
 	AccessKeyID     string `json:"accessKeyID"`
 	SecretAccessKey string `json:"secretAccessKey" kopia:"sensitive"`

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -1254,8 +1254,8 @@ func verifyContent(ctx context.Context, t *testing.T, bm *Manager, contentID ID,
 	if got, want := bi.Length, uint32(len(b)); got != want {
 		t.Errorf("invalid content size for %q: %v, wanted %v", contentID, got, want)
 	}
-
 }
+
 func writeContentAndVerify(ctx context.Context, t *testing.T, bm *Manager, b []byte) ID {
 	t.Helper()
 
@@ -1272,6 +1272,7 @@ func writeContentAndVerify(ctx context.Context, t *testing.T, bm *Manager, b []b
 
 	return contentID
 }
+
 func flushWithRetries(ctx context.Context, t *testing.T, bm *Manager) int {
 	t.Helper()
 

--- a/repo/content/format.go
+++ b/repo/content/format.go
@@ -29,7 +29,7 @@ type entry struct {
 	// 8 bits - format version (currently == 1)
 	// 8 least significant bits - length of pack content ID
 	timestampAndFlags uint64 //
-	packFileOffset    uint32 // 4 bytes, big endian, offset within index file where pack content ID begins
+	packFileOffset    uint32 // 4 bytes, big endian, offset within index file where pack (blob) ID begins
 	packedOffset      uint32 // 4 bytes, big endian, offset within pack file where the contents begin
 	packedLength      uint32 // 4 bytes, big endian, content length
 }


### PR DESCRIPTION
Flagged by `golangci` while testing version 1.21.0

There were other (noisy?) failures not addressed in this PR. Punting for now.
