### PR TITLE
Snapshot restore command

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -51,7 +51,7 @@ func runRestoreCommand(ctx context.Context, rep *repo.Repository) error {
 		return err
 	}
 
-	return snapshotfs.Restore(ctx, rep, *restoreCommandTargetPath, oid)
+	return snapshotfs.RestoreRoot(ctx, rep, *restoreCommandTargetPath, oid)
 }
 
 func init() {

--- a/cli/command_snapshot_restore.go
+++ b/cli/command_snapshot_restore.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/manifest"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+)
+
+var (
+	snapshotRestoreCommand    = snapshotCommands.Command("restore", "Restore a snapshot from the snapshot ID to the given target path")
+	snapshotRestoreSnapID     = snapshotRestoreCommand.Arg("id", "Snapshot ID to be restored").Required().String()
+	snapshotRestoreTargetPath = snapshotRestoreCommand.Arg("target-path", "Path of the directory for the contents to be restored").Required().String()
+)
+
+func runSnapRestoreCommand(ctx context.Context, rep *repo.Repository) error {
+	return snapshotfs.Restore(ctx, rep, *snapshotRestoreTargetPath, manifest.ID(*snapshotRestoreSnapID))
+}
+
+func init() {
+	snapshotRestoreCommand.Action(repositoryAction(runSnapRestoreCommand))
+}

--- a/snapshot/manager.go
+++ b/snapshot/manager.go
@@ -58,8 +58,8 @@ func ListSnapshots(ctx context.Context, rep *repo.Repository, si SourceInfo) ([]
 	return LoadSnapshots(ctx, rep, entryIDs(entries))
 }
 
-// loadSnapshot loads and parses a snapshot with a given ID.
-func loadSnapshot(ctx context.Context, rep *repo.Repository, manifestID manifest.ID) (*Manifest, error) {
+// LoadSnapshot loads and parses a snapshot with a given ID.
+func LoadSnapshot(ctx context.Context, rep *repo.Repository, manifestID manifest.ID) (*Manifest, error) {
 	sm := &Manifest{}
 	if err := rep.Manifests.Get(ctx, manifestID, sm); err != nil {
 		return nil, errors.Wrap(err, "unable to find manifest entries")
@@ -105,7 +105,7 @@ func LoadSnapshots(ctx context.Context, rep *repo.Repository, manifestIDs []mani
 		go func(i int, n manifest.ID) {
 			defer func() { <-sem }()
 
-			m, err := loadSnapshot(ctx, rep, n)
+			m, err := LoadSnapshot(ctx, rep, n)
 			if err != nil {
 				log.Warningf("unable to parse snapshot manifest %v: %v", n, err)
 				return

--- a/snapshot/snapshotfs/restore.go
+++ b/snapshot/snapshotfs/restore.go
@@ -3,12 +3,35 @@ package snapshotfs
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/repo/object"
+	"github.com/kopia/kopia/snapshot"
 )
 
-// Restore walks a snapshot root with given object ID and restores it to the local filesystem
-func Restore(ctx context.Context, rep *repo.Repository, targetPath string, oid object.ID) error {
+// Restore walks a snapshot root with given snapshot ID and restores it to the local filesystem
+func Restore(ctx context.Context, rep *repo.Repository, targetPath string, snapID manifest.ID) error {
+	m, err := snapshot.LoadSnapshot(ctx, rep, snapID)
+	if err != nil {
+		return err
+	}
+
+	if m.RootEntry == nil {
+		return errors.Errorf("No root entry found in manifest (%v)", snapID)
+	}
+
+	rootEntry, err := SnapshotRoot(rep, m)
+	if err != nil {
+		return err
+	}
+
+	return localfs.Copy(ctx, targetPath, rootEntry)
+}
+
+// RestoreRoot walks a snapshot root with given object ID and restores it to the local filesystem
+func RestoreRoot(ctx context.Context, rep *repo.Repository, targetPath string, oid object.ID) error {
 	return localfs.Copy(ctx, targetPath, DirectoryEntry(rep, oid, nil))
 }


### PR DESCRIPTION
Snapshot restore will take a snapshot ID and restore the
associated snapshot to the target path.
- Looks up the manifest with the snapshot ID
- Gets the snapshot root entry
- Copies the snapshot from the root entry to the target path

Because it uses the parent manifest with the copied permissions,
the restored directory will have the permissions of the original
source directory.