### PR TITLE
cleanup: fix linter errors

### DIFF
--- a/cli/command_snapshot_delete.go
+++ b/cli/command_snapshot_delete.go
@@ -3,9 +3,10 @@ package cli
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/manifest"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -21,21 +22,26 @@ func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
 	}
 
 	manifestID := manifest.ID(*snapshotDeleteID)
+
 	manifestMeta, err := rep.Manifests.GetMetadata(ctx, manifestID)
 	if err != nil {
 		return err
 	}
+
 	labels := manifestMeta.Labels
 	if labels["type"] != "snapshot" {
 		return errors.Errorf("snapshot ID provided (%v) did not reference a snapshot", manifestID)
 	}
+
 	if !*snapshotDeleteIgnoreSource {
 		if labels["hostname"] != getHostName() {
 			return errors.New("host name does not match for deleting requested snapshot ID")
 		}
+
 		if labels["username"] != getUserName() {
 			return errors.New("user name does not match for deleting requested snapshot ID")
 		}
+
 		if labels["path"] != *snapshotDeletePath {
 			return errors.New("path does not match for deleting requested snapshot ID")
 		}

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -300,9 +300,13 @@ how are you
 
 type deleteArgMaker func(manifestID string, source sourceInfo) []string
 
+//nolint:funlen
 func TestSnapshotDelete(t *testing.T) {
-	expectFail := false
-	expectSuccess := true
+	const (
+		expectFail    = false
+		expectSuccess = true
+	)
+
 	for _, tc := range []struct {
 		desc          string
 		mf            deleteArgMaker
@@ -512,8 +516,9 @@ how are you
 	for _, source := range si {
 		for _, ss := range source.snapshots {
 			manifestID := ss.snapshotID
-			t.Logf("manifestID: %v", manifestID)
 			args := argMaker(manifestID, source)
+			t.Logf("manifestID: %v", manifestID)
+
 			if expectDeleteSucceeds {
 				e.runAndExpectSuccess(t, args...)
 			} else {
@@ -534,10 +539,12 @@ func TestSnapshotDeleteTypeCheck(t *testing.T) {
 	if len(lines) != 1 {
 		t.Fatalf("Expected 1 line global policy output for manifest ls")
 	}
+
 	line := lines[0]
 	fields := strings.Fields(line)
 	manifestID := fields[0]
 	typeField := fields[5]
+
 	typeVal := strings.TrimPrefix(typeField, "type:")
 	if typeVal != "policy" {
 		t.Fatalf("Expected global policy manifest on a fresh repo")
@@ -555,7 +562,6 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 
 	source := filepath.Join(e.dataDir, "source")
 	createDirectory(t, source, 1)
-	restoreDir := filepath.Join(e.dataDir, "restored")
 
 	// Create snapshot
 	e.runAndExpectSuccess(t, "snapshot", "create", source)
@@ -565,12 +571,15 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 	if got, want := len(si), 1; got != want {
 		t.Fatalf("got %v sources, wanted %v", got, want)
 	}
+
 	if got, want := len(si[0].snapshots), 1; got != want {
 		t.Fatalf("got %v snapshots, wanted %v", got, want)
 	}
+
 	snapID := si[0].snapshots[0].snapshotID
 	rootID := si[0].snapshots[0].objectID
 
+	restoreDir := filepath.Join(e.dataDir, "restored")
 	e.runAndExpectSuccess(t, "restore", rootID, restoreDir)
 
 	// Note: restore does not reset the permissions for the top directory due to
@@ -581,14 +590,10 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 	compareDirs(t, source, restoreDir)
 
 	// snapshot delete should succeed
-	e.runAndExpectSuccess(t, "snapshot", "delete", snapID,
-		"--unsafe-ignore-source",
-	)
+	e.runAndExpectSuccess(t, "snapshot", "delete", snapID, "--unsafe-ignore-source")
 
 	// Subsequent snapshot delete to the same ID should fail
-	e.runAndExpectFailure(t, "snapshot", "delete", snapID,
-		"--unsafe-ignore-source",
-	)
+	e.runAndExpectFailure(t, "snapshot", "delete", snapID, "--unsafe-ignore-source")
 
 	// garbage-collect to clean up the root object. Otherwise
 	// a restore will succeed
@@ -601,6 +606,7 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 	// Make sure the restore did not happen from the deleted snapshot
 	fileInfo, err := ioutil.ReadDir(notRestoreDir)
 	assertNoError(t, err)
+
 	if len(fileInfo) != 0 {
 		t.Fatalf("expected nothing to be restored")
 	}


### PR DESCRIPTION
Fix various errors flagged by the `goimports`, `wsl`, `funlen` linters

Not sure why these did not show up in the original PR.

```
make lint
kopia/tools/.tools/bin/golangci-lint --deadline 180s run | tee .linterr.txt
cli/command_snapshot_delete.go:5: File is not `goimports`-ed with -local github.com/kopia/kopia (goimports)

tests/end_to_end_test/end_to_end_test.go:303: Function 'TestSnapshotDelete' is too long (187 > 100) (funlen)
func TestSnapshotDelete(t *testing.T) {
tests/end_to_end_test/end_to_end_test.go:306:2: only one cuddle assignment allowed before range statement (wsl)
	for _, tc := range []struct {
	^
tests/end_to_end_test/end_to_end_test.go:517:4: only one cuddle assignment allowed before if statement (wsl)
			if expectDeleteSucceeds {
			^
tests/end_to_end_test/end_to_end_test.go:537:2: assignments should only be cuddled with other assignments (wsl)
	line := lines[0]
	^
tests/end_to_end_test/end_to_end_test.go:542:2: only one cuddle assignment allowed before if statement (wsl)
	if typeVal != "policy" {
	^
tests/end_to_end_test/end_to_end_test.go:558:2: assignments should only be cuddled with other assignments (wsl)
	restoreDir := filepath.Join(e.dataDir, "restored")
	^
tests/end_to_end_test/end_to_end_test.go:568:2: if statements should only be cuddled with assignments (wsl)
	if got, want := len(si[0].snapshots), 1; got != want {
	^
tests/end_to_end_test/end_to_end_test.go:571:2: assignments should only be cuddled with other assignments (wsl)
	snapID := si[0].snapshots[0].snapshotID
	^
tests/end_to_end_test/end_to_end_test.go:604:2: if statements should only be cuddled with assignments (wsl)
	if len(fileInfo) != 0 {
	^
cli/command_snapshot_delete.go:25:2: only one cuddle assignment allowed before if statement (wsl)
	if err != nil {
	^
cli/command_snapshot_delete.go:36:3: if statements should only be cuddled with assignments (wsl)
		if labels["username"] != getUserName() {
		^
```