### PR TITLE
build: added simple Windows-based build script

### DIFF
--- a/htmlui/build.cmd
+++ b/htmlui/build.cmd
@@ -1,0 +1,2 @@
+if not exist node_modules\nul call npm install
+call npm run build

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,21 @@
+@echo Installing tools...
+
+pushd tools
+call install.cmd
+popd
+
+@echo Building HTML UI...
+
+pushd htmlui
+call build.cmd
+popd
+
+@echo Building embedded data...
+
+pushd htmlui\build
+echo on
+..\..\tools\.tools\go-bindata.exe -fs -tags embedhtml -o ..\..\internal\server\htmlui_bindata.go -pkg server -ignore .map . static/css static/js static/media
+popd
+
+@echo Building binary...
+go build -o kopia.exe -tags embedhtml github.com/kopia/kopia

--- a/site/content/docs/Installation/_index.md
+++ b/site/content/docs/Installation/_index.md
@@ -80,13 +80,12 @@ $ deb -i kopia*.deb
 
 ### Compilation From Source
 
-If you have [Go 1.12](https://golang.org/) or newer, you may download and build Kopia yourself. No special setup is necessary, other than the Go compiler. You can simply run:
+If you have [Go 1.13](https://golang.org/) or newer, you may download and build Kopia yourself. No special setup is necessary, other than the Go compiler. You can simply run:
 
 ```shell
 $ go get github.com/kopia/kopia
 ```
 
-The resulting binary will be available in `$HOME/go/bin`.
+The resulting binary will be available in `$HOME/go/bin`. Note that this will produce basic binary that has all the features except support for HTML-based UI. To build full binary, download the source from GitHub and run:
 
-
-
+`make install` (on macOS/Linux) or `install.cmd` on Windows. Note that building on Windows also requires [NPM](https://nodejs.org/) to be installed.

--- a/tools/install.cmd
+++ b/tools/install.cmd
@@ -1,0 +1,1 @@
+if not exist .tools\go-bindata.exe go build -o .tools\go-bindata.exe github.com/go-bindata/go-bindata/go-bindata


### PR DESCRIPTION
This orchestrates building HTMLUI and main binary, only uses built-in shell script and avoids having any dependencies on Unix tools. Latest go and npm are required.