### PR TITLE
Refactor: misc cleanups

### DIFF
--- a/cli/command_snapshot_expire.go
+++ b/cli/command_snapshot_expire.go
@@ -13,7 +13,7 @@ var (
 	snapshotExpireCommand = snapshotCommands.Command("expire", "Remove old snapshots according to defined expiration policies.")
 
 	snapshotExpireAll    = snapshotExpireCommand.Flag("all", "Expire all snapshots").Bool()
-	snapshotExpirePaths  = snapshotExpireCommand.Arg("path", "Expire snapshots for a given paths only").Strings()
+	snapshotExpirePaths  = snapshotExpireCommand.Arg("path", "Expire snapshots for given paths only").Strings()
 	snapshotExpireDelete = snapshotExpireCommand.Flag("delete", "Whether to actually delete snapshots").Bool()
 )
 

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -254,13 +254,11 @@ func Directory(path string) (fs.Directory, error) {
 		return nil, err
 	}
 
-	switch e := e.(type) {
-	case fs.Directory:
-		return e, nil
-
-	default:
-		return nil, errors.Errorf("not a directory: %v", path)
+	if d, ok := e.(fs.Directory); ok {
+		return d, nil
 	}
+
+	return nil, errors.Errorf("not a directory: %v", path)
 }
 
 func entryFromChildFileInfo(fi os.FileInfo, parentDir string) (fs.Entry, error) {

--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -89,6 +89,9 @@ func (b *committedContentIndex) packFilesChanged(packFiles []blob.ID) bool {
 	return false
 }
 
+// Uses packFiles for indexing and returns whether or not the set of index
+// packs have changed compared to the previous set. An error is returned if the
+// indices cannot be read for any reason.
 func (b *committedContentIndex) use(packFiles []blob.ID) (bool, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -124,7 +127,7 @@ func (b *committedContentIndex) use(packFiles []blob.ID) (bool, error) {
 		log.Warningf("unable to expire unused content index files: %v", err)
 	}
 
-	newMerged = nil
+	newMerged = nil // prevent closing newMerged indices
 
 	return true, nil
 }

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -163,6 +163,7 @@ func (bm *lockFreeManager) tryLoadPackIndexBlobsUnlocked(ctx context.Context, co
 // unprocessedIndexBlobsUnlocked returns a closed channel filled with content IDs that are not in committedContents cache.
 func (bm *lockFreeManager) unprocessedIndexBlobsUnlocked(contents []IndexBlobInfo) (resultCh <-chan blob.ID, totalSize int64, err error) {
 	ch := make(chan blob.ID, len(contents))
+	defer close(ch)
 
 	for _, c := range contents {
 		has, err := bm.committedContents.cache.hasIndexBlobID(c.BlobID)
@@ -178,8 +179,6 @@ func (bm *lockFreeManager) unprocessedIndexBlobsUnlocked(contents []IndexBlobInf
 		ch <- c.BlobID
 		totalSize += c.Length
 	}
-
-	close(ch)
 
 	return ch, totalSize, nil
 }

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -23,6 +23,7 @@ var log = repologging.Logger("kopia/manifest")
 // ErrNotFound is returned when the metadata item is not found.
 var ErrNotFound = errors.New("not found")
 
+// ContentPrefix is the prefix of the content id for manifests
 const ContentPrefix = "m"
 const autoCompactionContentCount = 16
 

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -26,6 +26,9 @@ var ErrNotFound = errors.New("not found")
 const ContentPrefix = "m"
 const autoCompactionContentCount = 16
 
+// TypeLabelKey is the label key for manifest type
+const TypeLabelKey = "type"
+
 type contentManager interface {
 	GetContent(ctx context.Context, contentID content.ID) ([]byte, error)
 	WriteContent(ctx context.Context, data []byte, prefix content.ID) (content.ID, error)
@@ -53,7 +56,7 @@ type Manager struct {
 
 // Put serializes the provided payload to JSON and persists it. Returns unique identifier that represents the manifest.
 func (m *Manager) Put(ctx context.Context, labels map[string]string, payload interface{}) (ID, error) {
-	if labels["type"] == "" {
+	if labels[TypeLabelKey] == "" {
 		return "", errors.Errorf("'type' label is required")
 	}
 

--- a/snapshot/manager.go
+++ b/snapshot/manager.go
@@ -14,12 +14,14 @@ import (
 // ManifestType is the value of the "type" label for snapshot manifests
 const ManifestType = "snapshot"
 
+const typeKey = manifest.TypeLabelKey
+
 var log = kopialogging.Logger("kopia/snapshot")
 
 // ListSources lists all snapshot sources in a given repository.
 func ListSources(ctx context.Context, rep *repo.Repository) ([]SourceInfo, error) {
 	items, err := rep.Manifests.Find(ctx, map[string]string{
-		"type": ManifestType,
+		typeKey: ManifestType,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to find manifest entries")
@@ -44,7 +46,7 @@ func sourceInfoFromLabels(labels map[string]string) SourceInfo {
 
 func sourceInfoToLabels(si SourceInfo) map[string]string {
 	return map[string]string{
-		"type":     ManifestType,
+		typeKey:    ManifestType,
 		"hostname": si.Host,
 		"username": si.UserName,
 		"path":     si.Path,
@@ -136,7 +138,7 @@ func LoadSnapshots(ctx context.Context, rep *repo.Repository, manifestIDs []mani
 // ListSnapshotManifests returns the list of snapshot manifests for a given source or all sources if nil.
 func ListSnapshotManifests(ctx context.Context, rep *repo.Repository, src *SourceInfo) ([]manifest.ID, error) {
 	labels := map[string]string{
-		"type": ManifestType,
+		typeKey: ManifestType,
 	}
 
 	if src != nil {

--- a/snapshot/manager.go
+++ b/snapshot/manager.go
@@ -11,12 +11,15 @@ import (
 	"github.com/kopia/kopia/repo/manifest"
 )
 
+// ManifestType is the value of the "type" label for snapshot manifests
+const ManifestType = "snapshot"
+
 var log = kopialogging.Logger("kopia/snapshot")
 
 // ListSources lists all snapshot sources in a given repository.
 func ListSources(ctx context.Context, rep *repo.Repository) ([]SourceInfo, error) {
 	items, err := rep.Manifests.Find(ctx, map[string]string{
-		"type": "snapshot",
+		"type": ManifestType,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to find manifest entries")
@@ -41,7 +44,7 @@ func sourceInfoFromLabels(labels map[string]string) SourceInfo {
 
 func sourceInfoToLabels(si SourceInfo) map[string]string {
 	return map[string]string{
-		"type":     "snapshot",
+		"type":     ManifestType,
 		"hostname": si.Host,
 		"username": si.UserName,
 		"path":     si.Path,
@@ -133,7 +136,7 @@ func LoadSnapshots(ctx context.Context, rep *repo.Repository, manifestIDs []mani
 // ListSnapshotManifests returns the list of snapshot manifests for a given source or all sources if nil.
 func ListSnapshotManifests(ctx context.Context, rep *repo.Repository, src *SourceInfo) ([]manifest.ID, error) {
 	labels := map[string]string{
-		"type": "snapshot",
+		"type": ManifestType,
 	}
 
 	if src != nil {

--- a/snapshot/policy/policy_manager.go
+++ b/snapshot/policy/policy_manager.go
@@ -14,6 +14,8 @@ import (
 	"github.com/kopia/kopia/snapshot"
 )
 
+const typeKey = manifest.TypeLabelKey
+
 // GlobalPolicySourceInfo is a source where global policy is attached.
 var GlobalPolicySourceInfo = snapshot.SourceInfo{}
 
@@ -172,7 +174,7 @@ func GetPolicyByID(ctx context.Context, rep *repo.Repository, id manifest.ID) (*
 // ListPolicies returns a list of all policies.
 func ListPolicies(ctx context.Context, rep *repo.Repository) ([]*Policy, error) {
 	ids, err := rep.Manifests.Find(ctx, map[string]string{
-		"type": "policy",
+		typeKey: "policy",
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list manifests")
@@ -221,7 +223,7 @@ func TreeForSource(ctx context.Context, rep *repo.Repository, si snapshot.Source
 
 	// Find all policies for this host and user
 	policies, err := rep.Manifests.Find(ctx, map[string]string{
-		"type":       "policy",
+		typeKey:      "policy",
 		"policyType": "path",
 		"username":   si.UserName,
 		"hostname":   si.Host,
@@ -267,7 +269,7 @@ func labelsForSource(si snapshot.SourceInfo) map[string]string {
 	switch {
 	case si.Path != "":
 		return map[string]string{
-			"type":       "policy",
+			typeKey:      "policy",
 			"policyType": "path",
 			"username":   si.UserName,
 			"hostname":   si.Host,
@@ -275,20 +277,20 @@ func labelsForSource(si snapshot.SourceInfo) map[string]string {
 		}
 	case si.UserName != "":
 		return map[string]string{
-			"type":       "policy",
+			typeKey:      "policy",
 			"policyType": "user",
 			"username":   si.UserName,
 			"hostname":   si.Host,
 		}
 	case si.Host != "":
 		return map[string]string{
-			"type":       "policy",
+			typeKey:      "policy",
 			"policyType": "host",
 			"hostname":   si.Host,
 		}
 	default:
 		return map[string]string{
-			"type":       "policy",
+			typeKey:      "policy",
 			"policyType": "global",
 		}
 	}

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -29,7 +29,7 @@ else
 endif
 	mv $(TOOLS_DIR)/nodejs/node-v$(NODE_VERSION)* $(TOOLS_DIR)/nodejs/node/
 
-BINDATA_TOOL=$(TOOLS_DIR)/go-bindata
+BINDATA_TOOL=$(TOOLS_DIR)/bin/go-bindata
 
 $(BINDATA_TOOL):
 	go build -o $(BINDATA_TOOL) github.com/go-bindata/go-bindata/go-bindata


### PR DESCRIPTION
- Fixes and adds clarifying comments, or comments to exported symbols
- Constants for manifest type label key and snapshot manifest type 
See commit train for details.