### PR TITLE
Change default behavior for localfs.Copy

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -5,6 +5,7 @@ import (
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
@@ -52,13 +53,20 @@ func addRestoreFlags(cmd *kingpin.CmdClause) {
 		BoolVar(&restoreOverwriteFiles)
 }
 
+func restoreOptions() localfs.CopyOptions {
+	return localfs.CopyOptions{
+		OverwriteDirectories: restoreOverwriteDirectories,
+		OverwriteFiles:       restoreOverwriteFiles,
+	}
+}
+
 func runRestoreCommand(ctx context.Context, rep *repo.Repository) error {
 	oid, err := parseObjectID(ctx, rep, *restoreCommandSourcePath)
 	if err != nil {
 		return err
 	}
 
-	return snapshotfs.RestoreRoot(ctx, rep, *restoreCommandTargetPath, oid)
+	return snapshotfs.RestoreRoot(ctx, rep, *restoreCommandTargetPath, oid, restoreOptions())
 }
 
 func init() {

--- a/cli/command_snapshot_restore.go
+++ b/cli/command_snapshot_restore.go
@@ -19,5 +19,6 @@ func runSnapRestoreCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
+	addRestoreFlags(snapshotRestoreCommand)
 	snapshotRestoreCommand.Action(repositoryAction(runSnapRestoreCommand))
 }

--- a/cli/command_snapshot_restore.go
+++ b/cli/command_snapshot_restore.go
@@ -15,7 +15,7 @@ var (
 )
 
 func runSnapRestoreCommand(ctx context.Context, rep *repo.Repository) error {
-	return snapshotfs.Restore(ctx, rep, *snapshotRestoreTargetPath, manifest.ID(*snapshotRestoreSnapID))
+	return snapshotfs.Restore(ctx, rep, *snapshotRestoreTargetPath, manifest.ID(*snapshotRestoreSnapID), restoreOptions())
 }
 
 func init() {

--- a/fs/localfs/copy.go
+++ b/fs/localfs/copy.go
@@ -25,20 +25,6 @@ func Copy(ctx context.Context, targetPath string, e fs.Entry) error {
 		return err
 	}
 
-	root, err := filepath.Abs(filepath.FromSlash("/"))
-	if err != nil {
-		return err
-	}
-
-	// special case when the target is the root directory
-	if targetPath == root {
-		if d, ok := e.(fs.Directory); ok {
-			return copyDirectoryContent(ctx, d, targetPath)
-		}
-
-		return errors.Errorf("cannot restore non-directory to root target path %q: %#v", targetPath, e)
-	}
-
 	return copyEntry(ctx, e, targetPath)
 }
 

--- a/snapshot/snapshotfs/restore.go
+++ b/snapshot/snapshotfs/restore.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Restore walks a snapshot root with given snapshot ID and restores it to the local filesystem
-func Restore(ctx context.Context, rep *repo.Repository, targetPath string, snapID manifest.ID) error {
+func Restore(ctx context.Context, rep *repo.Repository, targetPath string, snapID manifest.ID, opts localfs.CopyOptions) error {
 	m, err := snapshot.LoadSnapshot(ctx, rep, snapID)
 	if err != nil {
 		return err
@@ -28,10 +28,10 @@ func Restore(ctx context.Context, rep *repo.Repository, targetPath string, snapI
 		return err
 	}
 
-	return localfs.Copy(ctx, targetPath, rootEntry)
+	return localfs.Copy(ctx, targetPath, rootEntry, opts)
 }
 
 // RestoreRoot walks a snapshot root with given object ID and restores it to the local filesystem
-func RestoreRoot(ctx context.Context, rep *repo.Repository, targetPath string, oid object.ID) error {
-	return localfs.Copy(ctx, targetPath, DirectoryEntry(rep, oid, nil))
+func RestoreRoot(ctx context.Context, rep *repo.Repository, targetPath string, oid object.ID, opts localfs.CopyOptions) error {
+	return localfs.Copy(ctx, targetPath, DirectoryEntry(rep, oid, nil), opts)
 }


### PR DESCRIPTION
Addresses some of the feedback from #144

Allow copying to an existing directory
Remove special handling for the root directory, no longer needed.
Add copy options to control behavior
Allow overwriting an existing file (via options)
Expose copy options as flags
