### PR TITLE
lint: upgraded to 1.22.2 and make lint issues a build failure

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,11 @@
 linters-settings:
   govet:
     check-shadowing: true
-    settings:
-      printf:
-        funcs:
-          - (github.com/op/go-logging/Logger).Infof
-          - (github.com/op/go-logging/Logger).Warningf
-          - (github.com/op/go-logging/Logger).Errorf
-          - (github.com/op/go-logging/Logger).Fatalf
   funlen:
     lines: 100
     statements: 60
-  golint:
-    min-confidence: 0
+  gocognit:
+    min-complexity: 40
   gocyclo:
     min-complexity: 15
   maligned:
@@ -28,11 +21,14 @@ linters-settings:
     local-prefixes: github.com/kopia/kopia
   gocritic:
     enabled-tags:
+      - diagnostic
       - performance
       - style
+      - opinionated
       - experimental
     disabled-checks:
       - wrapperFunc
+      - whyNoLint
 linters:
   enable-all: true
   disable:
@@ -47,7 +43,18 @@ run:
     - test/testdata_etc
 
 issues:
+  exclude-use-default: false
   exclude-rules:
+    - path: _test\.go|testing
+      linters:
+      - gomnd
+      - gocognit
+      - funlen
+      - errcheck
+      - gosec
+    - text: "Magic number: 1e"
+      linters:
+      - gomnd
     - text: "weak cryptographic primitive"
       linters:
         - gosec
@@ -56,10 +63,19 @@ issues:
         - dupl
     - text: "Line contains TODO"
       linters:
-        - godox
+        - godox 
+    - text: ".*Magic number\\: [01],"
+      linters:
+        - gomnd
+    - text: "Errors unhandled"
+      linters:
+        - gosec
+    - path: cli
+      linters:
+      - gochecknoglobals
 
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.21.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.22.2 # use the fixed version to not introduce new linters unexpectedly
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ play:
 	go run cmd/playground/main.go
 
 lint: $(LINTER_TOOL)
+	$(LINTER_TOOL) --deadline 180s run
+
+lint-and-log: $(LINTER_TOOL)
 	$(LINTER_TOOL) --deadline 180s run | tee .linterr.txt
 
 vet:
@@ -177,5 +180,3 @@ travis-create-long-term-repository:
 	echo Not creating long-term repository.
 
 endif
-
-

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ play:
 	go run cmd/playground/main.go
 
 lint: $(LINTER_TOOL)
-	$(LINTER_TOOL) --deadline 180s run
+	# try running linter a couple of times since it is pretty flaky, especially on cold start
+	for retry in 1 2 3; do echo "Running linter, attempt #$$retry"; $(LINTER_TOOL) --deadline 180s run && s=0 && break || s=$$? && sleep 1; done; (exit $$s)
 
 lint-and-log: $(LINTER_TOOL)
 	$(LINTER_TOOL) --deadline 180s run | tee .linterr.txt

--- a/cli/cli_progress.go
+++ b/cli/cli_progress.go
@@ -10,6 +10,8 @@ import (
 	"github.com/kopia/kopia/snapshot"
 )
 
+const maxUnshortenedPath = 60
+
 type singleProgress struct {
 	desc      string
 	startTime time.Time
@@ -114,11 +116,14 @@ func (mp *multiProgress) UploadFinished() {
 }
 
 func shortenPath(s string) string {
-	if len(s) < 60 {
+	if len(s) < maxUnshortenedPath {
 		return s
 	}
 
-	return s[0:30] + "..." + s[len(s)-27:]
+	p1 := maxUnshortenedPath / 2 //nolint:gomnd
+	p2 := p1 - 3                 //nolint:gomnd
+
+	return s[0:p1] + "..." + s[len(s)-p2:]
 }
 
 var cliProgress = &multiProgress{}

--- a/cli/command_benchmark_compression.go
+++ b/cli/command_benchmark_compression.go
@@ -104,7 +104,7 @@ func init() {
 
 func hashOf(b []byte) uint64 {
 	h := fnv.New64a()
-	h.Write(b) // nolint:errcheck
+	h.Write(b) //nolint:errcheck
 
 	return h.Sum64()
 }

--- a/cli/command_benchmark_splitters.go
+++ b/cli/command_benchmark_splitters.go
@@ -40,7 +40,10 @@ func runBenchmarkSplitterAction(ctx *kingpin.ParseContext) error {
 
 	for i := 0; i < *benchmarkSplitterBlockCount; i++ {
 		b := make([]byte, *benchmarkSplitterBlockSize)
-		rnd.Read(b)
+		if _, err := rnd.Read(b); err != nil {
+			return err
+		}
+
 		dataBlocks = append(dataBlocks, b)
 	}
 

--- a/cli/command_mount_browse.go
+++ b/cli/command_mount_browse.go
@@ -48,7 +48,7 @@ func openInOSBrowser(mountPoint, addr string) error {
 }
 
 func netUSE(mountPoint, addr string) error {
-	c := exec.Command("net", "use", mountPoint, addr)
+	c := exec.Command("net", "use", mountPoint, addr) // nolint:gosec
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	c.Stdin = os.Stdin
@@ -60,7 +60,7 @@ func netUSE(mountPoint, addr string) error {
 	startWebBrowser("x:\\")
 	waitForCtrlC()
 
-	c = exec.Command("net", "use", mountPoint, "/d")
+	c = exec.Command("net", "use", mountPoint, "/d") // nolint:gosec
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	c.Stdin = os.Stdin

--- a/cli/command_mount_webdav.go
+++ b/cli/command_mount_webdav.go
@@ -56,6 +56,7 @@ func mountDirectoryWebDAV(entry fs.Directory, mountPoint string) error {
 	go func() {
 		defer wg.Done()
 		printStderr("Server listening at http://%v/ Press Ctrl-C to shut down.\n", s.Addr)
+
 		if err := s.ListenAndServe(); err != nil {
 			log.Warningf("server shut down with error: %v", err)
 		}

--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -132,6 +132,7 @@ func setPolicyFromFlags(p *policy.Policy, changeCount *int) error {
 func setFilesPolicyFromFlags(fp *policy.FilesPolicy, changeCount *int) {
 	if *policySetClearDotIgnore {
 		*changeCount++
+
 		printStderr(" - removing all rules for dot-ignore files\n")
 
 		fp.DotIgnoreFiles = nil
@@ -177,6 +178,7 @@ func setSchedulingPolicyFromFlags(sp *policy.SchedulingPolicy, changeCount *int)
 	// It's not really a list, just optional value.
 	for _, interval := range *policySetInterval {
 		*changeCount++
+
 		sp.SetInterval(interval)
 		printStderr(" - setting snapshot interval to %v\n", sp.Interval())
 
@@ -271,6 +273,7 @@ func addRemoveDedupeAndSort(desc string, base, add, remove []string, changeCount
 
 	for _, b := range add {
 		*changeCount++
+
 		printStderr(" - adding %v to %v\n", b, desc)
 
 		entries[b] = true
@@ -278,6 +281,7 @@ func addRemoveDedupeAndSort(desc string, base, add, remove []string, changeCount
 
 	for _, b := range remove {
 		*changeCount++
+
 		printStderr(" - removing %v from %v\n", b, desc)
 		delete(entries, b)
 	}
@@ -300,6 +304,7 @@ func applyPolicyNumber(desc string, val **int, str string, changeCount *int) err
 
 	if str == inheritPolicyString || str == "default" {
 		*changeCount++
+
 		printStderr(" - resetting %v to a default value inherited from parent.\n", desc)
 
 		*val = nil
@@ -314,6 +319,7 @@ func applyPolicyNumber(desc string, val **int, str string, changeCount *int) err
 
 	i := int(v)
 	*changeCount++
+
 	printStderr(" - setting %v to %v.\n", desc, i)
 	*val = &i
 
@@ -328,6 +334,7 @@ func applyPolicyNumber64(desc string, val *int64, str string, changeCount *int) 
 
 	if str == inheritPolicyString || str == "default" {
 		*changeCount++
+
 		printStderr(" - resetting %v to a default value inherited from parent.\n", desc)
 
 		*val = 0
@@ -341,6 +348,7 @@ func applyPolicyNumber64(desc string, val *int64, str string, changeCount *int) 
 	}
 
 	*changeCount++
+
 	printStderr(" - setting %v to %v.\n", desc, v)
 	*val = v
 

--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -36,7 +36,7 @@ func connectOptions() repo.ConnectOptions {
 	return repo.ConnectOptions{
 		CachingOptions: content.CachingOptions{
 			CacheDirectory:          connectCacheDirectory,
-			MaxCacheSizeBytes:       connectMaxCacheSizeMB << 20,
+			MaxCacheSizeBytes:       connectMaxCacheSizeMB << 20, //nolint:gomnd
 			MaxListCacheDurationSec: int(connectMaxListCacheDuration.Seconds()),
 		},
 	}

--- a/cli/command_repository_connect_from_config.go
+++ b/cli/command_repository_connect_from_config.go
@@ -33,7 +33,7 @@ func connectToStorageFromConfig(ctx context.Context, isNew bool) (blob.Storage, 
 func connectToStorageFromConfigFile(ctx context.Context) (blob.Storage, error) {
 	var cfg repo.LocalConfig
 
-	f, err := os.Open(connectFromConfigFile)
+	f, err := os.Open(connectFromConfigFile) //nolint:gosec
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open config")
 	}

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -17,11 +16,12 @@ import (
 var (
 	serverAddress = serverCommands.Flag("address", "Server address").Default("127.0.0.1:51515").String()
 
-	serverStartCommand  = serverCommands.Command("start", "Start Kopia server").Default()
-	serverStartHTMLPath = serverStartCommand.Flag("html", "Server the provided HTML at the root URL").ExistingDir()
-	serverStartUI       = serverStartCommand.Flag("ui", "Start the server with HTML UI (EXPERIMENTAL)").Bool()
-	serverStartUsername = serverStartCommand.Flag("server-username", "HTTP server username (basic auth)").Envar("KOPIA_SERVER_USERNAME").Default("kopia").String()
-	serverStartPassword = serverStartCommand.Flag("server-password", "Require HTTP server password (basic auth)").Envar("KOPIA_SERVER_PASSWORD").String()
+	serverStartCommand         = serverCommands.Command("start", "Start Kopia server").Default()
+	serverStartHTMLPath        = serverStartCommand.Flag("html", "Server the provided HTML at the root URL").ExistingDir()
+	serverStartUI              = serverStartCommand.Flag("ui", "Start the server with HTML UI (EXPERIMENTAL)").Bool()
+	serverStartUsername        = serverStartCommand.Flag("server-username", "HTTP server username (basic auth)").Envar("KOPIA_SERVER_USERNAME").Default("kopia").String()
+	serverStartPassword        = serverStartCommand.Flag("server-password", "Require HTTP server password (basic auth)").Envar("KOPIA_SERVER_PASSWORD").String()
+	serverStartRefreshInterval = serverStartCommand.Flag("refresh-interval", "Frequency for refreshing repository status").Default("10s").Duration()
 )
 
 func init() {
@@ -35,7 +35,7 @@ func runServer(ctx context.Context, rep *repo.Repository) error {
 		return errors.Wrap(err, "unable to initialize server")
 	}
 
-	go rep.RefreshPeriodically(ctx, 10*time.Second)
+	go rep.RefreshPeriodically(ctx, *serverStartRefreshInterval)
 
 	rootURL := "http://" + *serverAddress
 	log.Infof("starting server on %v", rootURL)

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -46,7 +46,7 @@ func runBackupCommand(ctx context.Context, rep *repo.Repository) error {
 	}
 
 	u := snapshotfs.NewUploader(rep)
-	u.MaxUploadBytes = *snapshotCreateCheckpointUploadLimitMB * 1024 * 1024
+	u.MaxUploadBytes = *snapshotCreateCheckpointUploadLimitMB << 20 //nolint:gomnd
 	u.ForceHashPercentage = *snapshotCreateForceHash
 	u.ParallelUploads = *snapshotCreateParallelUploads
 	onCtrlC(u.Cancel)

--- a/cli/command_snapshot_verify.go
+++ b/cli/command_snapshot_verify.go
@@ -151,7 +151,7 @@ func (v *verifier) doVerifyObject(ctx context.Context, oid object.ID, path strin
 		v.reportError(path, errors.Wrapf(err, "error verifying %v", oid))
 	}
 
-	if rand.Intn(100) < *verifyCommandFilesPercent {
+	if rand.Intn(100) < *verifyCommandFilesPercent { //nolint:gomnd
 		if err := v.readEntireObject(ctx, oid, path); err != nil {
 			v.reportError(path, errors.Wrapf(err, "error reading object %v", oid))
 		}

--- a/fs/cachefs/cache.go
+++ b/fs/cachefs/cache.go
@@ -12,6 +12,8 @@ import (
 
 var log = kopialogging.Logger("kopia/cachefs")
 
+const dirCacheExpiration = 24 * time.Hour
+
 type cacheEntry struct {
 	id   string
 	prev *cacheEntry
@@ -82,9 +84,8 @@ type Loader func(ctx context.Context) (fs.Entries, error)
 func (c *Cache) Readdir(ctx context.Context, d fs.Directory) (fs.Entries, error) {
 	if h, ok := d.(object.HasObjectID); ok {
 		cacheID := string(h.ObjectID())
-		cacheExpiration := 24 * time.Hour
 
-		return c.getEntries(ctx, cacheID, cacheExpiration, d.Readdir)
+		return c.getEntries(ctx, cacheID, dirCacheExpiration, d.Readdir)
 	}
 
 	return d.Readdir(ctx)
@@ -171,8 +172,8 @@ type Options struct {
 }
 
 var defaultOptions = &Options{
-	MaxCachedDirectories: 1000,
-	MaxCachedEntries:     100000,
+	MaxCachedDirectories: 1000,   //nolint:gomnd
+	MaxCachedEntries:     100000, //nolint:gomnd
 }
 
 // NewCache creates filesystem cache.

--- a/fs/cachefs/cache_test.go
+++ b/fs/cachefs/cache_test.go
@@ -25,6 +25,7 @@ type cacheSource struct {
 func (cs *cacheSource) get(id string) func(ctx context.Context) (fs.Entries, error) {
 	return func(context.Context) (fs.Entries, error) {
 		cs.callCounter[id]++
+
 		d, ok := cs.data[id]
 		if !ok {
 			return nil, errors.New("no such id")

--- a/fs/localfs/copy.go
+++ b/fs/localfs/copy.go
@@ -37,6 +37,7 @@ func Copy(ctx context.Context, targetPath string, e fs.Entry, opt CopyOptions) e
 	}
 
 	c := copier{CopyOptions: opt}
+
 	return c.copyEntry(ctx, e, targetPath)
 }
 
@@ -136,7 +137,9 @@ func (c *copier) createDirectory(path string) error {
 				return errors.Errorf("non-empty directory already exists, not overwriting it: %q", path)
 			}
 		}
+
 		log.Debug("Not creating already existing directory: ", path)
+
 		return nil
 	default:
 		return errors.Errorf("unable to create directory, %q already exists and it is not a directory", path)
@@ -150,6 +153,7 @@ func (c *copier) copyFileContent(ctx context.Context, targetPath string, f fs.Fi
 		if !c.OverwriteFiles {
 			return errors.Errorf("unable to create %q, it already exists", targetPath)
 		}
+
 		log.Debug("Overwriting existing file: ", targetPath)
 	default:
 		return errors.Wrap(err, "failed to stat "+targetPath)
@@ -167,12 +171,12 @@ func (c *copier) copyFileContent(ctx context.Context, targetPath string, f fs.Fi
 }
 
 func isEmptyDirectory(name string) (bool, error) {
-	f, err := os.Open(name)
+	f, err := os.Open(name) //nolint:gosec
 	if err != nil {
 		return false, err
 	}
 
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 
 	if _, err = f.Readdirnames(1); err == io.EOF {
 		return true, nil

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 )
 
+// DataMap is a map of blob ID to their contents.
 type DataMap map[blob.ID][]byte
 
 type mapStorage struct {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,3 +1,4 @@
+// Package diff implements helpers for comparing two filesystems.
 package diff
 
 import (
@@ -253,7 +254,7 @@ func (c *Comparer) compareFiles(ctx context.Context, f1, f2 fs.File, fname strin
 	args = append(args, c.DiffArguments...)
 	args = append(args, oldName, newName)
 
-	cmd := exec.CommandContext(ctx, c.DiffCommand, args...)
+	cmd := exec.CommandContext(ctx, c.DiffCommand, args...) // nolint:gosec
 	cmd.Dir = c.tmpDir
 	cmd.Stdout = c.out
 	cmd.Stderr = c.out

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -53,7 +53,7 @@ func EditLoop(fname, initial string, parse func(updated string) error) error {
 
 		var shouldReopen string
 
-		fmt.Scanf("%s", &shouldReopen) //nolint:errcheck
+		_, _ = fmt.Scanf("%s", &shouldReopen)
 
 		if strings.HasPrefix(strings.ToLower(shouldReopen), "n") {
 			return errors.New("aborted")
@@ -62,7 +62,7 @@ func EditLoop(fname, initial string, parse func(updated string) error) error {
 }
 
 func readAndStripComments(fname string) (string, error) {
-	f, err := os.Open(fname)
+	f, err := os.Open(fname) //nolint:gosec
 	if err != nil {
 		return "", err
 	}
@@ -90,7 +90,7 @@ func editFile(file string) error {
 	args = append(args, editorArgs...)
 	args = append(args, file)
 
-	cmd := exec.Command(editor, args...)
+	cmd := exec.Command(editor, args...) //nolint:gosec
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/fshasher/fshasher.go
+++ b/internal/fshasher/fshasher.go
@@ -25,7 +25,7 @@ func Hash(ctx context.Context, e fs.Entry) ([]byte, error) {
 	}
 
 	tw := tar.NewWriter(h)
-	defer tw.Close()
+	defer tw.Close() //nolint:errcheck
 
 	if err := write(ctx, tw, "", e); err != nil {
 		return nil, err
@@ -114,9 +114,10 @@ func writeFile(ctx context.Context, w io.Writer, f fs.File) error {
 	if err != nil {
 		return err
 	}
-	defer r.Close()
 
-	_, err = io.Copy(w, r)
+	if _, err = io.Copy(w, r); err != nil {
+		return err
+	}
 
-	return err
+	return r.Close()
 }

--- a/internal/fshasher/fshasher.go
+++ b/internal/fshasher/fshasher.go
@@ -114,10 +114,11 @@ func writeFile(ctx context.Context, w io.Writer, f fs.File) error {
 	if err != nil {
 		return err
 	}
+	defer r.Close() //nolint:errcheck
 
 	if _, err = io.Copy(w, r); err != nil {
 		return err
 	}
 
-	return r.Close()
+	return nil
 }

--- a/internal/ignore/ignore.go
+++ b/internal/ignore/ignore.go
@@ -65,6 +65,7 @@ func matchBaseDir(baseDir string, m nameMatcher) nameMatcher {
 		}
 
 		path = path[len(baseDir):]
+
 		return m(path)
 	}
 }
@@ -99,6 +100,7 @@ func parseGlobPattern(pattern string) nameMatcher {
 	return func(path string) bool {
 		last := path[strings.LastIndex(path, "/")+1:]
 		ok, _ := filepath.Match(pattern, last)
+
 		return ok
 	}
 }

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -173,6 +173,7 @@ func (imd *Directory) FailReaddir(err error) {
 	imd.readdirError = err
 }
 
+// Child gets the named child of a directory.
 func (imd *Directory) Child(ctx context.Context, name string) (fs.Entry, error) {
 	return fs.ReadDirAndFindChild(ctx, imd, name)
 }
@@ -230,16 +231,18 @@ func (imsl *inmemorySymlink) Readlink(ctx context.Context) (string, error) {
 	panic("not implemented yet")
 }
 
-// NewDirectory returns new mock directory.ds
+// NewDirectory returns new mock directory.
 func NewDirectory() *Directory {
 	return &Directory{
 		entry: entry{
 			name: "<root>",
-			mode: 0777 | os.ModeDir,
+			mode: 0777 | os.ModeDir, // nolint:gomnd
 		},
 	}
 }
 
-var _ fs.Directory = &Directory{}
-var _ fs.File = &File{}
-var _ fs.Symlink = &inmemorySymlink{}
+var (
+	_ fs.Directory = &Directory{}
+	_ fs.File      = &File{}
+	_ fs.Symlink   = &inmemorySymlink{}
+)

--- a/internal/parallelwork/parallel_work_queue.go
+++ b/internal/parallelwork/parallel_work_queue.go
@@ -1,3 +1,4 @@
+// Package parallelwork implements pallel work queue with fixed number of workers that concurrently process and add work items to the queue.
 package parallelwork
 
 import (
@@ -60,19 +61,20 @@ func (v *Queue) Process(workers int) error {
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
 
-		go func(workerID int) {
+		go func(_ int) {
 			defer wg.Done()
-			_ = workerID
 
 			for {
 				callback := v.dequeue()
 				if callback == nil {
 					break
 				}
+
 				if err := callback(); err != nil {
 					errors <- err
 					break
 				}
+
 				v.completed()
 			}
 		}(i)

--- a/internal/scrubber/scrub_sensitive.go
+++ b/internal/scrubber/scrub_sensitive.go
@@ -1,3 +1,4 @@
+// Package scrubber contains helpers that remove sensitive information from Go structs before it's presented to users.
 package scrubber
 
 import (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,3 +1,4 @@
+// Package server implements Kopia API server handlers.
 package server
 
 import (
@@ -62,10 +63,12 @@ func (s *Server) handleAPI(f func(ctx context.Context, r *http.Request) (interfa
 
 		v, err := f(context.Background(), r)
 		log.Debugf("returned %+v", v)
+
 		if err == nil {
 			if err := e.Encode(v); err != nil {
 				log.Warningf("error encoding response: %v", err)
 			}
+
 			return
 		}
 

--- a/internal/serverapi/client.go
+++ b/internal/serverapi/client.go
@@ -22,7 +22,7 @@ func (c *Client) Get(path string, respPayload interface{}) error {
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return errors.Errorf("invalid server response: %v", resp.Status)
 	}
 
@@ -47,7 +47,7 @@ func (c *Client) Post(path string, reqPayload, respPayload interface{}) error {
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return errors.Errorf("invalid server response: %v", resp.Status)
 	}
 

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -1,3 +1,4 @@
+// Package serverapi contains GO types corresponding to Kopia server API.
 package serverapi
 
 import (

--- a/internal/throttle/round_tripper.go
+++ b/internal/throttle/round_tripper.go
@@ -1,3 +1,4 @@
+// Package throttle implements helpers for throttling uploads and downloads.
 package throttle
 
 import (

--- a/internal/units/units.go
+++ b/internal/units/units.go
@@ -1,3 +1,4 @@
+// Package units contains helpers to convert sizes to humand-readable strings.
 package units
 
 import (

--- a/internal/webdavmount/webdavmount.go
+++ b/internal/webdavmount/webdavmount.go
@@ -1,3 +1,4 @@
+// Package webdavmount implements webdav filesystem for serving snapshots.
 package webdavmount
 
 import (

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -39,7 +39,7 @@ type fsImpl struct {
 }
 
 func (fs *fsImpl) GetBlobFromPath(ctx context.Context, dirPath, path string, offset, length int64) ([]byte, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(path) //nolint:gosec
 	if os.IsNotExist(err) {
 		return nil, blob.ErrBlobNotFound
 	}

--- a/repo/blob/logging/logging_storage.go
+++ b/repo/blob/logging/logging_storage.go
@@ -9,6 +9,8 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 )
 
+const maxLoggedBlobLength = 20 // maximum length of the blob to log contents of
+
 var log = repologging.Logger("repo/blob")
 
 type loggingStorage struct {
@@ -22,7 +24,7 @@ func (s *loggingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length
 	result, err := s.base.GetBlob(ctx, id, offset, length)
 	dt := time.Since(t0)
 
-	if len(result) < 20 {
+	if len(result) < maxLoggedBlobLength {
 		s.printf(s.prefix+"GetBlob(%q,%v,%v)=(%#v, %#v) took %v", id, offset, length, result, err, dt)
 	} else {
 		s.printf(s.prefix+"GetBlob(%q,%v,%v)=({%#v bytes}, %#v) took %v", id, offset, length, len(result), err, dt)

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 
 	"github.com/efarrer/iothrottler"
 	"github.com/minio/minio-go"
@@ -92,11 +93,11 @@ func isRetriableError(err error) bool {
 
 func translateError(err error) error {
 	if me, ok := err.(minio.ErrorResponse); ok {
-		if me.StatusCode == 200 {
+		if me.StatusCode == http.StatusOK {
 			return nil
 		}
 
-		if me.StatusCode == 404 {
+		if me.StatusCode == http.StatusNotFound {
 			return blob.ErrBlobNotFound
 		}
 	}

--- a/repo/compression/compressor.go
+++ b/repo/compression/compressor.go
@@ -4,7 +4,11 @@ package compression
 import (
 	"encoding/binary"
 	"fmt"
+
+	"github.com/pkg/errors"
 )
+
+const compressionHeaderSize = 4
 
 // Name is the name of the compressor to use.
 type Name string
@@ -41,4 +45,13 @@ func compressionHeader(id HeaderID) []byte {
 	binary.BigEndian.PutUint32(b, uint32(id))
 
 	return b
+}
+
+// IDFromHeader retrieves compression ID from content header
+func IDFromHeader(b []byte) (HeaderID, error) {
+	if len(b) < compressionHeaderSize {
+		return 0, errors.Errorf("invalid size: %v", len(b))
+	}
+
+	return HeaderID(binary.BigEndian.Uint32(b[0:compressionHeaderSize])), nil
 }

--- a/repo/compression/compressor_gzip.go
+++ b/repo/compression/compressor_gzip.go
@@ -52,19 +52,19 @@ func (c *gzipCompressor) Compress(b []byte) ([]byte, error) {
 }
 
 func (c *gzipCompressor) Decompress(b []byte) ([]byte, error) {
-	if len(b) < 4 {
+	if len(b) < compressionHeaderSize {
 		return nil, errors.Errorf("invalid compression header")
 	}
 
-	if !bytes.Equal(b[0:4], c.header) {
+	if !bytes.Equal(b[0:compressionHeaderSize], c.header) {
 		return nil, errors.Errorf("invalid compression header")
 	}
 
-	r, err := gzip.NewReader(bytes.NewReader(b[4:]))
+	r, err := gzip.NewReader(bytes.NewReader(b[compressionHeaderSize:]))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open gzip stream")
 	}
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, r); err != nil {

--- a/repo/compression/compressor_pgzip.go
+++ b/repo/compression/compressor_pgzip.go
@@ -52,19 +52,19 @@ func (c *pgzipCompressor) Compress(b []byte) ([]byte, error) {
 }
 
 func (c *pgzipCompressor) Decompress(b []byte) ([]byte, error) {
-	if len(b) < 4 {
+	if len(b) < compressionHeaderSize {
 		return nil, errors.Errorf("invalid compression header")
 	}
 
-	if !bytes.Equal(b[0:4], c.header) {
+	if !bytes.Equal(b[0:compressionHeaderSize], c.header) {
 		return nil, errors.Errorf("invalid compression header")
 	}
 
-	r, err := pgzip.NewReader(bytes.NewReader(b[4:]))
+	r, err := pgzip.NewReader(bytes.NewReader(b[compressionHeaderSize:]))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open gzip stream")
 	}
-	defer r.Close()
+	defer r.Close() //nolint:errcheck
 
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, r); err != nil {

--- a/repo/compression/compressor_s2.go
+++ b/repo/compression/compressor_s2.go
@@ -11,8 +11,8 @@ import (
 func init() {
 	RegisterCompressor("s2-default", newS2Compressor(headerS2Default))
 	RegisterCompressor("s2-better", newS2Compressor(headerS2Better, s2.WriterBetterCompression()))
-	RegisterCompressor("s2-parallel-4", newS2Compressor(headerS2Parallel4, s2.WriterConcurrency(4)))
-	RegisterCompressor("s2-parallel-8", newS2Compressor(headerS2Parallel8, s2.WriterConcurrency(8)))
+	RegisterCompressor("s2-parallel-4", newS2Compressor(headerS2Parallel4, s2.WriterConcurrency(4))) //nolint:gomnd
+	RegisterCompressor("s2-parallel-8", newS2Compressor(headerS2Parallel8, s2.WriterConcurrency(8))) //nolint:gomnd
 }
 
 func newS2Compressor(id HeaderID, opts ...s2.WriterOption) Compressor {
@@ -50,15 +50,15 @@ func (c *s2Compressor) Compress(b []byte) ([]byte, error) {
 }
 
 func (c *s2Compressor) Decompress(b []byte) ([]byte, error) {
-	if len(b) < 4 {
+	if len(b) < compressionHeaderSize {
 		return nil, errors.Errorf("invalid compression header")
 	}
 
-	if !bytes.Equal(b[0:4], c.header) {
+	if !bytes.Equal(b[0:compressionHeaderSize], c.header) {
 		return nil, errors.Errorf("invalid compression header")
 	}
 
-	r := s2.NewReader(bytes.NewReader(b[4:]))
+	r := s2.NewReader(bytes.NewReader(b[compressionHeaderSize:]))
 
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, r); err != nil {

--- a/repo/compression/compressor_zstd.go
+++ b/repo/compression/compressor_zstd.go
@@ -53,15 +53,15 @@ func (c *zstdCompressor) Compress(b []byte) ([]byte, error) {
 }
 
 func (c *zstdCompressor) Decompress(b []byte) ([]byte, error) {
-	if len(b) < 4 {
+	if len(b) < compressionHeaderSize {
 		return nil, errors.Errorf("invalid compression header")
 	}
 
-	if !bytes.Equal(b[0:4], c.header) {
+	if !bytes.Equal(b[0:compressionHeaderSize], c.header) {
 		return nil, errors.Errorf("invalid compression header")
 	}
 
-	r, err := zstd.NewReader(bytes.NewReader(b[4:]))
+	r, err := zstd.NewReader(bytes.NewReader(b[compressionHeaderSize:]))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open zstd stream")
 	}

--- a/repo/content/content_formatter.go
+++ b/repo/content/content_formatter.go
@@ -151,6 +151,7 @@ func truncatedHMACHashFuncFactory(hf func() hash.Hash, truncate int) HashFuncFac
 		return func(b []byte) []byte {
 			h := hmac.New(hf, o.HMACSecret)
 			h.Write(b) // nolint:errcheck
+
 			return h.Sum(nil)[0:truncate]
 		}, nil
 	}
@@ -167,6 +168,7 @@ func truncatedKeyedHashFuncFactory(hf func(key []byte) (hash.Hash, error), trunc
 		return func(b []byte) []byte {
 			h, _ := hf(o.HMACSecret)
 			h.Write(b) // nolint:errcheck
+
 			return h.Sum(nil)[0:truncate]
 		}, nil
 	}
@@ -244,9 +246,9 @@ func init() {
 	RegisterEncryption("NONE", func(f *FormattingOptions) (Encryptor, error) {
 		return nullEncryptor{}, nil
 	})
-	RegisterEncryption("AES-128-CTR", newCTREncryptorFactory(16, aes.NewCipher))
-	RegisterEncryption("AES-192-CTR", newCTREncryptorFactory(24, aes.NewCipher))
-	RegisterEncryption("AES-256-CTR", newCTREncryptorFactory(32, aes.NewCipher))
+	RegisterEncryption("AES-128-CTR", newCTREncryptorFactory(16, aes.NewCipher)) //nolint:gomnd
+	RegisterEncryption("AES-192-CTR", newCTREncryptorFactory(24, aes.NewCipher)) //nolint:gomnd
+	RegisterEncryption("AES-256-CTR", newCTREncryptorFactory(32, aes.NewCipher)) //nolint:gomnd
 	RegisterEncryption("SALSA20", func(f *FormattingOptions) (Encryptor, error) {
 		var k [32]byte
 		copy(k[:], f.MasterKey[0:32])

--- a/repo/content/content_id_to_bytes.go
+++ b/repo/content/content_id_to_bytes.go
@@ -4,12 +4,15 @@ import (
 	"encoding/hex"
 )
 
+// unpackedContentIDPrefix is a prefix for all content IDs that are stored unpacked in the index.
+const unpackedContentIDPrefix = 0xff
+
 func bytesToContentID(b []byte) ID {
 	if len(b) == 0 {
 		return ""
 	}
 
-	if b[0] == 0xff {
+	if b[0] == unpackedContentIDPrefix {
 		return ID(b[1:])
 	}
 
@@ -36,7 +39,7 @@ func contentIDToBytes(c ID) []byte {
 
 	b, err := hex.DecodeString(string(c[skip:]))
 	if err != nil {
-		return append([]byte{0xff}, []byte(c)...)
+		return append([]byte{unpackedContentIDPrefix}, []byte(c)...)
 	}
 
 	return append(prefix, b...)

--- a/repo/content/content_index_recovery.go
+++ b/repo/content/content_index_recovery.go
@@ -61,7 +61,7 @@ func (p *packContentPostamble) toBytes() ([]byte, error) {
 	binary.BigEndian.PutUint32(buf[n:], checksum)
 	n += 4
 
-	if n > 255 {
+	if n > 255 { // nolint:gomnd
 		return nil, errors.Errorf("postamble too long: %v", n)
 	}
 
@@ -81,7 +81,7 @@ func findPostamble(b []byte) *packContentPostamble {
 
 	// length of postamble is the last byte
 	postambleLength := int(b[len(b)-1])
-	if postambleLength < 5 {
+	if postambleLength < 5 { // nolint:gomnd
 		// too short, must be at least 5 bytes (checksum + own length)
 		return nil
 	}

--- a/repo/content/content_manager_iterate.go
+++ b/repo/content/content_manager_iterate.go
@@ -64,6 +64,7 @@ func maybeParallelExecutor(parallel int, originalCallback IterateCallback) (Iter
 
 		go func() {
 			defer wg.Done()
+
 			for i := range workch {
 				if err := originalCallback(i); err != nil {
 					select {
@@ -196,7 +197,7 @@ func (bm *Manager) IteratePacks(options IteratePackOptions, callback IteratePack
 // packs shorter than the given threshold.
 func (bm *Manager) IterateContentInShortPacks(threshold int64, callback IterateCallback) error {
 	if threshold <= 0 {
-		threshold = int64(bm.maxPackSize) * 8 / 10
+		threshold = int64(bm.maxPackSize) * 8 / 10 // nolint:gomnd
 	}
 
 	return bm.IteratePacks(

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -66,7 +66,7 @@ func appendRandomBytes(b []byte, count int) ([]byte, error) {
 }
 
 func (bm *lockFreeManager) loadPackIndexesUnlocked(ctx context.Context) ([]IndexBlobInfo, bool, error) {
-	nextSleepTime := 100 * time.Millisecond
+	nextSleepTime := 100 * time.Millisecond //nolint:gomnd
 
 	for i := 0; i < indexLoadAttempts; i++ {
 		if err := ctx.Err(); err != nil {

--- a/repo/content/format.go
+++ b/repo/content/format.go
@@ -35,7 +35,7 @@ type entry struct {
 }
 
 func (e *entry) parse(b []byte) error {
-	if len(b) < 20 {
+	if len(b) < entryFixedHeaderLength {
 		return errors.Errorf("invalid entry length: %v", len(b))
 	}
 
@@ -52,11 +52,11 @@ func (e *entry) IsDeleted() bool {
 }
 
 func (e *entry) TimestampSeconds() int64 {
-	return int64(e.timestampAndFlags >> 16)
+	return int64(e.timestampAndFlags >> 16) // nolint:gomnd
 }
 
 func (e *entry) PackedFormatVersion() byte {
-	return byte(e.timestampAndFlags >> 8)
+	return byte(e.timestampAndFlags >> 8) // nolint:gomnd
 }
 
 func (e *entry) PackFileLength() byte {

--- a/repo/content/index.go
+++ b/repo/content/index.go
@@ -68,7 +68,7 @@ func (b *index) Iterate(prefix ID, cb func(Info) error) error {
 	entry := make([]byte, stride)
 
 	for i := startPos; i < b.hdr.entryCount; i++ {
-		n, err := b.readerAt.ReadAt(entry, int64(8+stride*i))
+		n, err := b.readerAt.ReadAt(entry, int64(packHeaderSize+stride*i))
 		if err != nil || n != len(entry) {
 			return errors.Wrap(err, "unable to read from index")
 		}
@@ -103,7 +103,7 @@ func (b *index) findEntryPosition(contentID ID) (int, error) {
 		if readErr != nil {
 			return false
 		}
-		_, err := b.readerAt.ReadAt(entryBuf, int64(8+stride*p))
+		_, err := b.readerAt.ReadAt(entryBuf, int64(packHeaderSize+stride*p))
 		if err != nil {
 			readErr = err
 			return false
@@ -133,7 +133,7 @@ func (b *index) findEntry(contentID ID) ([]byte, error) {
 	}
 
 	entryBuf := make([]byte, stride)
-	if _, err := b.readerAt.ReadAt(entryBuf, int64(8+stride*position)); err != nil {
+	if _, err := b.readerAt.ReadAt(entryBuf, int64(packHeaderSize+stride*position)); err != nil {
 		return nil, err
 	}
 
@@ -164,10 +164,6 @@ func (b *index) GetInfo(contentID ID) (*Info, error) {
 }
 
 func (b *index) entryToInfo(contentID ID, entryData []byte) (Info, error) {
-	if len(entryData) < 20 {
-		return Info{}, errors.Errorf("invalid entry length: %v", len(entryData))
-	}
-
 	var e entry
 	if err := e.parse(entryData); err != nil {
 		return Info{}, err

--- a/repo/content/merged.go
+++ b/repo/content/merged.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 )
 
+const iterateParallelism = 16
+
 // mergedIndex is an implementation of Index that transparently merges returns from underlying Indexes.
 type mergedIndex []packIndex
 
@@ -73,7 +75,7 @@ func (h *nextInfoHeap) Pop() interface{} {
 }
 
 func iterateChan(prefix ID, ndx packIndex, done chan bool) <-chan Info {
-	ch := make(chan Info, 16)
+	ch := make(chan Info, iterateParallelism)
 
 	go func() {
 		defer close(ch)

--- a/repo/crypto_key_derivation.go
+++ b/repo/crypto_key_derivation.go
@@ -28,7 +28,10 @@ func (f *formatBlob) deriveMasterKeyFromPassword(password string) ([]byte, error
 func deriveKeyFromMasterKey(masterKey, uniqueID, purpose []byte, length int) []byte {
 	key := make([]byte, length)
 	k := hkdf.New(sha256.New, masterKey, uniqueID, purpose)
-	io.ReadFull(k, key) //nolint:errcheck
+
+	if _, err := io.ReadFull(k, key); err != nil {
+		panic("unable to derive key from master key, this should never happen")
+	}
 
 	return key
 }

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -18,6 +18,12 @@ var (
 	BuildVersion = "v0-unofficial"
 )
 
+const (
+	hmacSecretLength = 32
+	masterKeyLength  = 32
+	uniqueIDLength   = 32
+)
+
 // NewRepositoryOptions specifies options that apply to newly created repositories.
 // All fields are optional, when not provided, reasonable defaults will be used.
 type NewRepositoryOptions struct {
@@ -66,7 +72,7 @@ func formatBlobFromOptions(opt *NewRepositoryOptions) *formatBlob {
 		Tool:                   "https://github.com/kopia/kopia",
 		BuildInfo:              BuildInfo,
 		KeyDerivationAlgorithm: defaultKeyDerivationAlgorithm,
-		UniqueID:               applyDefaultRandomBytes(opt.UniqueID, 32),
+		UniqueID:               applyDefaultRandomBytes(opt.UniqueID, uniqueIDLength),
 		Version:                "1",
 		EncryptionAlgorithm:    defaultFormatEncryption,
 	}
@@ -84,9 +90,9 @@ func repositoryObjectFormatFromOptions(opt *NewRepositoryOptions) *repositoryObj
 			Version:     1,
 			Hash:        applyDefaultString(opt.BlockFormat.Hash, content.DefaultHash),
 			Encryption:  applyDefaultString(opt.BlockFormat.Encryption, content.DefaultEncryption),
-			HMACSecret:  applyDefaultRandomBytes(opt.BlockFormat.HMACSecret, 32),
-			MasterKey:   applyDefaultRandomBytes(opt.BlockFormat.MasterKey, 32),
-			MaxPackSize: applyDefaultInt(opt.BlockFormat.MaxPackSize, 20<<20), // 20 MB
+			HMACSecret:  applyDefaultRandomBytes(opt.BlockFormat.HMACSecret, hmacSecretLength), //nolint:gomnd
+			MasterKey:   applyDefaultRandomBytes(opt.BlockFormat.MasterKey, masterKeyLength),   //nolint:gomnd
+			MaxPackSize: applyDefaultInt(opt.BlockFormat.MaxPackSize, 20<<20),                  //nolint:gomnd
 		},
 		Format: object.Format{
 			Splitter: applyDefaultString(opt.ObjectFormat.Splitter, object.DefaultSplitter),

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -42,7 +42,7 @@ func (lc *LocalConfig) Save(w io.Writer) error {
 
 // loadConfigFromFile reads the local configuration from the specified file.
 func loadConfigFromFile(fileName string) (*LocalConfig, error) {
-	f, err := os.Open(fileName)
+	f, err := os.Open(fileName) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -18,6 +18,8 @@ import (
 	"github.com/kopia/kopia/repo/content"
 )
 
+const manifestLoadParallelism = 8
+
 var log = repologging.Logger("kopia/manifest")
 
 // ErrNotFound is returned when the metadata item is not found.
@@ -299,7 +301,7 @@ func (m *Manager) loadCommittedContentsLocked(ctx context.Context) error {
 
 		err := m.b.IterateContents(content.IterateOptions{
 			Prefix:   ContentPrefix,
-			Parallel: 8,
+			Parallel: manifestLoadParallelism,
 		}, func(ci content.Info) error {
 			man, err := m.loadManifestContent(ctx, ci.ID)
 			if err != nil {

--- a/repo/object/object_manager.go
+++ b/repo/object/object_manager.go
@@ -4,7 +4,6 @@ package object
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"io"
 
@@ -238,11 +237,10 @@ func (om *Manager) newRawReader(ctx context.Context, objectID ID, assertLength i
 }
 
 func (om *Manager) decompress(b []byte) ([]byte, error) {
-	if len(b) < 4 {
-		return nil, errors.Errorf("invalid compression header")
+	compressorID, err := compression.IDFromHeader(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid compression header")
 	}
-
-	compressorID := compression.HeaderID(binary.BigEndian.Uint32(b[0:4]))
 
 	compressor := compression.ByHeaderID[compressorID]
 	if compressor == nil {

--- a/repo/object/object_reader.go
+++ b/repo/object/object_reader.go
@@ -106,7 +106,7 @@ func (r *objectReader) findChunkIndexForOffset(offset int64) (int, error) {
 	right := len(r.seekTable) - 1
 
 	for left <= right {
-		middle := (left + right) / 2
+		middle := (left + right) / 2 //nolint:gomnd
 
 		if offset < r.seekTable[middle].Start {
 			right = middle - 1

--- a/repo/object/object_splitter.go
+++ b/repo/object/object_splitter.go
@@ -22,27 +22,27 @@ type SplitterFactory func() Splitter
 
 // splitterFactories is a map of registered splitter factories.
 var splitterFactories = map[string]SplitterFactory{
-	"FIXED-1M": newFixedSplitterFactory(megabytes(1)),
-	"FIXED-2M": newFixedSplitterFactory(megabytes(2)),
-	"FIXED-4M": newFixedSplitterFactory(megabytes(4)),
-	"FIXED-8M": newFixedSplitterFactory(megabytes(8)),
+	"FIXED-1M": newFixedSplitterFactory(megabytes(1)), //nolint:gomnd
+	"FIXED-2M": newFixedSplitterFactory(megabytes(2)), //nolint:gomnd
+	"FIXED-4M": newFixedSplitterFactory(megabytes(4)), //nolint:gomnd
+	"FIXED-8M": newFixedSplitterFactory(megabytes(8)), //nolint:gomnd
 
-	"DYNAMIC-1M-BUZHASH": newBuzHash32SplitterFactory(megabytes(1)),
-	"DYNAMIC-2M-BUZHASH": newBuzHash32SplitterFactory(megabytes(2)),
-	"DYNAMIC-4M-BUZHASH": newBuzHash32SplitterFactory(megabytes(4)),
-	"DYNAMIC-8M-BUZHASH": newBuzHash32SplitterFactory(megabytes(8)),
+	"DYNAMIC-1M-BUZHASH": newBuzHash32SplitterFactory(megabytes(1)), //nolint:gomnd
+	"DYNAMIC-2M-BUZHASH": newBuzHash32SplitterFactory(megabytes(2)), //nolint:gomnd
+	"DYNAMIC-4M-BUZHASH": newBuzHash32SplitterFactory(megabytes(4)), //nolint:gomnd
+	"DYNAMIC-8M-BUZHASH": newBuzHash32SplitterFactory(megabytes(8)), //nolint:gomnd
 
-	"DYNAMIC-1M-RABINKARP": newRabinKarp64SplitterFactory(megabytes(1)),
-	"DYNAMIC-2M-RABINKARP": newRabinKarp64SplitterFactory(megabytes(2)),
-	"DYNAMIC-4M-RABINKARP": newRabinKarp64SplitterFactory(megabytes(4)),
-	"DYNAMIC-8M-RABINKARP": newRabinKarp64SplitterFactory(megabytes(8)),
+	"DYNAMIC-1M-RABINKARP": newRabinKarp64SplitterFactory(megabytes(1)), //nolint:gomnd
+	"DYNAMIC-2M-RABINKARP": newRabinKarp64SplitterFactory(megabytes(2)), //nolint:gomnd
+	"DYNAMIC-4M-RABINKARP": newRabinKarp64SplitterFactory(megabytes(4)), //nolint:gomnd
+	"DYNAMIC-8M-RABINKARP": newRabinKarp64SplitterFactory(megabytes(8)), //nolint:gomnd
 
 	// handle deprecated legacy names to splitters of arbitrary size
-	"FIXED": newFixedSplitterFactory(4 << 20),
+	"FIXED": newFixedSplitterFactory(4 << 20), //nolint:gomnd
 
 	// we don't want to use old DYNAMIC splitter because of its license, so
 	// map this one to arbitrary buzhash32 (different)
-	"DYNAMIC": newBuzHash32SplitterFactory(megabytes(4)),
+	"DYNAMIC": newBuzHash32SplitterFactory(megabytes(4)), //nolint:gomnd
 }
 
 func megabytes(mb int) int {

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -76,7 +76,9 @@ func (w *objectWriter) Write(data []byte) (n int, err error) {
 	w.totalLength += int64(dataLen)
 
 	for _, d := range data {
-		w.buffer.WriteByte(d)
+		if err := w.buffer.WriteByte(d); err != nil {
+			return 0, err
+		}
 
 		if w.splitter.ShouldSplit(d) {
 			if err := w.flushBuffer(); err != nil {
@@ -133,7 +135,10 @@ func (w *objectWriter) maybeCompressedContentBytes() (data []byte, isCompressed 
 
 	var b2 bytes.Buffer
 
-	w.buffer.WriteTo(&b2) //nolint:errcheck
+	if _, err := w.buffer.WriteTo(&b2); err != nil {
+		return nil, false, err
+	}
+
 	w.buffer.Reset()
 
 	return b2.Bytes(), false, nil

--- a/repo/object/objectid.go
+++ b/repo/object/objectid.go
@@ -63,7 +63,7 @@ func (i ID) Validate() error {
 	}
 
 	if contentID, _, ok := i.ContentID(); ok {
-		if len(contentID) < 2 {
+		if len(contentID) <= 1 {
 			return errors.Errorf("missing content ID")
 		}
 

--- a/repo/object/splitter_buzhash32.go
+++ b/repo/object/splitter_buzhash32.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package object
 
 import (
@@ -36,12 +35,13 @@ func newBuzHash32SplitterFactory(avgSize int) SplitterFactory {
 	// avgSize must be a power of two, so 0b000001000...0000
 	// it just so happens that mask is avgSize-1 :)
 	mask := uint32(avgSize - 1)
-	maxSize := avgSize * 2
-	minSize := avgSize / 2
+	maxSize := avgSize * 2 // nolint:gomnd
+	minSize := avgSize / 2 // nolint:gomnd
 
 	return func() Splitter {
 		s := buzhash32.New()
 		s.Write(make([]byte, splitterSlidingWindowSize)) //nolint:errcheck
+
 		return &buzhash32Splitter{s, mask, 0, minSize, maxSize}
 	}
 }

--- a/repo/object/splitter_rabinkarp64.go
+++ b/repo/object/splitter_rabinkarp64.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package object
 
 import "github.com/chmduquesne/rollinghash/rabinkarp64"
@@ -32,12 +31,12 @@ func (rs *rabinKarp64Splitter) ShouldSplit(b byte) bool {
 
 func newRabinKarp64SplitterFactory(avgSize int) SplitterFactory {
 	mask := uint64(avgSize - 1)
-	maxSize := avgSize * 2
-	minSize := avgSize / 2
+	minSize, maxSize := avgSize/2, avgSize*2 //nolint:gomnd
 
 	return func() Splitter {
 		s := rabinkarp64.New()
 		s.Write(make([]byte, splitterSlidingWindowSize)) //nolint:errcheck
+
 		return &rabinKarp64Splitter{s, mask, 0, minSize, maxSize}
 	}
 }

--- a/repo/open.go
+++ b/repo/open.go
@@ -99,8 +99,10 @@ func OpenWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 	caching.HMACSecret = deriveKeyFromMasterKey(masterKey, f.UniqueID, []byte("local-cache-integrity"), 16)
 
 	fo := &repoConfig.FormattingOptions
+
 	if fo.MaxPackSize == 0 {
-		fo.MaxPackSize = 20 << 20 // 20 MB
+		// legacy only, apply default
+		fo.MaxPackSize = 20 << 20 // nolint:gomnd
 	}
 
 	cm, err := content.NewManager(ctx, st, fo, caching, fb)
@@ -157,7 +159,7 @@ func readAndCacheFormatBlobBytes(ctx context.Context, st blob.Storage, cacheDire
 	cachedFile := filepath.Join(cacheDirectory, "kopia.repository")
 
 	if cacheDirectory != "" {
-		b, err := ioutil.ReadFile(cachedFile)
+		b, err := ioutil.ReadFile(cachedFile) //nolint:gosec
 		if err == nil {
 			// read from cache.
 			return b, nil

--- a/site/cli2md/cli2md.go
+++ b/site/cli2md/cli2md.go
@@ -122,7 +122,7 @@ func generateAppFlags(app *kingpin.ApplicationModel) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to create common flags file")
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 
 	title := "Flags"
 	fmt.Fprintf(f, `---
@@ -138,7 +138,7 @@ weight: 3
 
 func generateCommands(app *kingpin.ApplicationModel, section string, weight int, advanced bool) error {
 	dir := filepath.Join(baseDir, section)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0750); err != nil {
 		return err
 	}
 
@@ -146,7 +146,7 @@ func generateCommands(app *kingpin.ApplicationModel, section string, weight int,
 	if err != nil {
 		return errors.Wrap(err, "unable to create common flags file")
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 
 	title := section + " Commands"
 	fmt.Fprintf(f, `---
@@ -244,7 +244,7 @@ func generateSubcommandPage(fname string, cmd *kingpin.CmdModel) {
 	if err != nil {
 		log.Fatalf("unable to create page: %v", err)
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 
 	title := cmd.FullCommand
 	fmt.Fprintf(f, `---

--- a/snapshot/gc/gc.go
+++ b/snapshot/gc/gc.go
@@ -1,3 +1,4 @@
+// Package gc implements garbage collection of contents that are no longer referenced through snapshots.
 package gc
 
 import (

--- a/snapshot/policy/compression_policy.go
+++ b/snapshot/policy/compression_policy.go
@@ -17,6 +17,7 @@ type CompressionPolicy struct {
 	MaxSize        int64            `json:"maxSize,omitempty"`
 }
 
+// CompressorForFile returns compression name to be used for compressing a given file according to policy, using attributes such as name or size.
 func (p *CompressionPolicy) CompressorForFile(e fs.File) compression.Name {
 	ext := filepath.Ext(e.Name())
 	size := e.Size()

--- a/snapshot/policy/files_policy.go
+++ b/snapshot/policy/files_policy.go
@@ -12,7 +12,7 @@ type FilesPolicy struct {
 }
 
 // Merge applies default values from the provided policy.
-func (p *FilesPolicy) Merge(src FilesPolicy) { //nolint:hugeParam
+func (p *FilesPolicy) Merge(src FilesPolicy) {
 	if p.MaxFileSize == 0 {
 		p.MaxFileSize = src.MaxFileSize
 	}

--- a/snapshot/policy/policy_tree.go
+++ b/snapshot/policy/policy_tree.go
@@ -33,6 +33,7 @@ func (t *Tree) EffectivePolicy() *Policy {
 	return t.effective
 }
 
+// IsInherited returns true if the policy inherited to the given tree hode has been inherited from its parent.
 func (t *Tree) IsInherited() bool {
 	if t == nil {
 		return true
@@ -41,6 +42,7 @@ func (t *Tree) IsInherited() bool {
 	return t.inherited
 }
 
+// Child gets a subtree for an entry with a given name.
 func (t *Tree) Child(name string) *Tree {
 	if t == nil {
 		return nil

--- a/snapshot/policy/retention_policy.go
+++ b/snapshot/policy/retention_policy.go
@@ -125,7 +125,7 @@ func daysAgo(base time.Time, n int) time.Time {
 }
 
 func weeksAgo(base time.Time, n int) time.Time {
-	return base.AddDate(0, 0, -n*7)
+	return base.AddDate(0, 0, -n*7) //nolint:gomnd
 }
 
 func hoursAgo(base time.Time, n int) time.Time {
@@ -133,12 +133,12 @@ func hoursAgo(base time.Time, n int) time.Time {
 }
 
 var defaultRetentionPolicy = RetentionPolicy{
-	KeepLatest:  intPtr(1),
-	KeepHourly:  intPtr(48),
-	KeepDaily:   intPtr(7),
-	KeepWeekly:  intPtr(4),
-	KeepMonthly: intPtr(4),
-	KeepAnnual:  intPtr(0),
+	KeepLatest:  intPtr(1),  // nolint:gomnd
+	KeepHourly:  intPtr(48), // nolint:gomnd
+	KeepDaily:   intPtr(7),  // nolint:gomnd
+	KeepWeekly:  intPtr(4),  // nolint:gomnd
+	KeepMonthly: intPtr(4),  // nolint:gomnd
+	KeepAnnual:  intPtr(0),  // nolint:gomnd
 }
 
 // Merge applies default values from the provided policy.

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -182,7 +182,7 @@ func withFileInfo(r object.Reader, e fs.Entry) fs.Reader {
 func DirectoryEntry(rep *repo.Repository, objectID object.ID, dirSummary *fs.DirectorySummary) fs.Directory {
 	d, _ := EntryFromDirEntry(rep, &snapshot.DirEntry{
 		Name:        "/",
-		Permissions: 0555,
+		Permissions: 0555, //nolint:gomnd
 		Type:        snapshot.EntryTypeDirectory,
 		ObjectID:    objectID,
 		DirSummary:  dirSummary,

--- a/snapshot/snapshotfs/snapshot_tree_walker.go
+++ b/snapshot/snapshotfs/snapshot_tree_walker.go
@@ -11,6 +11,8 @@ import (
 	"github.com/kopia/kopia/internal/parallelwork"
 )
 
+const walkersPerCPU = 4
+
 // TreeWalker holds information for concurrently walking down FS trees specified
 // by their roots
 type TreeWalker struct {
@@ -70,7 +72,7 @@ func (w *TreeWalker) Run(ctx context.Context) error {
 // NewTreeWalker creates new tree walker.
 func NewTreeWalker() *TreeWalker {
 	return &TreeWalker{
-		Parallelism: 4 * runtime.NumCPU(),
+		Parallelism: walkersPerCPU * runtime.NumCPU(),
 		queue:       parallelwork.NewQueue(),
 	}
 }

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -76,7 +76,7 @@ func (s *sourceSnapshots) Readdir(ctx context.Context) (fs.Entries, error) {
 
 		de := &snapshot.DirEntry{
 			Name:        name,
-			Permissions: 0555,
+			Permissions: 0555, //nolint:gomnd
 			Type:        snapshot.EntryTypeDirectory,
 			ModTime:     m.StartTime,
 			ObjectID:    m.RootObjectID(),

--- a/tests/end_to_end_test/end_to_end.go
+++ b/tests/end_to_end_test/end_to_end.go
@@ -1,1 +1,0 @@
-package endtoend

--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -796,11 +796,13 @@ func TestSnapshotRestore(t *testing.T) {
 	// Attempt to restore snapshot with an already-existing target directory
 	// It should fail because the directory is not empty
 	_ = os.MkdirAll(restoreFailDir, 0700)
+
 	e.runAndExpectFailure(t, "snapshot", "restore", "--no-overwrite-directories", snapID, restoreDir)
 
 	// Attempt to restore snapshot with an already-existing target directory
 	// It should fail because target files already exist
 	_ = os.MkdirAll(restoreFailDir, 0700)
+
 	e.runAndExpectFailure(t, "snapshot", "restore", "--no-overwrite-files", snapID, restoreDir)
 }
 

--- a/tests/repository_stress_test/repository_stress.go
+++ b/tests/repository_stress_test/repository_stress.go
@@ -1,3 +1,0 @@
-package repositorystress
-
-// dummy package

--- a/tests/stress_test/stress.go
+++ b/tests/stress_test/stress.go
@@ -1,3 +1,0 @@
-package stress
-
-// dummy package

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -3,7 +3,7 @@ TOOLS_DIR:=$(SELF_DIR)/.tools
 uname := $(shell uname -s)
 
 # tool versions
-GOLANGCI_LINT_VERSION=v1.21.0
+GOLANGCI_LINT_VERSION=v1.22.2
 NODE_VERSION=12.13.0
 HUGO_VERSION=0.59.1
 
@@ -35,11 +35,12 @@ $(BINDATA_TOOL):
 	go build -o $(BINDATA_TOOL) github.com/go-bindata/go-bindata/go-bindata
 
 # linter
-LINTER_TOOL=$(TOOLS_DIR)/bin/golangci-lint
+LINTER_TOOL=$(TOOLS_DIR)/bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
 
 $(LINTER_TOOL):
 	mkdir -p $(TOOLS_DIR)
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(TOOLS_DIR)/bin/ $(GOLANGCI_LINT_VERSION)
+	ln -sf $(TOOLS_DIR)/bin/golangci-lint $(LINTER_TOOL)
 
 # hugo
 HUGO_TOOL=$(TOOLS_DIR)/hugo/hugo


### PR DESCRIPTION
fixed or silenced linter warnings, mostly due to magic numeric constants