### PR TITLE
Adding exit code check to e2e testing

### DIFF
--- a/tests/end_to_end_test/end_to_end_test.go
+++ b/tests/end_to_end_test/end_to_end_test.go
@@ -916,6 +916,14 @@ func (e *testenv) run(t *testing.T, args ...string) ([]string, error) {
 
 	o, err := c.Output()
 
+	code := c.ProcessState.ExitCode()
+	if code != 0 && err == nil {
+		t.Fatalf("kopia exited with code %d but no error status", code)
+	}
+	if code == 0 && err != nil {
+		t.Fatalf("kopia exited with an error %s but zero exit code", err)
+	}
+
 	wg.Wait()
 	t.Logf("finished 'kopia %v' with err=%v and output:\n%v\nstderr:\n%v\n", strings.Join(args, " "), err, trimOutput(string(o)), trimOutput(string(stderr)))
 


### PR DESCRIPTION
Adding a check of exit code after kopia process execution in
e2e testing. The exit code is checked against the error, such
that if there is a non-nil error, a non-zero exit code is expected and
vice versa.

This should be sufficient to address [K10-3199: Verify Kopia's exit code during a restore failure](https://kasten.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=K10&modal=detail&selectedIssue=K10-3199), since between `kopia restore` and `kopia snap restore` there are 11 instances in e2e tests where the kopia command is expected to fail. Do you agree, @julio-lopez?

The e2e tests also already cover cases where a failure is expected with `snapshot delete` and `repo connect` as well.

Still need to do additional work to address [K10-2737: Verify Kopia's exit code when there is an error during backup](https://kasten.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=K10&modal=detail&selectedIssue=K10-3092), since there are no instances in the e2e tests yet that expect a backup to fail

