### PR TITLE
cli: improvements for 'kopia server' and client

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -3,7 +3,6 @@ package cli
 
 import (
 	"context"
-	"net/http"
 	"os"
 
 	"github.com/pkg/errors"
@@ -51,7 +50,17 @@ func noRepositoryAction(act func(ctx context.Context) error) func(ctx *kingpin.P
 
 func serverAction(act func(ctx context.Context, cli *serverapi.Client) error) func(ctx *kingpin.ParseContext) error {
 	return func(_ *kingpin.ParseContext) error {
-		return act(context.Background(), serverapi.NewClient(*serverAddress, http.DefaultClient))
+		opts, err := serverAPIClientOptions()
+		if err != nil {
+			return errors.Wrap(err, "unable to create API client options")
+		}
+
+		apiClient, err := serverapi.NewClient(opts)
+		if err != nil {
+			return errors.Wrap(err, "unable to create API client")
+		}
+
+		return act(context.Background(), apiClient)
 	}
 }
 

--- a/cli/command_server.go
+++ b/cli/command_server.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"github.com/kopia/kopia/internal/serverapi"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	serverAddress  = serverCommands.Flag("address", "Server address").Default("http://127.0.0.1:51515").String()
+	serverUsername = serverCommands.Flag("server-username", "HTTP server username (basic auth)").Envar("KOPIA_SERVER_USERNAME").Default("kopia").String()
+	serverPassword = serverCommands.Flag("server-password", "HTTP server password (basic auth)").Envar("KOPIA_SERVER_PASSWORD").String()
+)
+
+func serverAPIClientOptions() (serverapi.ClientOptions, error) {
+	if *serverAddress == "" {
+		return serverapi.ClientOptions{}, errors.Errorf("missing server address")
+	}
+
+	return serverapi.ClientOptions{
+		BaseURL:  *serverAddress,
+		Username: *serverUsername,
+		Password: *serverPassword,
+	}, nil
+}

--- a/cli/command_server_tls.go
+++ b/cli/command_server_tls.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const oneDay = 24 * time.Hour
+
+var (
+	serverStartTLSGenerateCert          = serverStartCommand.Flag("tls-generate-cert", "Generate TLS certificate").Hidden().Bool()
+	serverStartTLSCertFile              = serverStartCommand.Flag("tls-cert-file", "TLS certificate PEM").String()
+	serverStartTLSKeyFile               = serverStartCommand.Flag("tls-key-file", "TLS key PEM file").String()
+	serverStartTLSGenerateRSAKeySize    = serverStartCommand.Flag("tls-generate-rsa-key-size", "TLS RSA Key size (bits)").Hidden().Default("4096").Int()
+	serverStartTLSGenerateCertValidDays = serverStartCommand.Flag("tls-generate-cert-valid-days", "How long should the TLS certificate be valid").Default("3650").Hidden().Int()
+	serverStartTLSGenerateCertNames     = serverStartCommand.Flag("tls-generate-cert-name", "Host names/IP addresses to generate TLS certificate for").Default("127.0.0.1").Hidden().Strings()
+)
+
+func generateServerCertificate() (*x509.Certificate, *rsa.PrivateKey, error) {
+	log.Infof("generating new TLS certificate")
+
+	priv, err := rsa.GenerateKey(rand.Reader, *serverStartTLSGenerateRSAKeySize)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "unable to generate RSA key")
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(time.Duration(*serverStartTLSGenerateCertValidDays) * oneDay)
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "unable to generate serial number")
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Kopia"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	for _, n := range *serverStartTLSGenerateCertNames {
+		if ip := net.ParseIP(n); ip != nil {
+			log.Infof("adding alternative IP to certificate: %v", ip)
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			log.Infof("adding alternative DNS name to certificate: %v", n)
+			template.DNSNames = append(template.DNSNames, n)
+		}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create certificate")
+	}
+
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to parse certificate")
+	}
+
+	return cert, priv, nil
+}
+
+func writePrivateKeyToFile(fname string, priv *rsa.PrivateKey) error {
+	f, err := os.Create(fname)
+	if err != nil {
+		return err
+	}
+	defer f.Close() //nolint:errcheck
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return errors.Wrap(err, "Unable to marshal private key")
+	}
+
+	if err := pem.Encode(f, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
+		return errors.Wrap(err, "Failed to write data to")
+	}
+
+	return nil
+}
+
+func writeCertificateToFile(fname string, cert *x509.Certificate) error {
+	f, err := os.Create(fname)
+	if err != nil {
+		return err
+	}
+	defer f.Close() //nolint:errcheck
+
+	if err := pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+		return errors.Wrap(err, "Failed to write data")
+	}
+
+	return nil
+}
+
+func startServerWithOptionalTLS(httpServer *http.Server) error {
+	// generate and save to PEM files
+	if *serverStartTLSGenerateCert && *serverStartTLSCertFile != "" && *serverStartTLSKeyFile != "" {
+		if _, err := os.Stat(*serverStartTLSCertFile); err == nil {
+			return errors.Errorf("TLS cert file already exists: %q", *serverStartTLSCertFile)
+		}
+
+		if _, err := os.Stat(*serverStartTLSKeyFile); err == nil {
+			return errors.Errorf("TLS key file already exists: %q", *serverStartTLSKeyFile)
+		}
+
+		cert, key, err := generateServerCertificate()
+		if err != nil {
+			return errors.Wrap(err, "unable to generate server cert")
+		}
+
+		log.Infof("writing TLS certificate to %v", *serverStartTLSCertFile)
+
+		if err := writeCertificateToFile(*serverStartTLSCertFile, cert); err != nil {
+			return errors.Wrap(err, "unable to write private key")
+		}
+
+		log.Infof("writing TLS private key to %v", *serverStartTLSKeyFile)
+
+		if err := writePrivateKeyToFile(*serverStartTLSKeyFile, key); err != nil {
+			return errors.Wrap(err, "unable to write private key")
+		}
+	}
+
+	switch {
+	case *serverStartTLSCertFile != "" && *serverStartTLSKeyFile != "":
+		// PEM files provided
+		fmt.Fprintf(os.Stderr, "SERVER ADDRESS: https://%v\n", httpServer.Addr)
+		return httpServer.ListenAndServeTLS(*serverStartTLSCertFile, *serverStartTLSKeyFile)
+
+	case *serverStartTLSGenerateCert:
+		// PEM files not provided, generate in-memory TLS cert/key but don't persit.
+		cert, key, err := generateServerCertificate()
+		if err != nil {
+			return errors.Wrap(err, "unable to generate server cert")
+		}
+
+		httpServer.TLSConfig = &tls.Config{
+			Certificates: []tls.Certificate{
+				{
+					Certificate: [][]byte{cert.Raw},
+					PrivateKey:  key,
+				},
+			},
+		}
+
+		fingerprint := sha256.Sum256(cert.Raw)
+		fmt.Fprintf(os.Stderr, "SERVER CERT SHA256: %v\n", hex.EncodeToString(fingerprint[:]))
+		fmt.Fprintf(os.Stderr, "SERVER ADDRESS: https://%v\n", httpServer.Addr)
+
+		return httpServer.ListenAndServeTLS("", "")
+
+	default:
+		fmt.Fprintf(os.Stderr, "SERVER ADDRESS: http://%v\n", httpServer.Addr)
+		return httpServer.ListenAndServe()
+	}
+}

--- a/cli/server_watchdog.go
+++ b/cli/server_watchdog.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type serverWatchdog struct {
+	inFlightRequests int32
+	inner            http.Handler
+	stop             func()
+	interval         time.Duration
+
+	mu       sync.Mutex
+	deadline time.Time
+}
+
+func (d *serverWatchdog) getDeadline() time.Time {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.deadline
+}
+
+func (d *serverWatchdog) setDeadline(t time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if t.After(d.deadline) {
+		d.deadline = t
+	}
+}
+
+func (d *serverWatchdog) Run() {
+	for time.Now().Before(d.getDeadline()) || atomic.LoadInt32(&d.inFlightRequests) > 0 {
+		// sleep for no less than 1 second to avoid burning CPU
+		sleepTime := time.Until(d.getDeadline())
+		if sleepTime < time.Second {
+			sleepTime = time.Second
+		}
+
+		time.Sleep(sleepTime)
+	}
+
+	d.stop()
+}
+
+func (d *serverWatchdog) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	atomic.AddInt32(&d.inFlightRequests, 1)
+	defer atomic.AddInt32(&d.inFlightRequests, -1)
+
+	d.setDeadline(time.Now().Add(d.interval))
+	d.inner.ServeHTTP(w, r)
+}
+
+func startServerWatchdog(h http.Handler, interval time.Duration, stop func()) http.Handler {
+	w := &serverWatchdog{
+		inner:    h,
+		interval: interval,
+		deadline: time.Now().Add(interval),
+		stop:     stop,
+	}
+	go w.Run()
+
+	return w
+}

--- a/internal/serverapi/client.go
+++ b/internal/serverapi/client.go
@@ -2,21 +2,36 @@ package serverapi
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 
 	"github.com/pkg/errors"
 )
 
+// DefaultUsername is the default username for Kopia server.
+const DefaultUsername = "kopia"
+
 // Client provides helper methods for communicating with Kopia API serevr.
 type Client struct {
-	baseURL string
-	client  *http.Client
+	options ClientOptions
 }
 
 // Get sends HTTP GET request and decodes the JSON response into the provided payload structure.
 func (c *Client) Get(path string, respPayload interface{}) error {
-	resp, err := c.client.Get(c.baseURL + path)
+	req, err := http.NewRequest("GET", c.options.BaseURL+path, nil)
+	if err != nil {
+		return err
+	}
+
+	if c.options.Username != "" {
+		req.SetBasicAuth(c.options.Username, c.options.Password)
+	}
+
+	resp, err := c.options.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -41,10 +56,22 @@ func (c *Client) Post(path string, reqPayload, respPayload interface{}) error {
 		return errors.Wrap(err, "unable to encode request")
 	}
 
-	resp, err := c.client.Post(c.baseURL+path, "application/json", &buf)
+	req, err := http.NewRequest("POST", c.options.BaseURL+path, &buf)
 	if err != nil {
 		return err
 	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if c.options.Username != "" {
+		req.SetBasicAuth(c.options.Username, c.options.Password)
+	}
+
+	resp, err := c.options.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
@@ -58,11 +85,62 @@ func (c *Client) Post(path string, reqPayload, respPayload interface{}) error {
 	return nil
 }
 
-// NewClient creates a client for connecting to Kopia HTTP API.
-func NewClient(serverAddress string, cli *http.Client) *Client {
-	if cli == nil {
-		cli = http.DefaultClient
+// ClientOptions encapsulates all optional API options.HTTPClient options.
+type ClientOptions struct {
+	BaseURL string
+
+	HTTPClient *http.Client
+
+	Username string
+	Password string
+
+	TrustedServerCertificateFingerprint string
+
+	RootCAs *x509.CertPool
+}
+
+// NewClient creates a options.HTTPClient for connecting to Kopia HTTP API.
+// nolint:hugeParam
+func NewClient(options ClientOptions) (*Client, error) {
+	if options.HTTPClient == nil {
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: options.RootCAs,
+			},
+		}
+
+		if f := options.TrustedServerCertificateFingerprint; f != "" {
+			if options.RootCAs != nil {
+				return nil, errors.Errorf("can't set both RootCAs and TrustedServerCertificateFingerprint")
+			}
+
+			transport.TLSClientConfig.InsecureSkipVerify = true
+			transport.TLSClientConfig.VerifyPeerCertificate = verifyPeerCertificate(f)
+		}
+
+		options.HTTPClient = &http.Client{
+			Transport: transport,
+		}
 	}
 
-	return &Client{"http://" + serverAddress + "/api/v1/", cli}
+	if options.Username == "" {
+		options.Username = DefaultUsername
+	}
+
+	options.BaseURL += "/api/v1/"
+
+	return &Client{options}, nil
+}
+
+func verifyPeerCertificate(sha256Fingerprint string) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		for _, c := range rawCerts {
+			h := sha256.Sum256(c)
+			if hex.EncodeToString(h[:]) == sha256Fingerprint {
+				return nil
+			}
+		}
+
+		return errors.Errorf("can't find certificate matching SHA256 fingerprint %q", sha256Fingerprint)
+	}
 }

--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -1,0 +1,82 @@
+package endtoend_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+// Pattern in stderr that `kopia server` uses to pass ephemeral data.
+const (
+	serverOutputAddress    = "SERVER ADDRESS: "
+	serverOutputCertSHA256 = "SERVER CERT SHA256: "
+	serverOutputPassword   = "SERVER PASSWORD: "
+)
+
+type serverParameters struct {
+	baseURL           string
+	sha256Fingerprint string
+	password          string
+}
+
+func (s *serverParameters) ProcessOutput(l string) bool {
+	if strings.HasPrefix(l, serverOutputAddress) {
+		s.baseURL = strings.TrimPrefix(l, serverOutputAddress)
+		return false
+	}
+
+	if strings.HasPrefix(l, serverOutputCertSHA256) {
+		s.sha256Fingerprint = strings.TrimPrefix(l, serverOutputCertSHA256)
+	}
+
+	if strings.HasPrefix(l, serverOutputPassword) {
+		s.password = strings.TrimPrefix(l, serverOutputPassword)
+	}
+
+	return true
+}
+
+func TestServerStart(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+	defer e.Cleanup(t)
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	// Start the server and wait for it to auto-shutdown in 3 seconds.
+	// If this does not work, we avoid starting a longer test.
+	e.RunAndExpectSuccess(t, "server", "start", "--ui", "--auto-shutdown=3s")
+	time.Sleep(3 * time.Second)
+
+	var sp serverParameters
+
+	e.RunAndProcessStderr(t, sp.ProcessOutput, "server", "start", "--ui", "--random-password", "--tls-generate-cert", "--auto-shutdown=60s")
+	t.Logf("detected server parameters %#v", sp)
+
+	cli, err := serverapi.NewClient(serverapi.ClientOptions{
+		BaseURL:                             sp.baseURL,
+		Password:                            sp.password,
+		TrustedServerCertificateFingerprint: sp.sha256Fingerprint,
+	})
+	if err != nil {
+		t.Fatalf("unable to create API client")
+	}
+
+	time.Sleep(1 * time.Second)
+
+	if err := cli.Get("status", &serverapi.Empty{}); err != nil {
+		t.Errorf("status error: %v", err)
+	}
+
+	// TODO - add more tests
+
+	// explicit shutdown
+	if err := cli.Post("shutdown", &serverapi.Empty{}, &serverapi.Empty{}); err != nil {
+		t.Logf("expected shutdown error: %v", err)
+	}
+}


### PR DESCRIPTION
Those will make it possible to securely host 'kopia server' embedded
in a desktop app that runs in the background and can access UI.

- added support for using and generating TLS certificates
- added /api/v1/shutdown API to remotely trigger server shutdown
- added support for automatically shutting down server if no requests
  arrive in certain amount of time
- added support for generating and printing random password to STDERR

TLS supports 3 modes:

1. serve TLS using externally-provided cert/key PEM files
2. generate & write PEM files, then serve TLS using them
3. generate and use emphemeral cert/key (prints SHA256 fingerprint)