### PR TITLE
[robustness testing] Adding low-level FSWalker walker/reporter functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible // indirect
 	github.com/go-ini/ini v1.46.0 // indirect
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
+	github.com/golang/protobuf v1.3.2
+	github.com/google/fswalker v0.2.0
 	github.com/klauspost/compress v1.9.4
 	github.com/klauspost/crc32 v1.2.0 // indirect
 	github.com/klauspost/pgzip v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/fswalker v0.2.0 h1:0K5ijtxA74gDcrd138nFsgW7zrRIjf+vpdWcn7ljWK8=
+github.com/google/fswalker v0.2.0/go.mod h1:ZSEBqY0IHKqWPeAbTyvccv9bb9vCnaQfHe31cm911Ng=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -61,6 +63,8 @@ github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPg
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS0VQKc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -478,6 +478,15 @@ func AssertNoError(t *testing.T, err error) {
 	t.Helper()
 
 	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+// CheckNoError fails the test if a given error is not nil.
+func CheckNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
 		t.Errorf("err: %v", err)
 	}
 }

--- a/tests/tools/fswalker/protofile/protofile.go
+++ b/tests/tools/fswalker/protofile/protofile.go
@@ -1,0 +1,19 @@
+// Package protofile contains helper functions common
+// across multiple fswalker tool wrappers
+package protofile
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// WriteTextProto writes a text format proto buf for the provided proto message.
+func WriteTextProto(path string, pb proto.Message) error {
+	blob := proto.MarshalTextString(pb)
+	// replace message boundary characters as curly braces look nicer (both is fine to parse)
+	blob = strings.Replace(strings.Replace(blob, "<", "{", -1), ">", "}", -1)
+
+	return ioutil.WriteFile(path, []byte(blob), 0644)
+}

--- a/tests/tools/fswalker/reporter/reporter.go
+++ b/tests/tools/fswalker/reporter/reporter.go
@@ -1,0 +1,82 @@
+// Package reporter wraps calls to the the fswalker Reporter
+package reporter
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/google/fswalker"
+	fspb "github.com/google/fswalker/proto/fswalker"
+
+	"github.com/kopia/kopia/tests/tools/fswalker/protofile"
+)
+
+// Report performs a report governed by the contents of the provided
+// ReportConfig of the comparison of the two Walks provided
+func Report(ctx context.Context, config *fspb.ReportConfig, beforeWalk, afterWalk *fspb.Walk) (*fswalker.Report, error) {
+	tmpCfgFile, err := writeTempConfigFile(config)
+	if err != nil {
+		return nil, err
+	}
+
+	defer os.RemoveAll(tmpCfgFile) //nolint:errcheck
+
+	verbose := false
+
+	reporter, err := fswalker.ReporterFromConfigFile(ctx, tmpCfgFile, verbose)
+	if err != nil {
+		return nil, err
+	}
+
+	return reporter.Compare(beforeWalk, afterWalk)
+}
+
+// ReportFiles performs a report governed by the contents of the provided
+// ReportConfig of the two Walks at the provided file paths
+func ReportFiles(ctx context.Context, config *fspb.ReportConfig, beforeFile, afterFile string) (*fswalker.Report, error) {
+	tmpCfgFile, err := writeTempConfigFile(config)
+	if err != nil {
+		return nil, err
+	}
+
+	defer os.RemoveAll(tmpCfgFile) //nolint:errcheck
+
+	verbose := false
+
+	reporter, err := fswalker.ReporterFromConfigFile(ctx, tmpCfgFile, verbose)
+	if err != nil {
+		return nil, err
+	}
+
+	var before, after *fswalker.WalkFile
+
+	after, err = reporter.ReadWalk(ctx, afterFile)
+	if err != nil {
+		return nil, fmt.Errorf("file cannot be read: %s", afterFile)
+	}
+
+	if beforeFile != "" {
+		before, err = reporter.ReadWalk(ctx, beforeFile)
+		if err != nil {
+			return nil, fmt.Errorf("file cannot be read: %s", beforeFile)
+		}
+	}
+
+	return reporter.Compare(before.Walk, after.Walk)
+}
+
+func writeTempConfigFile(config *fspb.ReportConfig) (string, error) {
+	f, err := ioutil.TempFile("", "fswalker-report-config-")
+	if err != nil {
+		return "", err
+	}
+
+	f.Close() //nolint:errcheck
+
+	configFileName := f.Name()
+	err = protofile.WriteTextProto(configFileName, config)
+
+	return configFileName, err
+}

--- a/tests/tools/fswalker/reporter/reporter_test.go
+++ b/tests/tools/fswalker/reporter/reporter_test.go
@@ -1,0 +1,134 @@
+package reporter
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	fspb "github.com/google/fswalker/proto/fswalker"
+
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestReporterWithFiles(t *testing.T) {
+	ctx := context.TODO()
+
+	config := &fspb.ReportConfig{
+		Version:    1,
+		ExcludePfx: nil,
+	}
+
+	fileList := []*fspb.File{
+		{
+			Version: 0,
+			Path:    filepath.Join("some", "path"),
+			Info: &fspb.FileInfo{
+				Name: "this_is_a.file",
+				Size: 11235,
+				Mode: 0700,
+				Modified: &timestamp.Timestamp{
+					Seconds: 12,
+					Nanos:   0,
+				},
+				IsDir: false,
+			},
+			Stat: &fspb.FileStat{
+				Dev:     0,
+				Inode:   0,
+				Nlink:   0,
+				Mode:    0,
+				Uid:     0,
+				Gid:     0,
+				Rdev:    0,
+				Size:    0,
+				Blksize: 0,
+				Blocks:  0,
+				Atime: &timestamp.Timestamp{
+					Seconds: 0,
+					Nanos:   0,
+				},
+				Mtime: &timestamp.Timestamp{
+					Seconds: 0,
+					Nanos:   0,
+				},
+				Ctime: &timestamp.Timestamp{
+					Seconds: 0,
+					Nanos:   0,
+				},
+			},
+			Fingerprint: nil,
+		},
+	}
+
+	beforeWalk := &fspb.Walk{
+		Id:      "first-walk-ID",
+		Version: 1,
+		Policy: &fspb.Policy{
+			Version:              0,
+			Include:              nil,
+			ExcludePfx:           nil,
+			HashPfx:              nil,
+			MaxHashFileSize:      0,
+			WalkCrossDevice:      false,
+			IgnoreIrregularFiles: false,
+			MaxDirectoryDepth:    0,
+		},
+		File:         fileList,
+		Notification: nil,
+		Hostname:     "a-hostname",
+		StartWalk: &timestamp.Timestamp{
+			Seconds: 0,
+			Nanos:   0,
+		},
+		StopWalk: &timestamp.Timestamp{
+			Seconds: 0,
+			Nanos:   0,
+		},
+	}
+
+	afterWalk := &fspb.Walk{
+		Id:      "second-walk-ID",
+		Version: 1,
+		Policy: &fspb.Policy{
+			Version:              0,
+			Include:              nil,
+			ExcludePfx:           nil,
+			HashPfx:              nil,
+			MaxHashFileSize:      0,
+			WalkCrossDevice:      false,
+			IgnoreIrregularFiles: false,
+			MaxDirectoryDepth:    0,
+		},
+		File:         fileList,
+		Notification: nil,
+		Hostname:     "a-hostname",
+		StartWalk: &timestamp.Timestamp{
+			Seconds: 100,
+			Nanos:   0,
+		},
+		StopWalk: &timestamp.Timestamp{
+			Seconds: 101,
+			Nanos:   0,
+		},
+	}
+
+	report, err := Report(ctx, config, beforeWalk, afterWalk)
+	testenv.AssertNoError(t, err)
+
+	if got, want := len(report.Deleted), 0; got != want {
+		t.Errorf("Expected %d deleted files, but got %d", want, got)
+	}
+
+	if got, want := len(report.Added), 0; got != want {
+		t.Errorf("Expected %d added files, but got %d", want, got)
+	}
+
+	if got, want := len(report.Modified), 0; got != want {
+		t.Errorf("Expected %d modified files, but got %d", want, got)
+	}
+
+	if got, want := len(report.Errors), 0; got != want {
+		t.Errorf("Expected %d modified files, but got %d", want, got)
+	}
+}

--- a/tests/tools/fswalker/walker/walker_test.go
+++ b/tests/tools/fswalker/walker/walker_test.go
@@ -1,0 +1,63 @@
+package walker
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	fspb "github.com/google/fswalker/proto/fswalker"
+
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestWalk(t *testing.T) {
+	dataDir, err := ioutil.TempDir("", "walk-data-")
+	testenv.AssertNoError(t, err)
+
+	defer os.RemoveAll(dataDir)
+
+	counters := new(testenv.DirectoryTreeCounters)
+	err = testenv.CreateDirectoryTree(
+		dataDir,
+		testenv.DirectoryTreeOptions{
+			Depth:                  2,
+			MaxSubdirsPerDirectory: 2,
+			MaxFilesPerDirectory:   2,
+		},
+		counters,
+	)
+	testenv.AssertNoError(t, err)
+
+	walk, err := Walk(context.TODO(),
+		&fspb.Policy{
+			Include: []string{
+				dataDir,
+			},
+		})
+	testenv.AssertNoError(t, err)
+
+	fileList := walk.GetFile()
+	if got, want := len(fileList), counters.Files+counters.Directories; got != want {
+		t.Errorf("Expected number of walk entries (%v) to equal sum of file and dir counts (%v)", got, want)
+	}
+}
+
+func TestWalkFail(t *testing.T) {
+	_, err := Walk(
+		context.TODO(),
+		&fspb.Policy{
+			Include: []string{
+				"some/nonexistent/directory",
+			},
+		},
+	)
+	if err == nil {
+		t.Fatalf("Expected non-nil error when walk directory is not present")
+	}
+
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("Expected walk call to return an error for finding no directory but got %q", err.Error())
+	}
+}


### PR DESCRIPTION
Adds a wrapper around `Walk` that takes a Policy (protobuf definition) and performs a walk using it as configuration. The resulting Walk struct pointer is returned. The only exported functionality is unfortunately to read the Policy as a protobuf text file, so the implementation creates a temporary policy file whose lifetime is the duration of the call.

Adds a wrapper around the the FSWalker reporter `Compare` functionality. Takes a config file and two Walk pointers and compares the walks, returning the pb-defined Report struct. Again, the only exported functionality for reading config information is to read it as a protobuf text file. Creates a temporary config file, whose lifetime is the duration of the call, to pass in to the fswalker function.

This PR pertains to #179 