### PR TITLE
gcs: added --embed-credentials options which persists --credentials-file as part of Kopia configuration

### DIFF
--- a/cli/storage_gcs.go
+++ b/cli/storage_gcs.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"io/ioutil"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -12,6 +14,8 @@ import (
 func init() {
 	var options gcs.Options
 
+	var embedCredentials bool
+
 	RegisterStorageConnectFlags(
 		"google",
 		"a Google Cloud Storage bucket",
@@ -19,11 +23,22 @@ func init() {
 			cmd.Flag("bucket", "Name of the Google Cloud Storage bucket").Required().StringVar(&options.BucketName)
 			cmd.Flag("prefix", "Prefix to use for objects in the bucket").StringVar(&options.Prefix)
 			cmd.Flag("read-only", "Use read-only GCS scope to prevent write access").BoolVar(&options.ReadOnly)
-			cmd.Flag("credentials-file", "Use the provided JSON file with credentials").ExistingFileVar(&options.ServiceAccountCredentials)
+			cmd.Flag("credentials-file", "Use the provided JSON file with credentials").ExistingFileVar(&options.ServiceAccountCredentialsFile)
 			cmd.Flag("max-download-speed", "Limit the download speed.").PlaceHolder("BYTES_PER_SEC").IntVar(&options.MaxDownloadSpeedBytesPerSecond)
 			cmd.Flag("max-upload-speed", "Limit the upload speed.").PlaceHolder("BYTES_PER_SEC").IntVar(&options.MaxUploadSpeedBytesPerSecond)
+			cmd.Flag("embed-credentials", "Embed GCS credentials JSON in Kopia configuration").BoolVar(&embedCredentials)
 		},
 		func(ctx context.Context, isNew bool) (blob.Storage, error) {
+			if embedCredentials {
+				data, err := ioutil.ReadFile(options.ServiceAccountCredentialsFile)
+				if err != nil {
+					return nil, err
+				}
+
+				options.ServiceAccountCredentialJSON = json.RawMessage(data)
+				options.ServiceAccountCredentialsFile = ""
+			}
+
 			return gcs.New(ctx, &options)
 		},
 	)

--- a/repo/blob/gcs/gcs_options.go
+++ b/repo/blob/gcs/gcs_options.go
@@ -1,5 +1,7 @@
 package gcs
 
+import "encoding/json"
+
 // Options defines options Google Cloud Storage-backed storage.
 type Options struct {
 	// BucketName is the name of the GCS bucket where data is stored.
@@ -8,8 +10,11 @@ type Options struct {
 	// Prefix specifies additional string to prepend to all objects.
 	Prefix string `json:"prefix,omitempty"`
 
-	// ServiceAccountCredentials specifies the name of the file with GCS credentials.
-	ServiceAccountCredentials string `json:"credentialsFile,omitempty"`
+	// ServiceAccountCredentialsFile specifies the name of the file with GCS credentials.
+	ServiceAccountCredentialsFile string `json:"credentialsFile,omitempty"`
+
+	// ServiceAccountCredentialJSON specifies the raw JSON credentials.
+	ServiceAccountCredentialJSON json.RawMessage `kopia:"sensitive" json:"credentials,omitempty"`
 
 	// ReadOnly causes GCS connection to be opened with read-only scope to prevent accidental mutations.
 	ReadOnly bool `json:"readOnly,omitempty"`

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -2,6 +2,7 @@ package gcs_test
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -17,15 +18,15 @@ func TestGCSStorage(t *testing.T) {
 		t.Skip("KOPIA_GCS_TEST_BUCKET not provided")
 	}
 
-	credsFile := os.Getenv("KOPIA_GCS_CREDENTIALS_FILE")
-	if _, err := os.Stat(credsFile); err != nil {
+	credData, err := ioutil.ReadFile(os.Getenv("KOPIA_GCS_CREDENTIALS_FILE"))
+	if err != nil {
 		t.Skip("skipping test because GCS credentials file can't be opened")
 	}
 
 	ctx := context.Background()
 	st, err := gcs.New(ctx, &gcs.Options{
-		BucketName:                bucket,
-		ServiceAccountCredentials: credsFile,
+		BucketName:                   bucket,
+		ServiceAccountCredentialJSON: credData,
 	})
 
 	if err != nil {
@@ -61,8 +62,8 @@ func TestGCSStorageInvalid(t *testing.T) {
 
 	ctx := context.Background()
 	st, err := gcs.New(ctx, &gcs.Options{
-		BucketName:                bucket + "-no-such-bucket",
-		ServiceAccountCredentials: os.Getenv("KOPIA_GCS_CREDENTIALS_FILE"),
+		BucketName:                    bucket + "-no-such-bucket",
+		ServiceAccountCredentialsFile: os.Getenv("KOPIA_GCS_CREDENTIALS_FILE"),
 	})
 
 	if err != nil {


### PR DESCRIPTION
This enables credentials file to be discarded and makes `kopia repo status -st` fully round-trippable even when the credentials file is gone.