### PR TITLE
kopia-ui: UI/API server security (TLS & basic auth)

### DIFF
--- a/app/public/server.js
+++ b/app/public/server.js
@@ -6,6 +6,37 @@ const { defaultServerBinary } = require('./utils');
 const { spawn } = require('child_process');
 
 let serverProcess = null;
+let serverCertSHA256 = "";
+let serverPassword = "";
+let serverAddress = "";
+
+function detectServerParam(data) {
+    let lines = (data + '').split('\n');
+    for (let i = 0; i < lines.length; i++) {
+        const p = lines[i].indexOf(": ");
+        if (p < 0) {
+            continue
+        }
+
+        const key = lines[i].substring(0, p);
+        const value = lines[i].substring(p + 2);
+        switch (key) {
+            case "SERVER PASSWORD":
+                serverPassword = value;
+                break;
+
+            case "SERVER CERT SHA256":
+                serverCertSHA256 = value;
+                break;
+
+            case "SERVER ADDRESS":
+                serverAddress = value;
+                break;
+        }
+    }
+
+    appendToLog(data);
+}
 
 function startServer() {
     let kopiaPath = config.get('kopiaPath');
@@ -22,12 +53,16 @@ function startServer() {
 
     args.push('server', '--ui');
 
+    args.push('--random-password')
+    args.push('--tls-generate-cert')
+    // args.push('--auto-shutdown=600s')
+
     console.log(`spawning ${kopiaPath} ${args.join(' ')}`);
     serverProcess = spawn(kopiaPath, args);
     ipcMain.emit('server-status-updated');
 
     serverProcess.stdout.on('data', appendToLog);
-    serverProcess.stderr.on('data', appendToLog);
+    serverProcess.stderr.on('data', detectServerParam);
 
     serverProcess.on('close', (code, signal) => {
         appendToLog(`child process exited with code ${code} and signal ${signal}`);
@@ -79,6 +114,18 @@ module.exports = {
         if (!config.get('remoteServer')) {
             startServer();
         }
+    },
+
+    getServerAddress() {
+        return serverAddress;
+    },
+
+    getServerCertSHA256() {
+        return serverCertSHA256;
+    },
+
+    getServerPassword() {
+        return serverPassword;
     },
 
     stopServer: stopServer,


### PR DESCRIPTION
This automatically launches Kopia CLI with new flags:

`--tls-generate-cert` which generates in-memory TLS certs for the server
and prints its fingerprint to stderr.

`--random-password` which sets up random basic auth password

KopiaUI will then listen to the stderr messages and parse the cert
fingerprint and password and automatically provide them in the browser
it opens to show the UI.

This ensures that any local process (or script in a browser, etc.)
other than KopiaUI itself won't have access to the server API nor
UI because they won't know the ephemeral random password and won't
be able to intercept it due to TLS protection.