### PR TITLE
Ignore read errors based on policy settings

### DIFF
--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -165,7 +165,7 @@ func setErrorHandlingPolicyFromFlags(fp *policy.ErrorHandlingPolicy, changeCount
 	case *policyIgnoreFileErrors == inheritPolicyString:
 		*changeCount++
 
-		fp.IgnoreFileErrorsSet = false
+		fp.IgnoreFileErrors = nil
 
 		printStderr(" - inherit file read error behavior from parent\n")
 	default:
@@ -176,8 +176,7 @@ func setErrorHandlingPolicyFromFlags(fp *policy.ErrorHandlingPolicy, changeCount
 
 		*changeCount++
 
-		fp.IgnoreFileErrors = val
-		fp.IgnoreFileErrorsSet = true
+		fp.IgnoreFileErrors = &val
 
 		printStderr(" - setting ignore file read errors to %v\n", val)
 	}
@@ -187,7 +186,7 @@ func setErrorHandlingPolicyFromFlags(fp *policy.ErrorHandlingPolicy, changeCount
 	case *policyIgnoreDirectoryErrors == inheritPolicyString:
 		*changeCount++
 
-		fp.IgnoreDirectoryErrorsSet = false
+		fp.IgnoreDirectoryErrors = nil
 
 		printStderr(" - inherit directory read error behavior from parent\n")
 	default:
@@ -198,8 +197,7 @@ func setErrorHandlingPolicyFromFlags(fp *policy.ErrorHandlingPolicy, changeCount
 
 		*changeCount++
 
-		fp.IgnoreDirectoryErrors = val
-		fp.IgnoreDirectoryErrorsSet = true
+		fp.IgnoreDirectoryErrors = &val
 
 		printStderr(" - setting ignore directory read errors to %v\n", val)
 	}

--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kopia/kopia/snapshot/policy"
+)
+
+func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
+	initialFileFlagVal := *policyIgnoreFileErrors
+	initialDirFlagVal := *policyIgnoreDirectoryErrors
+
+	defer func() {
+		*policyIgnoreFileErrors = initialFileFlagVal
+		*policyIgnoreDirectoryErrors = initialDirFlagVal
+	}()
+
+	for _, tc := range []struct {
+		name           string
+		startingPolicy *policy.ErrorHandlingPolicy
+		fileArg        string
+		dirArg         string
+		expResult      *policy.ErrorHandlingPolicy
+		expErr         bool
+		expChangeCount int
+	}{
+		{
+			name: "No values provided as command line arguments",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			fileArg: "",
+			dirArg:  "",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 0,
+		},
+		{
+			name:           "Malformed arguments",
+			startingPolicy: &policy.ErrorHandlingPolicy{},
+			fileArg:        "not-true-or-false",
+			dirArg:         "not-even-inherit",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			expErr:         true,
+			expChangeCount: 0,
+		},
+		{
+			name:           "One is malformed, the other well formed",
+			startingPolicy: &policy.ErrorHandlingPolicy{},
+			fileArg:        "true",
+			dirArg:         "some-malformed-arg",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			expErr:         true,
+			expChangeCount: 1,
+		},
+		{
+			name: "Inherit case",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			fileArg: "inherit",
+			dirArg:  "inherit",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name:           "Set to true",
+			startingPolicy: &policy.ErrorHandlingPolicy{},
+			fileArg:        "true",
+			dirArg:         "true",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "Set to false",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:      true,
+				IgnoreDirectoryErrors: true,
+			},
+			fileArg: "false",
+			dirArg:  "false",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "File false, dir true",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:      true,
+				IgnoreDirectoryErrors: true,
+			},
+			fileArg: "false",
+			dirArg:  "true",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "File true, dir false",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:      true,
+				IgnoreDirectoryErrors: true,
+			},
+			fileArg: "true",
+			dirArg:  "false",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "File inherit, dir true",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:      true,
+				IgnoreDirectoryErrors: true,
+			},
+			fileArg: "inherit",
+			dirArg:  "true",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "File true, dir inherit",
+			startingPolicy: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:      true,
+				IgnoreDirectoryErrors: true,
+			},
+			fileArg: "true",
+			dirArg:  "inherit",
+			expResult: &policy.ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+	} {
+		t.Log(tc.name)
+
+		changeCount := 0
+
+		*policyIgnoreFileErrors = tc.fileArg
+		*policyIgnoreDirectoryErrors = tc.dirArg
+
+		setErrorHandlingPolicyFromFlags(tc.startingPolicy, &changeCount)
+
+		if !reflect.DeepEqual(tc.startingPolicy, tc.expResult) {
+			t.Errorf("Did not get expected output: (actual) %v != %v (expected)", tc.startingPolicy, tc.expResult)
+		}
+	}
+}

--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -28,18 +28,14 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 		{
 			name: "No values provided as command line arguments",
 			startingPolicy: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: newBool(true),
 			},
 			fileArg: "",
 			dirArg:  "",
 			expResult: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: newBool(true),
 			},
 			expErr:         false,
 			expChangeCount: 0,
@@ -50,10 +46,8 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 			fileArg:        "not-true-or-false",
 			dirArg:         "not-even-inherit",
 			expResult: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
+				IgnoreFileErrors:      nil,
+				IgnoreDirectoryErrors: nil,
 			},
 			expErr:         true,
 			expChangeCount: 0,
@@ -64,27 +58,20 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 			fileArg:        "true",
 			dirArg:         "some-malformed-arg",
 			expResult: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: nil,
 			},
 			expErr:         true,
 			expChangeCount: 1,
 		},
 		{
-			name: "Inherit case",
-			startingPolicy: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrorsSet: true,
-			},
-			fileArg: "inherit",
-			dirArg:  "inherit",
+			name:           "Inherit case",
+			startingPolicy: &policy.ErrorHandlingPolicy{},
+			fileArg:        "inherit",
+			dirArg:         "inherit",
 			expResult: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
+				IgnoreFileErrors:      nil,
+				IgnoreDirectoryErrors: nil,
 			},
 			expErr:         false,
 			expChangeCount: 2,
@@ -95,10 +82,8 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 			fileArg:        "true",
 			dirArg:         "true",
 			expResult: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: newBool(true),
 			},
 			expErr:         false,
 			expChangeCount: 2,
@@ -106,16 +91,14 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 		{
 			name: "Set to false",
 			startingPolicy: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:      true,
-				IgnoreDirectoryErrors: true,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: newBool(true),
 			},
 			fileArg: "false",
 			dirArg:  "false",
 			expResult: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(false),
+				IgnoreDirectoryErrors: newBool(false),
 			},
 			expErr:         false,
 			expChangeCount: 2,
@@ -123,16 +106,14 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 		{
 			name: "File false, dir true",
 			startingPolicy: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:      true,
-				IgnoreDirectoryErrors: true,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: newBool(false),
 			},
 			fileArg: "false",
 			dirArg:  "true",
 			expResult: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(false),
+				IgnoreDirectoryErrors: newBool(true),
 			},
 			expErr:         false,
 			expChangeCount: 2,
@@ -140,16 +121,14 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 		{
 			name: "File true, dir false",
 			startingPolicy: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:      true,
-				IgnoreDirectoryErrors: true,
+				IgnoreFileErrors:      newBool(false),
+				IgnoreDirectoryErrors: newBool(true),
 			},
 			fileArg: "true",
 			dirArg:  "false",
 			expResult: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: newBool(false),
 			},
 			expErr:         false,
 			expChangeCount: 2,
@@ -157,16 +136,14 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 		{
 			name: "File inherit, dir true",
 			startingPolicy: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:      true,
-				IgnoreDirectoryErrors: true,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: newBool(false),
 			},
 			fileArg: "inherit",
 			dirArg:  "true",
 			expResult: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      nil,
+				IgnoreDirectoryErrors: newBool(true),
 			},
 			expErr:         false,
 			expChangeCount: 2,
@@ -174,16 +151,14 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 		{
 			name: "File true, dir inherit",
 			startingPolicy: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:      true,
-				IgnoreDirectoryErrors: true,
+				IgnoreFileErrors:      newBool(false),
+				IgnoreDirectoryErrors: newBool(true),
 			},
 			fileArg: "true",
 			dirArg:  "inherit",
 			expResult: &policy.ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: false,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: nil,
 			},
 			expErr:         false,
 			expChangeCount: 2,
@@ -202,4 +177,8 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 			t.Errorf("Did not get expected output: (actual) %v != %v (expected)", tc.startingPolicy, tc.expResult)
 		}
 	}
+}
+
+func newBool(b bool) *bool {
+	return &b
 }

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -80,6 +80,8 @@ func printPolicy(p *policy.Policy, parents []*policy.Policy) {
 	printStdout("\n")
 	printFilesPolicy(p, parents)
 	printStdout("\n")
+	printErrorHandlingPolicy(p, parents)
+	printStdout("\n")
 	printSchedulingPolicy(p, parents)
 	printStdout("\n")
 	printCompressionPolicy(p, parents)
@@ -153,6 +155,22 @@ func printFilesPolicy(p *policy.Policy, parents []*policy.Policy) {
 				return pol.FilesPolicy.MaxFileSize != 0
 			}))
 	}
+}
+
+func printErrorHandlingPolicy(p *policy.Policy, parents []*policy.Policy) {
+	printStdout("Error handling policy:\n")
+
+	printStdout("  Ignore file read errors:       %5v       %v\n",
+		p.ErrorHandlingPolicy.IgnoreFileErrors,
+		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
+			return pol.ErrorHandlingPolicy.IgnoreFileErrorsSet
+		}))
+
+	printStdout("  Ignore directory read errors:  %5v       %v\n",
+		p.ErrorHandlingPolicy.IgnoreDirectoryErrors,
+		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
+			return pol.ErrorHandlingPolicy.IgnoreDirectoryErrorsSet
+		}))
 }
 
 func printSchedulingPolicy(p *policy.Policy, parents []*policy.Policy) {

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -163,13 +163,13 @@ func printErrorHandlingPolicy(p *policy.Policy, parents []*policy.Policy) {
 	printStdout("  Ignore file read errors:       %5v       %v\n",
 		p.ErrorHandlingPolicy.IgnoreFileErrors,
 		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
-			return pol.ErrorHandlingPolicy.IgnoreFileErrorsSet
+			return pol.ErrorHandlingPolicy.IgnoreFileErrors != nil
 		}))
 
 	printStdout("  Ignore directory read errors:  %5v       %v\n",
 		p.ErrorHandlingPolicy.IgnoreDirectoryErrors,
 		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
-			return pol.ErrorHandlingPolicy.IgnoreDirectoryErrorsSet
+			return pol.ErrorHandlingPolicy.IgnoreDirectoryErrors != nil
 		}))
 }
 

--- a/cli/command_snapshot_migrate.go
+++ b/cli/command_snapshot_migrate.go
@@ -72,7 +72,7 @@ func runMigrateCommand(ctx context.Context, destRepo *repo.Repository) error {
 
 		uploader := snapshotfs.NewUploader(destRepo)
 		uploader.Progress = cliProgress
-		uploader.IgnoreFileErrors = *migrateIgnoreErrors
+		uploader.IgnoreReadErrors = *migrateIgnoreErrors
 		activeUploaders[s] = uploader
 		mu.Unlock()
 

--- a/snapshot/policy/error_handling_policy.go
+++ b/snapshot/policy/error_handling_policy.go
@@ -1,0 +1,37 @@
+package policy
+
+// ErrorHandlingPolicy controls error hadnling behavior when taking snapshots.
+type ErrorHandlingPolicy struct {
+	// IgnoreFileErrors controls whether or not snapshot operation should terminate when a file throws an error on being read
+	IgnoreFileErrors bool `json:"ignoreFileErrs,omitempty"`
+
+	// IgnoreFileErrorSet denotes whether the IgnoreFileErrors bool was actually set in this policy, or if it should be inherited
+	IgnoreFileErrorsSet bool `json:"ignoreFileErrsSet,omitempty"`
+
+	// IgnoreDirectoryErrors controls whether or not snapshot operation should terminate when a directory throws an error on being read or opened
+	IgnoreDirectoryErrors bool `json:"ignoreDirErrs,omitempty"`
+
+	// IgnoreDirectoryErrorsSet denotes whether the IgnoreDirectoryErrors bool was actually set in this policy, or if it should be inherited
+	IgnoreDirectoryErrorsSet bool `json:"ignoreDirErrsSet,omitempty"`
+}
+
+// Merge applies default values from the provided policy.
+func (p *ErrorHandlingPolicy) Merge(src ErrorHandlingPolicy) {
+	if !p.IgnoreFileErrorsSet && src.IgnoreFileErrorsSet {
+		p.IgnoreFileErrors = src.IgnoreFileErrors
+		p.IgnoreFileErrorsSet = true
+	}
+
+	if !p.IgnoreDirectoryErrorsSet && src.IgnoreDirectoryErrorsSet {
+		p.IgnoreDirectoryErrors = src.IgnoreDirectoryErrors
+		p.IgnoreDirectoryErrorsSet = true
+	}
+}
+
+// defaultErrorHandlingPolicy is the default error handling policy.
+var defaultErrorHandlingPolicy = ErrorHandlingPolicy{
+	IgnoreFileErrors:         false,
+	IgnoreFileErrorsSet:      true,
+	IgnoreDirectoryErrors:    false,
+	IgnoreDirectoryErrorsSet: true,
+}

--- a/snapshot/policy/error_handling_policy.go
+++ b/snapshot/policy/error_handling_policy.go
@@ -3,35 +3,29 @@ package policy
 // ErrorHandlingPolicy controls error hadnling behavior when taking snapshots.
 type ErrorHandlingPolicy struct {
 	// IgnoreFileErrors controls whether or not snapshot operation should terminate when a file throws an error on being read
-	IgnoreFileErrors bool `json:"ignoreFileErrs,omitempty"`
-
-	// IgnoreFileErrorSet denotes whether the IgnoreFileErrors bool was actually set in this policy, or if it should be inherited
-	IgnoreFileErrorsSet bool `json:"ignoreFileErrsSet,omitempty"`
+	IgnoreFileErrors *bool `json:"ignoreFileErrors,omitempty"`
 
 	// IgnoreDirectoryErrors controls whether or not snapshot operation should terminate when a directory throws an error on being read or opened
-	IgnoreDirectoryErrors bool `json:"ignoreDirErrs,omitempty"`
-
-	// IgnoreDirectoryErrorsSet denotes whether the IgnoreDirectoryErrors bool was actually set in this policy, or if it should be inherited
-	IgnoreDirectoryErrorsSet bool `json:"ignoreDirErrsSet,omitempty"`
+	IgnoreDirectoryErrors *bool `json:"ignoreDirectoryErrors,omitempty"`
 }
 
 // Merge applies default values from the provided policy.
 func (p *ErrorHandlingPolicy) Merge(src ErrorHandlingPolicy) {
-	if !p.IgnoreFileErrorsSet && src.IgnoreFileErrorsSet {
-		p.IgnoreFileErrors = src.IgnoreFileErrors
-		p.IgnoreFileErrorsSet = true
+	if p.IgnoreFileErrors == nil && src.IgnoreFileErrors != nil {
+		p.IgnoreFileErrors = newBool(*src.IgnoreFileErrors)
 	}
 
-	if !p.IgnoreDirectoryErrorsSet && src.IgnoreDirectoryErrorsSet {
-		p.IgnoreDirectoryErrors = src.IgnoreDirectoryErrors
-		p.IgnoreDirectoryErrorsSet = true
+	if p.IgnoreDirectoryErrors == nil && src.IgnoreDirectoryErrors != nil {
+		p.IgnoreDirectoryErrors = newBool(*src.IgnoreDirectoryErrors)
 	}
 }
 
 // defaultErrorHandlingPolicy is the default error handling policy.
 var defaultErrorHandlingPolicy = ErrorHandlingPolicy{
-	IgnoreFileErrors:         false,
-	IgnoreFileErrorsSet:      true,
-	IgnoreDirectoryErrors:    false,
-	IgnoreDirectoryErrorsSet: true,
+	IgnoreFileErrors:      newBool(false),
+	IgnoreDirectoryErrors: newBool(false),
+}
+
+func newBool(b bool) *bool {
+	return &b
 }

--- a/snapshot/policy/error_handling_policy_test.go
+++ b/snapshot/policy/error_handling_policy_test.go
@@ -1,0 +1,248 @@
+package policy
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestErrorHandlingPolicyMerge(t *testing.T) {
+	type fields struct {
+		IgnoreFileErrors         bool
+		IgnoreFileErrorsSet      bool
+		IgnoreDirectoryErrors    bool
+		IgnoreDirectoryErrorsSet bool
+	}
+
+	type args struct {
+		src ErrorHandlingPolicy
+	}
+
+	for _, tt := range []struct {
+		name      string
+		fields    fields
+		args      args
+		expResult ErrorHandlingPolicy
+	}{
+		{
+			name: "Policy being merged has no value set - expect no change",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      false,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: false,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+		},
+		{
+			name: "Policy being merged has a true value but it wasn't actually set - expect no change",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         true,
+					IgnoreFileErrorsSet:      false,
+					IgnoreDirectoryErrors:    true,
+					IgnoreDirectoryErrorsSet: false,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+		},
+		{
+			name: "Starting policy has a true value but not set - expect no change",
+			fields: fields{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      false,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: false,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: false,
+			},
+		},
+		{
+			name: "Policy being merged has a value set at false - expect result to have value set at false",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+		{
+			name: "Policy being merged has a value set at true - expect result to have value set at true",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         true,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    true,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+		{
+			name: "Starting policy already has a value set at false - expect no change from merged policy",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         true,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    true,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+		{
+			name: "Value was true in starting policy but not set - expect to be overridden by incoming policy",
+			fields: fields{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+		{
+			name: "Policy being merged has a value set at true - expect no change from merged policy",
+			fields: fields{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      true,
+					IgnoreDirectoryErrors:    false,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         true,
+				IgnoreFileErrorsSet:      true,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+		{
+			name: "Change just one param",
+			fields: fields{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    false,
+				IgnoreDirectoryErrorsSet: false,
+			},
+			args: args{
+				src: ErrorHandlingPolicy{
+					IgnoreFileErrors:         false,
+					IgnoreFileErrorsSet:      false,
+					IgnoreDirectoryErrors:    true,
+					IgnoreDirectoryErrorsSet: true,
+				},
+			},
+			expResult: ErrorHandlingPolicy{
+				IgnoreFileErrors:         false,
+				IgnoreFileErrorsSet:      false,
+				IgnoreDirectoryErrors:    true,
+				IgnoreDirectoryErrorsSet: true,
+			},
+		},
+	} {
+		t.Log(tt.name)
+
+		p := &ErrorHandlingPolicy{
+			IgnoreFileErrors:         tt.fields.IgnoreFileErrors,
+			IgnoreFileErrorsSet:      tt.fields.IgnoreFileErrorsSet,
+			IgnoreDirectoryErrors:    tt.fields.IgnoreDirectoryErrors,
+			IgnoreDirectoryErrorsSet: tt.fields.IgnoreDirectoryErrorsSet,
+		}
+		p.Merge(tt.args.src)
+
+		if !reflect.DeepEqual(*p, tt.expResult) {
+			t.Errorf("Policy after merge was not what was expected\n%v != %v", p, tt.expResult)
+		}
+	}
+}

--- a/snapshot/policy/error_handling_policy_test.go
+++ b/snapshot/policy/error_handling_policy_test.go
@@ -7,10 +7,8 @@ import (
 
 func TestErrorHandlingPolicyMerge(t *testing.T) {
 	type fields struct {
-		IgnoreFileErrors         bool
-		IgnoreFileErrorsSet      bool
-		IgnoreDirectoryErrors    bool
-		IgnoreDirectoryErrorsSet bool
+		IgnoreFileErrors      *bool
+		IgnoreDirectoryErrors *bool
 	}
 
 	type args struct {
@@ -26,218 +24,111 @@ func TestErrorHandlingPolicyMerge(t *testing.T) {
 		{
 			name: "Policy being merged has no value set - expect no change",
 			fields: fields{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
+				IgnoreFileErrors:      nil,
+				IgnoreDirectoryErrors: nil,
 			},
 			args: args{
 				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         false,
-					IgnoreFileErrorsSet:      false,
-					IgnoreDirectoryErrors:    false,
-					IgnoreDirectoryErrorsSet: false,
+					IgnoreFileErrors:      nil,
+					IgnoreDirectoryErrors: nil,
 				},
 			},
 			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
-			},
-		},
-		{
-			name: "Policy being merged has a true value but it wasn't actually set - expect no change",
-			fields: fields{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
-			},
-			args: args{
-				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         true,
-					IgnoreFileErrorsSet:      false,
-					IgnoreDirectoryErrors:    true,
-					IgnoreDirectoryErrorsSet: false,
-				},
-			},
-			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
-			},
-		},
-		{
-			name: "Starting policy has a true value but not set - expect no change",
-			fields: fields{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: false,
-			},
-			args: args{
-				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         false,
-					IgnoreFileErrorsSet:      false,
-					IgnoreDirectoryErrors:    false,
-					IgnoreDirectoryErrorsSet: false,
-				},
-			},
-			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: false,
+				IgnoreFileErrors:      nil,
+				IgnoreDirectoryErrors: nil,
 			},
 		},
 		{
 			name: "Policy being merged has a value set at false - expect result to have value set at false",
 			fields: fields{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
+				IgnoreFileErrors:      nil,
+				IgnoreDirectoryErrors: nil,
 			},
 			args: args{
 				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         false,
-					IgnoreFileErrorsSet:      true,
-					IgnoreDirectoryErrors:    false,
-					IgnoreDirectoryErrorsSet: true,
+					IgnoreFileErrors:      newBool(false),
+					IgnoreDirectoryErrors: newBool(false),
 				},
 			},
 			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(false),
+				IgnoreDirectoryErrors: newBool(false),
 			},
 		},
 		{
 			name: "Policy being merged has a value set at true - expect result to have value set at true",
 			fields: fields{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
+				IgnoreFileErrors:      nil,
+				IgnoreDirectoryErrors: nil,
 			},
 			args: args{
 				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         true,
-					IgnoreFileErrorsSet:      true,
-					IgnoreDirectoryErrors:    true,
-					IgnoreDirectoryErrorsSet: true,
+					IgnoreFileErrors:      newBool(true),
+					IgnoreDirectoryErrors: newBool(true),
 				},
 			},
 			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: newBool(true),
 			},
 		},
 		{
 			name: "Starting policy already has a value set at false - expect no change from merged policy",
 			fields: fields{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(false),
+				IgnoreDirectoryErrors: newBool(false),
 			},
 			args: args{
 				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         true,
-					IgnoreFileErrorsSet:      true,
-					IgnoreDirectoryErrors:    true,
-					IgnoreDirectoryErrorsSet: true,
+					IgnoreFileErrors:      newBool(true),
+					IgnoreDirectoryErrors: newBool(true),
 				},
 			},
 			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: true,
-			},
-		},
-		{
-			name: "Value was true in starting policy but not set - expect to be overridden by incoming policy",
-			fields: fields{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: false,
-			},
-			args: args{
-				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         false,
-					IgnoreFileErrorsSet:      true,
-					IgnoreDirectoryErrors:    false,
-					IgnoreDirectoryErrorsSet: true,
-				},
-			},
-			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(false),
+				IgnoreDirectoryErrors: newBool(false),
 			},
 		},
 		{
 			name: "Policy being merged has a value set at true - expect no change from merged policy",
 			fields: fields{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: newBool(true),
 			},
 			args: args{
 				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         false,
-					IgnoreFileErrorsSet:      true,
-					IgnoreDirectoryErrors:    false,
-					IgnoreDirectoryErrorsSet: true,
+					IgnoreFileErrors:      newBool(false),
+					IgnoreDirectoryErrors: newBool(false),
 				},
 			},
 			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         true,
-				IgnoreFileErrorsSet:      true,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      newBool(true),
+				IgnoreDirectoryErrors: newBool(true),
 			},
 		},
 		{
 			name: "Change just one param",
 			fields: fields{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    false,
-				IgnoreDirectoryErrorsSet: false,
+				IgnoreFileErrors:      nil,
+				IgnoreDirectoryErrors: nil,
 			},
 			args: args{
 				src: ErrorHandlingPolicy{
-					IgnoreFileErrors:         false,
-					IgnoreFileErrorsSet:      false,
-					IgnoreDirectoryErrors:    true,
-					IgnoreDirectoryErrorsSet: true,
+					IgnoreFileErrors:      nil,
+					IgnoreDirectoryErrors: newBool(true),
 				},
 			},
 			expResult: ErrorHandlingPolicy{
-				IgnoreFileErrors:         false,
-				IgnoreFileErrorsSet:      false,
-				IgnoreDirectoryErrors:    true,
-				IgnoreDirectoryErrorsSet: true,
+				IgnoreFileErrors:      nil,
+				IgnoreDirectoryErrors: newBool(true),
 			},
 		},
 	} {
 		t.Log(tt.name)
 
 		p := &ErrorHandlingPolicy{
-			IgnoreFileErrors:         tt.fields.IgnoreFileErrors,
-			IgnoreFileErrorsSet:      tt.fields.IgnoreFileErrorsSet,
-			IgnoreDirectoryErrors:    tt.fields.IgnoreDirectoryErrors,
-			IgnoreDirectoryErrorsSet: tt.fields.IgnoreDirectoryErrorsSet,
+			IgnoreFileErrors:      tt.fields.IgnoreFileErrors,
+			IgnoreDirectoryErrors: tt.fields.IgnoreDirectoryErrors,
 		}
 		p.Merge(tt.args.src)
 

--- a/snapshot/policy/policy.go
+++ b/snapshot/policy/policy.go
@@ -13,12 +13,13 @@ var ErrPolicyNotFound = errors.New("policy not found")
 
 // Policy describes snapshot policy for a single source.
 type Policy struct {
-	Labels            map[string]string `json:"-"`
-	RetentionPolicy   RetentionPolicy   `json:"retention,omitempty"`
-	FilesPolicy       FilesPolicy       `json:"files,omitempty"`
-	SchedulingPolicy  SchedulingPolicy  `json:"scheduling,omitempty"`
-	CompressionPolicy CompressionPolicy `json:"compression,omitempty"`
-	NoParent          bool              `json:"noParent,omitempty"`
+	Labels              map[string]string   `json:"-"`
+	RetentionPolicy     RetentionPolicy     `json:"retention,omitempty"`
+	FilesPolicy         FilesPolicy         `json:"files,omitempty"`
+	ErrorHandlingPolicy ErrorHandlingPolicy `json:"errorhandling,omitempty"`
+	SchedulingPolicy    SchedulingPolicy    `json:"scheduling,omitempty"`
+	CompressionPolicy   CompressionPolicy   `json:"compression,omitempty"`
+	NoParent            bool                `json:"noParent,omitempty"`
 }
 
 func (p *Policy) String() string {
@@ -59,6 +60,7 @@ func MergePolicies(policies []*Policy) *Policy {
 
 		merged.RetentionPolicy.Merge(p.RetentionPolicy)
 		merged.FilesPolicy.Merge(p.FilesPolicy)
+		merged.ErrorHandlingPolicy.Merge(p.ErrorHandlingPolicy)
 		merged.SchedulingPolicy.Merge(p.SchedulingPolicy)
 		merged.CompressionPolicy.Merge(p.CompressionPolicy)
 	}
@@ -66,6 +68,7 @@ func MergePolicies(policies []*Policy) *Policy {
 	// Merge default expiration policy.
 	merged.RetentionPolicy.Merge(defaultRetentionPolicy)
 	merged.FilesPolicy.Merge(defaultFilesPolicy)
+	merged.ErrorHandlingPolicy.Merge(defaultErrorHandlingPolicy)
 	merged.SchedulingPolicy.Merge(defaultSchedulingPolicy)
 	merged.CompressionPolicy.Merge(defaultCompressionPolicy)
 

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -36,8 +36,8 @@ type Uploader struct {
 	// automatically cancel the Upload after certain number of bytes
 	MaxUploadBytes int64
 
-	// ignore file read errors
-	IgnoreFileErrors bool
+	// ignore read errors
+	IgnoreReadErrors bool
 
 	// probability with cached entries will be ignored, must be [0..100]
 	// 0=always use cached object entries if possible
@@ -329,6 +329,14 @@ func (u *Uploader) processSubdirectories(ctx context.Context, relativePath strin
 		}
 
 		if err != nil {
+			// Note: This only catches errors in subdirectories of the snapshot root, not on the snapshot
+			// root itself. The intention is to always fail if the top level directory can't be read,
+			// otherwise a meaningless, empty snapshot is created that can't be restored.
+			ignoreDirErr := u.IgnoreReadErrors || policyTree.EffectivePolicy().ErrorHandlingPolicy.IgnoreDirectoryErrors
+			if _, ok := err.(dirReadError); ok && ignoreDirErr {
+				log.Warningf("unable to read directory %q: %s, ignoring", dir.Name(), err)
+				return nil
+			}
 			return errors.Errorf("unable to process directory %q: %s", entry.Name(), err)
 		}
 
@@ -536,7 +544,7 @@ func (u *Uploader) launchWorkItems(workItems []*uploadWorkItem, wg *sync.WaitGro
 	}
 }
 
-func (u *Uploader) processUploadWorkItems(workItems []*uploadWorkItem, dirManifest *snapshot.DirManifest) error {
+func (u *Uploader) processUploadWorkItems(workItems []*uploadWorkItem, dirManifest *snapshot.DirManifest, ignoreFileErrs bool) error {
 	var wg sync.WaitGroup
 
 	u.launchWorkItems(workItems, &wg)
@@ -550,7 +558,7 @@ func (u *Uploader) processUploadWorkItems(workItems []*uploadWorkItem, dirManife
 		}
 
 		if result.err != nil {
-			if u.IgnoreFileErrors {
+			if ignoreFileErrs {
 				u.stats.ReadErrors++
 
 				log.Warningf("unable to hash file %q: %s, ignoring", it.entryRelativePath, result.err)
@@ -606,6 +614,11 @@ func uniqueDirectories(dirs []fs.Directory) []fs.Directory {
 	return result
 }
 
+// dirReadError distinguishes an error thrown when attempting to read a directory
+type dirReadError struct {
+	error
+}
+
 func uploadDirInternal(
 	ctx context.Context,
 	u *Uploader,
@@ -630,7 +643,7 @@ func uploadDirInternal(
 	log.Debugf("finished reading directory %v", dirRelativePath)
 
 	if direrr != nil {
-		return "", fs.DirectorySummary{}, direrr
+		return "", fs.DirectorySummary{}, dirReadError{direrr}
 	}
 
 	var prevEntries []fs.Entries
@@ -663,7 +676,10 @@ func uploadDirInternal(
 		return "", fs.DirectorySummary{}, workItemErr
 	}
 
-	if err := u.processUploadWorkItems(workItems, dirManifest); err != nil && err != errCancelled {
+	errHandlingPolicy := policyTree.EffectivePolicy().ErrorHandlingPolicy
+	ignoreFileErrs := u.IgnoreReadErrors || errHandlingPolicy.IgnoreFileErrors
+
+	if err := u.processUploadWorkItems(workItems, dirManifest, ignoreFileErrs); err != nil && err != errCancelled {
 		return "", fs.DirectorySummary{}, err
 	}
 
@@ -690,7 +706,7 @@ func NewUploader(r *repo.Repository) *Uploader {
 	return &Uploader{
 		repo:             r,
 		Progress:         &nullUploadProgress{},
-		IgnoreFileErrors: true,
+		IgnoreReadErrors: false,
 		ParallelUploads:  1,
 	}
 }

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -701,12 +701,30 @@ func uploadDirInternal(
 
 func (u *Uploader) shouldIgnoreFileReadErrors(policyTree *policy.Tree) bool {
 	errHandlingPolicy := policyTree.EffectivePolicy().ErrorHandlingPolicy
-	return u.IgnoreReadErrors || (errHandlingPolicy.IgnoreFileErrors != nil && *errHandlingPolicy.IgnoreFileErrors)
+
+	if u.IgnoreReadErrors {
+		return true
+	}
+
+	if errHandlingPolicy.IgnoreFileErrors != nil {
+		return *errHandlingPolicy.IgnoreFileErrors
+	}
+
+	return false
 }
 
 func (u *Uploader) shouldIgnoreDirectoryReadErrors(policyTree *policy.Tree) bool {
 	errHandlingPolicy := policyTree.EffectivePolicy().ErrorHandlingPolicy
-	return u.IgnoreReadErrors || (errHandlingPolicy.IgnoreDirectoryErrors != nil && *errHandlingPolicy.IgnoreDirectoryErrors)
+
+	if u.IgnoreReadErrors {
+		return true
+	}
+
+	if errHandlingPolicy.IgnoreDirectoryErrors != nil {
+		return *errHandlingPolicy.IgnoreDirectoryErrors
+	}
+
+	return false
 }
 
 // NewUploader creates new Uploader object for a given repository.

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -332,7 +332,8 @@ func (u *Uploader) processSubdirectories(ctx context.Context, relativePath strin
 			// Note: This only catches errors in subdirectories of the snapshot root, not on the snapshot
 			// root itself. The intention is to always fail if the top level directory can't be read,
 			// otherwise a meaningless, empty snapshot is created that can't be restored.
-			ignoreDirErr := u.IgnoreReadErrors || policyTree.EffectivePolicy().ErrorHandlingPolicy.IgnoreDirectoryErrors
+			errHandlingPolicy := policyTree.EffectivePolicy().ErrorHandlingPolicy
+			ignoreDirErr := u.IgnoreReadErrors || (errHandlingPolicy.IgnoreDirectoryErrors != nil && *errHandlingPolicy.IgnoreDirectoryErrors)
 			if _, ok := err.(dirReadError); ok && ignoreDirErr {
 				log.Warningf("unable to read directory %q: %s, ignoring", dir.Name(), err)
 				return nil
@@ -677,7 +678,7 @@ func uploadDirInternal(
 	}
 
 	errHandlingPolicy := policyTree.EffectivePolicy().ErrorHandlingPolicy
-	ignoreFileErrs := u.IgnoreReadErrors || errHandlingPolicy.IgnoreFileErrors
+	ignoreFileErrs := u.IgnoreReadErrors || (errHandlingPolicy.IgnoreFileErrors != nil && *errHandlingPolicy.IgnoreFileErrors)
 
 	if err := u.processUploadWorkItems(workItems, dirManifest, ignoreFileErrs); err != nil && err != errCancelled {
 		return "", fs.DirectorySummary{}, err

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -205,7 +205,7 @@ func TestUpload_TopLevelDirectoryReadFailure(t *testing.T) {
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 
 	s, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{})
-	if err != errTest {
+	if err.Error() != errTest.Error() {
 		t.Errorf("expected error: %v", err)
 	}
 
@@ -223,7 +223,7 @@ func TestUpload_SubDirectoryReadFailure(t *testing.T) {
 	th.sourceDir.Subdir("d1").FailReaddir(errTest)
 
 	u := NewUploader(th.repo)
-	u.IgnoreFileErrors = false
+	u.IgnoreReadErrors = false
 
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -242,7 +242,7 @@ func trimOutput(s string) string {
 
 // ListSnapshotsAndExpectSuccess lists given snapshots and parses the output.
 func (e *CLITest) ListSnapshotsAndExpectSuccess(t *testing.T, targets ...string) []SourceInfo {
-	lines := e.RunAndExpectSuccess(t, append([]string{"snapshot", "list", "-l", "--manifest-id"}, targets...)...)
+	lines := e.RunAndExpectSuccess(t, append([]string{"snapshot", "list", "-l", "--manifest-id", "--max-results", "400"}, targets...)...)
 	return mustParseSnapshots(t, lines)
 }
 

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -242,7 +242,7 @@ func trimOutput(s string) string {
 
 // ListSnapshotsAndExpectSuccess lists given snapshots and parses the output.
 func (e *CLITest) ListSnapshotsAndExpectSuccess(t *testing.T, targets ...string) []SourceInfo {
-	lines := e.RunAndExpectSuccess(t, append([]string{"snapshot", "list", "-l", "--manifest-id", "--max-results", "400"}, targets...)...)
+	lines := e.RunAndExpectSuccess(t, append([]string{"snapshot", "list", "-l", "--manifest-id"}, targets...)...)
 	return mustParseSnapshots(t, lines)
 }
 


### PR DESCRIPTION
Added an error handling policy section. Can independently control error handling for directory and file read errors, toggle-able from the `policy set` command to either "true", "false", or "inherit". If any read error is hit, the error handling will check the effective policy on whether to ignore it or not. Currently there is no differentiation between read error types, though in the future we may want to add the `errors.Is(err, os.ErrPermission)` conditional.

Fix was implemented such that the policy ignores read errors ONLY on child entries of the source. So a snapshot will still fail if the source root directory itself can't be read, but you can ignore the error if a file or a subdirectory in the snapshot source root can't be read. I did this to address some otherwise strange behavior where you would successfully snapshot (because you ignored the error), but couldn't restore that snapshot because nothing really happened during the operation.

Fixes #177 