### PR TITLE
Add fio install and robustness-tool-tests makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ quick-install:
 	# same as install but assumes HTMLUI has been built
 	go install -tags embedhtml
 
-install-noui: 
+install-noui:
 	go install
 
 escape-analysis:
@@ -76,6 +76,7 @@ else
 travis-release: goreleaser kopia-ui website
 	$(MAKE) test-all
 	$(MAKE) integration-tests
+	$(MAKE) robustness-tool-tests
 	$(MAKE) stress-test
 ifneq ($(TRAVIS_TAG),)
 	$(MAKE) travis-create-long-term-repository
@@ -119,7 +120,7 @@ dev-deps:
 	GO111MODULE=off go get -u github.com/lukehoban/go-outline
 	GO111MODULE=off go get -u github.com/newhook/go-symbols
 	GO111MODULE=off go get -u github.com/sqs/goreturns
-	
+
 test-with-coverage:
 	$(GO_TEST) -count=1 -coverprofile=tmp.cov --coverpkg $(COVERAGE_PACKAGES) -timeout 90s `go list ./...`
 
@@ -137,6 +138,9 @@ dist-binary:
 
 integration-tests: dist-binary
 	KOPIA_EXE=$(CURDIR)/dist/integration/kopia $(GO_TEST) $(TEST_FLAGS) -count=1 -parallel $(PARALLEL) -timeout 300s github.com/kopia/kopia/tests/end_to_end_test
+
+robustness-tool-tests: fio
+	FIO_EXE=$(shell which fio) $(GO_TEST) -v -count=1 -timeout 90s github.com/kopia/kopia/tests/tools/...
 
 stress-test:
 	KOPIA_LONG_STRESS_TEST=1 $(GO_TEST) -count=1 -timeout 200s github.com/kopia/kopia/tests/stress_test
@@ -164,7 +168,7 @@ travis-install-gpg-key:
 	@echo Installing GPG key...
 	openssl aes-256-cbc -K "$(encrypted_fa1db4b894bb_key)" -iv "$(encrypted_fa1db4b894bb_iv)" -in kopia.gpg.enc -out /tmp/kopia.gpg -d
 	gpg --import /tmp/kopia.gpg
-	
+
 travis-install-test-credentials:
 	@echo Installing test credentials...
 	openssl aes-256-cbc -K "$(encrypted_fa1db4b894bb_key)" -iv "$(encrypted_fa1db4b894bb_iv)" -in tests/credentials/gcs/test_service_account.json.enc -out repo/blob/gcs/test_service_account.json -d

--- a/tests/tools/fio/fio.go
+++ b/tests/tools/fio/fio.go
@@ -54,7 +54,6 @@ func NewRunner() (*Runner, error) {
 					"blocksize":         "1m",
 					"refill_buffers":    "",
 					"rw":                "write",
-					"unique_filename":   "1",
 					"directory":         dataDir,
 				},
 			},

--- a/tests/tools/fio/fio_test.go
+++ b/tests/tools/fio/fio_test.go
@@ -18,7 +18,7 @@ func TestFIORun(t *testing.T) {
 		t.Fatal("Expected error to be set as no params were passed")
 	}
 
-	if !strings.Contains(stderr, "No job(s) defined") {
+	if !strings.Contains(stderr, "No job") {
 		t.Fatal("Expected an error indicating no jobs were defined")
 	}
 

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -55,6 +55,15 @@ else
 	curl -LsS https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_extended_$(HUGO_VERSION)_macOS-64bit.tar.gz | tar zxv -C $(TOOLS_DIR)/hugo
 endif
 
+# fio 
+# - this install is currently conditional, only supported on systems with apt-get capability. Tests relying on fio should be skipped if it is not found.
+# - fio is installed using the package manager, and is thus not installed into TOOLS_DIR. It is not purged with the clean-tools target.
+fio:
+ifneq (, $(strip $(shell which apt-get)))
+	sudo apt-get -qq update
+	sudo apt-get -y install fio
+endif
+
 # linter
 GORELEASER_TOOL=$(TOOLS_DIR)/goreleaser-$(GORELEASER_VERSION)/goreleaser
 


### PR DESCRIPTION
Fio install target is added, a robustness tools target invokes it and sets the FIO_EXE environment variable, launches tests from the robustness tools directory (for now).

Currently fio is only installed if the `apt-get` binary is found, otherwise install skips to avoid error. The `FIO_EXE` env is populated with the `fio` executable if it is found (independent of whether it was explicitly installed), empty otherwise. The tests will skip if that env is empty.

@jkowalski - I welcome any suggestions you have on how to do this better. There doesn't seem to be a common fio binary that can be downloaded the same way the other tools are in `tools.mk`. The documentation lists different binary download links for every os type and distro: https://fio.readthedocs.io/en/latest/fio_doc.html#binary-packages