### PR TITLE
Place fswalker packages behind build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ kopia-ui: goreleaser
 	$(MAKE) -C app $(KOPIA_UI_BUILD_TARGET)
 
 ifeq ($(TRAVIS_OS_NAME),osx)
-travis-release: kopia-ui
+travis-release: lint kopia-ui test
 else
 travis-release: goreleaser kopia-ui website
 	$(MAKE) test-all

--- a/tests/tools/fswalker/reporter/reporter.go
+++ b/tests/tools/fswalker/reporter/reporter.go
@@ -1,3 +1,5 @@
+// +build linux
+
 // Package reporter wraps calls to the the fswalker Reporter
 package reporter
 

--- a/tests/tools/fswalker/reporter/reporter_test.go
+++ b/tests/tools/fswalker/reporter/reporter_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package reporter
 
 import (

--- a/tests/tools/fswalker/walker/walker.go
+++ b/tests/tools/fswalker/walker/walker.go
@@ -1,3 +1,5 @@
+// +build linux
+
 // Package walker wraps calls to the the fswalker Walker
 package walker
 

--- a/tests/tools/fswalker/walker/walker_test.go
+++ b/tests/tools/fswalker/walker/walker_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package walker
 
 import (


### PR DESCRIPTION
Temporary workaround for compile issues on MacOS and Windows due
to upstream fswalker bug. Only build the reporter and walker
packages as GOOS=linux for now.