### PR TITLE
travis: added bare-bones Windows build that does go test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,18 @@ go:
 os:
 - linux
 - osx
+- windows
 addons:
   apt:
     packages:
     - rpm
+before_install:
+- |-
+    case $TRAVIS_OS_NAME in
+      windows)
+        choco install --no-progress -y make
+        ;;
+    esac
 install: make travis-setup
 script: make -j4 travis-release
 cache:
@@ -27,6 +35,7 @@ deploy:
   on:
     repo: kopia/kopia
     tags: true
+    condition: $TRAVIS_OS_NAME != windows
 - provider: pages
   skip_cleanup: true
   github_token: "$GITHUB_TOKEN"

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,15 @@ endif
 kopia-ui: goreleaser
 	$(MAKE) -C app $(KOPIA_UI_BUILD_TARGET)
 
+ifeq ($(TRAVIS_OS_NAME),windows)
+travis-release: test
+endif
+
 ifeq ($(TRAVIS_OS_NAME),osx)
 travis-release: lint kopia-ui test
-else
+endif
+
+ifeq ($(TRAVIS_OS_NAME),linux)
 travis-release: goreleaser kopia-ui website
 	$(MAKE) test-all
 	$(MAKE) integration-tests
@@ -81,6 +87,7 @@ ifneq ($(TRAVIS_TAG),)
 	$(MAKE) travis-create-long-term-repository
 endif
 endif
+
 test-all: lint vet test-with-coverage
 
 # goreleaser - builds binaries for all platforms

--- a/internal/blobtesting/verify.go
+++ b/internal/blobtesting/verify.go
@@ -11,6 +11,8 @@ import (
 
 // VerifyStorage verifies the behavior of the specified storage.
 func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage) {
+	t.Helper()
+
 	blocks := []struct {
 		blk      blob.ID
 		contents []byte

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -4,7 +4,7 @@ package sharded
 import (
 	"context"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/kopia/kopia/repo/blob"
@@ -113,7 +113,7 @@ func (s Storage) getShardDirectory(blobID blob.ID) (string, blob.ID) {
 	}
 
 	for _, size := range s.Shards {
-		shardPath = filepath.Join(shardPath, string(blobID[0:size]))
+		shardPath = path.Join(shardPath, string(blobID[0:size]))
 		blobID = blobID[size:]
 	}
 
@@ -123,7 +123,7 @@ func (s Storage) getShardDirectory(blobID blob.ID) (string, blob.ID) {
 // GetShardedPathAndFilePath returns the path of the shard and file name within the shard for a given blob ID.
 func (s Storage) GetShardedPathAndFilePath(blobID blob.ID) (shardPath, filePath string) {
 	shardPath, blobID = s.getShardDirectory(blobID)
-	filePath = filepath.Join(shardPath, s.makeFileName(blobID))
+	filePath = path.Join(shardPath, s.makeFileName(blobID))
 
 	return
 }

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -177,6 +177,15 @@ func sourcesToStrings(sources ...snapshot.SourceInfo) []string {
 	return res
 }
 
+func mustAbs(t *testing.T, p string) string {
+	p2, err := filepath.Abs(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return p2
+}
+
 func TestParseSourceInfo(t *testing.T) {
 	cwd, _ := os.Getwd()
 
@@ -189,8 +198,8 @@ func TestParseSourceInfo(t *testing.T) {
 		{".", snapshot.SourceInfo{UserName: "default-user", Host: "default-host", Path: cwd}},
 		{"..", snapshot.SourceInfo{UserName: "default-user", Host: "default-host", Path: filepath.Clean(filepath.Join(cwd, ".."))}},
 		{"foo@bar:/some/path", snapshot.SourceInfo{UserName: "foo", Host: "bar", Path: "/some/path"}},
-		{"/some/path", snapshot.SourceInfo{UserName: "default-user", Host: "default-host", Path: "/some/path"}},
-		{"/some/path/../other-path", snapshot.SourceInfo{UserName: "default-user", Host: "default-host", Path: "/some/other-path"}},
+		{"/some/path", snapshot.SourceInfo{UserName: "default-user", Host: "default-host", Path: mustAbs(t, "/some/path")}},
+		{"/some/path/../other-path", snapshot.SourceInfo{UserName: "default-user", Host: "default-host", Path: mustAbs(t, "/some/other-path")}},
 		{"@some-host", snapshot.SourceInfo{Host: "some-host"}},
 		{"some-user@some-host", snapshot.SourceInfo{UserName: "some-user", Host: "some-host"}},
 	}


### PR DESCRIPTION
fixed some issues that prevented go test from passing on Windows:

- webdav client used \ instead of /
- need retries around mmap.Open()
- paths are prefixed with C:\ on windows
- time.Now() does not always move forward on Windows