### PR TITLE
[minor] Fix error handling policy print

### DIFF
--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -160,14 +160,24 @@ func printFilesPolicy(p *policy.Policy, parents []*policy.Policy) {
 func printErrorHandlingPolicy(p *policy.Policy, parents []*policy.Policy) {
 	printStdout("Error handling policy:\n")
 
+	ignoreFile := false
+	if p.ErrorHandlingPolicy.IgnoreFileErrors != nil {
+		ignoreFile = *p.ErrorHandlingPolicy.IgnoreFileErrors
+	}
+
 	printStdout("  Ignore file read errors:       %5v       %v\n",
-		p.ErrorHandlingPolicy.IgnoreFileErrors,
+		ignoreFile,
 		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
 			return pol.ErrorHandlingPolicy.IgnoreFileErrors != nil
 		}))
 
+	ignoreDir := false
+	if p.ErrorHandlingPolicy.IgnoreDirectoryErrors != nil {
+		ignoreFile = *p.ErrorHandlingPolicy.IgnoreDirectoryErrors
+	}
+
 	printStdout("  Ignore directory read errors:  %5v       %v\n",
-		p.ErrorHandlingPolicy.IgnoreDirectoryErrors,
+		ignoreDir,
 		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
 			return pol.ErrorHandlingPolicy.IgnoreDirectoryErrors != nil
 		}))

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -161,13 +161,13 @@ func printErrorHandlingPolicy(p *policy.Policy, parents []*policy.Policy) {
 	printStdout("Error handling policy:\n")
 
 	printStdout("  Ignore file read errors:       %5v       %v\n",
-		p.ErrorHandlingPolicy.IgnoreDirectoryErrorsOrDefault(false),
+		p.ErrorHandlingPolicy.IgnoreFileErrorsOrDefault(false),
 		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
 			return pol.ErrorHandlingPolicy.IgnoreFileErrors != nil
 		}))
 
 	printStdout("  Ignore directory read errors:  %5v       %v\n",
-		p.ErrorHandlingPolicy.IgnoreFileErrorsOrDefault(false),
+		p.ErrorHandlingPolicy.IgnoreDirectoryErrorsOrDefault(false),
 		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
 			return pol.ErrorHandlingPolicy.IgnoreDirectoryErrors != nil
 		}))

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -160,24 +160,14 @@ func printFilesPolicy(p *policy.Policy, parents []*policy.Policy) {
 func printErrorHandlingPolicy(p *policy.Policy, parents []*policy.Policy) {
 	printStdout("Error handling policy:\n")
 
-	ignoreFile := false
-	if p.ErrorHandlingPolicy.IgnoreFileErrors != nil {
-		ignoreFile = *p.ErrorHandlingPolicy.IgnoreFileErrors
-	}
-
 	printStdout("  Ignore file read errors:       %5v       %v\n",
-		ignoreFile,
+		p.ErrorHandlingPolicy.IgnoreDirectoryErrorsOrDefault(false),
 		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
 			return pol.ErrorHandlingPolicy.IgnoreFileErrors != nil
 		}))
 
-	ignoreDir := false
-	if p.ErrorHandlingPolicy.IgnoreDirectoryErrors != nil {
-		ignoreFile = *p.ErrorHandlingPolicy.IgnoreDirectoryErrors
-	}
-
 	printStdout("  Ignore directory read errors:  %5v       %v\n",
-		ignoreDir,
+		p.ErrorHandlingPolicy.IgnoreFileErrorsOrDefault(false),
 		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
 			return pol.ErrorHandlingPolicy.IgnoreDirectoryErrors != nil
 		}))

--- a/snapshot/policy/error_handling_policy.go
+++ b/snapshot/policy/error_handling_policy.go
@@ -20,6 +20,26 @@ func (p *ErrorHandlingPolicy) Merge(src ErrorHandlingPolicy) {
 	}
 }
 
+// IgnoreFileErrorsOrDefault returns the ignore-file-error setting if it is set,
+// and returns the passed default if not
+func (p *ErrorHandlingPolicy) IgnoreFileErrorsOrDefault(def bool) bool {
+	if p.IgnoreFileErrors == nil {
+		return def
+	}
+
+	return *p.IgnoreFileErrors
+}
+
+// IgnoreDirectoryErrorsOrDefault returns the ignore-directory-error setting if it is set,
+// and returns the passed default if not
+func (p *ErrorHandlingPolicy) IgnoreDirectoryErrorsOrDefault(def bool) bool {
+	if p.IgnoreDirectoryErrors == nil {
+		return def
+	}
+
+	return *p.IgnoreDirectoryErrors
+}
+
 // defaultErrorHandlingPolicy is the default error handling policy.
 var defaultErrorHandlingPolicy = ErrorHandlingPolicy{
 	IgnoreFileErrors:      newBool(false),

--- a/snapshot/policy/error_handling_policy_test.go
+++ b/snapshot/policy/error_handling_policy_test.go
@@ -137,3 +137,115 @@ func TestErrorHandlingPolicyMerge(t *testing.T) {
 		}
 	}
 }
+
+func TestErrorHandlingPolicy_IgnoreFileErrorsOrDefault(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		ignoreFileErrors *bool
+		def              bool
+		want             bool
+	}{
+		{
+			name:             "ignoreFileErrors is nil, default is false",
+			ignoreFileErrors: nil,
+			def:              false,
+			want:             false,
+		},
+		{
+			name:             "ignoreFileErrors is false, default is false",
+			ignoreFileErrors: newBool(false),
+			def:              false,
+			want:             false,
+		},
+		{
+			name:             "ignoreFileErrors is true, default is false",
+			ignoreFileErrors: newBool(true),
+			def:              false,
+			want:             true,
+		},
+		{
+			name:             "ignoreFileErrors is nil, default is true",
+			ignoreFileErrors: nil,
+			def:              true,
+			want:             true,
+		},
+		{
+			name:             "ignoreFileErrors is false, default is true",
+			ignoreFileErrors: newBool(false),
+			def:              true,
+			want:             false,
+		},
+		{
+			name:             "ignoreFileErrors is true, default is true",
+			ignoreFileErrors: newBool(true),
+			def:              true,
+			want:             true,
+		},
+	} {
+		t.Log(tt.name)
+
+		p := &ErrorHandlingPolicy{
+			IgnoreFileErrors: tt.ignoreFileErrors,
+		}
+
+		if got := p.IgnoreFileErrorsOrDefault(tt.def); got != tt.want {
+			t.Errorf("ErrorHandlingPolicy.IgnoreFileErrorsOrDefault() = %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func TestErrorHandlingPolicy_IgnoreDirectoryErrorsOrDefault(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		ignoreDirErrors *bool
+		def             bool
+		want            bool
+	}{
+		{
+			name:            "ignoreDirErrors is nil, default is false",
+			ignoreDirErrors: nil,
+			def:             false,
+			want:            false,
+		},
+		{
+			name:            "ignoreDirErrors is false, default is false",
+			ignoreDirErrors: newBool(false),
+			def:             false,
+			want:            false,
+		},
+		{
+			name:            "ignoreDirErrors is true, default is false",
+			ignoreDirErrors: newBool(true),
+			def:             false,
+			want:            true,
+		},
+		{
+			name:            "ignoreDirErrors is nil, default is true",
+			ignoreDirErrors: nil,
+			def:             true,
+			want:            true,
+		},
+		{
+			name:            "ignoreDirErrors is false, default is true",
+			ignoreDirErrors: newBool(false),
+			def:             true,
+			want:            false,
+		},
+		{
+			name:            "ignoreDirErrors is true, default is true",
+			ignoreDirErrors: newBool(true),
+			def:             true,
+			want:            true,
+		},
+	} {
+		t.Log(tt.name)
+
+		p := &ErrorHandlingPolicy{
+			IgnoreDirectoryErrors: tt.ignoreDirErrors,
+		}
+
+		if got := p.IgnoreDirectoryErrorsOrDefault(tt.def); got != tt.want {
+			t.Errorf("ErrorHandlingPolicy.IgnoreDirectoryErrorsOrDefault() = %v, want %v", got, tt.want)
+		}
+	}
+}

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -706,11 +706,7 @@ func (u *Uploader) shouldIgnoreFileReadErrors(policyTree *policy.Tree) bool {
 		return true
 	}
 
-	if errHandlingPolicy.IgnoreFileErrors != nil {
-		return *errHandlingPolicy.IgnoreFileErrors
-	}
-
-	return false
+	return errHandlingPolicy.IgnoreFileErrorsOrDefault(false)
 }
 
 func (u *Uploader) shouldIgnoreDirectoryReadErrors(policyTree *policy.Tree) bool {
@@ -720,11 +716,7 @@ func (u *Uploader) shouldIgnoreDirectoryReadErrors(policyTree *policy.Tree) bool
 		return true
 	}
 
-	if errHandlingPolicy.IgnoreDirectoryErrors != nil {
-		return *errHandlingPolicy.IgnoreDirectoryErrors
-	}
-
-	return false
+	return errHandlingPolicy.IgnoreDirectoryErrorsOrDefault(false)
 }
 
 // NewUploader creates new Uploader object for a given repository.


### PR DESCRIPTION
Fixes print for error handling policy. Previously was printing
pointer address, now dereference pointer to print boolean itself.
Nil check in case the caller passes a policy with nil. In that
case print "false" which is the behavior in uploader for nil
pointer.

Issue was introduced when changing bool pair implementation
to bool pointer from PR suggestions in #207 and uncaught
at the time the swap was made.

before:
```
Error handling policy:
  Ignore file read errors:       0xc005f4dbfc       (default)
  Ignore directory read errors:  0xc005f4dbfd       (default)
```

after:
```
Error handling policy:
  Ignore file read errors:        true       (defined for this target)
  Ignore directory read errors:  false       (default)
```