### PR TITLE
Add comparer interface and fswalker implementation

### DIFF
--- a/tests/robustness/checker/comparer.go
+++ b/tests/robustness/checker/comparer.go
@@ -1,0 +1,15 @@
+// Package checker defines the framework for creating and restoring snapshots
+// with a data integrity check
+package checker
+
+import (
+	"context"
+	"io"
+)
+
+// Comparer describes an interface that gathers state data on a provided
+// path, and compares that data to the state on another path.
+type Comparer interface {
+	Gather(ctx context.Context, path string) ([]byte, error)
+	Compare(ctx context.Context, path string, data []byte, reportOut io.Writer) error
+}

--- a/tests/tools/fswalker/fswalker.go
+++ b/tests/tools/fswalker/fswalker.go
@@ -7,15 +7,15 @@ package fswalker
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
+	"log"
 	"path/filepath"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/fswalker"
 	fspb "github.com/google/fswalker/proto/fswalker"
+	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/tests/robustness/checker"
 	"github.com/kopia/kopia/tests/tools/fswalker/reporter"
@@ -46,18 +46,18 @@ func NewWalkCompare() *WalkCompare {
 func (chk *WalkCompare) Gather(ctx context.Context, path string) ([]byte, error) {
 	walkData, err := walker.WalkPathHash(ctx, path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "walk with hashing error during gather phase")
 	}
 
 	err = rerootWalkDataPaths(walkData, path)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "reroot walk paths error during gather phase")
 	}
 
 	// Store the walk data along with the snapshot ID
 	b, err := proto.Marshal(walkData)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "walk data proto marshal error")
 	}
 
 	return b, nil
@@ -73,22 +73,22 @@ func (chk *WalkCompare) Compare(ctx context.Context, path string, data []byte, r
 
 	err := proto.Unmarshal(data, beforeWalk)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "walk data unmarshal error")
 	}
 
 	afterWalk, err := walker.WalkPathHash(ctx, path)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "walk with hashing error during compare phase")
 	}
 
 	err = rerootWalkDataPaths(afterWalk, path)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "reroot walk paths error during compare phase")
 	}
 
 	report, err := reporter.Report(ctx, &fspb.ReportConfig{}, beforeWalk, afterWalk)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "report error")
 	}
 
 	chk.filterReportDiffs(report)
@@ -101,17 +101,17 @@ func (chk *WalkCompare) Compare(ctx context.Context, path string, data []byte, r
 		if marshalErr != nil {
 			_, reportErr := reportOut.Write([]byte(marshalErr.Error()))
 			if reportErr != nil {
-				return fmt.Errorf("error while writing marshal error (%v): %v", marshalErr.Error(), reportErr.Error())
+				return errors.Wrapf(reportErr, "error while writing out marshal error (%v)", marshalErr.Error())
 			}
 
-			return marshalErr
+			return errors.Wrap(marshalErr, "error JSON marshaling report")
 		}
 
 		if _, wrErr := reportOut.Write(b); wrErr != nil {
-			return err
+			return errors.Wrap(err, "error writing report to output")
 		}
 
-		return err
+		return errors.Wrap(err, "validation error")
 	}
 
 	return nil
@@ -136,14 +136,14 @@ func (chk *WalkCompare) filterReportDiffs(report *fswalker.Report) {
 		for _, diffItem := range diffItems {
 			for _, filterStr := range chk.GlobalFilterMatchers {
 				if strings.Contains(diffItem, filterStr) {
-					fmt.Printf("FILTERING %s due to filtered prefix %q\n", diffItem, filterStr)
+					log.Printf("Filtering %s due to filtered prefix %q\n", diffItem, filterStr)
 					continue DiffItemLoop
 				}
 			}
 
 			// Filter the rename of the root directory
 			if isRootDirectoryRename(diffItem, mod) {
-				fmt.Println("Filtering", diffItem, "due to root directory rename")
+				log.Println("Filtering", diffItem, "due to root directory rename")
 				continue DiffItemLoop
 			}
 
@@ -151,7 +151,7 @@ func (chk *WalkCompare) filterReportDiffs(report *fswalker.Report) {
 		}
 
 		if len(newDiffItemList) > 0 {
-			fmt.Println("Not Filtering", newDiffItemList)
+			log.Println("Not Filtering", newDiffItemList)
 			mod.Diff = strings.Join(newDiffItemList, "\n")
 			newModList = append(newModList, mod)
 		}

--- a/tests/tools/fswalker/fswalker.go
+++ b/tests/tools/fswalker/fswalker.go
@@ -1,0 +1,204 @@
+// +build linux
+
+// Package fswalker provides the checker.Comparer interface using FSWalker
+// walker and reporter.
+package fswalker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/fswalker"
+	fspb "github.com/google/fswalker/proto/fswalker"
+
+	"github.com/kopia/kopia/tests/robustness/checker"
+	"github.com/kopia/kopia/tests/tools/fswalker/reporter"
+	"github.com/kopia/kopia/tests/tools/fswalker/walker"
+)
+
+var _ checker.Comparer = &WalkCompare{}
+
+// WalkCompare is a checker.Comparer that utilizes the fswalker
+// libraries to perform the data consistency check.
+type WalkCompare struct {
+	GlobalFilterMatchers []string
+}
+
+// NewWalkCompare instantiates a new WalkCompare and returns its pointer
+func NewWalkCompare() *WalkCompare {
+	return &WalkCompare{
+		GlobalFilterMatchers: []string{
+			"ctime:",
+			"atime:",
+			"mtime:",
+		},
+	}
+}
+
+// Gather meets the checker.Comparer interface. It performs a fswalker Walk
+// and returns the resulting Walk as a protobuf Marshaled buffer.
+func (chk *WalkCompare) Gather(ctx context.Context, path string) ([]byte, error) {
+	walkData, err := walker.WalkPathHash(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = rerootWalkDataPaths(walkData, path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store the walk data along with the snapshot ID
+	b, err := proto.Marshal(walkData)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// Compare meets the checker.Comparer interface. It performs a fswalker Walk
+// on the provided file path, unmarshals the comparison data as a fswalker Walk,
+// and generates a fswalker report comparing the two Walks. If there are any differences
+// an error is returned, and the full report will be written to the provided writer
+// as JSON.
+func (chk *WalkCompare) Compare(ctx context.Context, path string, data []byte, reportOut io.Writer) error {
+	beforeWalk := &fspb.Walk{}
+
+	err := proto.Unmarshal(data, beforeWalk)
+	if err != nil {
+		return err
+	}
+
+	afterWalk, err := walker.WalkPathHash(ctx, path)
+	if err != nil {
+		return err
+	}
+
+	err = rerootWalkDataPaths(afterWalk, path)
+	if err != nil {
+		return err
+	}
+
+	report, err := reporter.Report(ctx, &fspb.ReportConfig{}, beforeWalk, afterWalk)
+	if err != nil {
+		return err
+	}
+
+	chk.filterReportDiffs(report)
+
+	err = validateReport(report)
+	if err != nil {
+		printReportSummary(report, reportOut)
+
+		b, marshalErr := json.MarshalIndent(report, "", "   ")
+		if marshalErr != nil {
+			_, reportErr := reportOut.Write([]byte(marshalErr.Error()))
+			if reportErr != nil {
+				return fmt.Errorf("error while writing marshal error (%v): %v", marshalErr.Error(), reportErr.Error())
+			}
+
+			return marshalErr
+		}
+
+		if _, wrErr := reportOut.Write(b); wrErr != nil {
+			return err
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func printReportSummary(report *fswalker.Report, reportOut io.Writer) {
+	rptr := &fswalker.Reporter{}
+	rptr.PrintDiffSummary(reportOut, report)
+	rptr.PrintReportSummary(reportOut, report)
+	rptr.PrintRuleSummary(reportOut, report)
+}
+
+func (chk *WalkCompare) filterReportDiffs(report *fswalker.Report) {
+	var newModList []fswalker.ActionData
+
+	for _, mod := range report.Modified {
+		var newDiffItemList []string
+
+		diffItems := strings.Split(mod.Diff, "\n")
+
+	DiffItemLoop:
+		for _, diffItem := range diffItems {
+			for _, filterStr := range chk.GlobalFilterMatchers {
+				if strings.Contains(diffItem, filterStr) {
+					fmt.Printf("FILTERING %s due to filtered prefix %q\n", diffItem, filterStr)
+					continue DiffItemLoop
+				}
+			}
+
+			// Filter the rename of the root directory
+			if isRootDirectoryRename(diffItem, mod) {
+				fmt.Println("Filtering", diffItem, "due to root directory rename")
+				continue DiffItemLoop
+			}
+
+			newDiffItemList = append(newDiffItemList, diffItem)
+		}
+
+		if len(newDiffItemList) > 0 {
+			fmt.Println("Not Filtering", newDiffItemList)
+			mod.Diff = strings.Join(newDiffItemList, "\n")
+			newModList = append(newModList, mod)
+		}
+	}
+
+	report.Modified = newModList
+}
+
+func isRootDirectoryRename(diffItem string, mod fswalker.ActionData) bool {
+	if !strings.HasPrefix(diffItem, "name: ") {
+		return false
+	}
+
+	// The mod.Before.Path may be given from fswalker Report as "./", so
+	// clean it before compare
+	return mod.Before.Info.IsDir && filepath.Clean(mod.Before.Path) == "."
+}
+
+func validateReport(report *fswalker.Report) error {
+	if len(report.Modified) > 0 {
+		return errors.New("files were modified")
+	}
+
+	if len(report.Added) > 0 {
+		return errors.New("files were added")
+	}
+
+	if len(report.Deleted) > 0 {
+		return errors.New("files were deleted")
+	}
+
+	if len(report.Errors) > 0 {
+		return errors.New("errors were thrown in the walk")
+	}
+
+	return nil
+}
+
+func rerootWalkDataPaths(walk *fspb.Walk, newRoot string) error {
+	for _, f := range walk.File {
+		var err error
+
+		f.Path, err = filepath.Rel(newRoot, f.Path)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/tests/tools/fswalker/fswalker_test.go
+++ b/tests/tools/fswalker/fswalker_test.go
@@ -1,0 +1,634 @@
+// +build linux
+
+package fswalker
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/fswalker"
+	fspb "github.com/google/fswalker/proto/fswalker"
+)
+
+func TestWalkChecker_GatherCompare(t *testing.T) {
+	type fields struct {
+		GlobalFilterMatchers []string
+	}
+
+	for _, tt := range []struct {
+		name             string
+		fields           fields
+		fileTreeMaker    func(root string) error
+		fileTreeModifier func(root string) error
+		wantErr          bool
+	}{
+		{
+			name: "empty directory, unchanged",
+			fields: fields{
+				GlobalFilterMatchers: nil,
+			},
+			fileTreeMaker:    func(rootDir string) error { return nil },
+			fileTreeModifier: func(rootDir string) error { return nil },
+			wantErr:          false,
+		},
+		{
+			name: "subdirectory tree, unchanged",
+			fields: fields{
+				GlobalFilterMatchers: nil,
+			},
+			fileTreeMaker: func(rootDir string) error {
+				return os.MkdirAll(filepath.Join(rootDir, "some", "path"), 0700)
+			},
+			fileTreeModifier: func(rootDir string) error { return nil },
+			wantErr:          false,
+		},
+		{
+			name: "file in root, unchanged",
+			fields: fields{
+				GlobalFilterMatchers: nil,
+			},
+			fileTreeMaker: func(rootDir string) error {
+				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0700)
+			},
+			fileTreeModifier: func(rootDir string) error { return nil },
+			wantErr:          false,
+		},
+		{
+			name: "file in root, contents modified",
+			fields: fields{
+				GlobalFilterMatchers: nil,
+			},
+			fileTreeMaker: func(rootDir string) error {
+				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0700)
+			},
+			fileTreeModifier: func(rootDir string) error {
+				ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some different data"), 0700)
+				return nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "file in deep subdirectory, contents modified",
+			fields: fields{
+				GlobalFilterMatchers: nil,
+			},
+			fileTreeMaker: func(rootDir string) error {
+				subdir := filepath.Join(rootDir, "some", "really", "really", "very", "substantially", "deep", "directory", "tree")
+
+				err := os.MkdirAll(subdir, 0700)
+				if err != nil {
+					return err
+				}
+
+				return ioutil.WriteFile(filepath.Join(subdir, "test-file"), []byte("some data"), 0700)
+			},
+			fileTreeModifier: func(rootDir string) error {
+				subdir := filepath.Join(rootDir, "some", "really", "really", "very", "substantially", "deep", "directory", "tree")
+				return ioutil.WriteFile(filepath.Join(subdir, "test-file"), []byte("some different data"), 0700)
+			},
+			wantErr: true,
+		},
+		{
+			name: "add a file",
+			fields: fields{
+				GlobalFilterMatchers: nil,
+			},
+			fileTreeMaker: func(rootDir string) error {
+				return nil
+			},
+			fileTreeModifier: func(rootDir string) error {
+				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0700)
+			},
+			wantErr: true,
+		},
+		{
+			name: "delete a file",
+			fields: fields{
+				GlobalFilterMatchers: nil,
+			},
+			fileTreeMaker: func(rootDir string) error {
+				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0700)
+			},
+			fileTreeModifier: func(rootDir string) error {
+				return os.Remove(filepath.Join(rootDir, "test-file"))
+			},
+			wantErr: true,
+		},
+		{
+			name: "get an error when walking",
+			fields: fields{
+				GlobalFilterMatchers: nil,
+			},
+			fileTreeMaker: func(rootDir string) error {
+				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0700)
+			},
+			fileTreeModifier: func(rootDir string) error {
+				return os.Chmod(filepath.Join(rootDir, "test-file"), 0000)
+			},
+			wantErr: true,
+		},
+		{
+			name: "add a directory",
+			fields: fields{
+				GlobalFilterMatchers: nil,
+			},
+			fileTreeMaker: func(rootDir string) error {
+				subdir := filepath.Join(rootDir, "some", "really", "really", "very", "substantially", "deep", "directory", "tree")
+				return os.MkdirAll(subdir, 0700)
+			},
+			fileTreeModifier: func(rootDir string) error {
+				subdir := filepath.Join(rootDir, "some", "other", "path")
+				return os.MkdirAll(subdir, 0700)
+			},
+			wantErr: true,
+		},
+		{
+			name: "file in root, contents modified, filter just fingerprint (not size or mtime)",
+			fields: fields{
+				GlobalFilterMatchers: []string{
+					"fingerprint:",
+				},
+			},
+			fileTreeMaker: func(rootDir string) error {
+				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0700)
+			},
+			fileTreeModifier: func(rootDir string) error {
+				ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some different data"), 0700)
+				return nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "file in root, contents modified, filter fingerprint, size, and mtime",
+			fields: fields{
+				GlobalFilterMatchers: []string{
+					"fingerprint:",
+					"mtime:",
+					"size",
+				},
+			},
+			fileTreeMaker: func(rootDir string) error {
+				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0700)
+			},
+			fileTreeModifier: func(rootDir string) error {
+				ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some different data"), 0700)
+				return nil
+			},
+			wantErr: false,
+		},
+	} {
+		t.Log(tt.name)
+
+		chk := &WalkCompare{
+			GlobalFilterMatchers: tt.fields.GlobalFilterMatchers,
+		}
+
+		tmpDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer os.RemoveAll(tmpDir) //nolint:errcheck
+
+		err = tt.fileTreeMaker(tmpDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.TODO()
+
+		walk, err := chk.Gather(ctx, tmpDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tt.fileTreeModifier(tmpDir)
+
+		reportOut := &bytes.Buffer{}
+		if err := chk.Compare(ctx, tmpDir, walk, reportOut); (err != nil) != tt.wantErr {
+			t.Errorf("Compare error = %v, wantErr %v", err, tt.wantErr)
+			return
+		}
+
+		// If an error was thrown, expect a report to be written to the provided writer
+		if (reportOut.Len() > 0) != tt.wantErr {
+			t.Errorf("report length unexpected len = %v, expReport %v", reportOut.Len(), tt.wantErr)
+		}
+	}
+}
+
+func TestWalkChecker_filterReportDiffs(t *testing.T) {
+	type fields struct {
+		GlobalFilterMatchers []string
+	}
+
+	for _, tt := range []struct {
+		name        string
+		fields      fields
+		inputReport *fswalker.Report
+		expModCount int
+	}{
+		{
+			name: "No filters",
+			fields: fields{
+				GlobalFilterMatchers: nil,
+			},
+			inputReport: &fswalker.Report{
+				Modified: []fswalker.ActionData{
+					{
+						Diff: "some difference",
+					},
+				},
+			},
+			expModCount: 1,
+		},
+		{
+			name: "filter the only diff as prefix",
+			fields: fields{
+				GlobalFilterMatchers: []string{
+					"some",
+				},
+			},
+			inputReport: &fswalker.Report{
+				Modified: []fswalker.ActionData{
+					{
+						Diff: "some difference",
+					},
+				},
+			},
+			expModCount: 0,
+		},
+		{
+			name: "filter the only diff as substring",
+			fields: fields{
+				GlobalFilterMatchers: []string{
+					"iff",
+				},
+			},
+			inputReport: &fswalker.Report{
+				Modified: []fswalker.ActionData{
+					{
+						Diff: "some difference",
+					},
+				},
+			},
+			expModCount: 0,
+		},
+		{
+			name: "filter some but not all diffs",
+			fields: fields{
+				GlobalFilterMatchers: []string{
+					"definitely",
+				},
+			},
+			inputReport: &fswalker.Report{
+				Modified: []fswalker.ActionData{
+					{
+						Diff: "this will not be filtered",
+					},
+					{
+						Diff: "this will definitely be filtered",
+					},
+				},
+			},
+			expModCount: 1,
+		},
+		{
+			name: "filter multiple diffs",
+			fields: fields{
+				GlobalFilterMatchers: []string{
+					"definitely",
+				},
+			},
+			inputReport: &fswalker.Report{
+				Modified: []fswalker.ActionData{
+					{
+						Diff: "this will not be filtered",
+					},
+					{
+						Diff: "this will definitely be filtered",
+					},
+					{
+						Diff: "this will also definitely be filtered",
+					},
+				},
+			},
+			expModCount: 1,
+		},
+	} {
+		t.Log(tt.name)
+
+		chk := &WalkCompare{
+			GlobalFilterMatchers: tt.fields.GlobalFilterMatchers,
+		}
+		chk.filterReportDiffs(tt.inputReport)
+
+		if want, got := tt.expModCount, len(tt.inputReport.Modified); want != got {
+			t.Errorf("Expected %v modifications after filter but got %v (%v)", want, got, tt.inputReport.Modified)
+		}
+	}
+}
+
+func Test_isRootDirectoryRename(t *testing.T) {
+	type args struct {
+		diffItem string
+		mod      fswalker.ActionData
+	}
+
+	for _, tt := range []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Check a root name change",
+			args: args{
+				diffItem: "name: \"fio-data-902268402\" => \"restore-snap-43720e98eaa9b40ec0be735e347bb853964221402\"",
+				mod: fswalker.ActionData{
+					Before: &fspb.File{
+						Path: ".",
+						Info: &fspb.FileInfo{
+							IsDir: true,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Check path is \"./\", equivalent representation of root dir",
+			args: args{
+				diffItem: "name: \"fio-data-902268402\" => \"restore-snap-43720e98eaa9b40ec0be735e347bb853964221402\"",
+				mod: fswalker.ActionData{
+					Before: &fspb.File{
+						Path: "./",
+						Info: &fspb.FileInfo{
+							IsDir: true,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Check path is \"./asdf/bsdf/../../\", equivalent representation of root dir",
+			args: args{
+				diffItem: "name: \"fio-data-902268402\" => \"restore-snap-43720e98eaa9b40ec0be735e347bb853964221402\"",
+				mod: fswalker.ActionData{
+					Before: &fspb.File{
+						Path: "./asdf/bsdf/../../",
+						Info: &fspb.FileInfo{
+							IsDir: true,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Check a root name change",
+			args: args{
+				diffItem: "name: \"fio-data-902268402\" => \"restore-snap-43720e98eaa9b40ec0be735e347bb853964221402\"",
+				mod: fswalker.ActionData{
+					Before: &fspb.File{
+						Path: "this_is_in_the_root",
+						Info: &fspb.FileInfo{
+							IsDir: true,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Check a non-root name change",
+			args: args{
+				diffItem: "name: \"fio-data-902268402\" => \"restore-snap-43720e98eaa9b40ec0be735e347bb853964221402\"",
+				mod: fswalker.ActionData{
+					Before: &fspb.File{
+						Path: filepath.Join("this_is_restore_directory_root", "with", "more", "subdirectories"),
+						Info: &fspb.FileInfo{
+							IsDir: true,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Check empty path",
+			args: args{
+				diffItem: "name: \"fio-data-902268402\" => \"restore-snap-43720e98eaa9b40ec0be735e347bb853964221402\"",
+				mod: fswalker.ActionData{
+					Before: &fspb.File{
+						Path: "",
+						Info: &fspb.FileInfo{
+							IsDir: true,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Check a non-name change diff item on root",
+			args: args{
+				diffItem: "ctime: 2020-02-06 00:30:41 UTC => 2020-02-06 00:30:47 UTC",
+				mod: fswalker.ActionData{
+					Before: &fspb.File{
+						Path: "",
+						Info: &fspb.FileInfo{
+							IsDir: true,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Check a non-name change diff item in another directory",
+			args: args{
+				diffItem: "ctime: 2020-02-06 00:30:41 UTC => 2020-02-06 00:30:47 UTC",
+				mod: fswalker.ActionData{
+					Before: &fspb.File{
+						Path: filepath.Join("some", "path"),
+						Info: &fspb.FileInfo{
+							IsDir: true,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Check not a directory",
+			args: args{
+				diffItem: "name: \"fio-data-902268402\" => \"restore-snap-43720e98eaa9b40ec0be735e347bb853964221402\"",
+				mod: fswalker.ActionData{
+					Before: &fspb.File{
+						Path: "",
+						Info: &fspb.FileInfo{
+							IsDir: false,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	} {
+		t.Log(tt.name)
+
+		if got := isRootDirectoryRename(tt.args.diffItem, tt.args.mod); got != tt.want {
+			t.Errorf("isRootDirectoryRename() = %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func Test_validateReport(t *testing.T) {
+	type args struct {
+		report *fswalker.Report
+	}
+
+	for _, tc := range []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "no entries in the report",
+			args: args{
+				report: &fswalker.Report{
+					Added:    nil,
+					Deleted:  nil,
+					Modified: nil,
+					Errors:   nil,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "something was added",
+			args: args{
+				report: &fswalker.Report{
+					Added:    []fswalker.ActionData{{}},
+					Deleted:  nil,
+					Modified: nil,
+					Errors:   nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "something was deleted",
+			args: args{
+				report: &fswalker.Report{
+					Added:    nil,
+					Deleted:  []fswalker.ActionData{{}},
+					Modified: nil,
+					Errors:   nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "something was modified",
+			args: args{
+				report: &fswalker.Report{
+					Added:    nil,
+					Deleted:  nil,
+					Modified: []fswalker.ActionData{{}},
+					Errors:   nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "something hit an error",
+			args: args{
+				report: &fswalker.Report{
+					Added:    nil,
+					Deleted:  nil,
+					Modified: nil,
+					Errors:   []fswalker.ActionData{{}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple issues in report",
+			args: args{
+				report: &fswalker.Report{
+					Added:    []fswalker.ActionData{{}},
+					Deleted:  []fswalker.ActionData{{}},
+					Modified: []fswalker.ActionData{{}},
+					Errors:   []fswalker.ActionData{{}},
+				},
+			},
+			wantErr: true,
+		},
+	} {
+		t.Log(tc.name)
+
+		if err := validateReport(tc.args.report); (err != nil) != tc.wantErr {
+			t.Errorf("validateReport() error = %v, wantErr %v", err, tc.wantErr)
+		}
+	}
+}
+
+func Test_rerootWithCheckRename(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		file     *fspb.File
+		newRoot  string
+		diffItem string
+		want     bool
+	}{
+		{
+			name: "diff item refers to root dir",
+			file: &fspb.File{
+				Path: "/some/absolute/path/to/source",
+				Info: &fspb.FileInfo{
+					Name:  "source",
+					IsDir: true,
+				},
+			},
+			newRoot:  "/some/absolute/path/to/source",
+			diffItem: "name: \"source\" => \"target\"",
+			want:     true,
+		},
+		{
+			name: "diff item refers to a subdir of root dir",
+			file: &fspb.File{
+				Path: "/some/absolute/path/to/source/subdir",
+				Info: &fspb.FileInfo{
+					Name:  "subdir",
+					IsDir: true,
+				},
+			},
+			newRoot:  "/some/absolute/path/to/source",
+			diffItem: "name: \"subdir\" => \"some_unexpected_name\"",
+			want:     false,
+		},
+	} {
+		t.Log(tt.name)
+
+		walk := &fspb.Walk{
+			File: []*fspb.File{
+				tt.file,
+			},
+		}
+
+		err := rerootWalkDataPaths(walk, tt.newRoot)
+		if err != nil {
+			t.Errorf("rerootWalkDataPaths() error = %v", err)
+		}
+
+		if got := isRootDirectoryRename(tt.diffItem, fswalker.ActionData{Before: tt.file}); got != tt.want {
+			t.Errorf("isRootDirectoryRename() got = %v, want %v", got, tt.want)
+		}
+	}
+}

--- a/tests/tools/fswalker/walker/walker.go
+++ b/tests/tools/fswalker/walker/walker.go
@@ -14,6 +14,11 @@ import (
 	"github.com/kopia/kopia/tests/tools/fswalker/protofile"
 )
 
+const (
+	// MaxFileSizeToHash gives an upper bound to the size of file that can be hashed by the walker
+	MaxFileSizeToHash = 1 << 32
+)
+
 // Walk performs a walk governed by the contents of the provided
 // Policy, and returns the pointer to the Walk.
 func Walk(ctx context.Context, policy *fspb.Policy) (*fspb.Walk, error) { //nolint:interfacer
@@ -50,4 +55,15 @@ func Walk(ctx context.Context, policy *fspb.Policy) (*fspb.Walk, error) { //noli
 	}
 
 	return retWalk, nil
+}
+
+// WalkPathHash performs a walk at the path prvided and returns a pointer
+// to the Walk result
+func WalkPathHash(ctx context.Context, path string) (*fspb.Walk, error) {
+	return Walk(ctx, &fspb.Policy{
+		Version:         1,
+		Include:         []string{path},
+		HashPfx:         []string{""}, // Hash everything
+		MaxHashFileSize: MaxFileSizeToHash,
+	})
 }


### PR DESCRIPTION
Add comparer interface which gathers data on a path and
compares that data to a new path, returning error if the path
differs in any way from the input data. The details of what
constitutes a difference is left to the implementation.

FSWalker implementation uses Walk and Report to do the data
gathering and comparison. Filters are applied to sort out any
modifications that might be expected (e.g. ctime, atime, mtime,
rename of root directory after restore) from the report.