### PR TITLE
Generate shorter file names, and thus paths, in E2E tests

### DIFF
--- a/tests/end_to_end_test/main_test.go
+++ b/tests/end_to_end_test/main_test.go
@@ -78,7 +78,7 @@ func randomString(n int) string {
 
 func makeScratchDir(t *testing.T) string {
 	baseTestName := strings.Split(t.Name(), "/")[0]
-	d := filepath.Join(sharedTestDataDirBase, baseTestName, randomString(8))
+	d := filepath.Join(sharedTestDataDirBase, baseTestName, randomString(4))
 
 	if err := os.MkdirAll(d, 0700); err != nil {
 		t.Fatalf("unable to make scratch dir: %v", err)

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -426,10 +426,12 @@ func randomName(opt DirectoryTreeOptions) string {
 	maxNameLength := intOrDefault(opt.MaxNameLength, 15)
 	minNameLength := intOrDefault(opt.MinNameLength, 3)
 
-	b := make([]byte, rand.Intn(maxNameLength-minNameLength)+minNameLength)
+	l := rand.Intn(maxNameLength-minNameLength) + minNameLength
+	b := make([]byte, (l+1)/2) // nolint:gomnd
+
 	cryptorand.Read(b) // nolint:errcheck
 
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b)[:l]
 }
 
 func mustParseSnaphotInfo(t *testing.T, l string) SnapshotInfo {

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -426,7 +426,7 @@ func randomName(opt DirectoryTreeOptions) string {
 	maxNameLength := intOrDefault(opt.MaxNameLength, 15)
 	minNameLength := intOrDefault(opt.MinNameLength, 3)
 
-	l := rand.Intn(maxNameLength-minNameLength) + minNameLength
+	l := rand.Intn(maxNameLength-minNameLength + 1) + minNameLength
 	b := make([]byte, (l+1)/2) // nolint:gomnd
 
 	cryptorand.Read(b) // nolint:errcheck

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -426,7 +426,7 @@ func randomName(opt DirectoryTreeOptions) string {
 	maxNameLength := intOrDefault(opt.MaxNameLength, 15)
 	minNameLength := intOrDefault(opt.MinNameLength, 3)
 
-	l := rand.Intn(maxNameLength-minNameLength + 1) + minNameLength
+	l := rand.Intn(maxNameLength-minNameLength+1) + minNameLength
 	b := make([]byte, (l+1)/2) // nolint:gomnd
 
 	cryptorand.Read(b) // nolint:errcheck


### PR DESCRIPTION
Reduces name lengths by ~ 1/2.

Motivation: address failures observed in e2e tests in Windows.