### PR TITLE
Add WalkCrossDevice option to walk policy

### DIFF
--- a/tests/tools/fswalker/walker/walker.go
+++ b/tests/tools/fswalker/walker/walker.go
@@ -65,5 +65,6 @@ func WalkPathHash(ctx context.Context, path string) (*fspb.Walk, error) {
 		Include:         []string{path},
 		HashPfx:         []string{""}, // Hash everything
 		MaxHashFileSize: MaxFileSizeToHash,
+		WalkCrossDevice: true,
 	})
 }

--- a/tests/tools/fswalker/walker/walker_test.go
+++ b/tests/tools/fswalker/walker/walker_test.go
@@ -37,6 +37,7 @@ func TestWalk(t *testing.T) {
 			Include: []string{
 				dataDir,
 			},
+			WalkCrossDevice: true,
 		})
 	testenv.AssertNoError(t, err)
 


### PR DESCRIPTION
Add the walk policy flag WalkCrossDevice to the fswalker Walk calls. This will avoid potential issues when running in a docker container where a FS tree is made of many overlays. Without the flag set, the Walk operation skips over files on devices that do not match the device at the base path.