### PR TITLE
Cleanup Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
   apt:
     packages:
     - rpm
-addons:
   snaps:
     - name: snapcraft
       confinement: classic
@@ -31,9 +30,9 @@ cache:
   - $HOME/.cache/electron-builder-docker
 deploy:
 - provider: releases
-  api_key:
+  token:
     secure: L8xxKXwaUFByM0y/ztlimRsYOURwPY6HusQfeplHVp67y/GCpoSBDPLdk3KmzzQuxafl9u/jiSHUXAvC5h18no89a0AWjQjy63GjGAC1ND9kt2WfS6lwrtUo9ISLr5GasSOb0aMJ7V5oIrslKU1wuDraoGZIdXb0uNIiVVG86g2BDoY5gnYLpdmeqIOHtUIYgbHSfvW++t0PuD4OE/unRhoAXUFGb0Gz9KdQIBRZBvULLCySQ4wZp+LLh8GsRr982Rv4oraa++ddVGFqaDTfZq+hezuCXcmuSsWmTTk7M/J1mU0vuNQw90zAomLxPKZRWXSYBy4Sw1XBJH2Gkav3dKV3T7ZmN+mLmcUdTqnG5R2NC2lYtgQD5usFPjBgchrLUEATdlTOoKneZV3aieXcwTxRGXK9lG+a2VIHo3mAebUnbBmcASdpRwo52V42lsMgTWStTgC4Y7MdrH3zp4FolB/K6S6oKWwBakxYWAxJkMqnrG638EkJdhqGa5/rUVep6powPG4VurkNvuoNsYruj3Wp1Wzk2yj5yNIHfXHISaddeP3qqzF7Y540siyMnf+j3ji2FVrZBmqFl8/kgXd/p47Aum7XqgA7xhEgVm+6BSdheLy7FVuHfpP1G7SIw9yhuC5BSeKZ9BxYU7DHAWa2URQTTAy58NDXzB6ZeIwoFx8=
-  skip_cleanup: true
+  cleanup: false
   file: "dist/**"
   draft: true
   on:
@@ -41,8 +40,8 @@ deploy:
     tags: true
     condition: $TRAVIS_OS_NAME != windows
 - provider: pages
-  skip_cleanup: true
-  github_token: "$GITHUB_TOKEN"
+  cleanup: false
+  token: "$GITHUB_TOKEN"
   keep_history: false
   local_dir: site/public
   repo: kopia/kopia.github.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - rpm
   snaps:
     - name: snapcraft
-      confinement: classic
+      classic: true
 before_install:
 - |-
     case $TRAVIS_OS_NAME in


### PR DESCRIPTION

Removes warnings in Travis v2 config validation:

> root: duplicate key: addons
 deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
 deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
 addons.snaps: unknown key confinement (classic)
 deploy: key github_token is an alias for token, using token
 deploy: key api_key is an alias for token, using token


Changes:

- remove duplicate `addons` key
- replace `github_token` with `token` in `deploy.provider:"pages"`
- replace api_key with `token` in `deploy.provider:"release"`
- replace `skip_cleanup:true` with `cleanup:false` in `deploy.provider.*`

Ref:
- https://docs.travis-ci.com/user/deployment-v2/providers/pages/
- https://docs.travis-ci.com/user/deployment-v2/providers/releases/
- https://config.travis-ci.com/ref/job/addons/snaps
