### PR TITLE
logging: refactored logging

### DIFF
--- a/cli/command_benchmark_compression.go
+++ b/cli/command_benchmark_compression.go
@@ -42,7 +42,7 @@ func runBenchmarkCompressionAction(ctx *kingpin.ParseContext) error {
 	}
 
 	for name, comp := range compression.ByName {
-		log.Infof("Benchmarking compressor '%v' (%v x %v bytes)", name, *benchmarkCompressionRepeat, len(data))
+		printStderr("Benchmarking compressor '%v' (%v x %v bytes)\n", name, *benchmarkCompressionRepeat, len(data))
 
 		t0 := time.Now()
 
@@ -54,7 +54,7 @@ func runBenchmarkCompressionAction(ctx *kingpin.ParseContext) error {
 		for i := 0; i < cnt; i++ {
 			compressed, err := comp.Compress(data)
 			if err != nil {
-				log.Warningf("compression failed: %v", err)
+				printStderr("compression %q failed: %v\n", name, err)
 				continue
 			}
 
@@ -66,7 +66,7 @@ func runBenchmarkCompressionAction(ctx *kingpin.ParseContext) error {
 				if i == 0 {
 					lastHash = h
 				} else if h != lastHash {
-					log.Warningf("compression is not stable")
+					printStderr("compression %q is not stable\n", name)
 					continue
 				}
 			}

--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -45,7 +45,7 @@ func runBenchmarkCryptoAction(ctx *kingpin.ParseContext) error {
 				continue
 			}
 
-			log.Infof("Benchmarking hash '%v' and encryption '%v'... (%v x %v bytes)", ha, ea, *benchmarkCryptoRepeat, len(data))
+			printStderr("Benchmarking hash '%v' and encryption '%v'... (%v x %v bytes)\n", ha, ea, *benchmarkCryptoRepeat, len(data))
 
 			t0 := time.Now()
 
@@ -53,7 +53,7 @@ func runBenchmarkCryptoAction(ctx *kingpin.ParseContext) error {
 			for i := 0; i < hashCount; i++ {
 				contentID := h(data)
 				if _, encerr := e.Encrypt(data, contentID); encerr != nil {
-					log.Warningf("encryption failed: %v", encerr)
+					printStderr("encryption failed: %v\n", encerr)
 					break
 				}
 			}

--- a/cli/command_benchmark_splitters.go
+++ b/cli/command_benchmark_splitters.go
@@ -47,7 +47,7 @@ func runBenchmarkSplitterAction(ctx *kingpin.ParseContext) error {
 		dataBlocks = append(dataBlocks, b)
 	}
 
-	log.Infof("splitting %v blocks of %v each", *benchmarkSplitterBlockCount, *benchmarkSplitterBlockSize)
+	printStderr("splitting %v blocks of %v each\n", *benchmarkSplitterBlockCount, *benchmarkSplitterBlockSize)
 
 	for _, sp := range object.SupportedSplitters {
 		fact := object.GetSplitterFactory(sp)

--- a/cli/command_cache_set.go
+++ b/cli/command_cache_set.go
@@ -24,27 +24,27 @@ func runCacheSetCommand(ctx context.Context, rep *repo.Repository) error {
 	changed := 0
 
 	if v := *cacheSetDirectory; v != "" {
-		log.Infof("setting cache directory to %v", v)
+		log(ctx).Infof("setting cache directory to %v", v)
 		opts.CacheDirectory = v
 		changed++
 	}
 
 	if v := *cacheSetContentCacheSizeMB; v != -1 {
 		v *= 1e6 // convert MB to bytes
-		log.Infof("changing content cache size to %v", units.BytesStringBase10(v))
+		log(ctx).Infof("changing content cache size to %v", units.BytesStringBase10(v))
 		opts.MaxCacheSizeBytes = v
 		changed++
 	}
 
 	if v := *cacheSetMaxMetadataCacheSizeMB; v != -1 {
 		v *= 1e6 // convert MB to bytes
-		log.Infof("changing metadata cache size to %v", units.BytesStringBase10(v))
+		log(ctx).Infof("changing metadata cache size to %v", units.BytesStringBase10(v))
 		opts.MaxMetadataCacheSizeBytes = v
 		changed++
 	}
 
 	if v := *cacheSetMaxListCacheDuration; v != -1 {
-		log.Infof("changing list cache duration to %v", v)
+		log(ctx).Infof("changing list cache duration to %v", v)
 		opts.MaxListCacheDurationSec = int(v.Seconds())
 		changed++
 	}
@@ -53,7 +53,7 @@ func runCacheSetCommand(ctx context.Context, rep *repo.Repository) error {
 		return errors.Errorf("no changes")
 	}
 
-	return rep.SetCachingConfig(opts)
+	return rep.SetCachingConfig(ctx, opts)
 }
 
 func init() {

--- a/cli/command_content_list.go
+++ b/cli/command_content_list.go
@@ -27,6 +27,7 @@ func runContentListCommand(ctx context.Context, rep *repo.Repository) error {
 	var totalSize int64
 
 	err := rep.Content.IterateContents(
+		ctx,
 		content.IterateOptions{
 			Prefix:         content.ID(*contentListPrefix),
 			IncludeDeleted: *contentListIncludeDeleted || *contentListDeletedOnly,

--- a/cli/command_content_rm.go
+++ b/cli/command_content_rm.go
@@ -14,7 +14,7 @@ var (
 
 func runContentRemoveCommand(ctx context.Context, rep *repo.Repository) error {
 	for _, contentID := range toContentIDs(*contentRemoveIDs) {
-		if err := rep.Content.DeleteContent(contentID); err != nil {
+		if err := rep.Content.DeleteContent(ctx, contentID); err != nil {
 			return err
 		}
 	}

--- a/cli/command_content_stats.go
+++ b/cli/command_content_stats.go
@@ -32,6 +32,7 @@ func runContentStatsCommand(ctx context.Context, rep *repo.Repository) error {
 	var totalSize, count int64
 
 	if err := rep.Content.IterateContents(
+		ctx,
 		content.IterateOptions{},
 		func(b content.Info) error {
 			totalSize += int64(b.Length)

--- a/cli/command_content_verify.go
+++ b/cli/command_content_verify.go
@@ -34,7 +34,7 @@ func runContentVerifyCommand(ctx context.Context, rep *repo.Repository) error {
 func verifyAllContents(ctx context.Context, rep *repo.Repository) error {
 	var errorCount int32
 
-	err := rep.Content.IterateContents(content.IterateOptions{
+	err := rep.Content.IterateContents(ctx, content.IterateOptions{
 		Parallel: *contentVerifyParallel,
 	}, func(ci content.Info) error {
 		if err := contentVerify(ctx, rep, ci.ID); err != nil {
@@ -56,11 +56,11 @@ func verifyAllContents(ctx context.Context, rep *repo.Repository) error {
 
 func contentVerify(ctx context.Context, r *repo.Repository, contentID content.ID) error {
 	if _, err := r.Content.GetContent(ctx, contentID); err != nil {
-		log.Warningf("content %v is invalid: %v", contentID, err)
+		log(ctx).Warningf("content %v is invalid: %v", contentID, err)
 		return err
 	}
 
-	log.Infof("content %v is ok", contentID)
+	log(ctx).Infof("content %v is ok", contentID)
 
 	return nil
 }

--- a/cli/command_index_recover.go
+++ b/cli/command_index_recover.go
@@ -21,14 +21,14 @@ func runRecoverBlockIndexesAction(ctx context.Context, rep *repo.Repository) err
 
 	defer func() {
 		if totalCount == 0 {
-			log.Noticef("No blocks recovered.")
+			log(ctx).Infof("No blocks recovered.")
 			return
 		}
 
 		if !*blockIndexRecoverCommit {
-			log.Noticef("Found %v blocks to recover, but not committed. Re-run with --commit", totalCount)
+			log(ctx).Infof("Found %v blocks to recover, but not committed. Re-run with --commit", totalCount)
 		} else {
-			log.Noticef("Recovered %v blocks.", totalCount)
+			log(ctx).Infof("Recovered %v blocks.", totalCount)
 		}
 	}()
 
@@ -54,12 +54,12 @@ func runRecoverBlockIndexesAction(ctx context.Context, rep *repo.Repository) err
 func recoverIndexFromSinglePackFile(ctx context.Context, rep *repo.Repository, blobID blob.ID, length int64, totalCount *int) {
 	recovered, err := rep.Content.RecoverIndexFromPackBlob(ctx, blobID, length, *blockIndexRecoverCommit)
 	if err != nil {
-		log.Warningf("unable to recover index from %v: %v", blobID, err)
+		log(ctx).Warningf("unable to recover index from %v: %v", blobID, err)
 		return
 	}
 
 	*totalCount += len(recovered)
-	log.Infof("Recovered %v entries from %v (commit=%v)", len(recovered), blobID, *blockIndexRecoverCommit)
+	log(ctx).Infof("Recovered %v entries from %v (commit=%v)", len(recovered), blobID, *blockIndexRecoverCommit)
 }
 
 func init() {

--- a/cli/command_mount.go
+++ b/cli/command_mount.go
@@ -34,16 +34,16 @@ func runMountCommand(ctx context.Context, rep *repo.Repository) error {
 	}
 
 	if *mountTraceFS {
-		entry = loggingfs.Wrap(entry).(fs.Directory)
+		entry = loggingfs.Wrap(entry, log(ctx).Debugf).(fs.Directory)
 	}
 
 	entry = cachefs.Wrap(entry, newFSCache()).(fs.Directory)
 
 	switch *mountMode {
 	case "FUSE":
-		return mountDirectoryFUSE(entry, *mountPoint)
+		return mountDirectoryFUSE(ctx, entry, *mountPoint)
 	case "WEBDAV":
-		return mountDirectoryWebDAV(entry, *mountPoint)
+		return mountDirectoryWebDAV(ctx, entry, *mountPoint)
 	default:
 		return errors.Errorf("unsupported mode: %q", *mountMode)
 	}

--- a/cli/command_mount_fuse.go
+++ b/cli/command_mount_fuse.go
@@ -3,6 +3,8 @@
 package cli
 
 import (
+	"context"
+
 	"bazil.org/fuse"
 	fusefs "bazil.org/fuse/fs"
 
@@ -22,7 +24,7 @@ var (
 	mountMode = mountCommand.Flag("mode", "Mount mode").Default("FUSE").Enum("WEBDAV", "FUSE")
 )
 
-func mountDirectoryFUSE(entry fs.Directory, mountPoint string) error {
+func mountDirectoryFUSE(ctx context.Context, entry fs.Directory, mountPoint string) error {
 	rootNode := fusemount.NewDirectoryNode(entry)
 
 	fuseConnection, err := fuse.Mount(
@@ -40,7 +42,7 @@ func mountDirectoryFUSE(entry fs.Directory, mountPoint string) error {
 
 	onCtrlC(func() {
 		if unmounterr := fuse.Unmount(mountPoint); unmounterr != nil {
-			log.Warningf("unmount failed: %v", unmounterr)
+			log(ctx).Warningf("unmount failed: %v", unmounterr)
 		}
 	})
 

--- a/cli/command_mount_nofuse.go
+++ b/cli/command_mount_nofuse.go
@@ -3,6 +3,8 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/fs"
@@ -12,6 +14,6 @@ var (
 	mountMode = mountCommand.Flag("mode", "Mount mode").Default("WEBDAV").Enum("WEBDAV")
 )
 
-func mountDirectoryFUSE(entry fs.Directory, mountPoint string) error {
+func mountDirectoryFUSE(ctx context.Context, entry fs.Directory, mountPoint string) error {
 	return errors.New("FUSE is not supported")
 }

--- a/cli/command_mount_webdav.go
+++ b/cli/command_mount_webdav.go
@@ -23,13 +23,13 @@ func webdavServerLogger(r *http.Request, err error) {
 	}
 
 	if err != nil {
-		log.Debugf("%v %v%v err: %v", r.Method, r.URL.RequestURI(), maybeRange, err)
+		printStderr("%v %v%v err: %v\n", r.Method, r.URL.RequestURI(), maybeRange, err)
 	} else {
-		log.Debugf("%v %v%v OK", r.Method, r.URL.RequestURI(), maybeRange)
+		printStderr("%v %v%v OK\n", r.Method, r.URL.RequestURI(), maybeRange)
 	}
 }
 
-func mountDirectoryWebDAV(entry fs.Directory, mountPoint string) error {
+func mountDirectoryWebDAV(ctx context.Context, entry fs.Directory, mountPoint string) error {
 	mux := http.NewServeMux()
 
 	var logger func(r *http.Request, err error)
@@ -58,17 +58,17 @@ func mountDirectoryWebDAV(entry fs.Directory, mountPoint string) error {
 		printStderr("Server listening at http://%v/ Press Ctrl-C to shut down.\n", s.Addr)
 
 		if err := s.ListenAndServe(); err != nil {
-			log.Warningf("server shut down with error: %v", err)
+			log(ctx).Warningf("server shut down with error: %v", err)
 		}
 	}()
 
-	if err := browseMount(mountPoint, fmt.Sprintf("http://%v", s.Addr)); err != nil {
-		log.Warningf("unable to browse %v: %v", s.Addr, err)
+	if err := browseMount(ctx, mountPoint, fmt.Sprintf("http://%v", s.Addr)); err != nil {
+		log(ctx).Warningf("unable to browse %v: %v", s.Addr, err)
 	}
 
 	// Shut down the server and wait for it.
-	if err := s.Shutdown(context.Background()); err != nil {
-		log.Warningf("shutdown failed: %v", err)
+	if err := s.Shutdown(ctx); err != nil {
+		log(ctx).Warningf("shutdown failed: %v", err)
 	}
 
 	wg.Wait()

--- a/cli/command_policy_edit.go
+++ b/cli/command_policy_edit.go
@@ -80,7 +80,7 @@ func editPolicy(ctx context.Context, rep *repo.Repository) error {
 
 		var updated *policy.Policy
 
-		if err := editor.EditLoop("policy.conf", s, func(edited string) error {
+		if err := editor.EditLoop(ctx, "policy.conf", s, func(edited string) error {
 			updated = &policy.Policy{}
 			d := json.NewDecoder(bytes.NewBufferString(edited))
 			d.DisallowUnknownFields()

--- a/cli/command_policy_remove.go
+++ b/cli/command_policy_remove.go
@@ -25,7 +25,7 @@ func removePolicy(ctx context.Context, rep *repo.Repository) error {
 	}
 
 	for _, target := range targets {
-		log.Infof("Removing policy on %q...", target)
+		log(ctx).Infof("Removing policy on %q...", target)
 
 		if err := policy.RemovePolicy(ctx, rep, target); err != nil {
 			return err

--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 func runConnectCommandWithStorage(ctx context.Context, st blob.Storage) error {
-	password, err := getPasswordFromFlags(false, false)
+	password, err := getPasswordFromFlags(ctx, false, false)
 	if err != nil {
 		return errors.Wrap(err, "getting password")
 	}

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -60,7 +60,7 @@ func runCreateCommandWithStorage(ctx context.Context, st blob.Storage) error {
 
 	options := newRepositoryOptionsFromFlags()
 
-	password, err := getPasswordFromFlags(true, false)
+	password, err := getPasswordFromFlags(ctx, true, false)
 	if err != nil {
 		return errors.Wrap(err, "getting password")
 	}
@@ -86,7 +86,7 @@ func runCreateCommandWithStorage(ctx context.Context, st blob.Storage) error {
 }
 
 func populateRepository(ctx context.Context, password string) error {
-	rep, err := repo.Open(ctx, repositoryConfigFileName(), password, applyOptionsFromFlags(nil))
+	rep, err := repo.Open(ctx, repositoryConfigFileName(), password, applyOptionsFromFlags(ctx, nil))
 	if err != nil {
 		return errors.Wrap(err, "unable to open repository")
 	}

--- a/cli/command_repository_disconnect.go
+++ b/cli/command_repository_disconnect.go
@@ -15,5 +15,5 @@ func init() {
 }
 
 func runDisconnectCommand(ctx context.Context) error {
-	return repo.Disconnect(repositoryConfigFileName())
+	return repo.Disconnect(ctx, repositoryConfigFileName())
 }

--- a/cli/command_repository_repair.go
+++ b/cli/command_repository_repair.go
@@ -39,10 +39,10 @@ func runRepairCommandWithStorage(ctx context.Context, st blob.Storage) error {
 func maybeRecoverFormatBlob(ctx context.Context, st blob.Storage) error {
 	switch *repairCommandRecoverFormatBlob {
 	case "auto":
-		log.Infof("looking for format blob...")
+		log(ctx).Infof("looking for format blob...")
 
 		if _, err := st.GetBlob(ctx, repo.FormatBlobID, 0, -1); err == nil {
-			log.Infof("format blob already exists, not recovering, pass --recover-format=yes")
+			log(ctx).Infof("format blob already exists, not recovering, pass --recover-format=yes")
 			return nil
 		}
 
@@ -63,7 +63,7 @@ func recoverFormatBlob(ctx context.Context, st blob.Storage, prefixes []string) 
 
 	for _, prefix := range prefixes {
 		err := st.ListBlobs(ctx, blob.ID(prefix), func(bi blob.Metadata) error {
-			log.Infof("looking for replica of format blob in %v...", bi.BlobID)
+			log(ctx).Infof("looking for replica of format blob in %v...", bi.BlobID)
 			if b, err := repo.RecoverFormatBlob(ctx, st, bi.BlobID, bi.Length); err == nil {
 				if !*repairDryDrun {
 					if puterr := st.PutBlob(ctx, repo.FormatBlobID, b); puterr != nil {
@@ -71,7 +71,7 @@ func recoverFormatBlob(ctx context.Context, st blob.Storage, prefixes []string) 
 					}
 				}
 
-				log.Infof("recovered replica block from %v", bi.BlobID)
+				log(ctx).Infof("recovered replica block from %v", bi.BlobID)
 				return errSuccess
 			}
 

--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -48,7 +48,7 @@ func runStatusCommand(ctx context.Context, rep *repo.Repository) error {
 		if *statusReconnectTokenIncludePassword {
 			var err error
 
-			pass, err = getPasswordFromFlags(false, true)
+			pass, err = getPasswordFromFlags(ctx, false, true)
 			if err != nil {
 				return errors.Wrap(err, "getting password")
 			}

--- a/cli/command_server_cancel.go
+++ b/cli/command_server_cancel.go
@@ -15,5 +15,5 @@ func init() {
 }
 
 func runServerCancelUpload(ctx context.Context, cli *serverapi.Client) error {
-	return cli.Post("sources/cancel", &serverapi.Empty{}, &serverapi.Empty{})
+	return cli.Post(ctx, "sources/cancel", &serverapi.Empty{}, &serverapi.Empty{})
 }

--- a/cli/command_server_flush.go
+++ b/cli/command_server_flush.go
@@ -15,5 +15,5 @@ func init() {
 }
 
 func runServerFlush(ctx context.Context, cli *serverapi.Client) error {
-	return cli.Post("flush", &serverapi.Empty{}, &serverapi.Empty{})
+	return cli.Post(ctx, "flush", &serverapi.Empty{}, &serverapi.Empty{})
 }

--- a/cli/command_server_pause.go
+++ b/cli/command_server_pause.go
@@ -15,5 +15,5 @@ func init() {
 }
 
 func runServerPause(ctx context.Context, cli *serverapi.Client) error {
-	return cli.Post("sources/pause", &serverapi.Empty{}, &serverapi.Empty{})
+	return cli.Post(ctx, "sources/pause", &serverapi.Empty{}, &serverapi.Empty{})
 }

--- a/cli/command_server_refresh.go
+++ b/cli/command_server_refresh.go
@@ -15,5 +15,5 @@ func init() {
 }
 
 func runServerRefresh(ctx context.Context, cli *serverapi.Client) error {
-	return cli.Post("refresh", &serverapi.Empty{}, &serverapi.Empty{})
+	return cli.Post(ctx, "refresh", &serverapi.Empty{}, &serverapi.Empty{})
 }

--- a/cli/command_server_resume.go
+++ b/cli/command_server_resume.go
@@ -15,5 +15,5 @@ func init() {
 }
 
 func runServerResume(ctx context.Context, cli *serverapi.Client) error {
-	return cli.Post("sources/resume", &serverapi.Empty{}, &serverapi.Empty{})
+	return cli.Post(ctx, "sources/resume", &serverapi.Empty{}, &serverapi.Empty{})
 }

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -64,27 +64,27 @@ func runServer(ctx context.Context, rep *repo.Repository) error {
 	srv.OnShutdown = httpServer.Shutdown
 
 	onCtrlC(func() {
-		log.Infof("Shutting down...")
+		log(ctx).Infof("Shutting down...")
 
 		if err = httpServer.Shutdown(ctx); err != nil {
-			log.Warningf("unable to shut down: %v", err)
+			log(ctx).Warningf("unable to shut down: %v", err)
 		}
 	})
 
 	handler := addInterceptors(mux)
 
 	if as := *serverStartAutoShutdown; as > 0 {
-		log.Infof("starting a watchdog to stop the server if there's no activity for %v", as)
+		log(ctx).Infof("starting a watchdog to stop the server if there's no activity for %v", as)
 		handler = startServerWatchdog(handler, as, func() {
 			if serr := httpServer.Shutdown(ctx); err != nil {
-				log.Warningf("unable to stop the server: %v", serr)
+				log(ctx).Warningf("unable to stop the server: %v", serr)
 			}
 		})
 	}
 
 	httpServer.Handler = handler
 
-	err = startServerWithOptionalTLS(httpServer)
+	err = startServerWithOptionalTLS(ctx, httpServer)
 	if err != http.ErrServerClosed {
 		return err
 	}

--- a/cli/command_server_status.go
+++ b/cli/command_server_status.go
@@ -17,7 +17,7 @@ func init() {
 
 func runServerStatus(ctx context.Context, cli *serverapi.Client) error {
 	var status serverapi.SourcesResponse
-	if err := cli.Get("sources", &status); err != nil {
+	if err := cli.Get(ctx, "sources", &status); err != nil {
 		return err
 	}
 

--- a/cli/command_server_upload.go
+++ b/cli/command_server_upload.go
@@ -16,13 +16,13 @@ func init() {
 }
 
 func runServerStartUpload(ctx context.Context, cli *serverapi.Client) error {
-	return triggerActionOnMatchingSources(cli, "sources/upload")
+	return triggerActionOnMatchingSources(ctx, cli, "sources/upload")
 }
 
-func triggerActionOnMatchingSources(cli *serverapi.Client, path string) error {
+func triggerActionOnMatchingSources(ctx context.Context, cli *serverapi.Client, path string) error {
 	var resp serverapi.MultipleSourceActionResponse
 
-	if err := cli.Post(path, &serverapi.Empty{}, &resp); err != nil {
+	if err := cli.Post(ctx, path, &serverapi.Empty{}, &resp); err != nil {
 		return err
 	}
 

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -91,7 +91,7 @@ func snapshotSingleSource(ctx context.Context, rep *repo.Repository, u *snapshot
 
 	rep.Content.ResetStats()
 
-	localEntry, err := getLocalFSEntry(sourceInfo.Path)
+	localEntry, err := getLocalFSEntry(ctx, sourceInfo.Path)
 	if err != nil {
 		return errors.Wrap(err, "unable to get local filesystem entry")
 	}
@@ -106,7 +106,7 @@ func snapshotSingleSource(ctx context.Context, rep *repo.Repository, u *snapshot
 		return errors.Wrap(err, "unable to get policy tree")
 	}
 
-	log.Debugf("uploading %v using %v previous manifests", sourceInfo, len(previous))
+	log(ctx).Debugf("uploading %v using %v previous manifests", sourceInfo, len(previous))
 
 	manifest, err := u.Upload(ctx, localEntry, policyTree, sourceInfo, previous...)
 	if err != nil {
@@ -187,7 +187,7 @@ func findPreviousSnapshotManifest(ctx context.Context, rep *repo.Repository, sou
 func getLocalBackupPaths(ctx context.Context, rep *repo.Repository) ([]string, error) {
 	h := getHostName()
 	u := getUserName()
-	log.Debugf("Looking for previous backups of '%v@%v'...", u, h)
+	log(ctx).Debugf("Looking for previous backups of '%v@%v'...", u, h)
 
 	sources, err := snapshot.ListSources(ctx, rep)
 	if err != nil {

--- a/cli/command_snapshot_estimate.go
+++ b/cli/command_snapshot_estimate.go
@@ -78,7 +78,7 @@ func runSnapshotEstimateCommand(ctx context.Context, rep *repo.Repository) error
 	eb := makeBuckets()
 
 	onIgnoredFile := func(relativePath string, e fs.Entry) {
-		log.Noticef("ignoring %v", relativePath)
+		log(ctx).Infof("ignoring %v", relativePath)
 		eb.add(relativePath, e.Size())
 
 		if e.IsDir() {
@@ -89,7 +89,7 @@ func runSnapshotEstimateCommand(ctx context.Context, rep *repo.Repository) error
 		}
 	}
 
-	entry, err := getLocalFSEntry(path)
+	entry, err := getLocalFSEntry(ctx, path)
 	if err != nil {
 		return err
 	}

--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -51,7 +51,7 @@ func findSnapshotsForSource(ctx context.Context, rep *repo.Repository, sourceInf
 			relPath = filepath.Base(sourceInfo.Path)
 		}
 
-		log.Debugf("No snapshots of %v@%v:%v", sourceInfo.UserName, sourceInfo.Host, sourceInfo.Path)
+		log(ctx).Debugf("No snapshots of %v@%v:%v", sourceInfo.UserName, sourceInfo.Host, sourceInfo.Path)
 
 		parentPath := filepath.Dir(sourceInfo.Path)
 		if parentPath == sourceInfo.Path {
@@ -117,7 +117,7 @@ func outputManifestGroups(ctx context.Context, rep *repo.Repository, manifests [
 	for _, snapshotGroup := range snapshot.GroupBySource(manifests) {
 		src := snapshotGroup[0].Source
 		if !shouldOutputSnapshotSource(src) {
-			log.Debugf("skipping %v", src)
+			log(ctx).Debugf("skipping %v", src)
 			continue
 		}
 
@@ -128,7 +128,7 @@ func outputManifestGroups(ctx context.Context, rep *repo.Repository, manifests [
 
 		pol, _, err := policy.GetEffectivePolicy(ctx, rep, src)
 		if err != nil {
-			log.Warningf("unable to determine effective policy for %v", src)
+			log(ctx).Warningf("unable to determine effective policy for %v", src)
 		} else {
 			pol.RetentionPolicy.ComputeRetentionReasons(snapshotGroup)
 		}
@@ -186,7 +186,7 @@ func outputManifestFromSingleSource(ctx context.Context, rep *repo.Repository, m
 		}
 
 		if _, ok := ent.(object.HasObjectID); !ok {
-			log.Warningf("entry does not have object ID: %v", ent, err)
+			log(ctx).Warningf("entry does not have object ID: %v", ent, err)
 			continue
 		}
 

--- a/cli/memory_tracking.go
+++ b/cli/memory_tracking.go
@@ -1,16 +1,17 @@
 package cli
 
 import (
+	"context"
 	"runtime"
 	"sync"
 	"time"
 
-	"github.com/kopia/kopia/internal/kopialogging"
+	"github.com/kopia/kopia/repo/logging"
 )
 
 var trackMemoryUsage = app.Flag("track-memory-usage", "Periodically force GC and log current memory usage").Hidden().Duration()
 
-var memlog = kopialogging.Logger("kopia/memory")
+var memlog = logging.GetContextLoggerFunc("kopia/memory")
 
 var (
 	memoryTrackerMutex            sync.Mutex
@@ -18,7 +19,7 @@ var (
 	maxHeapUsage, maxStackInUse   uint64
 )
 
-func dumpMemoryUsage() {
+func dumpMemoryUsage(ctx context.Context) {
 	runtime.GC()
 
 	var ms runtime.MemStats
@@ -27,7 +28,7 @@ func dumpMemoryUsage() {
 
 	memoryTrackerMutex.Lock()
 	defer memoryTrackerMutex.Unlock()
-	memlog.Debugf("in use heap %v (delta %v max %v) stack %v (delta %v max %v)", ms.HeapInuse, int64(ms.HeapInuse-lastHeapUsage), maxHeapUsage, ms.StackInuse, int64(ms.StackInuse-lastStackInUse), maxStackInUse)
+	memlog(ctx).Debugf("in use heap %v (delta %v max %v) stack %v (delta %v max %v)", ms.HeapInuse, int64(ms.HeapInuse-lastHeapUsage), maxHeapUsage, ms.StackInuse, int64(ms.StackInuse-lastStackInUse), maxStackInUse)
 
 	if ms.HeapInuse > maxHeapUsage {
 		maxHeapUsage = ms.HeapInuse
@@ -41,17 +42,17 @@ func dumpMemoryUsage() {
 	lastStackInUse = ms.StackInuse
 }
 
-func startMemoryTracking() {
+func startMemoryTracking(ctx context.Context) {
 	if *trackMemoryUsage > 0 {
 		go func() {
 			for {
-				dumpMemoryUsage()
+				dumpMemoryUsage(ctx)
 				time.Sleep(*trackMemoryUsage)
 			}
 		}()
 	}
 }
 
-func finishMemoryTracking() {
-	dumpMemoryUsage()
+func finishMemoryTracking(ctx context.Context) {
+	dumpMemoryUsage(ctx)
 }

--- a/cli/password.go
+++ b/cli/password.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -47,14 +48,14 @@ func askForExistingRepositoryPassword() (string, error) {
 
 var passwordFromToken string
 
-func getPasswordFromFlags(isNew, allowPersistent bool) (string, error) {
+func getPasswordFromFlags(ctx context.Context, isNew, allowPersistent bool) (string, error) {
 	if passwordFromToken != "" {
 		// password provided via token
 		return passwordFromToken, nil
 	}
 
 	if !isNew && allowPersistent {
-		pass, ok := repo.GetPersistedPassword(repositoryConfigFileName())
+		pass, ok := repo.GetPersistedPassword(ctx, repositoryConfigFileName())
 		if ok {
 			return pass, nil
 		}

--- a/cli/storage_filesystem.go
+++ b/cli/storage_filesystem.go
@@ -44,10 +44,10 @@ func connect(ctx context.Context, isNew bool) (blob.Storage, error) {
 	}
 
 	if isNew {
-		log.Debugf("creating directory for repository: %v dir mode: %v", fso.Path, fso.DirectoryMode)
+		log(ctx).Debugf("creating directory for repository: %v dir mode: %v", fso.Path, fso.DirectoryMode)
 
 		if err := os.MkdirAll(fso.Path, fso.DirectoryMode); err != nil {
-			log.Warningf("unable to create directory: %v", fso.Path)
+			log(ctx).Warningf("unable to create directory: %v", fso.Path)
 		}
 	}
 

--- a/cli/storage_providers.go
+++ b/cli/storage_providers.go
@@ -21,7 +21,7 @@ func RegisterStorageConnectFlags(
 		cc := createCommand.Command(name, "Create repository in "+description)
 		flags(cc)
 		cc.Action(func(_ *kingpin.ParseContext) error {
-			ctx := context.Background()
+			ctx := rootContext()
 			st, err := connect(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "can't connect to storage")
@@ -35,7 +35,7 @@ func RegisterStorageConnectFlags(
 	cc := connectCommand.Command(name, "Connect to repository in "+description)
 	flags(cc)
 	cc.Action(func(_ *kingpin.ParseContext) error {
-		ctx := context.Background()
+		ctx := rootContext()
 		st, err := connect(ctx, false)
 		if err != nil {
 			return errors.Wrap(err, "can't connect to storage")
@@ -48,7 +48,7 @@ func RegisterStorageConnectFlags(
 	cc = repairCommand.Command(name, "Repair repository in "+description)
 	flags(cc)
 	cc.Action(func(_ *kingpin.ParseContext) error {
-		ctx := context.Background()
+		ctx := rootContext()
 		st, err := connect(ctx, false)
 		if err != nil {
 			return errors.Wrap(err, "can't connect to storage")

--- a/cli/userhost.go
+++ b/cli/userhost.go
@@ -21,7 +21,7 @@ func getUserName() string {
 func getDefaultUserName() string {
 	currentUser, err := user.Current()
 	if err != nil {
-		log.Warningf("Cannot determine current user: %s", err)
+		printStderr("warning: Cannot determine current user: %s", err)
 		return "nobody"
 	}
 
@@ -44,7 +44,7 @@ func getHostName() string {
 func getDefaultHostName() string {
 	hostname, err := os.Hostname()
 	if err != nil {
-		log.Warningf("Unable to determine hostname: %s", err)
+		printStderr("Unable to determine hostname: %s\n", err)
 		return "nohost"
 	}
 

--- a/examples/upload_download/main.go
+++ b/examples/upload_download/main.go
@@ -31,6 +31,7 @@ func main() {
 
 	// Now list contents found in the repository.
 	if err := r.Content.IterateContents(
+		ctx,
 		content.IterateOptions{},
 		func(ci content.Info) error {
 			log.Printf("found content %v", ci)

--- a/examples/upload_download/setup_repository.go
+++ b/examples/upload_download/setup_repository.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"os"
 
 	"github.com/pkg/errors"
@@ -25,6 +26,7 @@ func setupRepositoryAndConnect(ctx context.Context, password string) error {
 	if err := os.MkdirAll(storageDir, 0700); err != nil {
 		return errors.Wrap(err, "unable to create directory")
 	}
+
 	st, err := filesystem.New(ctx, &filesystem.Options{
 		Path: storageDir,
 	})
@@ -33,7 +35,7 @@ func setupRepositoryAndConnect(ctx context.Context, password string) error {
 	}
 
 	// set up logging so we can see what's going on
-	st = logging.NewWrapper(st)
+	st = logging.NewWrapper(st, log.Printf, "")
 
 	// see if we already have the config file, if not connect.
 	if _, err := os.Stat(configFile); os.IsNotExist(err) {

--- a/fs/cachefs/cache_test.go
+++ b/fs/cachefs/cache_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/internal/testlogging"
 )
 
 const expirationTime = 10 * time.Hour
@@ -147,7 +148,7 @@ func (ls *lockState) Unlocked() bool {
 }
 
 func TestCache(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	c := NewCache(&Options{
 		MaxCachedDirectories: 4,
 		MaxCachedEntries:     100,
@@ -235,7 +236,7 @@ func TestCache(t *testing.T) {
 
 // Simple test for getEntries() locking/unlocking. Related to PRs #130 and #132
 func TestCacheGetEntriesLocking(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	c := NewCache(&Options{
 		MaxCachedDirectories: 4,
 		MaxCachedEntries:     100,

--- a/fs/ignorefs/ignorefs_test.go
+++ b/fs/ignorefs/ignorefs_test.go
@@ -2,7 +2,6 @@ package ignorefs_test
 
 import (
 	"bytes"
-	"context"
 	"sort"
 	"testing"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/fs/ignorefs"
 	"github.com/kopia/kopia/internal/mockfs"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/snapshot/policy"
 )
 
@@ -271,7 +271,7 @@ func walkTree(t *testing.T, dir fs.Directory) []string {
 	walk = func(path string, d fs.Directory) error {
 		output = append(output, path+"/")
 
-		entries, err := d.Readdir(context.Background())
+		entries, err := d.Readdir(testlogging.Context(t))
 		if err != nil {
 			return err
 		}

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/fs"
-	"github.com/kopia/kopia/internal/kopialogging"
+	"github.com/kopia/kopia/repo/logging"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 	dirListingPrefetch = 200 // number of directory items to os.Lstat() in advance
 )
 
-var log = kopialogging.Logger("kopia/localfs")
+var log = logging.GetContextLoggerFunc("kopia/localfs")
 
 type sortedEntries fs.Entries
 
@@ -189,7 +189,7 @@ func (fsd *filesystemDirectory) Readdir(ctx context.Context) (fs.Entries, error)
 
 				e, fierr := entryFromChildFileInfo(fi, fullPath)
 				if fierr != nil {
-					log.Warningf("unable to create directory entry %q: %v", fi.Name(), fierr)
+					log(ctx).Warningf("unable to create directory entry %q: %v", fi.Name(), fierr)
 					continue
 				}
 

--- a/fs/localfs/local_fs_test.go
+++ b/fs/localfs/local_fs_test.go
@@ -1,7 +1,6 @@
 package localfs
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,13 +8,14 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/internal/testlogging"
 
 	"testing"
 )
 
 //nolint:gocyclo,gocognit
 func TestFiles(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	var err error
 
@@ -102,7 +102,7 @@ func TestFiles(t *testing.T) {
 }
 
 func verifyChild(t *testing.T, dir fs.Directory) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	child, err := dir.Child(ctx, "f3")
 	if err != nil {

--- a/fs/loggingfs/loggingfs.go
+++ b/fs/loggingfs/loggingfs.go
@@ -6,10 +6,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/fs"
-	"github.com/kopia/kopia/internal/kopialogging"
 )
-
-var log = kopialogging.Logger("kopia/loggingfs")
 
 type loggingOptions struct {
 	printf func(fmt string, args ...interface{})
@@ -63,8 +60,8 @@ type loggingSymlink struct {
 type Option func(o *loggingOptions)
 
 // Wrap returns an Entry that wraps another Entry and logs all method calls.
-func Wrap(e fs.Entry, options ...Option) fs.Entry {
-	return wrapWithOptions(e, applyOptions(options), ".")
+func Wrap(e fs.Entry, printf func(msg string, args ...interface{}), options ...Option) fs.Entry {
+	return wrapWithOptions(e, applyOptions(printf, options), ".")
 }
 
 func wrapWithOptions(e fs.Entry, opts *loggingOptions, relativePath string) fs.Entry {
@@ -83,9 +80,9 @@ func wrapWithOptions(e fs.Entry, opts *loggingOptions, relativePath string) fs.E
 	}
 }
 
-func applyOptions(opts []Option) *loggingOptions {
+func applyOptions(printf func(msg string, args ...interface{}), opts []Option) *loggingOptions {
 	o := &loggingOptions{
-		printf: log.Debugf,
+		printf: printf,
 	}
 
 	for _, f := range opts {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/google/fswalker v0.2.0
-	github.com/google/martian v2.1.0+incompatible
+	github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible
 	github.com/gorilla/mux v1.7.4
 	github.com/klauspost/compress v1.9.7
 	github.com/klauspost/crc32 v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -42,5 +42,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	google.golang.org/api v0.10.0
+	google.golang.org/appengine v1.6.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/internal/blobtesting/concurrent.go
+++ b/internal/blobtesting/concurrent.go
@@ -1,7 +1,6 @@
 package blobtesting
 
 import (
-	"context"
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -12,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -48,7 +48,7 @@ func VerifyConcurrentAccess(t *testing.T, st blob.Storage, options ConcurrentAcc
 		return blobs[rand.Intn(len(blobs))]
 	}
 
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(testlogging.Context(t))
 
 	// start readers that will be reading random blob out of the pool
 	for i := 0; i < options.Getters; i++ {

--- a/internal/blobtesting/faulty.go
+++ b/internal/blobtesting/faulty.go
@@ -5,11 +5,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kopia/kopia/internal/repologging"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = repologging.Logger("faulty-storage")
+var log = logging.GetContextLoggerFunc("faulty-storage")
 
 // Fault describes the behavior of a single fault.
 type Fault struct {
@@ -30,7 +30,7 @@ type FaultyStorage struct {
 
 // GetBlob implements blob.Storage
 func (s *FaultyStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64) ([]byte, error) {
-	if err := s.getNextFault("GetBlob", id, offset, length); err != nil {
+	if err := s.getNextFault(ctx, "GetBlob", id, offset, length); err != nil {
 		return nil, err
 	}
 
@@ -39,7 +39,7 @@ func (s *FaultyStorage) GetBlob(ctx context.Context, id blob.ID, offset, length 
 
 // PutBlob implements blob.Storage
 func (s *FaultyStorage) PutBlob(ctx context.Context, id blob.ID, data []byte) error {
-	if err := s.getNextFault("PutBlob", id, len(data)); err != nil {
+	if err := s.getNextFault(ctx, "PutBlob", id, len(data)); err != nil {
 		return err
 	}
 
@@ -48,7 +48,7 @@ func (s *FaultyStorage) PutBlob(ctx context.Context, id blob.ID, data []byte) er
 
 // DeleteBlob implements blob.Storage
 func (s *FaultyStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
-	if err := s.getNextFault("DeleteBlob", id); err != nil {
+	if err := s.getNextFault(ctx, "DeleteBlob", id); err != nil {
 		return err
 	}
 
@@ -57,12 +57,12 @@ func (s *FaultyStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
 
 // ListBlobs implements blob.Storage
 func (s *FaultyStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback func(blob.Metadata) error) error {
-	if err := s.getNextFault("ListBlobs", prefix); err != nil {
+	if err := s.getNextFault(ctx, "ListBlobs", prefix); err != nil {
 		return err
 	}
 
 	return s.Base.ListBlobs(ctx, prefix, func(bm blob.Metadata) error {
-		if err := s.getNextFault("ListBlobsItem", prefix); err != nil {
+		if err := s.getNextFault(ctx, "ListBlobsItem", prefix); err != nil {
 			return err
 		}
 		return callback(bm)
@@ -71,7 +71,7 @@ func (s *FaultyStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback 
 
 // Close implements blob.Storage
 func (s *FaultyStorage) Close(ctx context.Context) error {
-	if err := s.getNextFault("Close"); err != nil {
+	if err := s.getNextFault(ctx, "Close"); err != nil {
 		return err
 	}
 
@@ -83,13 +83,13 @@ func (s *FaultyStorage) ConnectionInfo() blob.ConnectionInfo {
 	return s.Base.ConnectionInfo()
 }
 
-func (s *FaultyStorage) getNextFault(method string, args ...interface{}) error {
+func (s *FaultyStorage) getNextFault(ctx context.Context, method string, args ...interface{}) error {
 	s.mu.Lock()
 
 	faults := s.Faults[method]
 	if len(faults) == 0 {
 		s.mu.Unlock()
-		log.Debugf("no faults for %v %v", method, args)
+		log(ctx).Debugf("no faults for %v %v", method, args)
 
 		return nil
 	}
@@ -97,7 +97,7 @@ func (s *FaultyStorage) getNextFault(method string, args ...interface{}) error {
 	f := faults[0]
 	if f.Repeat > 0 {
 		f.Repeat--
-		log.Debugf("will repeat %v more times the fault for %v %v", f.Repeat, method, args)
+		log(ctx).Debugf("will repeat %v more times the fault for %v %v", f.Repeat, method, args)
 	} else {
 		s.Faults[method] = faults[1:]
 	}
@@ -105,23 +105,23 @@ func (s *FaultyStorage) getNextFault(method string, args ...interface{}) error {
 	s.mu.Unlock()
 
 	if f.WaitFor != nil {
-		log.Debugf("waiting for channel to be closed in %v %v", method, args)
+		log(ctx).Debugf("waiting for channel to be closed in %v %v", method, args)
 		<-f.WaitFor
 	}
 
 	if f.Sleep > 0 {
-		log.Debugf("sleeping for %v in %v %v", f.Sleep, method, args)
+		log(ctx).Debugf("sleeping for %v in %v %v", f.Sleep, method, args)
 		time.Sleep(f.Sleep)
 	}
 
 	if f.ErrCallback != nil {
 		err := f.ErrCallback()
-		log.Debugf("returning %v for %v %v", err, method, args)
+		log(ctx).Debugf("returning %v for %v %v", err, method, args)
 
 		return err
 	}
 
-	log.Debugf("returning %v for %v %v", f.Err, method, args)
+	log(ctx).Debugf("returning %v for %v %v", f.Err, method, args)
 
 	return f.Err
 }

--- a/internal/blobtesting/map_test.go
+++ b/internal/blobtesting/map_test.go
@@ -1,8 +1,9 @@
 package blobtesting
 
 import (
-	"context"
 	"testing"
+
+	"github.com/kopia/kopia/internal/testlogging"
 )
 
 func TestMapStorage(t *testing.T) {
@@ -13,5 +14,5 @@ func TestMapStorage(t *testing.T) {
 		t.Errorf("unexpected result: %v", r)
 	}
 
-	VerifyStorage(context.Background(), t, r)
+	VerifyStorage(testlogging.Context(t), t, r)
 }

--- a/internal/blobtesting/verify.go
+++ b/internal/blobtesting/verify.go
@@ -29,13 +29,9 @@ func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage) {
 		AssertGetBlobNotFound(ctx, t, r, b.blk)
 	}
 
-	ctx2 := blob.WithUploadProgressCallback(ctx, func(desc string, completed, total int64) {
-		log.Infof("progress %v: %v/%v", desc, completed, total)
-	})
-
 	// Now add blocks.
 	for _, b := range blocks {
-		if err := r.PutBlob(ctx2, b.blk, b.contents); err != nil {
+		if err := r.PutBlob(ctx, b.blk, b.contents); err != nil {
 			t.Errorf("can't put blob: %v", err)
 		}
 

--- a/internal/ctxutil/detach.go
+++ b/internal/ctxutil/detach.go
@@ -1,0 +1,21 @@
+// Package ctxutil implements utilities for manipulating context.
+package ctxutil
+
+import (
+	"context"
+)
+
+type detachedContext struct {
+	context.Context // inherit most methods from context.Background()
+
+	wrapped context.Context
+}
+
+// Detach returns a context that inheris provided context's values but not deadline or cancellation.
+func Detach(ctx context.Context) context.Context {
+	return detachedContext{context.Background(), ctx}
+}
+
+func (d detachedContext) Value(key interface{}) interface{} {
+	return d.wrapped.Value(key)
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -13,11 +13,11 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/fs"
-	"github.com/kopia/kopia/internal/kopialogging"
+	"github.com/kopia/kopia/repo/logging"
 	"github.com/kopia/kopia/repo/object"
 )
 
-var log = kopialogging.Logger("diff")
+var log = logging.GetContextLoggerFunc("diff")
 
 // Comparer outputs diff information between two filesystems.
 type Comparer struct {
@@ -39,7 +39,7 @@ func (c *Comparer) Close() error {
 }
 
 func (c *Comparer) compareDirectories(ctx context.Context, dir1, dir2 fs.Directory, parent string) error {
-	log.Debugf("comparing directories %v", parent)
+	log(ctx).Debugf("comparing directories %v", parent)
 
 	var entries1, entries2 fs.Entries
 
@@ -68,7 +68,7 @@ func (c *Comparer) compareEntry(ctx context.Context, e1, e2 fs.Entry, path strin
 	if h1, ok := e1.(object.HasObjectID); ok {
 		if h2, ok := e2.(object.HasObjectID); ok {
 			if h1.ObjectID() == h2.ObjectID() {
-				log.Debugf("unchanged %v", path)
+				log(ctx).Debugf("unchanged %v", path)
 				return nil
 			}
 		}
@@ -125,7 +125,7 @@ func (c *Comparer) compareEntry(ctx context.Context, e1, e2 fs.Entry, path strin
 
 	if isDir2 {
 		// left is non-directory, right is a directory
-		log.Infof("changed %v from non-directory to a directory", path)
+		log(ctx).Infof("changed %v from non-directory to a directory", path)
 		return nil
 	}
 

--- a/internal/fshasher/fshasher.go
+++ b/internal/fshasher/fshasher.go
@@ -12,10 +12,10 @@ import (
 	"golang.org/x/crypto/blake2s"
 
 	"github.com/kopia/kopia/fs"
-	"github.com/kopia/kopia/internal/repologging"
+	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = repologging.Logger("kopia/internal/fshasher")
+var log = logging.GetContextLoggerFunc("kopia/internal/fshasher")
 
 // Hash computes a recursive hash of e using the given hasher h
 func Hash(ctx context.Context, e fs.Entry) ([]byte, error) {
@@ -45,7 +45,7 @@ func write(ctx context.Context, tw *tar.Writer, fullpath string, e fs.Entry) err
 		return err
 	}
 
-	log.Debug(e.Mode(), h.ModTime.Format(time.RFC3339), h.Size, h.Name)
+	log(ctx).Debugf("%v %v %v %v", e.Mode(), h.ModTime.Format(time.RFC3339), h.Size, h.Name)
 
 	if err := tw.WriteHeader(h); err != nil {
 		return err

--- a/internal/fshasher/fshasher_test.go
+++ b/internal/fshasher/fshasher_test.go
@@ -1,12 +1,12 @@
 package fshasher
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/mockfs"
+	"github.com/kopia/kopia/internal/testlogging"
 )
 
 // nolint:gocritic
@@ -20,7 +20,7 @@ func TestHash(t *testing.T) {
 	d1.AddFile("d1-f1", []byte("d1-f1-content"), 0644)
 
 	ensure := require.New(t)
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	h1, err := Hash(ctx, root)
 	ensure.NoError(err)
 

--- a/internal/kopialogging/logging.go
+++ b/internal/kopialogging/logging.go
@@ -1,9 +1,0 @@
-// Package kopialogging provides loggers for the rest of codebase.
-package kopialogging
-
-import "github.com/op/go-logging"
-
-// Logger returns an instance of a logger used throughout Kopia codebase.
-func Logger(module string) *logging.Logger {
-	return logging.MustGetLogger(module)
-}

--- a/internal/repologging/logging.go
+++ b/internal/repologging/logging.go
@@ -1,9 +1,0 @@
-// Package repologging provides loggers.
-package repologging
-
-import "github.com/op/go-logging"
-
-// Logger returns an instance of a logger used throughout repository codebase.
-func Logger(module string) *logging.Logger {
-	return logging.MustGetLogger(module)
-}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/testlogging"
 )
 
 var (
@@ -40,12 +42,14 @@ func TestRetry(t *testing.T) {
 		{"retriable-never-succeeds", func() (interface{}, error) { return nil, errRetriable }, nil, errors.Errorf("unable to complete retriable-never-succeeds despite 3 retries")},
 	}
 
+	ctx := testlogging.Context(t)
+
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := WithExponentialBackoff(tc.desc, tc.f, isRetriable)
+			got, err := WithExponentialBackoff(ctx, tc.desc, tc.f, isRetriable)
 			if (err != nil) != (tc.wantError != nil) {
 				t.Errorf("invalid error %q, wanted %q", err, tc.wantError)
 			}

--- a/internal/server/api_repo.go
+++ b/internal/server/api_repo.go
@@ -174,7 +174,7 @@ func (s *Server) handleRepoDisconnect(ctx context.Context, r *http.Request) (int
 		return nil, internalServerError(err)
 	}
 
-	if err := repo.Disconnect(s.options.ConfigFile); err != nil {
+	if err := repo.Disconnect(ctx, s.options.ConfigFile); err != nil {
 		return nil, internalServerError(err)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,14 +12,14 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/kopialogging"
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/logging"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
 )
 
-var log = kopialogging.Logger("kopia/server")
+var log = logging.GetContextLoggerFunc("kopia/server")
 
 // Server exposes simple HTTP API for programmatically accessing Kopia features.
 type Server struct {
@@ -86,17 +86,19 @@ func (s *Server) handleAPIPossiblyNotConnected(f func(ctx context.Context, r *ht
 		s.mu.RLock()
 		defer s.mu.RUnlock()
 
-		log.Debug("request %v", r.URL)
+		ctx := r.Context()
+
+		log(ctx).Debugf("request %v", r.URL)
 
 		w.Header().Set("Content-Type", "application/json")
 		e := json.NewEncoder(w)
 		e.SetIndent("", "  ")
 
-		v, err := f(context.Background(), r)
+		v, err := f(ctx, r)
 
 		if err == nil {
 			if err := e.Encode(v); err != nil {
-				log.Warningf("error encoding response: %v", err)
+				log(ctx).Warningf("error encoding response: %v", err)
 			}
 
 			return
@@ -105,7 +107,7 @@ func (s *Server) handleAPIPossiblyNotConnected(f func(ctx context.Context, r *ht
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.WriteHeader(err.httpErrorCode)
-		log.Debug("error code %v message %v", err.apiErrorCode, err.message)
+		log(ctx).Debugf("error code %v message %v", err.apiErrorCode, err.message)
 
 		_ = e.Encode(&serverapi.ErrorResponse{
 			Code:  err.apiErrorCode,
@@ -115,22 +117,22 @@ func (s *Server) handleAPIPossiblyNotConnected(f func(ctx context.Context, r *ht
 }
 
 func (s *Server) handleRefresh(ctx context.Context, r *http.Request) (interface{}, *apiError) {
-	log.Infof("refreshing")
+	log(ctx).Infof("refreshing")
 	return &serverapi.Empty{}, nil
 }
 
 func (s *Server) handleFlush(ctx context.Context, r *http.Request) (interface{}, *apiError) {
-	log.Infof("flushing")
+	log(ctx).Infof("flushing")
 	return &serverapi.Empty{}, nil
 }
 
 func (s *Server) handleShutdown(ctx context.Context, r *http.Request) (interface{}, *apiError) {
-	log.Infof("shutting down due to API request")
+	log(ctx).Infof("shutting down due to API request")
 
 	if f := s.OnShutdown; f != nil {
 		go func() {
 			if err := f(ctx); err != nil {
-				log.Warningf("shutdown failed: %v", err)
+				log(ctx).Warningf("shutdown failed: %v", err)
 			}
 		}()
 	}
@@ -138,7 +140,7 @@ func (s *Server) handleShutdown(ctx context.Context, r *http.Request) (interface
 	return &serverapi.Empty{}, nil
 }
 
-func (s *Server) forAllSourceManagersMatchingURLFilter(c func(s *sourceManager) serverapi.SourceActionResponse, values url.Values) (interface{}, *apiError) {
+func (s *Server) forAllSourceManagersMatchingURLFilter(ctx context.Context, c func(s *sourceManager, ctx context.Context) serverapi.SourceActionResponse, values url.Values) (interface{}, *apiError) {
 	resp := &serverapi.MultipleSourceActionResponse{
 		Sources: map[string]serverapi.SourceActionResponse{},
 	}
@@ -148,29 +150,29 @@ func (s *Server) forAllSourceManagersMatchingURLFilter(c func(s *sourceManager) 
 			continue
 		}
 
-		resp.Sources[src.String()] = c(mgr)
+		resp.Sources[src.String()] = c(mgr, ctx)
 	}
 
 	return resp, nil
 }
 
 func (s *Server) handleUpload(ctx context.Context, r *http.Request) (interface{}, *apiError) {
-	return s.forAllSourceManagersMatchingURLFilter((*sourceManager).upload, r.URL.Query())
+	return s.forAllSourceManagersMatchingURLFilter(ctx, (*sourceManager).upload, r.URL.Query())
 }
 
 func (s *Server) handleCancel(ctx context.Context, r *http.Request) (interface{}, *apiError) {
-	return s.forAllSourceManagersMatchingURLFilter((*sourceManager).cancel, r.URL.Query())
+	return s.forAllSourceManagersMatchingURLFilter(ctx, (*sourceManager).cancel, r.URL.Query())
 }
 
-func (s *Server) beginUpload(src snapshot.SourceInfo) {
-	log.Debugf("waiting on semaphore to upload %v", src)
+func (s *Server) beginUpload(ctx context.Context, src snapshot.SourceInfo) {
+	log(ctx).Debugf("waiting on semaphore to upload %v", src)
 	s.uploadSemaphore <- struct{}{}
 
-	log.Debugf("entered semaphore to upload %v", src)
+	log(ctx).Debugf("entered semaphore to upload %v", src)
 }
 
-func (s *Server) endUpload(src snapshot.SourceInfo) {
-	log.Debugf("finished uploading %v", src)
+func (s *Server) endUpload(ctx context.Context, src snapshot.SourceInfo) {
+	log(ctx).Debugf("finished uploading %v", src)
 	<-s.uploadSemaphore
 }
 
@@ -187,9 +189,9 @@ func (s *Server) SetRepository(ctx context.Context, rep *repo.Repository) error 
 
 	if s.rep != nil {
 		// close previous source managers
-		log.Infof("stopping all source managers")
-		s.stopAllSourceManagersLocked()
-		log.Infof("stopped all source managers")
+		log(ctx).Infof("stopping all source managers")
+		s.stopAllSourceManagersLocked(ctx)
+		log(ctx).Infof("stopped all source managers")
 
 		if err := s.rep.Close(ctx); err != nil {
 			return errors.Wrap(err, "unable to close previous repository")
@@ -209,7 +211,7 @@ func (s *Server) SetRepository(ctx context.Context, rep *repo.Repository) error 
 	}
 
 	if err := s.syncSourcesLocked(ctx); err != nil {
-		s.stopAllSourceManagersLocked()
+		s.stopAllSourceManagersLocked(ctx)
 		s.rep = nil
 
 		return err
@@ -229,11 +231,11 @@ func (s *Server) refreshPeriodically(ctx context.Context, r *repo.Repository) {
 
 		case <-time.After(s.options.RefreshInterval):
 			if err := r.Refresh(ctx); err != nil {
-				log.Warningf("error refreshing repository: %v", err)
+				log(ctx).Warningf("error refreshing repository: %v", err)
 			}
 
 			if err := s.SyncSources(ctx); err != nil {
-				log.Warningf("unable to sync sources: %v", err)
+				log(ctx).Warningf("unable to sync sources: %v", err)
 			}
 		}
 	}
@@ -248,20 +250,20 @@ func (s *Server) SyncSources(ctx context.Context) error {
 }
 
 // StopAllSourceManagers causes all source managers to stop.
-func (s *Server) StopAllSourceManagers() {
+func (s *Server) StopAllSourceManagers(ctx context.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.stopAllSourceManagersLocked()
+	s.stopAllSourceManagersLocked(ctx)
 }
 
-func (s *Server) stopAllSourceManagersLocked() {
+func (s *Server) stopAllSourceManagersLocked(ctx context.Context) {
 	for _, sm := range s.sourceManagers {
-		sm.stop()
+		sm.stop(ctx)
 	}
 
 	for _, sm := range s.sourceManagers {
-		sm.waitUntilStopped()
+		sm.waitUntilStopped(ctx)
 	}
 
 	s.sourceManagers = map[snapshot.SourceInfo]*sourceManager{}
@@ -314,11 +316,11 @@ func (s *Server) syncSourcesLocked(ctx context.Context) error {
 	// whatever is left in oldSourceManagers are managers for sources that don't exist anymore.
 	// stop source manager for sources no longer in the repo.
 	for _, sm := range oldSourceManagers {
-		sm.stop()
+		sm.stop(ctx)
 	}
 
 	for src, sm := range oldSourceManagers {
-		sm.waitUntilStopped()
+		sm.waitUntilStopped(ctx)
 		delete(s.sourceManagers, src)
 	}
 

--- a/internal/serverapi/client.go
+++ b/internal/serverapi/client.go
@@ -2,6 +2,7 @@ package serverapi
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -11,10 +12,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/kopialogging"
+	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = kopialogging.Logger("kopia/client")
+var log = logging.GetContextLoggerFunc("kopia/client")
 
 // DefaultUsername is the default username for Kopia server.
 const DefaultUsername = "kopia"
@@ -25,14 +26,14 @@ type Client struct {
 }
 
 // Get sends HTTP GET request and decodes the JSON response into the provided payload structure.
-func (c *Client) Get(path string, respPayload interface{}) error {
+func (c *Client) Get(ctx context.Context, path string, respPayload interface{}) error {
 	req, err := http.NewRequest("GET", c.options.BaseURL+path, nil)
 	if err != nil {
 		return err
 	}
 
 	if c.options.LogRequests {
-		log.Debugf("GET %v", c.options.BaseURL+path)
+		log(ctx).Debugf("GET %v", c.options.BaseURL+path)
 	}
 
 	if c.options.Username != "" {
@@ -57,7 +58,7 @@ func (c *Client) Get(path string, respPayload interface{}) error {
 }
 
 // Post sends HTTP post request with given JSON payload structure and decodes the JSON response into another payload structure.
-func (c *Client) Post(path string, reqPayload, respPayload interface{}) error {
+func (c *Client) Post(ctx context.Context, path string, reqPayload, respPayload interface{}) error {
 	var buf bytes.Buffer
 
 	if err := json.NewEncoder(&buf).Encode(reqPayload); err != nil {
@@ -65,7 +66,7 @@ func (c *Client) Post(path string, reqPayload, respPayload interface{}) error {
 	}
 
 	if c.options.LogRequests {
-		log.Infof("POST %v (%v bytes)", c.options.BaseURL+path, buf.Len())
+		log(ctx).Infof("POST %v (%v bytes)", c.options.BaseURL+path, buf.Len())
 	}
 
 	req, err := http.NewRequest("POST", c.options.BaseURL+path, &buf)

--- a/internal/serverapi/client_wrappers.go
+++ b/internal/serverapi/client_wrappers.go
@@ -14,7 +14,7 @@ import (
 // CreateSnapshotSource creates snapshot source with a given path.
 func (c *Client) CreateSnapshotSource(ctx context.Context, req *CreateSnapshotSourceRequest) (*CreateSnapshotSourceResponse, error) {
 	resp := &CreateSnapshotSourceResponse{}
-	if err := c.Post("sources", req, resp); err != nil {
+	if err := c.Post(ctx, "sources", req, resp); err != nil {
 		return nil, err
 	}
 
@@ -24,7 +24,7 @@ func (c *Client) CreateSnapshotSource(ctx context.Context, req *CreateSnapshotSo
 // UploadSnapshots triggers snapshot upload on matching snapshots.
 func (c *Client) UploadSnapshots(ctx context.Context, match *snapshot.SourceInfo) (*MultipleSourceActionResponse, error) {
 	resp := &MultipleSourceActionResponse{}
-	if err := c.Post("sources/upload"+matchSourceParameters(match), &Empty{}, resp); err != nil {
+	if err := c.Post(ctx, "sources/upload"+matchSourceParameters(match), &Empty{}, resp); err != nil {
 		return nil, err
 	}
 
@@ -34,7 +34,7 @@ func (c *Client) UploadSnapshots(ctx context.Context, match *snapshot.SourceInfo
 // CancelUpload cancels snapshot upload on matching snapshots.
 func (c *Client) CancelUpload(ctx context.Context, match *snapshot.SourceInfo) (*MultipleSourceActionResponse, error) {
 	resp := &MultipleSourceActionResponse{}
-	if err := c.Post("sources/cancel"+matchSourceParameters(match), &Empty{}, resp); err != nil {
+	if err := c.Post(ctx, "sources/cancel"+matchSourceParameters(match), &Empty{}, resp); err != nil {
 		return nil, err
 	}
 
@@ -43,28 +43,28 @@ func (c *Client) CancelUpload(ctx context.Context, match *snapshot.SourceInfo) (
 
 // CreateRepository invokes the 'repo/create' API.
 func (c *Client) CreateRepository(ctx context.Context, req *CreateRepositoryRequest) error {
-	return c.Post("repo/create", req, &StatusResponse{})
+	return c.Post(ctx, "repo/create", req, &StatusResponse{})
 }
 
 // ConnectToRepository invokes the 'repo/connect' API.
 func (c *Client) ConnectToRepository(ctx context.Context, req *ConnectRepositoryRequest) error {
-	return c.Post("repo/connect", req, &StatusResponse{})
+	return c.Post(ctx, "repo/connect", req, &StatusResponse{})
 }
 
 // DisconnectFromRepository invokes the 'repo/disconnect' API.
 func (c *Client) DisconnectFromRepository(ctx context.Context) error {
-	return c.Post("repo/disconnect", &Empty{}, &Empty{})
+	return c.Post(ctx, "repo/disconnect", &Empty{}, &Empty{})
 }
 
 // Shutdown invokes the 'repo/shutdown' API.
 func (c *Client) Shutdown(ctx context.Context) {
-	_ = c.Post("shutdown", &Empty{}, &Empty{})
+	_ = c.Post(ctx, "shutdown", &Empty{}, &Empty{})
 }
 
 // Status invokes the 'repo/status' API.
 func (c *Client) Status(ctx context.Context) (*StatusResponse, error) {
 	resp := &StatusResponse{}
-	if err := c.Get("repo/status", resp); err != nil {
+	if err := c.Get(ctx, "repo/status", resp); err != nil {
 		return nil, err
 	}
 
@@ -74,7 +74,7 @@ func (c *Client) Status(ctx context.Context) (*StatusResponse, error) {
 // ListSources lists the snapshot sources managed by the server.
 func (c *Client) ListSources(ctx context.Context, match *snapshot.SourceInfo) (*SourcesResponse, error) {
 	resp := &SourcesResponse{}
-	if err := c.Get("sources"+matchSourceParameters(match), resp); err != nil {
+	if err := c.Get(ctx, "sources"+matchSourceParameters(match), resp); err != nil {
 		return nil, err
 	}
 
@@ -84,7 +84,7 @@ func (c *Client) ListSources(ctx context.Context, match *snapshot.SourceInfo) (*
 // ListSnapshots lists the snapshots managed by the server for a given source filter.
 func (c *Client) ListSnapshots(ctx context.Context, match *snapshot.SourceInfo) (*SnapshotsResponse, error) {
 	resp := &SnapshotsResponse{}
-	if err := c.Get("snapshots"+matchSourceParameters(match), resp); err != nil {
+	if err := c.Get(ctx, "snapshots"+matchSourceParameters(match), resp); err != nil {
 		return nil, err
 	}
 
@@ -94,7 +94,7 @@ func (c *Client) ListSnapshots(ctx context.Context, match *snapshot.SourceInfo) 
 // ListPolicies lists the policies managed by the server for a given target filter.
 func (c *Client) ListPolicies(ctx context.Context, match *snapshot.SourceInfo) (*PoliciesResponse, error) {
 	resp := &PoliciesResponse{}
-	if err := c.Get("policies"+matchSourceParameters(match), resp); err != nil {
+	if err := c.Get(ctx, "policies"+matchSourceParameters(match), resp); err != nil {
 		return nil, err
 	}
 
@@ -109,7 +109,7 @@ func (c *Client) GetObject(ctx context.Context, objectID string) ([]byte, error)
 	}
 
 	if c.options.LogRequests {
-		log.Debugf("GET %v", req.URL)
+		log(ctx).Debugf("GET %v", req.URL)
 	}
 
 	if c.options.Username != "" {

--- a/internal/testlogging/ctx.go
+++ b/internal/testlogging/ctx.go
@@ -1,0 +1,82 @@
+// Package testlogging implements logger that writes to testing.T log.
+package testlogging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kopia/kopia/repo/logging"
+)
+
+// Level specifies log level.
+type Level int
+
+// log levels
+const (
+	LevelDebug Level = iota
+	LevelInfo
+	LevelWarning
+	LevelError
+	LevelFatal
+)
+
+type testLogger struct {
+	t        *testing.T
+	prefix   string
+	minLevel Level
+}
+
+func (l *testLogger) Debugf(msg string, args ...interface{}) {
+	if l.minLevel > LevelDebug {
+		return
+	}
+
+	l.t.Helper()
+	l.t.Logf(l.prefix+msg, args...)
+}
+func (l *testLogger) Infof(msg string, args ...interface{}) {
+	if l.minLevel > LevelInfo {
+		return
+	}
+
+	l.t.Helper()
+	l.t.Logf(l.prefix+msg, args...)
+}
+func (l *testLogger) Warningf(msg string, args ...interface{}) {
+	if l.minLevel > LevelWarning {
+		return
+	}
+
+	l.t.Helper()
+	l.t.Logf(l.prefix+"warning: "+msg, args...)
+}
+func (l *testLogger) Errorf(msg string, args ...interface{}) {
+	if l.minLevel > LevelError {
+		return
+	}
+
+	l.t.Helper()
+	l.t.Errorf(l.prefix+msg, args...)
+}
+func (l *testLogger) Fatalf(msg string, args ...interface{}) {
+	if l.minLevel > LevelFatal {
+		return
+	}
+
+	l.t.Helper()
+	l.t.Fatalf(l.prefix+msg, args...)
+}
+
+var _ logging.Logger = &testLogger{}
+
+// Context returns a context with attached logger that emits all log entries to go testing.T log output.
+func Context(t *testing.T) context.Context {
+	return ContextWithLevel(t, LevelDebug)
+}
+
+// ContextWithLevel returns a context with attached logger that emits all log entries with given log level or above.
+func ContextWithLevel(t *testing.T, level Level) context.Context {
+	return logging.WithLogger(context.Background(), func(module string) logging.Logger {
+		return &testLogger{t, "[" + module + "] ", level}
+	})
+}

--- a/internal/webdavmount/webdavmount.go
+++ b/internal/webdavmount/webdavmount.go
@@ -11,10 +11,10 @@ import (
 	"golang.org/x/net/webdav"
 
 	"github.com/kopia/kopia/fs"
-	"github.com/kopia/kopia/internal/kopialogging"
+	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = kopialogging.Logger("kopia/webdavmount")
+var log = logging.GetContextLoggerFunc("kopia/webdavmount")
 
 var _ os.FileInfo = webdavFileInfo{}
 var _ webdav.File = (*webdavFile)(nil)
@@ -154,7 +154,7 @@ func (w *webdavFS) Rename(ctx context.Context, oldPath, newPath string) error {
 func (w *webdavFS) OpenFile(ctx context.Context, path string, flags int, mode os.FileMode) (webdav.File, error) {
 	f, err := w.findEntry(ctx, path)
 	if err != nil {
-		log.Warningf("OpenFile(%q) failed with %v", path, err)
+		log(ctx).Warningf("OpenFile(%q) failed with %v", path, err)
 		return nil, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,9 @@ import (
 	"github.com/kopia/kopia/cli"
 	"github.com/kopia/kopia/internal/logfile"
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/logging"
+
+	gologging "github.com/op/go-logging"
 )
 
 const usageTemplate = `{{define "FormatCommand"}}\
@@ -66,6 +69,9 @@ Commands (use --help-full to list all commands):
 func main() {
 	app := cli.App()
 
+	logging.SetDefault(func(module string) logging.Logger {
+		return gologging.MustGetLogger(module)
+	})
 	app.Version(repo.BuildVersion + " build: " + repo.BuildInfo)
 	app.PreAction(logfile.Initialize)
 	app.UsageTemplate(usageTemplate)

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -56,7 +56,7 @@ func (az *azStorage) GetBlob(ctx context.Context, b blob.ID, offset, length int6
 		return ioutil.ReadAll(throttled)
 	}
 
-	v, err := exponentialBackoff(fmt.Sprintf("GetBlob(%q,%v,%v)", b, offset, length), attempt)
+	v, err := exponentialBackoff(ctx, fmt.Sprintf("GetBlob(%q,%v,%v)", b, offset, length), attempt)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -69,8 +69,8 @@ func (az *azStorage) GetBlob(ctx context.Context, b blob.ID, offset, length int6
 	return fetched, nil
 }
 
-func exponentialBackoff(desc string, att retry.AttemptFunc) (interface{}, error) {
-	return retry.WithExponentialBackoff(desc, att, isRetriableError)
+func exponentialBackoff(ctx context.Context, desc string, att retry.AttemptFunc) (interface{}, error) {
+	return retry.WithExponentialBackoff(ctx, desc, att, isRetriableError)
 }
 
 func isRetriableError(err error) bool {
@@ -138,7 +138,7 @@ func (az *azStorage) DeleteBlob(ctx context.Context, b blob.ID) error {
 	attempt := func() (interface{}, error) {
 		return nil, az.bucket.Delete(ctx, az.getObjectNameString(b))
 	}
-	_, err := exponentialBackoff(fmt.Sprintf("DeleteBlob(%q)", b), attempt)
+	_, err := exponentialBackoff(ctx, fmt.Sprintf("DeleteBlob(%q)", b), attempt)
 	err = translateError(err)
 
 	// don't return error if blob is already deleted

--- a/repo/blob/filesystem/filesystem_storage_test.go
+++ b/repo/blob/filesystem/filesystem_storage_test.go
@@ -1,7 +1,6 @@
 package filesystem
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -12,12 +11,13 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/testlogging"
 )
 
 func TestFileStorage(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	// Test varioush shard configurations.
 	for _, shardSpec := range [][]int{
@@ -59,7 +59,7 @@ const (
 func TestFileStorageTouch(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	path, _ := ioutil.TempDir("", "r-fs")
 	defer os.RemoveAll(path)
@@ -100,7 +100,7 @@ func TestFileStorageConcurrency(t *testing.T) {
 	path, _ := ioutil.TempDir("", "fs-concurrency")
 	defer os.RemoveAll(path)
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	st, err := New(ctx, &Options{
 		Path: path,
@@ -123,7 +123,7 @@ func TestFileStorageConcurrency(t *testing.T) {
 }
 
 func verifyBlobTimestampOrder(t *testing.T, st blob.Storage, want ...blob.ID) {
-	blobs, err := blob.ListAllBlobs(context.Background(), st, "")
+	blobs, err := blob.ListAllBlobs(testlogging.Context(t), st, "")
 	if err != nil {
 		t.Errorf("error listing blobs: %v", err)
 		return

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -56,7 +56,7 @@ func (gcs *gcsStorage) GetBlob(ctx context.Context, b blob.ID, offset, length in
 		return ioutil.ReadAll(reader)
 	}
 
-	v, err := exponentialBackoff(fmt.Sprintf("GetBlob(%q,%v,%v)", b, offset, length), attempt)
+	v, err := exponentialBackoff(ctx, fmt.Sprintf("GetBlob(%q,%v,%v)", b, offset, length), attempt)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -69,8 +69,8 @@ func (gcs *gcsStorage) GetBlob(ctx context.Context, b blob.ID, offset, length in
 	return fetched, nil
 }
 
-func exponentialBackoff(desc string, att retry.AttemptFunc) (interface{}, error) {
-	return retry.WithExponentialBackoff(desc, att, isRetriableError)
+func exponentialBackoff(ctx context.Context, desc string, att retry.AttemptFunc) (interface{}, error) {
+	return retry.WithExponentialBackoff(ctx, desc, att, isRetriableError)
 }
 
 func isRetriableError(err error) bool {
@@ -142,7 +142,7 @@ func (gcs *gcsStorage) DeleteBlob(ctx context.Context, b blob.ID) error {
 		return nil, gcs.bucket.Object(gcs.getObjectNameString(b)).Delete(gcs.ctx)
 	}
 
-	_, err := exponentialBackoff(fmt.Sprintf("DeleteBlob(%q)", b), attempt)
+	_, err := exponentialBackoff(ctx, fmt.Sprintf("DeleteBlob(%q)", b), attempt)
 	err = translateError(err)
 
 	if err == blob.ErrBlobNotFound {

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -1,12 +1,12 @@
 package gcs_test
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/testlogging"
 
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/gcs"
@@ -23,7 +23,7 @@ func TestGCSStorage(t *testing.T) {
 		t.Skip("skipping test because GCS credentials file can't be opened")
 	}
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	st, err := gcs.New(ctx, &gcs.Options{
 		BucketName:                   bucket,
 		ServiceAccountCredentialJSON: credData,
@@ -60,7 +60,7 @@ func TestGCSStorageInvalid(t *testing.T) {
 		t.Skip("KOPIA_GCS_TEST_BUCKET not provided")
 	}
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	if _, err := gcs.New(ctx, &gcs.Options{
 		BucketName:                    bucket + "-no-such-bucket",

--- a/repo/blob/logging/logging_storage.go
+++ b/repo/blob/logging/logging_storage.go
@@ -5,13 +5,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/kopia/kopia/internal/repologging"
 	"github.com/kopia/kopia/repo/blob"
 )
 
 const maxLoggedBlobLength = 20 // maximum length of the blob to log contents of
-
-var log = repologging.Logger("repo/blob")
 
 type loggingStorage struct {
 	base   blob.Storage
@@ -80,26 +77,6 @@ func (s *loggingStorage) ConnectionInfo() blob.ConnectionInfo {
 type Option func(s *loggingStorage)
 
 // NewWrapper returns a Storage wrapper that logs all storage commands.
-func NewWrapper(wrapped blob.Storage, options ...Option) blob.Storage {
-	s := &loggingStorage{base: wrapped, printf: log.Debugf}
-
-	for _, o := range options {
-		o(s)
-	}
-
-	return s
-}
-
-// Output is a logging storage option that causes all output to be sent to a given function instead of log.Printf()
-func Output(outputFunc func(fmt string, args ...interface{})) Option {
-	return func(s *loggingStorage) {
-		s.printf = outputFunc
-	}
-}
-
-// Prefix specifies prefix to be prepended to all log output.
-func Prefix(prefix string) Option {
-	return func(s *loggingStorage) {
-		s.prefix = prefix
-	}
+func NewWrapper(wrapped blob.Storage, printf func(msg string, args ...interface{}), prefix string) blob.Storage {
+	return &loggingStorage{base: wrapped, printf: printf, prefix: prefix}
 }

--- a/repo/blob/logging/logging_storage_test.go
+++ b/repo/blob/logging/logging_storage_test.go
@@ -1,11 +1,11 @@
 package logging
 
 import (
-	"context"
 	"strings"
 	"testing"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/testlogging"
 )
 
 func TestLoggingStorage(t *testing.T) {
@@ -22,12 +22,12 @@ func TestLoggingStorage(t *testing.T) {
 	data := blobtesting.DataMap{}
 	underlying := blobtesting.NewMapStorage(data, nil, nil)
 
-	st := NewWrapper(underlying, Output(myOutput), Prefix(myPrefix))
+	st := NewWrapper(underlying, myOutput, myPrefix)
 	if st == nil {
 		t.Fatalf("unexpected result: %v", st)
 	}
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	blobtesting.VerifyStorage(ctx, t, st)
 
 	if err := st.Close(ctx); err != nil {

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -71,7 +71,7 @@ func (s *s3Storage) GetBlob(ctx context.Context, b blob.ID, offset, length int64
 		return b, nil
 	}
 
-	v, err := exponentialBackoff(fmt.Sprintf("GetBlob(%q,%v,%v)", b, offset, length), attempt)
+	v, err := exponentialBackoff(ctx, fmt.Sprintf("GetBlob(%q,%v,%v)", b, offset, length), attempt)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -79,8 +79,8 @@ func (s *s3Storage) GetBlob(ctx context.Context, b blob.ID, offset, length int64
 	return v.([]byte), nil
 }
 
-func exponentialBackoff(desc string, att retry.AttemptFunc) (interface{}, error) {
-	return retry.WithExponentialBackoff(desc, att, isRetriableError)
+func exponentialBackoff(ctx context.Context, desc string, att retry.AttemptFunc) (interface{}, error) {
+	return retry.WithExponentialBackoff(ctx, desc, att, isRetriableError)
 }
 
 func isRetriableError(err error) bool {
@@ -138,7 +138,7 @@ func (s *s3Storage) DeleteBlob(ctx context.Context, b blob.ID) error {
 		return nil, s.cli.RemoveObject(s.BucketName, s.getObjectNameString(b))
 	}
 
-	_, err := exponentialBackoff(fmt.Sprintf("DeleteBlob(%q)", b), attempt)
+	_, err := exponentialBackoff(ctx, fmt.Sprintf("DeleteBlob(%q)", b), attempt)
 
 	return translateError(err)
 }

--- a/repo/blob/sftp/sftp_storage_test.go
+++ b/repo/blob/sftp/sftp_storage_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/sftp"
 )
@@ -20,7 +21,7 @@ const (
 )
 
 func TestSFTPStorageValid(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	if runtime.GOOS == "windows" {
 		t.Skip("temporarily disabled - https://github.com/kopia/kopia/issues/216")

--- a/repo/blob/storage_test.go
+++ b/repo/blob/storage_test.go
@@ -1,16 +1,16 @@
 package blob_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 )
 
 func TestListAllBlobsConsistent(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, time.Now)
 	st.PutBlob(ctx, "foo1", []byte{1, 2, 3}) //nolint:errcheck
@@ -42,7 +42,7 @@ func TestListAllBlobsConsistent(t *testing.T) {
 }
 
 func TestListAllBlobsConsistentEmpty(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, time.Now)
 

--- a/repo/blob/webdav/webdav_storage_test.go
+++ b/repo/blob/webdav/webdav_storage_test.go
@@ -1,7 +1,6 @@
 package webdav
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -12,8 +11,8 @@ import (
 	"golang.org/x/net/webdav"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
-	"github.com/kopia/kopia/repo/blob/logging"
 )
 
 func basicAuth(h http.Handler) http.HandlerFunc {
@@ -89,9 +88,9 @@ func TestWebDAVStorageBuiltInServer(t *testing.T) {
 }
 
 func verifyWebDAVStorage(t *testing.T, url, username, password string, shardSpec []int) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
-	st, err := New(context.Background(), &Options{
+	st, err := New(testlogging.Context(t), &Options{
 		URL:             url,
 		DirectoryShards: shardSpec,
 		Username:        username,
@@ -101,8 +100,6 @@ func verifyWebDAVStorage(t *testing.T, url, username, password string, shardSpec
 	if st == nil || err != nil {
 		t.Errorf("unexpected result: %v %v", st, err)
 	}
-
-	st = logging.NewWrapper(st)
 
 	if err := st.ListBlobs(ctx, "", func(bm blob.Metadata) error {
 		return st.DeleteBlob(ctx, bm.BlobID)

--- a/repo/connect.go
+++ b/repo/connect.go
@@ -49,7 +49,7 @@ func Connect(ctx context.Context, configFile string, st blob.Storage, password s
 	var lc LocalConfig
 	lc.Storage = st.ConnectionInfo()
 
-	if err = setupCaching(configFile, &lc, opt.CachingOptions, f.UniqueID); err != nil {
+	if err = setupCaching(ctx, configFile, &lc, opt.CachingOptions, f.UniqueID); err != nil {
 		return errors.Wrap(err, "unable to set up caching")
 	}
 
@@ -71,25 +71,25 @@ func Connect(ctx context.Context, configFile string, st blob.Storage, password s
 	if err != nil {
 		// we failed to open the repository after writing the config file,
 		// remove the config file we just wrote and any caches.
-		if derr := Disconnect(configFile); derr != nil {
-			log.Warningf("unable to disconnect after unsuccessful opening: %v", derr)
+		if derr := Disconnect(ctx, configFile); derr != nil {
+			log(ctx).Warningf("unable to disconnect after unsuccessful opening: %v", derr)
 		}
 
 		return err
 	}
 
 	if opt.PersistCredentials {
-		if err := persistPassword(configFile, password); err != nil {
+		if err := persistPassword(ctx, configFile, password); err != nil {
 			return errors.Wrap(err, "unable to persist password")
 		}
 	} else {
-		deletePassword(configFile)
+		deletePassword(ctx, configFile)
 	}
 
 	return r.Close(ctx)
 }
 
-func setupCaching(configPath string, lc *LocalConfig, opt content.CachingOptions, uniqueID []byte) error {
+func setupCaching(ctx context.Context, configPath string, lc *LocalConfig, opt content.CachingOptions, uniqueID []byte) error {
 	if opt.MaxCacheSizeBytes == 0 {
 		lc.Caching = content.CachingOptions{}
 		return nil
@@ -118,27 +118,27 @@ func setupCaching(configPath string, lc *LocalConfig, opt content.CachingOptions
 	lc.Caching.MaxMetadataCacheSizeBytes = opt.MaxMetadataCacheSizeBytes
 	lc.Caching.MaxListCacheDurationSec = opt.MaxListCacheDurationSec
 
-	log.Debugf("Creating cache directory '%v' with max size %v", lc.Caching.CacheDirectory, lc.Caching.MaxCacheSizeBytes)
+	log(ctx).Debugf("Creating cache directory '%v' with max size %v", lc.Caching.CacheDirectory, lc.Caching.MaxCacheSizeBytes)
 
 	if err := os.MkdirAll(lc.Caching.CacheDirectory, 0700); err != nil {
-		log.Warningf("unablet to create cache directory: %v", err)
+		log(ctx).Warningf("unablet to create cache directory: %v", err)
 	}
 
 	return nil
 }
 
 // Disconnect removes the specified configuration file and any local cache directories.
-func Disconnect(configFile string) error {
+func Disconnect(ctx context.Context, configFile string) error {
 	cfg, err := loadConfigFromFile(configFile)
 	if err != nil {
 		return err
 	}
 
-	deletePassword(configFile)
+	deletePassword(ctx, configFile)
 
 	if cfg.Caching.CacheDirectory != "" {
 		if err = os.RemoveAll(cfg.Caching.CacheDirectory); err != nil {
-			log.Warningf("unable to remove cache directory: %v", err)
+			log(ctx).Warningf("unable to remove cache directory: %v", err)
 		}
 	}
 

--- a/repo/content/committed_content_index_mem_cache.go
+++ b/repo/content/committed_content_index_mem_cache.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"bytes"
+	"context"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -14,14 +15,14 @@ type memoryCommittedContentIndexCache struct {
 	contents map[blob.ID]packIndex
 }
 
-func (m *memoryCommittedContentIndexCache) hasIndexBlobID(indexBlobID blob.ID) (bool, error) {
+func (m *memoryCommittedContentIndexCache) hasIndexBlobID(ctx context.Context, indexBlobID blob.ID) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	return m.contents[indexBlobID] != nil, nil
 }
 
-func (m *memoryCommittedContentIndexCache) addContentToCache(indexBlobID blob.ID, data []byte) error {
+func (m *memoryCommittedContentIndexCache) addContentToCache(ctx context.Context, indexBlobID blob.ID, data []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -35,7 +36,7 @@ func (m *memoryCommittedContentIndexCache) addContentToCache(indexBlobID blob.ID
 	return nil
 }
 
-func (m *memoryCommittedContentIndexCache) openIndex(indexBlobID blob.ID) (packIndex, error) {
+func (m *memoryCommittedContentIndexCache) openIndex(ctx context.Context, indexBlobID blob.ID) (packIndex, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -47,6 +48,6 @@ func (m *memoryCommittedContentIndexCache) openIndex(indexBlobID blob.ID) (packI
 	return v, nil
 }
 
-func (m *memoryCommittedContentIndexCache) expireUnused(used []blob.ID) error {
+func (m *memoryCommittedContentIndexCache) expireUnused(ctx context.Context, used []blob.ID) error {
 	return nil
 }

--- a/repo/content/content_index_recovery.go
+++ b/repo/content/content_index_recovery.go
@@ -167,7 +167,7 @@ func (bm *lockFreeManager) buildLocalIndex(pending packIndexBuilder) ([]byte, er
 }
 
 // appendPackFileIndexRecoveryData appends data designed to help with recovery of pack index in case it gets damaged or lost.
-func (bm *lockFreeManager) appendPackFileIndexRecoveryData(contentData []byte, pending packIndexBuilder) ([]byte, error) {
+func (bm *lockFreeManager) appendPackFileIndexRecoveryData(ctx context.Context, contentData []byte, pending packIndexBuilder) ([]byte, error) {
 	// build, encrypt and append local index
 	localIndexOffset := len(contentData)
 
@@ -200,11 +200,11 @@ func (bm *lockFreeManager) appendPackFileIndexRecoveryData(contentData []byte, p
 
 	pa2 := findPostamble(contentData)
 	if pa2 == nil {
-		log.Fatalf("invalid postamble written, that could not be immediately decoded, it's a bug")
+		log(ctx).Fatalf("invalid postamble written, that could not be immediately decoded, it's a bug")
 	}
 
 	if !reflect.DeepEqual(postamble, *pa2) {
-		log.Fatalf("postamble did not round-trip: %v %v", postamble, *pa2)
+		log(ctx).Fatalf("postamble did not round-trip: %v %v", postamble, *pa2)
 	}
 
 	return contentData, nil

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -75,7 +75,7 @@ func (bm *lockFreeManager) loadPackIndexesUnlocked(ctx context.Context) ([]Index
 
 		if i > 0 {
 			bm.listCache.deleteListCache()
-			log.Debugf("encountered NOT_FOUND when loading, sleeping %v before retrying #%v", nextSleepTime, i)
+			log(ctx).Debugf("encountered NOT_FOUND when loading, sleeping %v before retrying #%v", nextSleepTime, i)
 			time.Sleep(nextSleepTime)
 			nextSleepTime *= 2
 		}
@@ -94,7 +94,7 @@ func (bm *lockFreeManager) loadPackIndexesUnlocked(ctx context.Context) ([]Index
 
 			var updated bool
 
-			updated, err = bm.committedContents.use(contentIDs)
+			updated, err = bm.committedContents.use(ctx, contentIDs)
 			if err != nil {
 				return nil, false, err
 			}
@@ -111,7 +111,7 @@ func (bm *lockFreeManager) loadPackIndexesUnlocked(ctx context.Context) ([]Index
 }
 
 func (bm *lockFreeManager) tryLoadPackIndexBlobsUnlocked(ctx context.Context, contents []IndexBlobInfo) error {
-	ch, unprocessedIndexesSize, err := bm.unprocessedIndexBlobsUnlocked(contents)
+	ch, unprocessedIndexesSize, err := bm.unprocessedIndexBlobsUnlocked(ctx, contents)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (bm *lockFreeManager) tryLoadPackIndexBlobsUnlocked(ctx context.Context, co
 		return nil
 	}
 
-	log.Debugf("downloading %v new index blobs (%v bytes)...", len(ch), unprocessedIndexesSize)
+	log(ctx).Debugf("downloading %v new index blobs (%v bytes)...", len(ch), unprocessedIndexesSize)
 
 	var wg sync.WaitGroup
 
@@ -139,7 +139,7 @@ func (bm *lockFreeManager) tryLoadPackIndexBlobsUnlocked(ctx context.Context, co
 					return
 				}
 
-				if err := bm.committedContents.addContent(indexBlobID, data, false); err != nil {
+				if err := bm.committedContents.addContent(ctx, indexBlobID, data, false); err != nil {
 					errch <- errors.Wrap(err, "unable to add to committed content cache")
 					return
 				}
@@ -155,24 +155,24 @@ func (bm *lockFreeManager) tryLoadPackIndexBlobsUnlocked(ctx context.Context, co
 		return err
 	}
 
-	log.Debugf("Index contents downloaded.")
+	log(ctx).Debugf("Index contents downloaded.")
 
 	return nil
 }
 
 // unprocessedIndexBlobsUnlocked returns a closed channel filled with content IDs that are not in committedContents cache.
-func (bm *lockFreeManager) unprocessedIndexBlobsUnlocked(contents []IndexBlobInfo) (resultCh <-chan blob.ID, totalSize int64, err error) {
+func (bm *lockFreeManager) unprocessedIndexBlobsUnlocked(ctx context.Context, contents []IndexBlobInfo) (resultCh <-chan blob.ID, totalSize int64, err error) {
 	ch := make(chan blob.ID, len(contents))
 	defer close(ch)
 
 	for _, c := range contents {
-		has, err := bm.committedContents.cache.hasIndexBlobID(c.BlobID)
+		has, err := bm.committedContents.cache.hasIndexBlobID(ctx, c.BlobID)
 		if err != nil {
 			return nil, 0, err
 		}
 
 		if has {
-			log.Debugf("index blob %q already in cache, skipping", c.BlobID)
+			log(ctx).Debugf("index blob %q already in cache, skipping", c.BlobID)
 			continue
 		}
 
@@ -253,7 +253,7 @@ func (bm *lockFreeManager) decryptAndVerify(encrypted, iv []byte) ([]byte, error
 }
 
 func (bm *lockFreeManager) preparePackDataContent(ctx context.Context, pp *pendingPackInfo, packFile blob.ID) ([]byte, packIndexBuilder, error) {
-	formatLog.Debugf("preparing content data with %v items", len(pp.currentPackItems))
+	formatLog(ctx).Debugf("preparing content data with %v items", len(pp.currentPackItems))
 
 	contentData, err := appendRandomBytes(append([]byte(nil), bm.repositoryFormatBytes...), rand.Intn(bm.maxPreambleLength-bm.minPreambleLength+1)+bm.minPreambleLength)
 	if err != nil {
@@ -279,7 +279,7 @@ func (bm *lockFreeManager) preparePackDataContent(ctx context.Context, pp *pendi
 			return nil, nil, errors.Wrapf(err, "unable to encrypt %q", contentID)
 		}
 
-		formatLog.Debugf("adding %v length=%v deleted=%v", contentID, len(info.Payload), info.Deleted)
+		formatLog(ctx).Debugf("adding %v length=%v deleted=%v", contentID, len(info.Payload), info.Deleted)
 
 		packFileIndex.Add(Info{
 			ID:               contentID,
@@ -316,9 +316,9 @@ func (bm *lockFreeManager) preparePackDataContent(ctx context.Context, pp *pendi
 	}
 
 	origContentLength := len(contentData)
-	contentData, err = bm.appendPackFileIndexRecoveryData(contentData, packFileIndex)
+	contentData, err = bm.appendPackFileIndexRecoveryData(ctx, contentData, packFileIndex)
 
-	formatLog.Debugf("finished content %v bytes (%v bytes index)", len(contentData), len(contentData)-origContentLength)
+	formatLog(ctx).Debugf("finished content %v bytes (%v bytes index)", len(contentData), len(contentData)-origContentLength)
 
 	return contentData, packFileIndex, err
 }

--- a/repo/format_block_test.go
+++ b/repo/format_block_test.go
@@ -1,19 +1,19 @@
 package repo
 
 import (
-	"context"
 	"crypto/sha256"
 	"reflect"
 	"testing"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 )
 
 func TestFormatBlobRecovery(t *testing.T) {
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, nil)
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	someDataBlock := []byte("aadsdasdas")
 

--- a/repo/logging/ctx.go
+++ b/repo/logging/ctx.go
@@ -1,0 +1,16 @@
+package logging
+
+import "context"
+
+type contextKey string
+
+const loggerKey contextKey = "logger"
+
+// WithLogger returns a derived context with associated logger.
+func WithLogger(ctx context.Context, l LoggerForModuleFunc) context.Context {
+	if l == nil {
+		l = getNullLogger
+	}
+
+	return context.WithValue(ctx, loggerKey, l)
+}

--- a/repo/logging/logging.go
+++ b/repo/logging/logging.go
@@ -1,0 +1,41 @@
+// Package logging provides loggers for Kopia.
+package logging
+
+import (
+	"context"
+)
+
+// defaultLoggerForModuleFunc is a logger to use when context-specific logger is not set.
+var defaultLoggerForModuleFunc = getNullLogger
+
+// LoggerForModuleFunc retrieves logger for a given module
+type LoggerForModuleFunc func(module string) Logger
+
+// SetDefault sets the logger to use when context-specific logger is not set.
+func SetDefault(l LoggerForModuleFunc) {
+	if l == nil {
+		defaultLoggerForModuleFunc = getNullLogger
+	} else {
+		defaultLoggerForModuleFunc = l
+	}
+}
+
+// Logger is an interface used by Kopia to output logs.
+type Logger interface {
+	Debugf(msg string, args ...interface{})
+	Infof(msg string, args ...interface{})
+	Warningf(msg string, args ...interface{})
+	Errorf(msg string, args ...interface{})
+	Fatalf(msg string, args ...interface{})
+}
+
+// GetContextLoggerFunc returns an function that returns a logger for a given module when provided with a context.
+func GetContextLoggerFunc(module string) func(ctx context.Context) Logger {
+	return func(ctx context.Context) Logger {
+		if l := ctx.Value(loggerKey); l != nil {
+			return l.(LoggerForModuleFunc)(module)
+		}
+
+		return defaultLoggerForModuleFunc(module)
+	}
+}

--- a/repo/logging/null_logger.go
+++ b/repo/logging/null_logger.go
@@ -1,0 +1,13 @@
+package logging
+
+type nullLogger struct{}
+
+func (nullLogger) Debugf(msg string, args ...interface{})   {}
+func (nullLogger) Infof(msg string, args ...interface{})    {}
+func (nullLogger) Warningf(msg string, args ...interface{}) {}
+func (nullLogger) Errorf(msg string, args ...interface{})   {}
+func (nullLogger) Fatalf(msg string, args ...interface{})   {}
+
+func getNullLogger(module string) Logger {
+	return nullLogger{}
+}

--- a/repo/logging/printf_logger.go
+++ b/repo/logging/printf_logger.go
@@ -1,0 +1,19 @@
+package logging
+
+type printfLogger struct {
+	printf func(msg string, args ...interface{})
+	prefix string
+}
+
+func (l *printfLogger) Debugf(msg string, args ...interface{})   { l.printf(l.prefix+msg, args...) }
+func (l *printfLogger) Infof(msg string, args ...interface{})    { l.printf(l.prefix+msg, args...) }
+func (l *printfLogger) Warningf(msg string, args ...interface{}) { l.printf(l.prefix+msg, args...) }
+func (l *printfLogger) Errorf(msg string, args ...interface{})   { l.printf(l.prefix+msg, args...) }
+func (l *printfLogger) Fatalf(msg string, args ...interface{})   { l.printf(l.prefix+msg, args...) }
+
+// Printf returns LoggerForModuleFunc that uses given printf-style function to print log output.
+func Printf(printf func(msg string, args ...interface{})) LoggerForModuleFunc {
+	return func(module string) Logger {
+		return &printfLogger{printf, "[" + module + "]"}
+	}
+}

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/content"
 )
 
 //nolint:funlen
 func TestManifest(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}
 	mgr := newManagerForTesting(ctx, t, data)
 
@@ -109,6 +110,7 @@ func TestManifest(t *testing.T) {
 	foundContents := 0
 
 	if err := mgr.b.IterateContents(
+		ctx,
 		content.IterateOptions{Prefix: ContentPrefix},
 		func(ci content.Info) error {
 			foundContents++
@@ -131,7 +133,7 @@ func TestManifest(t *testing.T) {
 }
 
 func TestManifestInitCorruptedBlock(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, nil)
 
@@ -307,7 +309,7 @@ func newManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.Da
 }
 
 func TestManifestInvalidPut(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}
 	mgr := newManagerForTesting(ctx, t, data)
 
@@ -329,7 +331,7 @@ func TestManifestInvalidPut(t *testing.T) {
 }
 
 func TestManifestAutoCompaction(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}
 
 	for i := 0; i < 100; i++ {

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/compression"
 	"github.com/kopia/kopia/repo/content"
@@ -69,7 +70,7 @@ func setupTest(t *testing.T) (map[content.ID][]byte, *Manager) {
 }
 
 func setupTestWithData(t *testing.T, data map[content.ID][]byte, opts ManagerOptions) (map[content.ID][]byte, *Manager) {
-	r, err := NewObjectManager(context.Background(), &fakeContentManager{data: data}, Format{
+	r, err := NewObjectManager(testlogging.Context(t), &fakeContentManager{data: data}, Format{
 		Splitter: "FIXED-1M",
 	}, opts)
 	if err != nil {
@@ -80,7 +81,7 @@ func setupTestWithData(t *testing.T, data map[content.ID][]byte, opts ManagerOpt
 }
 
 func TestWriters(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	cases := []struct {
 		data     []byte
 		objectID ID
@@ -129,7 +130,7 @@ func objectIDsEqual(o1, o2 ID) bool {
 }
 
 func TestWriterCompleteChunkInTwoWrites(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	_, om := setupTest(t)
 
 	b := make([]byte, 100)
@@ -160,7 +161,7 @@ func verifyIndirectBlock(ctx context.Context, t *testing.T, r *Manager, oid ID) 
 }
 
 func TestIndirection(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	splitterFactory := newFixedSplitterFactory(1000)
 	cases := []struct {
@@ -229,7 +230,7 @@ func indirectionLevel(oid ID) int {
 }
 
 func TestHMAC(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	c := bytes.Repeat([]byte{0xcd}, 50)
 
 	_, om := setupTest(t)
@@ -244,7 +245,7 @@ func TestHMAC(t *testing.T) {
 }
 
 func TestReader(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	data, om := setupTest(t)
 
 	storedPayload := []byte("foo\nbar")
@@ -284,7 +285,7 @@ func TestReader(t *testing.T) {
 }
 
 func TestReaderStoredBlockNotFound(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	_, om := setupTest(t)
 
 	objectID, err := ParseID("deadbeef")
@@ -299,7 +300,7 @@ func TestReaderStoredBlockNotFound(t *testing.T) {
 }
 
 func TestEndToEndReadAndSeek(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	_, om := setupTest(t)
 
 	for _, size := range []int{1, 199, 200, 201, 9999, 512434, 5012434} {
@@ -327,7 +328,7 @@ func TestEndToEndReadAndSeek(t *testing.T) {
 }
 
 func TestEndToEndReadAndSeekWithCompression(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	for compressorName := range compression.ByName {
 		totalBytesWritten := 0
@@ -414,7 +415,7 @@ func verify(ctx context.Context, t *testing.T, om *Manager, objectID ID, expecte
 
 // nolint:gocyclo
 func TestSeek(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	_, om := setupTest(t)
 
 	for _, size := range []int{0, 1, 500000, 15000000} {

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -63,13 +63,13 @@ func (r *Repository) Refresh(ctx context.Context) error {
 		return nil
 	}
 
-	log.Debugf("content index refreshed")
+	log(ctx).Debugf("content index refreshed")
 
 	if err := r.Manifests.Refresh(ctx); err != nil {
 		return errors.Wrap(err, "error reloading manifests")
 	}
 
-	log.Debugf("manifests refreshed")
+	log(ctx).Debugf("manifests refreshed")
 
 	return nil
 }
@@ -83,7 +83,7 @@ func (r *Repository) RefreshPeriodically(ctx context.Context, interval time.Dura
 
 		case <-time.After(interval):
 			if err := r.Refresh(ctx); err != nil {
-				log.Warningf("error refreshing repository: %v", err)
+				log(ctx).Warningf("error refreshing repository: %v", err)
 			}
 		}
 	}

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/object"
@@ -26,11 +27,11 @@ func TestWriters(t *testing.T) {
 		{make([]byte, 100), "1d804f1f69df08f3f59070bf962de69433e3d61ac18522a805a84d8c92741340"}, // 100 zero bytes
 	}
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	for _, c := range cases {
 		var env repotesting.Environment
-		defer env.Setup(t).Close(t)
+		defer env.Setup(t).Close(ctx, t)
 
 		writer := env.Repository.Objects.NewWriter(ctx, object.WriterOptions{})
 		if _, err := writer.Write(c.data); err != nil {
@@ -57,9 +58,9 @@ func objectIDsEqual(o1, o2 object.ID) bool {
 
 func TestWriterCompleteChunkInTwoWrites(t *testing.T) {
 	var env repotesting.Environment
-	defer env.Setup(t).Close(t)
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
+	defer env.Setup(t).Close(ctx, t)
 
 	b := make([]byte, 100)
 	writer := env.Repository.Objects.NewWriter(ctx, object.WriterOptions{})
@@ -74,9 +75,9 @@ func TestWriterCompleteChunkInTwoWrites(t *testing.T) {
 
 func TestPackingSimple(t *testing.T) {
 	var env repotesting.Environment
-	defer env.Setup(t).Close(t)
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
+	defer env.Setup(t).Close(ctx, t)
 
 	content1 := "hello, how do you do?"
 	content2 := "hi, how are you?"
@@ -147,9 +148,9 @@ func TestPackingSimple(t *testing.T) {
 
 func TestHMAC(t *testing.T) {
 	var env repotesting.Environment
-	defer env.Setup(t).Close(t)
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
+	defer env.Setup(t).Close(ctx, t)
 
 	c := bytes.Repeat([]byte{0xcd}, 50)
 
@@ -164,9 +165,9 @@ func TestHMAC(t *testing.T) {
 
 func TestUpgrade(t *testing.T) {
 	var env repotesting.Environment
-	defer env.Setup(t).Close(t)
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
+	defer env.Setup(t).Close(ctx, t)
 
 	if err := env.Repository.Upgrade(ctx); err != nil {
 		t.Errorf("upgrade error: %v", err)
@@ -179,9 +180,9 @@ func TestUpgrade(t *testing.T) {
 
 func TestReaderStoredBlockNotFound(t *testing.T) {
 	var env repotesting.Environment
-	defer env.Setup(t).Close(t)
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
+	defer env.Setup(t).Close(ctx, t)
 
 	objectID, err := object.ParseID("Ddeadbeef")
 	if err != nil {
@@ -247,7 +248,7 @@ func verify(ctx context.Context, t *testing.T, rep *repo.Repository, objectID ob
 }
 
 func TestFormats(t *testing.T) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	makeFormat := func(hash, encryption string) func(*repo.NewRepositoryOptions) {
 		return func(n *repo.NewRepositoryOptions) {
 			n.BlockFormat.Hash = hash
@@ -285,7 +286,7 @@ func TestFormats(t *testing.T) {
 
 	for caseIndex, c := range cases {
 		var env repotesting.Environment
-		defer env.Setup(t, c.format).Close(t)
+		defer env.Setup(t, c.format).Close(ctx, t)
 
 		for k, v := range c.oids {
 			bytesToWrite := []byte(k)

--- a/repo/upgrade.go
+++ b/repo/upgrade.go
@@ -10,8 +10,6 @@ import (
 func (r *Repository) Upgrade(ctx context.Context) error {
 	f := r.formatBlob
 
-	log.Debug("decrypting format...")
-
 	repoConfig, err := f.decryptFormatBytes(r.masterKey)
 	if err != nil {
 		return errors.Wrap(err, "unable to decrypt repository config")
@@ -21,17 +19,15 @@ func (r *Repository) Upgrade(ctx context.Context) error {
 
 	// add migration code here
 	if !migrated {
-		log.Infof("nothing to do")
+		log(ctx).Infof("nothing to do")
 		return nil
 	}
-
-	log.Debug("encrypting format...")
 
 	if err := encryptFormatBytes(f, repoConfig, r.masterKey, f.UniqueID); err != nil {
 		return errors.Errorf("unable to encrypt format bytes")
 	}
 
-	log.Infof("writing updated format content...")
+	log(ctx).Infof("writing updated format content...")
 
 	return writeFormatBlob(ctx, r.Blobs, f)
 }

--- a/snapshot/manager.go
+++ b/snapshot/manager.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/kopialogging"
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/logging"
 	"github.com/kopia/kopia/repo/manifest"
 )
 
@@ -20,7 +20,7 @@ const (
 	loadSnapshotsConcurrency = 50 // number of snapshots to load in parallel
 )
 
-var log = kopialogging.Logger("kopia/snapshot")
+var log = logging.GetContextLoggerFunc("kopia/snapshot")
 
 // ListSources lists all snapshot sources in a given repository.
 func ListSources(ctx context.Context, rep *repo.Repository) ([]SourceInfo, error) {
@@ -116,7 +116,7 @@ func LoadSnapshots(ctx context.Context, rep *repo.Repository, manifestIDs []mani
 
 			m, err := LoadSnapshot(ctx, rep, n)
 			if err != nil {
-				log.Warningf("unable to parse snapshot manifest %v: %v", n, err)
+				log(ctx).Warningf("unable to parse snapshot manifest %v: %v", n, err)
 				return
 			}
 

--- a/snapshot/policy/expire.go
+++ b/snapshot/policy/expire.go
@@ -60,10 +60,10 @@ func getExpiredSnapshotsForSource(ctx context.Context, rep *repo.Repository, sna
 
 	for _, s := range snapshots {
 		if len(s.RetentionReasons) == 0 {
-			log.Debugf("  deleting %v", s.StartTime)
+			log(ctx).Debugf("  deleting %v", s.StartTime)
 			toDelete = append(toDelete, s)
 		} else {
-			log.Debugf("  keeping %v reasons: [%v]", s.StartTime, strings.Join(s.RetentionReasons, ","))
+			log(ctx).Debugf("  keeping %v reasons: [%v]", s.StartTime, strings.Join(s.RetentionReasons, ","))
 		}
 	}
 

--- a/snapshot/policy/policy.go
+++ b/snapshot/policy/policy.go
@@ -29,7 +29,7 @@ func (p *Policy) String() string {
 	e.SetIndent("", "  ")
 
 	if err := e.Encode(p); err != nil {
-		log.Warningf("unable to policy as JSON: %v", err)
+		return "unable to policy as JSON: " + err.Error()
 	}
 
 	return buf.String()

--- a/snapshot/policy/policy_manager.go
+++ b/snapshot/policy/policy_manager.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/kopialogging"
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/logging"
 	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/snapshot"
 )
@@ -19,7 +19,7 @@ const typeKey = manifest.TypeLabelKey
 // GlobalPolicySourceInfo is a source where global policy is attached.
 var GlobalPolicySourceInfo = snapshot.SourceInfo{}
 
-var log = kopialogging.Logger("kopia/snapshot/policy")
+var log = logging.GetContextLoggerFunc("kopia/snapshot/policy")
 
 // GetEffectivePolicy calculates effective snapshot policy for a given source by combining the source-specifc policy (if any)
 // with parent policies. The source must contain a path.
@@ -78,7 +78,7 @@ func GetEffectivePolicy(ctx context.Context, rep *repo.Repository, si snapshot.S
 
 		p.Labels = em.Labels
 		policies = append(policies, p)
-		log.Debugf("loaded parent policy for %v: %v", si, p.Target())
+		log(ctx).Debugf("loaded parent policy for %v: %v", si, p.Target())
 	}
 
 	merged := MergePolicies(policies)
@@ -232,7 +232,7 @@ func TreeForSource(ctx context.Context, rep *repo.Repository, si snapshot.Source
 		return nil, errors.Wrapf(err, "unable to find manifests for %v@%v", si.UserName, si.Host)
 	}
 
-	log.Debugf("found %v policies for %v@%v", si.UserName, si.Host)
+	log(ctx).Debugf("found %v policies for %v@%v", si.UserName, si.Host)
 
 	for _, id := range policies {
 		em, err := rep.Manifests.GetMetadata(ctx, id.ID)
@@ -252,7 +252,7 @@ func TreeForSource(ctx context.Context, rep *repo.Repository, si snapshot.Source
 		}
 
 		rel = "./" + rel
-		log.Debugf("loading policy for %v (%v)", policyPath, rel)
+		log(ctx).Debugf("loading policy for %v (%v)", policyPath, rel)
 
 		pol := &Policy{}
 		if err := rep.Manifests.Get(ctx, id.ID, pol); err != nil {

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -1,7 +1,6 @@
 package snapshot_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -9,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/snapshot"
@@ -16,7 +16,9 @@ import (
 
 func TestSnapshotsAPI(t *testing.T) {
 	var env repotesting.Environment
-	defer env.Setup(t).Close(t)
+
+	ctx := testlogging.Context(t)
+	defer env.Setup(t).Close(ctx, t)
 
 	src1 := snapshot.SourceInfo{
 		Host:     "host-1",
@@ -77,7 +79,7 @@ func TestSnapshotsAPI(t *testing.T) {
 func verifySnapshotManifestIDs(t *testing.T, rep *repo.Repository, src *snapshot.SourceInfo, expected []manifest.ID) {
 	t.Helper()
 
-	res, err := snapshot.ListSnapshotManifests(context.Background(), rep, src)
+	res, err := snapshot.ListSnapshotManifests(testlogging.Context(t), rep, src)
 	if err != nil {
 		t.Errorf("error listing snapshot manifests: %v", err)
 	}
@@ -99,7 +101,7 @@ func sortManifestIDs(s []manifest.ID) {
 func mustSaveSnapshot(t *testing.T, rep *repo.Repository, man *snapshot.Manifest) manifest.ID {
 	t.Helper()
 
-	id, err := snapshot.SaveSnapshot(context.Background(), rep, man)
+	id, err := snapshot.SaveSnapshot(testlogging.Context(t), rep, man)
 	if err != nil {
 		t.Fatalf("error saving snapshot: %v", err)
 	}
@@ -108,7 +110,7 @@ func mustSaveSnapshot(t *testing.T, rep *repo.Repository, man *snapshot.Manifest
 }
 
 func verifySources(t *testing.T, rep *repo.Repository, sources ...snapshot.SourceInfo) {
-	actualSources, err := snapshot.ListSources(context.Background(), rep)
+	actualSources, err := snapshot.ListSources(testlogging.Context(t), rep)
 	if err != nil {
 		t.Errorf("error listing sources: %v", err)
 	}
@@ -121,7 +123,7 @@ func verifySources(t *testing.T, rep *repo.Repository, sources ...snapshot.Sourc
 func verifyListSnapshots(t *testing.T, rep *repo.Repository, src snapshot.SourceInfo, expected []*snapshot.Manifest) {
 	t.Helper()
 
-	got, err := snapshot.ListSnapshots(context.Background(), rep, src)
+	got, err := snapshot.ListSnapshots(testlogging.Context(t), rep, src)
 	if err != nil {
 		t.Errorf("error loading manifests: %v", err)
 		return
@@ -141,7 +143,7 @@ func verifyListSnapshots(t *testing.T, rep *repo.Repository, src snapshot.Source
 }
 
 func verifyLoadSnapshots(t *testing.T, rep *repo.Repository, ids []manifest.ID, expected []*snapshot.Manifest) {
-	got, err := snapshot.LoadSnapshots(context.Background(), rep, ids)
+	got, err := snapshot.LoadSnapshots(testlogging.Context(t), rep, ids)
 	if err != nil {
 		t.Errorf("error loading manifests: %v", err)
 		return

--- a/snapshot/snapshotfs/snapshot_tree_walker.go
+++ b/snapshot/snapshotfs/snapshot_tree_walker.go
@@ -63,7 +63,7 @@ func (w *TreeWalker) Run(ctx context.Context) error {
 	}
 
 	w.queue.ProgressCallback = func(enqueued, active, completed int64) {
-		log.Infof("processed(%v/%v) active %v", completed, enqueued, active)
+		log(ctx).Infof("processed(%v/%v) active %v", completed, enqueued, active)
 	}
 
 	return w.queue.Process(w.Parallelism)

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -1,7 +1,6 @@
 package endtoend_test
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/internal/diff"
 	"github.com/kopia/kopia/internal/fshasher"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -81,14 +81,14 @@ func compareDirs(t *testing.T, source, restoreDir string) {
 	// Restored contents should match source
 	s, err := localfs.Directory(source)
 	testenv.AssertNoError(t, err)
-	wantHash, err := fshasher.Hash(context.Background(), s)
+	wantHash, err := fshasher.Hash(testlogging.Context(t), s)
 	testenv.AssertNoError(t, err)
 
 	// check restored contents
 	r, err := localfs.Directory(restoreDir)
 	testenv.AssertNoError(t, err)
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 	gotHash, err := fshasher.Hash(ctx, r)
 	testenv.AssertNoError(t, err)
 

--- a/tests/repository_stress_test/repository_stress_test.go
+++ b/tests/repository_stress_test/repository_stress_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob/filesystem"
 	"github.com/kopia/kopia/repo/content"
@@ -34,7 +35,7 @@ func TestStressRepository(t *testing.T) {
 		t.Skip("skipping stress test during short tests")
 	}
 
-	ctx := content.UsingListCache(context.Background(), false)
+	ctx := content.UsingListCache(testlogging.Context(t), false)
 
 	tmpPath, err := ioutil.TempDir("", "kopia")
 	if err != nil {
@@ -256,6 +257,7 @@ func readKnownBlock(ctx context.Context, t *testing.T, r *repo.Repository) error
 
 func listContents(ctx context.Context, t *testing.T, r *repo.Repository) error {
 	return r.Content.IterateContents(
+		ctx,
 		content.IterateOptions{},
 		func(i content.Info) error { return nil },
 	)
@@ -263,6 +265,7 @@ func listContents(ctx context.Context, t *testing.T, r *repo.Repository) error {
 
 func listAndReadAllContents(ctx context.Context, t *testing.T, r *repo.Repository) error {
 	return r.Content.IterateContents(
+		ctx,
 		content.IterateOptions{},
 		func(ci content.Info) error {
 			cid := ci.ID

--- a/tests/stress_test/stress_test.go
+++ b/tests/stress_test/stress_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
 )
@@ -34,7 +35,7 @@ func TestStressBlockManager(t *testing.T) {
 }
 
 func stressTestWithStorage(t *testing.T, st blob.Storage, duration time.Duration) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	openMgr := func() (*content.Manager, error) {
 		return content.NewManager(ctx, st, &content.FormattingOptions{


### PR DESCRIPTION
This is mostly mechanical and changes how loggers are instantiated.

Logger is now associated with a context, passed around all methods,
(most methods had ctx, but had to add it in a few missing places).

By default Kopia does not produce any logs, but it can be overridden,
either locally for a nested context, by calling

ctx = logging.WithLogger(ctx, newLoggerFunc)

To override logs globally, call logging.SetDefaultLogger(newLoggerFunc)

This refactoring allowed removing dependency from Kopia repo
and go-logging library (the CLI still uses it, though).

It is now also possible to have all test methods emit logs using
t.Logf() so that they show up in failure reports, which should make
debugging of test failures suck less.