### PR TITLE
Fix typo in makefile so CI can pass (upload-coverage target)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ upload-coverage: $(GOVERALLS_TOOL)
 
 else
 
-uload-coverage:
+upload-coverage:
 	@echo Not uploading coverage during PR build.
 
 endif


### PR DESCRIPTION
Fixing a typo in the Makefile target upload-coverage. Without fix, the target it is not found if Travis is running against a PR.