### PR TITLE
[flake] Fix error clobbering race condition in kopia cli test runner

### DIFF
--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -216,17 +216,24 @@ func (e *CLITest) Run(t *testing.T, args ...string) (stdout, stderr []string, er
 
 	var wg sync.WaitGroup
 
+	var pipeErr error
+
 	wg.Add(1)
 
 	go func() {
 		defer wg.Done()
 
-		errOut, err = ioutil.ReadAll(stderrPipe)
+		errOut, pipeErr = ioutil.ReadAll(stderrPipe)
 	}()
 
 	o, err := c.Output()
 
 	wg.Wait()
+
+	if pipeErr != nil {
+		t.Fatalf("error reading out of the stderr pipe: %s", pipeErr)
+	}
+
 	t.Logf("finished 'kopia %v' with err=%v and output:\n%v\nstderr:\n%v\n", strings.Join(args, " "), err, trimOutput(string(o)), trimOutput(string(errOut)))
 
 	return splitLines(string(o)), splitLines(string(errOut)), err


### PR DESCRIPTION
Error variable `err` was being shared between `c.Output` and `ioutil.ReadAll` in separate goroutines. The two could race to set `err`, and if `Output` finishes first with an error, `ReadAll` could overwrite it with nil. Fix is to delegate an independent error for the pipe read, and fail the test if it is non-nil.

Should fix the flake mentioned in #284. Test performance improvements will be added separately.