### PR TITLE
Use docker to execute fio in robustness tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 COVERAGE_PACKAGES=github.com/kopia/kopia/repo/...,github.com/kopia/kopia/fs/...,github.com/kopia/kopia/snapshot/...
 GO_TEST=go test
 PARALLEL=8
-TEST_FLAGS=
+TEST_FLAGS?=
 KOPIA_INTEGRATION_EXE=$(CURDIR)/dist/integration/kopia.exe
-FIO_DOCKER_TAG=kopia-test-fio
+FIO_DOCKER_TAG=ljishen/fio
 
 all: test lint vet integration-tests
 
@@ -162,14 +162,11 @@ dist-binary:
 integration-tests: dist-binary
 	KOPIA_EXE=$(KOPIA_INTEGRATION_EXE) $(GO_TEST) $(TEST_FLAGS) -count=1 -parallel $(PARALLEL) -timeout 600s github.com/kopia/kopia/tests/end_to_end_test
 
-fio-docker-build:
-	docker build -t $(FIO_DOCKER_TAG) $(CURDIR)/tests/tools/fio_docker
-
-robustness-tool-tests: fio-docker-build
+robustness-tool-tests:
 	FIO_EXE="$(shell which fio)" \
 	FIO_DOCKER_IMAGE=$(FIO_DOCKER_TAG) \
 	FIO_USE_DOCKER=1 \
-	$(GO_TEST) -count=1 -timeout 90s github.com/kopia/kopia/tests/tools/...
+	$(GO_TEST) $(TEST_FLAGS) -count=1 -timeout 90s github.com/kopia/kopia/tests/tools/...
 
 stress-test:
 	KOPIA_LONG_STRESS_TEST=1 $(GO_TEST) -count=1 -timeout 200s github.com/kopia/kopia/tests/stress_test

--- a/Makefile
+++ b/Makefile
@@ -163,9 +163,7 @@ integration-tests: dist-binary
 	KOPIA_EXE=$(KOPIA_INTEGRATION_EXE) $(GO_TEST) $(TEST_FLAGS) -count=1 -parallel $(PARALLEL) -timeout 600s github.com/kopia/kopia/tests/end_to_end_test
 
 robustness-tool-tests:
-	FIO_EXE="$(shell which fio)" \
 	FIO_DOCKER_IMAGE=$(FIO_DOCKER_TAG) \
-	FIO_USE_DOCKER=1 \
 	$(GO_TEST) $(TEST_FLAGS) -count=1 -timeout 90s github.com/kopia/kopia/tests/tools/...
 
 stress-test:

--- a/tests/tools/fio/fio.go
+++ b/tests/tools/fio/fio.go
@@ -112,7 +112,7 @@ func NewRunner() (fr *Runner, err error) {
 			"run",
 			"--rm",
 			"-v",
-			fmt.Sprintf("%s:%s", hostFioDataPathStr, fioDataContainerPath), // /c/Users/usr/fio-data:/fio-data
+			fmt.Sprintf("%s:%s", hostFioDataPathStr, fioDataContainerPath),
 			imgStr,
 		}
 

--- a/tests/tools/fio/fio.go
+++ b/tests/tools/fio/fio.go
@@ -5,12 +5,18 @@
 package fio
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/pkg/errors"
 )
 
 // List of fio flags
@@ -18,32 +24,111 @@ const (
 	JobNameFlag = "--name"
 )
 
+const (
+	dockerExe            = "docker"
+	fioDataContainerPath = "/fio-data"
+)
+
+// Environment variable keys
+const (
+	// FioExeEnvKey gives the path to the fio executable to use in testing
+	FioExeEnvKey = "FIO_EXE"
+
+	// FioDockerImageEnvKey specifies the docker image tag to use. If
+	// FioExeEnvKey is set, the local executable will be used instead of
+	// docker, even if this variable is also set. The exception is if
+	// FioUseDockerEnvKey is not an empty string, which will force
+	// use of the fio docker image independent of FioExeEnvKey.
+	FioDockerImageEnvKey = "FIO_DOCKER_IMAGE"
+
+	// LocalFioDataPathEnvKey is the local path where fio data will be
+	// accessible. If not specified, defaults to the default temp directory (os.TempDir)
+	LocalFioDataPathEnvKey = "LOCAL_FIO_DATA_PATH"
+
+	// HostFioDataPathEnvKey specifies the path where fio data will be written,
+	// relative to the docker host. If left blank, defaults to local fio data path
+	// (works unless running via docker from within a container, e.g. for development)
+	HostFioDataPathEnvKey = "HOST_FIO_DATA_PATH"
+
+	// FioUseDockerEnvKey forces the fio runner to use the docker image, even if
+	// an executable path is provided.
+	FioUseDockerEnvKey = "FIO_USE_DOCKER"
+)
+
+// Known error messages
+var (
+	ErrEnvNotSet = fmt.Errorf("must set either %v or %v", FioExeEnvKey, FioDockerImageEnvKey)
+)
+
 // Runner is a helper for running fio commands
 type Runner struct {
-	Exe     string
-	DataDir string
-	Global  Config
+	Exe             string
+	ExecArgs        []string
+	LocalDataDir    string
+	FioWriteBaseDir string
+	Global          Config
 }
 
 // NewRunner creates a new fio runner
-func NewRunner() (*Runner, error) {
-	Exe := os.Getenv("FIO_EXE")
-	if Exe == "" {
-		Exe = "fio"
-	}
+func NewRunner() (fr *Runner, err error) {
+	exeStr := os.Getenv(FioExeEnvKey)
+	imgStr := os.Getenv(FioDockerImageEnvKey)
+	localFioDataPathStr := os.Getenv(LocalFioDataPathEnvKey)
+	hostFioDataPathStr := os.Getenv(HostFioDataPathEnvKey)
+	forceDocker := os.Getenv(FioUseDockerEnvKey) != ""
 
-	dataDir, err := ioutil.TempDir("", "fio-data")
+	var exeArgs []string
+
+	var fioWriteBaseDir string
+
+	var Exe string
+
+	dataDir, err := ioutil.TempDir(localFioDataPathStr, "fio-data-")
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unable to create temp directory for fio runner")
 	}
 
-	return &Runner{
-		Exe:     Exe,
-		DataDir: dataDir,
+	switch {
+	case exeStr != "" && !forceDocker:
+		// Provided a local FIO executable to run
+		Exe = exeStr
+
+		fioWriteBaseDir = dataDir
+
+	case imgStr != "":
+		// Provided a docker image to run inside
+		Exe = dockerExe
+
+		dataDirParent, dataDirName := filepath.Split(dataDir)
+		fioWriteBaseDir = filepath.Join(fioDataContainerPath, dataDirName)
+
+		// If the host path wasn't provided, assume it's the same as the local
+		// data directory path and we are not running from within a container already
+		if hostFioDataPathStr == "" {
+			hostFioDataPathStr = dataDirParent
+		}
+
+		exeArgs = []string{
+			"run",
+			"--rm",
+			"-v",
+			fmt.Sprintf("%s:%s", hostFioDataPathStr, fioDataContainerPath), // /c/Users/usr/fio-data:/fio-data
+			imgStr,
+		}
+
+	default:
+		return nil, ErrEnvNotSet
+	}
+
+	fr = &Runner{
+		Exe:             Exe,
+		ExecArgs:        exeArgs,
+		LocalDataDir:    dataDir,
+		FioWriteBaseDir: filepath.ToSlash(fioWriteBaseDir),
 		Global: Config{
 			{
 				Name: "global",
-				Options: map[string]string{
+				Options: Options{
 					"openfiles":         "10",
 					"create_fsync":      "0",
 					"create_serialize":  "1",
@@ -54,27 +139,82 @@ func NewRunner() (*Runner, error) {
 					"blocksize":         "1m",
 					"refill_buffers":    "",
 					"rw":                "write",
-					"unique_filename":   "1",
-					"directory":         dataDir,
-				},
+				}.WithDirectory(fioWriteBaseDir),
 			},
 		},
-	}, nil
+	}
+
+	err = fr.verifySetupWithTestWrites()
+	if err != nil {
+		log.Printf("Verify environment setup:\n")
+		log.Printf("   Set %s (=%q)to the fio executable\n", FioExeEnvKey, exeStr)
+		log.Printf("   - OR -\n")
+		log.Printf("   Set %s (=%q) to the fio docker image", FioDockerImageEnvKey, imgStr)
+		log.Printf("   Set %s (=%q) to the path where fio data will be used locally", LocalFioDataPathEnvKey, localFioDataPathStr)
+		log.Printf("   Set %s (=%q) to the fio data path on the docker host (defaults to %v, if not running in a dev container)", HostFioDataPathEnvKey, os.Getenv(HostFioDataPathEnvKey), LocalFioDataPathEnvKey)
+
+		return nil, errors.Wrap(err, "fio setup could not be validated")
+	}
+
+	return fr, nil
+}
+
+func (fr *Runner) verifySetupWithTestWrites() error {
+	var subDirPath = path.Join("test", "subdir")
+
+	const (
+		maxTestFiles = 5
+		fileSizeB    = 1 << 20 // 1 MiB
+	)
+
+	nrFiles := rand.Intn(maxTestFiles) + 1
+
+	opt := Options{}.WithNumFiles(nrFiles).WithFileSize(fileSizeB)
+
+	err := fr.WriteFiles(subDirPath, opt)
+	if err != nil {
+		return errors.Wrap(err, "unable to perform writes")
+	}
+
+	defer fr.DeleteRelDir("test") //nolint:errcheck
+
+	fl, err := ioutil.ReadDir(filepath.Join(fr.LocalDataDir, subDirPath))
+	if err != nil {
+		return errors.Wrapf(err, "error reading path %v", subDirPath)
+	}
+
+	if got, want := len(fl), nrFiles; got != want {
+		return errors.Errorf("did not find the expected number of files %v != %v (expected)", got, want)
+	}
+
+	for _, fi := range fl {
+		if got, want := fi.Size(), int64(fileSizeB); got != want {
+			return errors.Errorf("did not get expected file size from writes %v != %v (expected)", got, want)
+		}
+	}
+
+	return nil
 }
 
 // Cleanup cleans up the data directory
 func (fr *Runner) Cleanup() {
-	if fr.DataDir != "" {
-		os.RemoveAll(fr.DataDir) //nolint:errcheck
+	if fr.LocalDataDir != "" {
+		os.RemoveAll(fr.LocalDataDir) //nolint:errcheck
 	}
 }
 
 // RunConfigs runs fio using the provided Configs
 func (fr *Runner) RunConfigs(cfgs ...Config) (stdout, stderr string, err error) {
+	args := argsFromConfigs(append([]Config{fr.Global}, cfgs...)...)
+
+	return fr.Run(args...)
+}
+
+func argsFromConfigs(cfgs ...Config) []string {
 	var args []string
 
 	// Apply global config before any other configs
-	for _, cfg := range append([]Config{fr.Global}, cfgs...) {
+	for _, cfg := range cfgs {
 		log.Printf("Applying config:\n%s", cfg)
 
 		for _, job := range cfg {
@@ -89,11 +229,13 @@ func (fr *Runner) RunConfigs(cfgs ...Config) (stdout, stderr string, err error) 
 		}
 	}
 
-	return fr.Run(args...)
+	return args
 }
 
 // Run will execute the fio command with the given args
 func (fr *Runner) Run(args ...string) (stdout, stderr string, err error) {
+	args = append(fr.ExecArgs, args...)
+
 	argsStr := strings.Join(args, " ")
 	log.Printf("running '%s %v'", fr.Exe, argsStr)
 	// nolint:gosec

--- a/tests/tools/fio/main_test.go
+++ b/tests/tools/fio/main_test.go
@@ -7,9 +7,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	Exe := os.Getenv("FIO_EXE")
-	if Exe == "" {
-		fmt.Println("Skipping fio tests if FIO_EXE is not set")
+	fioExe := os.Getenv(FioExeEnvKey)
+	fioImg := os.Getenv(FioDockerImageEnvKey)
+
+	if fioExe == "" && fioImg == "" {
+		fmt.Printf("Skipping fio tests if neither %s no %s is set\n", FioExeEnvKey, FioDockerImageEnvKey)
 		os.Exit(0)
 	}
 

--- a/tests/tools/fio/options.go
+++ b/tests/tools/fio/options.go
@@ -1,11 +1,38 @@
 package fio
 
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+)
+
 // Options are flags to be set when running fio
 type Options map[string]string
 
+// List of FIO argument strings
+const (
+	BlockSizeFioArg        = "blocksize"
+	DedupePercentageFioArg = "dedupe_percentage"
+	DirectoryFioArg        = "directory"
+	FallocateFioArg        = "fallocate"
+	FileSizeFioArg         = "filesize"
+	IOLimitFioArg          = "io_limit"
+	IOSizeFioArg           = "io_size"
+	NumFilesFioArg         = "nrfiles"
+	RandRepeatFioArg       = "randrepeat"
+	SizeFioArg             = "size"
+)
+
+// List of FIO specific fields and delimiters
+const (
+	NoneFio       = "none"
+	RandWriteFio  = "randwrite"
+	RangeDelimFio = "-"
+)
+
 // Merge will merge two Options, overwriting common option keys
 // with the incoming option values. Returns the merged result
-func (o Options) Merge(other Options) map[string]string {
+func (o Options) Merge(other Options) Options {
 	out := make(map[string]string, len(o)+len(other))
 
 	for k, v := range o {
@@ -17,4 +44,100 @@ func (o Options) Merge(other Options) map[string]string {
 	}
 
 	return out
+}
+
+// WithSize sets the fio write size
+func (o Options) WithSize(sizeB int64) Options {
+	return o.Merge(Options{
+		SizeFioArg: strconv.Itoa(int(sizeB)),
+	})
+}
+
+// WithSizeRange sets the fio size range
+func (o Options) WithSizeRange(sizeMinB, sizeMaxB int64) Options {
+	return o.Merge(rangeOpt(SizeFioArg, int(sizeMinB), int(sizeMaxB)))
+}
+
+// WithIOLimit sets the fio io limit
+func (o Options) WithIOLimit(ioSizeB int64) Options {
+	return o.Merge(Options{
+		IOLimitFioArg: strconv.Itoa(int(ioSizeB)),
+	})
+}
+
+// WithIOSize sets the fio io size
+func (o Options) WithIOSize(sizeB int64) Options {
+	return o.Merge(Options{
+		IOSizeFioArg: strconv.Itoa(int(sizeB)),
+	})
+}
+
+// WithNumFiles sets the fio number of files
+func (o Options) WithNumFiles(numFiles int) Options {
+	return o.Merge(Options{
+		NumFilesFioArg: strconv.Itoa(numFiles),
+	})
+}
+
+// WithFileSize sets the fio file size
+func (o Options) WithFileSize(fileSizeB int64) Options {
+	return o.Merge(Options{
+		FileSizeFioArg: strconv.Itoa(int(fileSizeB)),
+	})
+}
+
+// WithFileSizeRange sets the fio file size range
+func (o Options) WithFileSizeRange(fileSizeMinB, fileSizeMaxB int64) Options {
+	return o.Merge(rangeOpt(FileSizeFioArg, int(fileSizeMinB), int(fileSizeMaxB)))
+}
+
+// WithDedupePercentage sets the fio dedupe percentage
+func (o Options) WithDedupePercentage(dPcnt int) Options {
+	return o.Merge(Options{
+		DedupePercentageFioArg: strconv.Itoa(dPcnt),
+	})
+}
+
+// WithBlockSize sets the fio block size option
+func (o Options) WithBlockSize(blockSizeB int64) Options {
+	return o.Merge(Options{
+		BlockSizeFioArg: strconv.Itoa(int(blockSizeB)),
+	})
+}
+
+// WithNoFallocate sets the fio option fallocate to "none"
+func (o Options) WithNoFallocate() Options {
+	return o.Merge(Options{
+		FallocateFioArg: NoneFio,
+	})
+}
+
+// WithRandRepeat sets the fio option rand repeat
+func (o Options) WithRandRepeat(set bool) Options {
+	return o.Merge(boolOpt(RandRepeatFioArg, set))
+}
+
+// WithDirectory sets the fio option for the directory to write in
+func (o Options) WithDirectory(dir string) Options {
+	return o.Merge(Options{
+		DirectoryFioArg: filepath.ToSlash(dir),
+	})
+}
+
+func boolOpt(key string, val bool) Options {
+	if val {
+		return Options{key: strconv.Itoa(1)}
+	}
+
+	return Options{key: strconv.Itoa(0)}
+}
+
+func rangeOpt(key string, min, max int) Options {
+	if min > max {
+		min, max = max, min
+	}
+
+	return Options{
+		key: fmt.Sprintf("%d%s%d", min, RangeDelimFio, max),
+	}
 }

--- a/tests/tools/fio/workload.go
+++ b/tests/tools/fio/workload.go
@@ -1,7 +1,6 @@
 package fio
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 

--- a/tests/tools/fio/workload.go
+++ b/tests/tools/fio/workload.go
@@ -30,7 +30,7 @@ func (fr *Runner) writeFiles(fullPath string, opt Options) error {
 
 	_, _, err = fr.RunConfigs(Config{
 		{
-			Name: fmt.Sprintf("writeFiles"),
+			Name: "writeFiles",
 			Options: opt.Merge(
 				Options{
 					"readwrite":       RandWriteFio,

--- a/tests/tools/fio/workload.go
+++ b/tests/tools/fio/workload.go
@@ -4,29 +4,46 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 // WriteFiles writes files to the directory specified by path, up to the
 // provided size and number of files
-func (fr *Runner) WriteFiles(path string, sizeB int64, numFiles int, opt Options) error {
-	fullPath := filepath.Join(fr.DataDir, path)
+func (fr *Runner) WriteFiles(relPath string, opt Options) error {
+	fullPath := filepath.Join(fr.LocalDataDir, relPath)
+	return fr.writeFiles(fullPath, opt)
+}
 
+func (fr *Runner) writeFiles(fullPath string, opt Options) error {
 	err := os.MkdirAll(fullPath, 0700)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "unable to make directory for write")
 	}
+
+	relWritePath, err := filepath.Rel(fr.LocalDataDir, fullPath)
+	if err != nil {
+		return errors.Wrapf(err, "error finding relative file path between %v and %v", fr.LocalDataDir, fullPath)
+	}
+
+	absWritePath := filepath.Join(fr.FioWriteBaseDir, relWritePath)
 
 	_, _, err = fr.RunConfigs(Config{
 		{
-			Name: fmt.Sprintf("write-%vB-%v", sizeB, numFiles),
-			Options: opt.Merge(Options{
-				"size":      strconv.Itoa(int(sizeB)),
-				"nrfiles":   strconv.Itoa(numFiles),
-				"directory": fullPath,
-			}),
+			Name: fmt.Sprintf("writeFiles"),
+			Options: opt.Merge(
+				Options{
+					"readwrite":       RandWriteFio,
+					"filename_format": "file_$filenum",
+				}.WithDirectory(absWritePath),
+			),
 		},
 	})
 
 	return err
+}
+
+// DeleteRelDir deletes a relative directory in the runner's data directory
+func (fr *Runner) DeleteRelDir(relDirPath string) error {
+	return os.RemoveAll(filepath.Join(fr.LocalDataDir, relDirPath))
 }

--- a/tests/tools/fio/workload_test.go
+++ b/tests/tools/fio/workload_test.go
@@ -1,7 +1,6 @@
 package fio
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -16,14 +15,15 @@ func TestWriteFiles(t *testing.T) {
 	defer r.Cleanup()
 
 	relativeWritePath := "some/path/to/check"
-	writeSizeB := int64(256 * 1024 * 1024) // 256 MiB
+	writeFileSizeB := int64(256 * 1024) // 256 KiB
 	numFiles := 13
+	fioOpt := Options{}.WithFileSize(writeFileSizeB).WithNumFiles(numFiles).WithBlockSize(4096)
 
 	// Test a call to WriteFiles
-	err = r.WriteFiles(relativeWritePath, writeSizeB, numFiles, Options{})
+	err = r.WriteFiles(relativeWritePath, fioOpt)
 	testenv.AssertNoError(t, err)
 
-	fullPath := filepath.Join(r.DataDir, relativeWritePath)
+	fullPath := filepath.Join(r.LocalDataDir, relativeWritePath)
 	dir, err := ioutil.ReadDir(fullPath)
 	testenv.AssertNoError(t, err)
 
@@ -34,11 +34,10 @@ func TestWriteFiles(t *testing.T) {
 	sizeTot := int64(0)
 
 	for _, fi := range dir {
-		fmt.Println(fi.Name(), fi.Size())
 		sizeTot += fi.Size()
 	}
 
-	want := (writeSizeB / int64(numFiles)) * int64(numFiles)
+	want := writeFileSizeB * int64(numFiles)
 	if got := sizeTot; got != want {
 		t.Errorf("Did not get the expected amount of data written %v (actual) != %v (expected)", got, want)
 	}

--- a/tests/tools/fio_docker/Dockerfile
+++ b/tests/tools/fio_docker/Dockerfile
@@ -1,9 +1,0 @@
-FROM golang:1
-
-RUN apt-get update \
-    #
-    # Install fio
-    && apt-get install fio -y
-
-WORKDIR "/fio-data"
-ENTRYPOINT [ "fio" ]

--- a/tests/tools/fio_docker/Dockerfile
+++ b/tests/tools/fio_docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1
+
+RUN apt-get update \
+    #
+    # Install fio
+    && apt-get install fio -y
+
+WORKDIR "/fio-data"
+ENTRYPOINT [ "fio" ]


### PR DESCRIPTION
Update the fio runner to use a docker image if the appropriate environment variable is set. Docker image is built via a makefile target and used in the robustness tool tests. The image uses `fio` as an entrypoint, so from the standpoint of the fio runner package implementation, it behaves similarly to a local executable fio.

This is a replacement implementation for #208, which I will close shortly.