### PR TITLE
Use bytes buffer to capture stderr instead of reading pipe

### DIFF
--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -3,9 +3,9 @@ package testenv
 
 import (
 	"bufio"
+	"bytes"
 	cryptorand "crypto/rand"
 	"encoding/hex"
-	goerrors "errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -208,41 +207,14 @@ func (e *CLITest) Run(t *testing.T, args ...string) (stdout, stderr []string, er
 	c := exec.Command(e.Exe, cmdArgs...)
 	c.Env = append(os.Environ(), e.environment...)
 
-	stderrPipe, err := c.StderrPipe()
-	if err != nil {
-		t.Fatalf("can't set up stderr pipe reader")
-	}
-
-	var errOut []byte
-
-	var wg sync.WaitGroup
-
-	var pipeErr error
-
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
-		errOut, pipeErr = ioutil.ReadAll(stderrPipe)
-		if goerrors.Is(pipeErr, os.ErrClosed) {
-			t.Logf("ignoring os.ErrClosed on stderr")
-
-			pipeErr = nil
-		}
-	}()
+	errOut := &bytes.Buffer{}
+	c.Stderr = errOut
 
 	o, err := c.Output()
 
-	wg.Wait()
+	t.Logf("finished 'kopia %v' with err=%v and output:\n%v\nstderr:\n%v\n", strings.Join(args, " "), err, trimOutput(string(o)), trimOutput(errOut.String()))
 
-	if pipeErr != nil {
-		t.Fatalf("error reading out of the stderr pipe: %s %T", pipeErr, pipeErr)
-	}
-
-	t.Logf("finished 'kopia %v' with err=%v and output:\n%v\nstderr:\n%v\n", strings.Join(args, " "), err, trimOutput(string(o)), trimOutput(string(errOut)))
-
-	return splitLines(string(o)), splitLines(string(errOut)), err
+	return splitLines(string(o)), splitLines(errOut.String()), err
 }
 
 func trimOutput(s string) string {


### PR DESCRIPTION
Give a `*bytes.Buffer` to the Command and let `package exec` read from the pipe into the buffer for us.

The current use of the `StderrPipe()` method is problematic; the documentation for os/exec states:

> Wait will close the pipe after seeing the command exit, so most callers need not close the pipe themselves. It is thus incorrect to call Wait before all reads from the pipe have completed. For the same reason, it is incorrect to use Run when using StderrPipe.

This should solve flake behavior seen in end to end testing, even following #285, which exposed the above problem.