### PR TITLE
cli: 'snapshot migrate' improvements to help with data migration

### DIFF
--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -31,7 +31,7 @@ func setupConnectOptions(cmd *kingpin.CmdClause) {
 	cmd.Flag("persist-credentials", "Persist credentials").Default("true").BoolVar(&connectPersistCredentials)
 	cmd.Flag("cache-directory", "Cache directory").PlaceHolder("PATH").StringVar(&connectCacheDirectory)
 	cmd.Flag("content-cache-size-mb", "Size of local content cache").PlaceHolder("MB").Default("5000").Int64Var(&connectMaxCacheSizeMB)
-	cmd.Flag("metadata-cache-size-mb", "Size of local metadata cache").PlaceHolder("MB").Default("500").Int64Var(&connectMaxMetadataCacheSizeMB)
+	cmd.Flag("metadata-cache-size-mb", "Size of local metadata cache").PlaceHolder("MB").Default("5000").Int64Var(&connectMaxMetadataCacheSizeMB)
 	cmd.Flag("max-list-cache-duration", "Duration of index cache").Default("600s").Hidden().DurationVar(&connectMaxListCacheDuration)
 	cmd.Flag("override-hostname", "Override hostname used by this repository connection").Hidden().StringVar(&connectHostname)
 	cmd.Flag("override-username", "Override username used by this repository connection").Hidden().StringVar(&connectUsername)
@@ -42,9 +42,10 @@ func connectOptions() *repo.ConnectOptions {
 	return &repo.ConnectOptions{
 		PersistCredentials: connectPersistCredentials,
 		CachingOptions: content.CachingOptions{
-			CacheDirectory:          connectCacheDirectory,
-			MaxCacheSizeBytes:       connectMaxCacheSizeMB << 20, //nolint:gomnd
-			MaxListCacheDurationSec: int(connectMaxListCacheDuration.Seconds()),
+			CacheDirectory:            connectCacheDirectory,
+			MaxCacheSizeBytes:         connectMaxCacheSizeMB << 20,         //nolint:gomnd
+			MaxMetadataCacheSizeBytes: connectMaxMetadataCacheSizeMB << 20, //nolint:gomnd
+			MaxListCacheDurationSec:   int(connectMaxListCacheDuration.Seconds()),
 		},
 		HostnameOverride: connectHostname,
 		UsernameOverride: connectUsername,


### PR DESCRIPTION
- cleaned up migration progress output
- fixed migration idempotency
- added migration of policies
- renamed --parallelism to --parallel
- improved e2e test
- do not prompt for password to source repository if persisted