### PR TITLE
Add snapshotter interface and kopia implementation

### DIFF
--- a/tests/robustness/snap/snap.go
+++ b/tests/robustness/snap/snap.go
@@ -1,0 +1,22 @@
+// Package snap describes entities that are capable of performing
+// common snapshot operations
+package snap
+
+// Snapshotter is an interface that describes methods
+// for taking, restoring, deleting snapshots, and
+// tracking them by a string snapshot ID.
+type Snapshotter interface {
+	RepoManager
+	CreateSnapshot(sourceDir string) (snapID string, err error)
+	RestoreSnapshot(snapID string, restoreDir string) error
+	DeleteSnapshot(snapID string) error
+	ListSnapshots() ([]string, error)
+	Run(args ...string) (stdout, stderr string, err error)
+}
+
+// RepoManager is an interface that describes connecting to
+// a repository
+type RepoManager interface {
+	ConnectOrCreateS3(bucketName, pathPrefix string) error
+	ConnectOrCreateFilesystem(path string) error
+}

--- a/tests/tools/kopiarunner/kopia_snapshotter.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter.go
@@ -1,0 +1,153 @@
+package kopiarunner
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/kopia/kopia/tests/robustness/snap"
+)
+
+var _ snap.Snapshotter = &KopiaSnapshotter{}
+
+// KopiaSnapshotter implements the Snapshotter interface using Kopia commands
+type KopiaSnapshotter struct {
+	Runner *Runner
+}
+
+// NewKopiaSnapshotter instantiates a new KopiaSnapshotter and returns its pointer
+func NewKopiaSnapshotter() (*KopiaSnapshotter, error) {
+	runner, err := NewRunner()
+	if err != nil {
+		return nil, err
+	}
+
+	return &KopiaSnapshotter{
+		Runner: runner,
+	}, nil
+}
+
+// Cleanup cleans up the kopia Runner
+func (ks *KopiaSnapshotter) Cleanup() {
+	if ks.Runner != nil {
+		ks.Runner.Cleanup()
+	}
+}
+
+// CreateRepo creates a kopia repository with the provided arguments
+func (ks *KopiaSnapshotter) CreateRepo(args ...string) (err error) {
+	args = append([]string{"repo", "create"}, args...)
+	_, _, err = ks.Runner.Run(args...)
+
+	return err
+}
+
+// ConnectRepo connects to the repository described by the provided arguments
+func (ks *KopiaSnapshotter) ConnectRepo(args ...string) (err error) {
+	args = append([]string{"repo", "connect"}, args...)
+	_, _, err = ks.Runner.Run(args...)
+
+	return err
+}
+
+// ConnectOrCreateRepo attempts to connect to a repo described by the provided
+// arguments, and attempts to create it if connection was unsuccessful.
+func (ks *KopiaSnapshotter) ConnectOrCreateRepo(args ...string) error {
+	err := ks.ConnectRepo(args...)
+	if err == nil {
+		return nil
+	}
+
+	return ks.CreateRepo(args...)
+}
+
+// ConnectOrCreateS3 attempts to connect to a kopia repo in the s3 bucket identified
+// by the provided bucketName, at the provided path prefix. It will attempt to
+// create one there if connection was unsuccessful.
+func (ks *KopiaSnapshotter) ConnectOrCreateS3(bucketName, pathPrefix string) error {
+	args := []string{"s3", "--bucket", bucketName, "--prefix", pathPrefix}
+
+	return ks.ConnectOrCreateRepo(args...)
+}
+
+// ConnectOrCreateFilesystem attempts to connect to a kopia repo in the local
+// filesystem at the path provided. It will attempt to create one there if
+// connection was unsuccessful.
+func (ks *KopiaSnapshotter) ConnectOrCreateFilesystem(repoPath string) error {
+	args := []string{"filesystem", "--path", repoPath}
+
+	return ks.ConnectOrCreateRepo(args...)
+}
+
+// CreateSnapshot implements the Snapshotter interface, issues a kopia snapshot
+// create command on the provided source path.
+func (ks *KopiaSnapshotter) CreateSnapshot(source string) (snapID string, err error) {
+	_, errOut, err := ks.Runner.Run("snapshot", "create", source)
+	if err != nil {
+		return "", err
+	}
+
+	return parseSnapID(strings.Split(errOut, "\n"))
+}
+
+// RestoreSnapshot implements the Snapshotter interface, issues a kopia snapshot
+// restore command of the provided snapshot ID to the provided restore destination
+func (ks *KopiaSnapshotter) RestoreSnapshot(snapID, restoreDir string) (err error) {
+	_, _, err = ks.Runner.Run("snapshot", "restore", snapID, restoreDir)
+	return err
+}
+
+// DeleteSnapshot implements the Snapshotter interface, issues a kopia snapshot
+// delete of the provided snapshot ID
+func (ks *KopiaSnapshotter) DeleteSnapshot(snapID string) (err error) {
+	_, _, err = ks.Runner.Run("snapshot", "delete", snapID, "--unsafe-ignore-source")
+	return err
+}
+
+// ListSnapshots implements the Snapshotter interface, issues a kopia snapshot
+// list and parses the snapshot IDs
+func (ks *KopiaSnapshotter) ListSnapshots() ([]string, error) {
+	stdout, _, err := ks.Runner.Run("manifest", "list")
+	if err != nil {
+		return nil, err
+	}
+
+	return parseListForSnapshotIDs(stdout), nil
+}
+
+// Run implements the Snapshotter interface, issues an arbitrary kopia command and returns
+// the output
+func (ks *KopiaSnapshotter) Run(args ...string) (stdout, stderr string, err error) {
+	return ks.Runner.Run(args...)
+}
+
+func parseSnapID(lines []string) (string, error) {
+	pattern := regexp.MustCompile(`uploaded snapshot ([\S]+)`)
+
+	for _, l := range lines {
+		match := pattern.FindAllStringSubmatch(l, 1)
+		if len(match) > 0 && len(match[0]) > 1 {
+			return match[0][1], nil
+		}
+	}
+
+	return "", errors.New("snap ID could not be parsed")
+}
+
+func parseListForSnapshotIDs(output string) []string {
+	var ret []string
+
+	lines := strings.Split(output, "\n")
+	for _, l := range lines {
+		fields := strings.Fields(l)
+
+		typeFieldIdx := 5
+		if len(fields) > typeFieldIdx {
+			if fields[typeFieldIdx] == "type:snapshot" {
+				ret = append(ret, fields[0])
+			}
+		}
+	}
+
+	return ret
+}

--- a/tests/tools/kopiarunner/kopiarun.go
+++ b/tests/tools/kopiarunner/kopiarun.go
@@ -1,0 +1,97 @@
+// Package kopiarunner wraps the execution of the kopia binary.
+package kopiarunner
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const (
+	repoPassword = "qWQPJ2hiiLgWRRCr" // nolint:gosec
+)
+
+// Runner is a helper for running kopia commands
+type Runner struct {
+	Exe         string
+	ConfigDir   string
+	fixedArgs   []string
+	environment []string
+}
+
+// ErrExeVariableNotSet is an exported error
+var ErrExeVariableNotSet = errors.New("KOPIA_EXE variable has not been set")
+
+// NewRunner initializes a new kopia runner and returns its pointer
+func NewRunner() (*Runner, error) {
+	exe := os.Getenv("KOPIA_EXE")
+	if exe == "" {
+		return nil, ErrExeVariableNotSet
+	}
+
+	configDir, err := ioutil.TempDir("", "kopia-config")
+	if err != nil {
+		return nil, err
+	}
+
+	fixedArgs := []string{
+		// use per-test config file, to avoid clobbering current user's setup.
+		"--config-file", filepath.Join(configDir, ".kopia.config"),
+	}
+
+	return &Runner{
+		Exe:         exe,
+		ConfigDir:   configDir,
+		fixedArgs:   fixedArgs,
+		environment: []string{"KOPIA_PASSWORD=" + repoPassword},
+	}, nil
+}
+
+// Cleanup cleans up the directories managed by the kopia Runner
+func (kr *Runner) Cleanup() {
+	if kr.ConfigDir != "" {
+		os.RemoveAll(kr.ConfigDir) //nolint:errcheck
+	}
+}
+
+// Run will execute the kopia command with the given args
+func (kr *Runner) Run(args ...string) (stdout, stderr string, err error) {
+	argsStr := strings.Join(args, " ")
+	log.Printf("running '%s %v'", kr.Exe, argsStr)
+	// nolint:gosec
+	cmdArgs := append(append([]string(nil), kr.fixedArgs...), args...)
+
+	// nolint:gosec
+	c := exec.Command(kr.Exe, cmdArgs...)
+	c.Env = append(os.Environ(), kr.environment...)
+
+	stderrPipe, err := c.StderrPipe()
+	if err != nil {
+		return stdout, stderr, err
+	}
+
+	var errOut []byte
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		errOut, err = ioutil.ReadAll(stderrPipe)
+	}()
+
+	o, err := c.Output()
+
+	wg.Wait()
+
+	log.Printf("finished '%s %v' with err=%v and output:\n%v\n%v", kr.Exe, argsStr, err, string(o), string(errOut))
+
+	return string(o), string(errOut), err
+}

--- a/tests/tools/kopiarunner/kopiarun_test.go
+++ b/tests/tools/kopiarunner/kopiarun_test.go
@@ -1,0 +1,78 @@
+package kopiarunner
+
+import (
+	"os"
+	"testing"
+)
+
+func TestKopiaRunner(t *testing.T) {
+	origEnv := os.Getenv("KOPIA_EXE")
+	if origEnv == "" {
+		t.Skip("Skipping kopia runner test: 'KOPIA_EXE' is unset")
+	}
+
+	defer func() {
+		envErr := os.Setenv("KOPIA_EXE", origEnv)
+		if envErr != nil {
+			t.Fatal("Unable to reset env KOPIA_EXE to original value")
+		}
+	}()
+
+	for _, tt := range []struct {
+		name            string
+		exe             string
+		args            []string
+		expNewRunnerErr bool
+		expRunErr       bool
+	}{
+		{
+			name:            "empty exe",
+			exe:             "",
+			args:            nil,
+			expNewRunnerErr: true,
+			expRunErr:       false,
+		},
+		{
+			name:            "invalid exe",
+			exe:             "not-a-program",
+			args:            []string{"some", "arguments"},
+			expNewRunnerErr: false,
+			expRunErr:       true,
+		},
+		{
+			name:            "kopia exe no args",
+			exe:             origEnv,
+			args:            []string{""},
+			expNewRunnerErr: false,
+			expRunErr:       true,
+		},
+		{
+			name:            "kopia exe help",
+			exe:             origEnv,
+			args:            []string{"--help"},
+			expNewRunnerErr: false,
+			expRunErr:       false,
+		},
+	} {
+		t.Log(tt.name)
+
+		err := os.Setenv("KOPIA_EXE", tt.exe)
+		if err != nil {
+			t.Fatal("Unable to set environment variable KOPIA_EXE")
+		}
+
+		runner, err := NewRunner()
+		if (err != nil) != tt.expNewRunnerErr {
+			t.Fatalf("Expected NewRunner error: %v, got %v", tt.expNewRunnerErr, err)
+		}
+
+		if err != nil {
+			continue
+		}
+
+		_, _, err = runner.Run(tt.args...)
+		if (err != nil) != tt.expRunErr {
+			t.Fatalf("Expected Run error: %v, got %v", tt.expRunErr, err)
+		}
+	}
+}


### PR DESCRIPTION
Snapshotter interface describes an entity that can create,
restore, and delete snapshots, as well as manage a repository.

Add kopia implementation of the snapshotter interface.