### PR TITLE
repo: refactored public API

### DIFF
--- a/cli/command_blob_delete.go
+++ b/cli/command_blob_delete.go
@@ -14,7 +14,7 @@ var (
 	blobDeleteBlobIDs = blobDeleteCommand.Arg("blobIDs", "Blob IDs").Required().Strings()
 )
 
-func runDeleteBlobs(ctx context.Context, rep *repo.Repository) error {
+func runDeleteBlobs(ctx context.Context, rep *repo.DirectRepository) error {
 	for _, b := range *blobDeleteBlobIDs {
 		err := rep.Blobs.DeleteBlob(ctx, blob.ID(b))
 		if err != nil {
@@ -26,5 +26,5 @@ func runDeleteBlobs(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	blobDeleteCommand.Action(repositoryAction(runDeleteBlobs))
+	blobDeleteCommand.Action(directRepositoryAction(runDeleteBlobs))
 }

--- a/cli/command_blob_gc.go
+++ b/cli/command_blob_gc.go
@@ -20,7 +20,7 @@ var (
 	blobGarbageCollectMinAge        = blobGarbageCollectCommand.Flag("min-age", "Garbage-collect blobs with minimum age").Default("24h").Duration()
 )
 
-func runBlobGarbageCollectCommand(ctx context.Context, rep *repo.Repository) error {
+func runBlobGarbageCollectCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	const deleteQueueSize = 100
 
 	var unreferenced, deleted stats.CountSum
@@ -94,5 +94,5 @@ func runBlobGarbageCollectCommand(ctx context.Context, rep *repo.Repository) err
 }
 
 func init() {
-	blobGarbageCollectCommand.Action(repositoryAction(runBlobGarbageCollectCommand))
+	blobGarbageCollectCommand.Action(directRepositoryAction(runBlobGarbageCollectCommand))
 }

--- a/cli/command_blob_list.go
+++ b/cli/command_blob_list.go
@@ -15,7 +15,7 @@ var (
 	blobListMaxSize = blobListCommand.Flag("max-size", "Maximum size").Int64()
 )
 
-func runBlobList(ctx context.Context, rep *repo.Repository) error {
+func runBlobList(ctx context.Context, rep *repo.DirectRepository) error {
 	return rep.Blobs.ListBlobs(ctx, blob.ID(*blobListPrefix), func(b blob.Metadata) error {
 		if *blobListMaxSize != 0 && b.Length > *blobListMaxSize {
 			return nil
@@ -31,5 +31,5 @@ func runBlobList(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	blobListCommand.Action(repositoryAction(runBlobList))
+	blobListCommand.Action(directRepositoryAction(runBlobList))
 }

--- a/cli/command_blob_show.go
+++ b/cli/command_blob_show.go
@@ -17,7 +17,7 @@ var (
 	blobShowIDs     = blobShowCommand.Arg("blobID", "Blob IDs").Required().Strings()
 )
 
-func runBlobShow(ctx context.Context, rep *repo.Repository) error {
+func runBlobShow(ctx context.Context, rep *repo.DirectRepository) error {
 	for _, blobID := range *blobShowIDs {
 		d, err := rep.Blobs.GetBlob(ctx, blob.ID(blobID), 0, -1)
 		if err != nil {
@@ -33,5 +33,5 @@ func runBlobShow(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	blobShowCommand.Action(repositoryAction(runBlobShow))
+	blobShowCommand.Action(directRepositoryAction(runBlobShow))
 }

--- a/cli/command_blob_stats.go
+++ b/cli/command_blob_stats.go
@@ -15,7 +15,7 @@ var (
 	blobStatsRaw     = blobStatsCommand.Flag("raw", "Raw numbers").Short('r').Bool()
 )
 
-func runBlobStatsCommand(ctx context.Context, rep *repo.Repository) error {
+func runBlobStatsCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	var sizeThreshold int64 = 10
 
 	countMap := map[int64]int{}
@@ -84,5 +84,5 @@ func runBlobStatsCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	blobStatsCommand.Action(repositoryAction(runBlobStatsCommand))
+	blobStatsCommand.Action(directRepositoryAction(runBlobStatsCommand))
 }

--- a/cli/command_cache_clear.go
+++ b/cli/command_cache_clear.go
@@ -13,7 +13,7 @@ var (
 	cacheClearCommand = cacheCommands.Command("clear", "Clears the cache")
 )
 
-func runCacheClearCommand(ctx context.Context, rep *repo.Repository) error {
+func runCacheClearCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	if d := rep.Content.CachingOptions.CacheDirectory; d != "" {
 		printStderr("Clearing cache directory: %v.\n", d)
 
@@ -35,5 +35,5 @@ func runCacheClearCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	cacheClearCommand.Action(repositoryAction(runCacheClearCommand))
+	cacheClearCommand.Action(directRepositoryAction(runCacheClearCommand))
 }

--- a/cli/command_cache_info.go
+++ b/cli/command_cache_info.go
@@ -17,7 +17,7 @@ var (
 	cacheInfoPathOnly = cacheInfoCommand.Flag("path", "Only display cache path").Bool()
 )
 
-func runCacheInfoCommand(ctx context.Context, rep *repo.Repository) error {
+func runCacheInfoCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	if *cacheInfoPathOnly {
 		fmt.Println(rep.Content.CachingOptions.CacheDirectory)
 		return nil
@@ -57,5 +57,5 @@ func runCacheInfoCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	cacheInfoCommand.Action(repositoryAction(runCacheInfoCommand))
+	cacheInfoCommand.Action(directRepositoryAction(runCacheInfoCommand))
 }

--- a/cli/command_cache_set.go
+++ b/cli/command_cache_set.go
@@ -18,7 +18,7 @@ var (
 	cacheSetMaxListCacheDuration   = cacheSetParamsCommand.Flag("max-list-cache-duration", "Duration of index cache").Default("-1ns").Duration()
 )
 
-func runCacheSetCommand(ctx context.Context, rep *repo.Repository) error {
+func runCacheSetCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	opts := rep.Content.CachingOptions
 
 	changed := 0
@@ -57,5 +57,5 @@ func runCacheSetCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	cacheSetParamsCommand.Action(repositoryAction(runCacheSetCommand))
+	cacheSetParamsCommand.Action(directRepositoryAction(runCacheSetCommand))
 }

--- a/cli/command_content_list.go
+++ b/cli/command_content_list.go
@@ -21,7 +21,7 @@ var (
 	contentListHuman          = contentListCommand.Flag("human", "Human-readable output").Short('h').Bool()
 )
 
-func runContentListCommand(ctx context.Context, rep *repo.Repository) error {
+func runContentListCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	var totalSize stats.CountSum
 
 	err := rep.Content.IterateContents(
@@ -71,5 +71,5 @@ func runContentListCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	contentListCommand.Action(repositoryAction(runContentListCommand))
+	contentListCommand.Action(directRepositoryAction(runContentListCommand))
 }

--- a/cli/command_content_rewrite.go
+++ b/cli/command_content_rewrite.go
@@ -30,7 +30,7 @@ type contentInfoOrError struct {
 	err error
 }
 
-func runContentRewriteCommand(ctx context.Context, rep *repo.Repository) error {
+func runContentRewriteCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	cnt := getContentToRewrite(ctx, rep)
 
 	var (
@@ -92,7 +92,7 @@ func runContentRewriteCommand(ctx context.Context, rep *repo.Repository) error {
 	return errors.Errorf("failed to rewrite %v contents", failedCount)
 }
 
-func getContentToRewrite(ctx context.Context, rep *repo.Repository) <-chan contentInfoOrError {
+func getContentToRewrite(ctx context.Context, rep *repo.DirectRepository) <-chan contentInfoOrError {
 	ch := make(chan contentInfoOrError)
 
 	go func() {
@@ -125,7 +125,7 @@ func toContentIDs(s []string) []content.ID {
 	return result
 }
 
-func findContentInfos(ctx context.Context, rep *repo.Repository, ch chan contentInfoOrError, contentIDs []content.ID) {
+func findContentInfos(ctx context.Context, rep *repo.DirectRepository, ch chan contentInfoOrError, contentIDs []content.ID) {
 	for _, contentID := range contentIDs {
 		i, err := rep.Content.ContentInfo(ctx, contentID)
 		if err != nil {
@@ -136,7 +136,7 @@ func findContentInfos(ctx context.Context, rep *repo.Repository, ch chan content
 	}
 }
 
-func findContentWithFormatVersion(ctx context.Context, rep *repo.Repository, ch chan contentInfoOrError, version int) {
+func findContentWithFormatVersion(ctx context.Context, rep *repo.DirectRepository, ch chan contentInfoOrError, version int) {
 	_ = rep.Content.IterateContents(
 		ctx,
 		content.IterateOptions{IncludeDeleted: true},
@@ -148,7 +148,7 @@ func findContentWithFormatVersion(ctx context.Context, rep *repo.Repository, ch 
 		})
 }
 
-func findContentInShortPacks(ctx context.Context, rep *repo.Repository, ch chan contentInfoOrError, threshold int64) {
+func findContentInShortPacks(ctx context.Context, rep *repo.DirectRepository, ch chan contentInfoOrError, threshold int64) {
 	if err := rep.Content.IterateContentInShortPacks(ctx, threshold, func(ci content.Info) error {
 		ch <- contentInfoOrError{Info: ci}
 		return nil
@@ -159,5 +159,5 @@ func findContentInShortPacks(ctx context.Context, rep *repo.Repository, ch chan 
 }
 
 func init() {
-	contentRewriteCommand.Action(repositoryAction(runContentRewriteCommand))
+	contentRewriteCommand.Action(directRepositoryAction(runContentRewriteCommand))
 }

--- a/cli/command_content_rm.go
+++ b/cli/command_content_rm.go
@@ -12,7 +12,7 @@ var (
 	contentRemoveIDs = contentRemoveCommand.Arg("id", "IDs of content to remove").Required().Strings()
 )
 
-func runContentRemoveCommand(ctx context.Context, rep *repo.Repository) error {
+func runContentRemoveCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	for _, contentID := range toContentIDs(*contentRemoveIDs) {
 		if err := rep.Content.DeleteContent(ctx, contentID); err != nil {
 			return err
@@ -24,5 +24,5 @@ func runContentRemoveCommand(ctx context.Context, rep *repo.Repository) error {
 
 func init() {
 	setupShowCommand(contentRemoveCommand)
-	contentRemoveCommand.Action(repositoryAction(runContentRemoveCommand))
+	contentRemoveCommand.Action(directRepositoryAction(runContentRemoveCommand))
 }

--- a/cli/command_content_show.go
+++ b/cli/command_content_show.go
@@ -14,7 +14,7 @@ var (
 	contentShowIDs = contentShowCommand.Arg("id", "IDs of contents to show").Required().Strings()
 )
 
-func runContentShowCommand(ctx context.Context, rep *repo.Repository) error {
+func runContentShowCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	for _, contentID := range toContentIDs(*contentShowIDs) {
 		if err := contentShow(ctx, rep, contentID); err != nil {
 			return err
@@ -24,7 +24,7 @@ func runContentShowCommand(ctx context.Context, rep *repo.Repository) error {
 	return nil
 }
 
-func contentShow(ctx context.Context, r *repo.Repository, contentID content.ID) error {
+func contentShow(ctx context.Context, r *repo.DirectRepository, contentID content.ID) error {
 	data, err := r.Content.GetContent(ctx, contentID)
 	if err != nil {
 		return err
@@ -35,5 +35,5 @@ func contentShow(ctx context.Context, r *repo.Repository, contentID content.ID) 
 
 func init() {
 	setupShowCommand(contentShowCommand)
-	contentShowCommand.Action(repositoryAction(runContentShowCommand))
+	contentShowCommand.Action(directRepositoryAction(runContentShowCommand))
 }

--- a/cli/command_content_stats.go
+++ b/cli/command_content_stats.go
@@ -15,7 +15,7 @@ var (
 	contentStatsRaw     = contentStatsCommand.Flag("raw", "Raw numbers").Short('r').Bool()
 )
 
-func runContentStatsCommand(ctx context.Context, rep *repo.Repository) error {
+func runContentStatsCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	var sizeThreshold uint32 = 10
 
 	countMap := map[uint32]int{}
@@ -81,5 +81,5 @@ func runContentStatsCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	contentStatsCommand.Action(repositoryAction(runContentStatsCommand))
+	contentStatsCommand.Action(directRepositoryAction(runContentStatsCommand))
 }

--- a/cli/command_content_verify.go
+++ b/cli/command_content_verify.go
@@ -19,7 +19,7 @@ var (
 	contentVerifyFull     = contentVerifyCommand.Flag("full", "Full verification (including download)").Bool()
 )
 
-func runContentVerifyCommand(ctx context.Context, rep *repo.Repository) error {
+func runContentVerifyCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	blobMap := map[blob.ID]blob.Metadata{}
 
 	if !*contentVerifyFull {
@@ -56,7 +56,7 @@ func runContentVerifyCommand(ctx context.Context, rep *repo.Repository) error {
 	return nil
 }
 
-func verifyAllContents(ctx context.Context, rep *repo.Repository, blobMap map[blob.ID]blob.Metadata) error {
+func verifyAllContents(ctx context.Context, rep *repo.DirectRepository, blobMap map[blob.ID]blob.Metadata) error {
 	var totalCount, successCount, errorCount int32
 
 	printStderr("Verifying all contents...\n")
@@ -91,7 +91,7 @@ func verifyAllContents(ctx context.Context, rep *repo.Repository, blobMap map[bl
 	return errors.Errorf("encountered %v errors", errorCount)
 }
 
-func contentVerify(ctx context.Context, r *repo.Repository, ci *content.Info, blobMap map[blob.ID]blob.Metadata) error {
+func contentVerify(ctx context.Context, r *repo.DirectRepository, ci *content.Info, blobMap map[blob.ID]blob.Metadata) error {
 	if *contentVerifyFull {
 		if _, err := r.Content.GetContent(ctx, ci.ID); err != nil {
 			return errors.Wrapf(err, "content %v is invalid", ci.ID)
@@ -113,5 +113,5 @@ func contentVerify(ctx context.Context, r *repo.Repository, ci *content.Info, bl
 }
 
 func init() {
-	contentVerifyCommand.Action(repositoryAction(runContentVerifyCommand))
+	contentVerifyCommand.Action(directRepositoryAction(runContentVerifyCommand))
 }

--- a/cli/command_diff.go
+++ b/cli/command_diff.go
@@ -20,7 +20,7 @@ var (
 	diffCommandCommand   = diffCommand.Flag("diff-command", "Displays differences between two repository objects (files or directories)").Default(defaultDiffCommand()).Envar("KOPIA_DIFF").String()
 )
 
-func runDiffCommand(ctx context.Context, rep *repo.Repository) error {
+func runDiffCommand(ctx context.Context, rep repo.Repository) error {
 	oid1, err := parseObjectID(ctx, rep, *diffFirstObjectPath)
 	if err != nil {
 		return err

--- a/cli/command_index_list.go
+++ b/cli/command_index_list.go
@@ -14,7 +14,7 @@ var (
 	blockIndexListSort    = blockIndexListCommand.Flag("sort", "Index blob sort order").Default("time").Enum("time", "size", "name")
 )
 
-func runListBlockIndexesAction(ctx context.Context, rep *repo.Repository) error {
+func runListBlockIndexesAction(ctx context.Context, rep *repo.DirectRepository) error {
 	blks, err := rep.Content.IndexBlobs(ctx)
 	if err != nil {
 		return err
@@ -47,5 +47,5 @@ func runListBlockIndexesAction(ctx context.Context, rep *repo.Repository) error 
 }
 
 func init() {
-	blockIndexListCommand.Action(repositoryAction(runListBlockIndexesAction))
+	blockIndexListCommand.Action(directRepositoryAction(runListBlockIndexesAction))
 }

--- a/cli/command_index_optimize.go
+++ b/cli/command_index_optimize.go
@@ -14,7 +14,7 @@ var (
 	optimizeAllIndexes           = optimizeCommand.Flag("all", "Optimize all indexes, even those above maximum size.").Bool()
 )
 
-func runOptimizeCommand(ctx context.Context, rep *repo.Repository) error {
+func runOptimizeCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	return rep.Content.CompactIndexes(ctx, content.CompactOptions{
 		MaxSmallBlobs:        *optimizeMaxSmallBlobs,
 		AllIndexes:           *optimizeAllIndexes,
@@ -23,5 +23,5 @@ func runOptimizeCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	optimizeCommand.Action(repositoryAction(runOptimizeCommand))
+	optimizeCommand.Action(directRepositoryAction(runOptimizeCommand))
 }

--- a/cli/command_index_recover.go
+++ b/cli/command_index_recover.go
@@ -16,7 +16,7 @@ var (
 	blockIndexRecoverCommit  = blockIndexRecoverCommand.Flag("commit", "Commit recovered content").Bool()
 )
 
-func runRecoverBlockIndexesAction(ctx context.Context, rep *repo.Repository) error {
+func runRecoverBlockIndexesAction(ctx context.Context, rep *repo.DirectRepository) error {
 	var totalCount int
 
 	defer func() {
@@ -51,7 +51,7 @@ func runRecoverBlockIndexesAction(ctx context.Context, rep *repo.Repository) err
 	return nil
 }
 
-func recoverIndexFromSinglePackFile(ctx context.Context, rep *repo.Repository, blobID blob.ID, length int64, totalCount *int) {
+func recoverIndexFromSinglePackFile(ctx context.Context, rep *repo.DirectRepository, blobID blob.ID, length int64, totalCount *int) {
 	recovered, err := rep.Content.RecoverIndexFromPackBlob(ctx, blobID, length, *blockIndexRecoverCommit)
 	if err != nil {
 		log(ctx).Warningf("unable to recover index from %v: %v", blobID, err)
@@ -63,5 +63,5 @@ func recoverIndexFromSinglePackFile(ctx context.Context, rep *repo.Repository, b
 }
 
 func init() {
-	blockIndexRecoverCommand.Action(repositoryAction(runRecoverBlockIndexesAction))
+	blockIndexRecoverCommand.Action(directRepositoryAction(runRecoverBlockIndexesAction))
 }

--- a/cli/command_ls.go
+++ b/cli/command_ls.go
@@ -20,7 +20,7 @@ var (
 	lsCommandPath      = lsCommand.Arg("object-path", "Path").Required().String()
 )
 
-func runLSCommand(ctx context.Context, rep *repo.Repository) error {
+func runLSCommand(ctx context.Context, rep repo.Repository) error {
 	oid, err := parseObjectID(ctx, rep, *lsCommandPath)
 	if err != nil {
 		return err
@@ -41,7 +41,7 @@ func init() {
 	lsCommand.Action(repositoryAction(runLSCommand))
 }
 
-func listDirectory(ctx context.Context, rep *repo.Repository, prefix string, oid object.ID, indent string) error {
+func listDirectory(ctx context.Context, rep repo.Repository, prefix string, oid object.ID, indent string) error {
 	d := snapshotfs.DirectoryEntry(rep, oid, nil)
 
 	entries, err := d.Readdir(ctx)

--- a/cli/command_manifest_ls.go
+++ b/cli/command_manifest_ls.go
@@ -21,7 +21,7 @@ func init() {
 	manifestListCommand.Action(repositoryAction(listManifestItems))
 }
 
-func listManifestItems(ctx context.Context, rep *repo.Repository) error {
+func listManifestItems(ctx context.Context, rep repo.Repository) error {
 	filter := map[string]string{}
 
 	for _, kv := range *manifestListFilter {
@@ -33,7 +33,7 @@ func listManifestItems(ctx context.Context, rep *repo.Repository) error {
 		filter[kv[0:p]] = kv[p+1:]
 	}
 
-	items, err := rep.Manifests.Find(ctx, filter)
+	items, err := rep.FindManifests(ctx, filter)
 	if err != nil {
 		return err
 	}

--- a/cli/command_manifest_rm.go
+++ b/cli/command_manifest_rm.go
@@ -11,9 +11,9 @@ var (
 	manifestRemoveItems   = manifestRemoveCommand.Arg("item", "Items to remove").Required().Strings()
 )
 
-func runManifestRemoveCommand(ctx context.Context, rep *repo.Repository) error {
+func runManifestRemoveCommand(ctx context.Context, rep repo.Repository) error {
 	for _, it := range toManifestIDs(*manifestRemoveItems) {
-		if err := rep.Manifests.Delete(ctx, it); err != nil {
+		if err := rep.DeleteManifest(ctx, it); err != nil {
 			return err
 		}
 	}

--- a/cli/command_manifest_show.go
+++ b/cli/command_manifest_show.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 
 	"github.com/pkg/errors"
 
@@ -29,16 +30,13 @@ func toManifestIDs(s []string) []manifest.ID {
 	return result
 }
 
-func showManifestItems(ctx context.Context, rep *repo.Repository) error {
+func showManifestItems(ctx context.Context, rep repo.Repository) error {
 	for _, it := range toManifestIDs(*manifestShowItems) {
-		md, err := rep.Manifests.GetMetadata(ctx, it)
+		var b json.RawMessage
+
+		md, err := rep.GetManifest(ctx, it, &b)
 		if err != nil {
 			return errors.Wrapf(err, "error getting metadata for %q", it)
-		}
-
-		b, err := rep.Manifests.GetRaw(ctx, it)
-		if err != nil {
-			return errors.Wrapf(err, "error showing %q", it)
 		}
 
 		printStderr("// id: %v\n", it)

--- a/cli/command_mount.go
+++ b/cli/command_mount.go
@@ -20,7 +20,7 @@ var (
 	mountTraceFS  = mountCommand.Flag("trace-fs", "Trace filesystem operations").Bool()
 )
 
-func runMountCommand(ctx context.Context, rep *repo.Repository) error {
+func runMountCommand(ctx context.Context, rep repo.Repository) error {
 	var entry fs.Directory
 
 	if *mountObjectID == "all" {

--- a/cli/command_policy.go
+++ b/cli/command_policy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kopia/kopia/snapshot/policy"
 )
 
-func policyTargets(ctx context.Context, rep *repo.Repository, globalFlag *bool, targetsFlag *[]string) ([]snapshot.SourceInfo, error) {
+func policyTargets(ctx context.Context, rep repo.Repository, globalFlag *bool, targetsFlag *[]string) ([]snapshot.SourceInfo, error) {
 	if *globalFlag == (len(*targetsFlag) > 0) {
 		return nil, errors.New("must pass either '--global' or a list of path targets")
 	}
@@ -31,7 +31,7 @@ func policyTargets(ctx context.Context, rep *repo.Repository, globalFlag *bool, 
 			continue
 		}
 
-		target, err := snapshot.ParseSourceInfo(ts, rep.Hostname, rep.Username)
+		target, err := snapshot.ParseSourceInfo(ts, rep.Hostname(), rep.Username())
 		if err != nil {
 			return nil, err
 		}

--- a/cli/command_policy_edit.go
+++ b/cli/command_policy_edit.go
@@ -58,7 +58,7 @@ func init() {
 	policyEditCommand.Action(repositoryAction(editPolicy))
 }
 
-func editPolicy(ctx context.Context, rep *repo.Repository) error {
+func editPolicy(ctx context.Context, rep repo.Repository) error {
 	targets, err := policyTargets(ctx, rep, policyEditGlobal, policyEditTargets)
 	if err != nil {
 		return err

--- a/cli/command_policy_ls.go
+++ b/cli/command_policy_ls.go
@@ -17,7 +17,7 @@ func init() {
 	policyListCommand.Action(repositoryAction(listPolicies))
 }
 
-func listPolicies(ctx context.Context, rep *repo.Repository) error {
+func listPolicies(ctx context.Context, rep repo.Repository) error {
 	policies, err := policy.ListPolicies(ctx, rep)
 	if err != nil {
 		return err

--- a/cli/command_policy_remove.go
+++ b/cli/command_policy_remove.go
@@ -17,7 +17,7 @@ func init() {
 	policyRemoveCommand.Action(repositoryAction(removePolicy))
 }
 
-func removePolicy(ctx context.Context, rep *repo.Repository) error {
+func removePolicy(ctx context.Context, rep repo.Repository) error {
 	targets, err := policyTargets(ctx, rep, policyRemoveGlobal, policyRemoveTargets)
 	if err != nil {
 		return err

--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -74,7 +74,7 @@ func init() {
 	policySetCommand.Action(repositoryAction(setPolicy))
 }
 
-func setPolicy(ctx context.Context, rep *repo.Repository) error {
+func setPolicy(ctx context.Context, rep repo.Repository) error {
 	targets, err := policyTargets(ctx, rep, policySetGlobal, policySetTargets)
 	if err != nil {
 		return err

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -22,7 +22,7 @@ func init() {
 	policyShowCommand.Action(repositoryAction(showPolicy))
 }
 
-func showPolicy(ctx context.Context, rep *repo.Repository) error {
+func showPolicy(ctx context.Context, rep repo.Repository) error {
 	targets, err := policyTargets(ctx, rep, policyShowGlobal, policyShowTargets)
 	if err != nil {
 		return err

--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -21,7 +21,7 @@ var (
 	statusReconnectTokenIncludePassword = statusCommand.Flag("reconnect-token-with-password", "Include password in reconnect token").Short('s').Bool()
 )
 
-func runStatusCommand(ctx context.Context, rep *repo.Repository) error {
+func runStatusCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	fmt.Printf("Config file:         %v\n", rep.ConfigFile)
 
 	ci := rep.Blobs.ConnectionInfo()
@@ -33,8 +33,8 @@ func runStatusCommand(ctx context.Context, rep *repo.Repository) error {
 
 	fmt.Println()
 	fmt.Printf("Unique ID:           %x\n", rep.UniqueID)
-	fmt.Printf("Hostname:            %v\n", rep.Hostname)
-	fmt.Printf("Username:            %v\n", rep.Username)
+	fmt.Printf("Hostname:            %v\n", rep.Hostname())
+	fmt.Printf("Username:            %v\n", rep.Username())
 	fmt.Println()
 	fmt.Printf("Hash:                %v\n", rep.Content.Format.Hash)
 	fmt.Printf("Encryption:          %v\n", rep.Content.Format.Encryption)
@@ -99,5 +99,5 @@ func scanCacheDir(dirname string) (fileCount int, totalFileLength int64, err err
 }
 
 func init() {
-	statusCommand.Action(repositoryAction(runStatusCommand))
+	statusCommand.Action(directRepositoryAction(runStatusCommand))
 }

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -10,10 +10,10 @@ var (
 	upgradeCommand = repositoryCommands.Command("upgrade", "Upgrade repository format.")
 )
 
-func runUpgradeCommand(ctx context.Context, rep *repo.Repository) error {
+func runUpgradeCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	return rep.Upgrade(ctx)
 }
 
 func init() {
-	upgradeCommand.Action(repositoryAction(runUpgradeCommand))
+	upgradeCommand.Action(directRepositoryAction(runUpgradeCommand))
 }

--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -60,7 +60,7 @@ func restoreOptions() localfs.CopyOptions {
 	}
 }
 
-func runRestoreCommand(ctx context.Context, rep *repo.Repository) error {
+func runRestoreCommand(ctx context.Context, rep repo.Repository) error {
 	oid, err := parseObjectID(ctx, rep, *restoreCommandSourcePath)
 	if err != nil {
 		return err

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -35,8 +35,8 @@ func init() {
 	serverStartCommand.Action(optionalRepositoryAction(runServer))
 }
 
-func runServer(ctx context.Context, rep *repo.Repository) error {
-	srv, err := server.New(ctx, rep, server.Options{
+func runServer(ctx context.Context, rep repo.Repository) error {
+	srv, err := server.New(ctx, server.Options{
 		ConfigFile:      repositoryConfigFileName(),
 		ConnectOptions:  connectOptions(),
 		RefreshInterval: *serverStartRefreshInterval,

--- a/cli/command_show.go
+++ b/cli/command_show.go
@@ -13,13 +13,13 @@ var (
 	catCommandPath = catCommand.Arg("object-path", "Path").Required().String()
 )
 
-func runCatCommand(ctx context.Context, rep *repo.Repository) error {
+func runCatCommand(ctx context.Context, rep repo.Repository) error {
 	oid, err := parseObjectID(ctx, rep, *catCommandPath)
 	if err != nil {
 		return err
 	}
 
-	r, err := rep.Objects.Open(ctx, oid)
+	r, err := rep.OpenObject(ctx, oid)
 	if err != nil {
 		return err
 	}

--- a/cli/command_snapshot_delete.go
+++ b/cli/command_snapshot_delete.go
@@ -18,14 +18,14 @@ var (
 	snapshotDeleteIgnoreSource = snapshotDeleteCommand.Flag("unsafe-ignore-source", "Override the requirement to specify source info for the delete to succeed").Bool()
 )
 
-func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
+func runDeleteCommand(ctx context.Context, rep repo.Repository) error {
 	if !*snapshotDeleteIgnoreSource && *snapshotDeletePath == "" {
 		return errors.New("path is required")
 	}
 
 	manifestID := manifest.ID(*snapshotDeleteID)
 
-	manifestMeta, err := rep.Manifests.GetMetadata(ctx, manifestID)
+	manifestMeta, err := rep.GetManifest(ctx, manifestID, nil)
 	if err != nil {
 		return err
 	}
@@ -38,7 +38,7 @@ func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
 	if !*snapshotDeleteIgnoreSource {
 		h := *snapshotDeleteHostname
 		if h == "" {
-			h = rep.Hostname
+			h = rep.Hostname()
 		}
 
 		if labels["hostname"] != h {
@@ -47,7 +47,7 @@ func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
 
 		u := *snapshotDeleteUsername
 		if u == "" {
-			u = rep.Username
+			u = rep.Username()
 		}
 
 		if labels["username"] != u {
@@ -59,7 +59,7 @@ func runDeleteCommand(ctx context.Context, rep *repo.Repository) error {
 		}
 	}
 
-	return rep.Manifests.Delete(ctx, manifestID)
+	return rep.DeleteManifest(ctx, manifestID)
 }
 
 func init() {

--- a/cli/command_snapshot_estimate.go
+++ b/cli/command_snapshot_estimate.go
@@ -64,7 +64,7 @@ func makeBuckets() buckets {
 	}
 }
 
-func runSnapshotEstimateCommand(ctx context.Context, rep *repo.Repository) error {
+func runSnapshotEstimateCommand(ctx context.Context, rep repo.Repository) error {
 	path, err := filepath.Abs(*snapshotEstimateSource)
 	if err != nil {
 		return errors.Errorf("invalid path: '%s': %s", path, err)
@@ -72,8 +72,8 @@ func runSnapshotEstimateCommand(ctx context.Context, rep *repo.Repository) error
 
 	sourceInfo := snapshot.SourceInfo{
 		Path:     filepath.Clean(path),
-		Host:     rep.Hostname,
-		UserName: rep.Username,
+		Host:     rep.Hostname(),
+		UserName: rep.Username(),
 	}
 
 	var stats snapshot.Stats

--- a/cli/command_snapshot_expire.go
+++ b/cli/command_snapshot_expire.go
@@ -17,7 +17,7 @@ var (
 	snapshotExpireDelete = snapshotExpireCommand.Flag("delete", "Whether to actually delete snapshots").Bool()
 )
 
-func getSnapshotSourcesToExpire(ctx context.Context, rep *repo.Repository) ([]snapshot.SourceInfo, error) {
+func getSnapshotSourcesToExpire(ctx context.Context, rep repo.Repository) ([]snapshot.SourceInfo, error) {
 	if *snapshotExpireAll {
 		return snapshot.ListSources(ctx, rep)
 	}
@@ -25,7 +25,7 @@ func getSnapshotSourcesToExpire(ctx context.Context, rep *repo.Repository) ([]sn
 	var result []snapshot.SourceInfo
 
 	for _, p := range *snapshotExpirePaths {
-		src, err := snapshot.ParseSourceInfo(p, rep.Hostname, rep.Username)
+		src, err := snapshot.ParseSourceInfo(p, rep.Hostname(), rep.Username())
 		if err != nil {
 			return nil, err
 		}
@@ -36,7 +36,7 @@ func getSnapshotSourcesToExpire(ctx context.Context, rep *repo.Repository) ([]sn
 	return result, nil
 }
 
-func runExpireCommand(ctx context.Context, rep *repo.Repository) error {
+func runExpireCommand(ctx context.Context, rep repo.Repository) error {
 	sources, err := getSnapshotSourcesToExpire(ctx, rep)
 	if err != nil {
 		return err

--- a/cli/command_snapshot_gc.go
+++ b/cli/command_snapshot_gc.go
@@ -14,7 +14,7 @@ var (
 	snapshotGCDelete        = snapshotGCCommand.Flag("delete", "Delete unreferenced contents").Bool()
 )
 
-func runSnapshotGCCommand(ctx context.Context, rep *repo.Repository) error {
+func runSnapshotGCCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	st, err := gc.Run(ctx, rep, *snapshotGCMinContentAge, *snapshotGCDelete)
 
 	log(ctx).Infof("GC found %v unused contents (%v bytes)", st.UnusedCount, units.BytesStringBase2(st.UnusedBytes))
@@ -26,5 +26,5 @@ func runSnapshotGCCommand(ctx context.Context, rep *repo.Repository) error {
 }
 
 func init() {
-	snapshotGCCommand.Action(repositoryAction(runSnapshotGCCommand))
+	snapshotGCCommand.Action(directRepositoryAction(runSnapshotGCCommand))
 }

--- a/cli/command_snapshot_restore.go
+++ b/cli/command_snapshot_restore.go
@@ -14,7 +14,7 @@ var (
 	snapshotRestoreTargetPath = snapshotRestoreCommand.Arg("target-path", "Path of the directory for the contents to be restored").Required().String()
 )
 
-func runSnapRestoreCommand(ctx context.Context, rep *repo.Repository) error {
+func runSnapRestoreCommand(ctx context.Context, rep repo.Repository) error {
 	return snapshotfs.Restore(ctx, rep, *snapshotRestoreTargetPath, manifest.ID(*snapshotRestoreSnapID), restoreOptions())
 }
 

--- a/cli/command_snapshot_verify.go
+++ b/cli/command_snapshot_verify.go
@@ -32,7 +32,7 @@ var (
 )
 
 type verifier struct {
-	rep       *repo.Repository
+	rep       repo.Repository
 	om        *object.Manager
 	workQueue *parallelwork.Queue
 	startTime time.Time
@@ -177,10 +177,9 @@ func (v *verifier) readEntireObject(ctx context.Context, oid object.ID, path str
 	return err
 }
 
-func runVerifyCommand(ctx context.Context, rep *repo.Repository) error {
+func runVerifyCommand(ctx context.Context, rep repo.Repository) error {
 	v := &verifier{
 		rep:       rep,
-		om:        rep.Objects,
 		startTime: time.Now(),
 		workQueue: parallelwork.NewQueue(),
 		seen:      map[object.ID]bool{},
@@ -202,7 +201,7 @@ func runVerifyCommand(ctx context.Context, rep *repo.Repository) error {
 	return errors.Errorf("encountered %v errors", len(v.errors))
 }
 
-func enqueueRootsToVerify(ctx context.Context, v *verifier, rep *repo.Repository) error {
+func enqueueRootsToVerify(ctx context.Context, v *verifier, rep repo.Repository) error {
 	manifests, err := loadSourceManifests(ctx, rep, *verifyCommandSources)
 	if err != nil {
 		return err
@@ -243,7 +242,7 @@ func enqueueRootsToVerify(ctx context.Context, v *verifier, rep *repo.Repository
 	return nil
 }
 
-func loadSourceManifests(ctx context.Context, rep *repo.Repository, sources []string) ([]*snapshot.Manifest, error) {
+func loadSourceManifests(ctx context.Context, rep repo.Repository, sources []string) ([]*snapshot.Manifest, error) {
 	var manifestIDs []manifest.ID
 
 	if *verifyCommandAllSources {
@@ -255,7 +254,7 @@ func loadSourceManifests(ctx context.Context, rep *repo.Repository, sources []st
 		manifestIDs = append(manifestIDs, man...)
 	} else {
 		for _, srcStr := range sources {
-			src, err := snapshot.ParseSourceInfo(srcStr, rep.Hostname, rep.Username)
+			src, err := snapshot.ParseSourceInfo(srcStr, rep.Hostname(), rep.Username())
 			if err != nil {
 				return nil, errors.Wrapf(err, "error parsing %q", srcStr)
 			}

--- a/cli/config.go
+++ b/cli/config.go
@@ -59,7 +59,7 @@ func waitForCtrlC() {
 	<-done
 }
 
-func openRepository(ctx context.Context, opts *repo.Options, required bool) (*repo.Repository, error) {
+func openRepository(ctx context.Context, opts *repo.Options, required bool) (repo.Repository, error) {
 	if _, err := os.Stat(repositoryConfigFileName()); os.IsNotExist(err) && !required {
 		return nil, nil
 	}

--- a/cli/objref.go
+++ b/cli/objref.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ParseObjectID interprets the given ID string and returns corresponding object.ID.
-func parseObjectID(ctx context.Context, rep *repo.Repository, id string) (object.ID, error) {
+func parseObjectID(ctx context.Context, rep repo.Repository, id string) (object.ID, error) {
 	parts := strings.Split(id, "/")
 
 	oid, err := object.ParseID(parts[0])

--- a/examples/upload_download/upload_download_objects.go
+++ b/examples/upload_download/upload_download_objects.go
@@ -13,8 +13,8 @@ import (
 	"github.com/kopia/kopia/repo/object"
 )
 
-func uploadRandomObject(ctx context.Context, r *repo.Repository, length int) (object.ID, error) {
-	w := r.Objects.NewWriter(ctx, object.WriterOptions{})
+func uploadRandomObject(ctx context.Context, r repo.Repository, length int) (object.ID, error) {
+	w := r.NewObjectWriter(ctx, object.WriterOptions{})
 	defer w.Close() //nolint:errcheck
 
 	buf := make([]byte, 256*1024)
@@ -32,8 +32,8 @@ func uploadRandomObject(ctx context.Context, r *repo.Repository, length int) (ob
 	return w.Result()
 }
 
-func downloadObject(ctx context.Context, r *repo.Repository, oid object.ID) ([]byte, error) {
-	rd, err := r.Objects.Open(ctx, oid)
+func downloadObject(ctx context.Context, r repo.Repository, oid object.ID) ([]byte, error) {
+	rd, err := r.OpenObject(ctx, oid)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func downloadObject(ctx context.Context, r *repo.Repository, oid object.ID) ([]b
 	return ioutil.ReadAll(rd)
 }
 
-func uploadAndDownloadObjects(ctx context.Context, r *repo.Repository) {
+func uploadAndDownloadObjects(ctx context.Context, r repo.Repository) {
 	var oids []object.ID
 
 	for size := 100; size < 100000000; size *= 2 {

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -21,7 +21,7 @@ const masterPassword = "foobarbazfoobarbaz"
 
 // Environment encapsulates details of a test environment.
 type Environment struct {
-	Repository *repo.Repository
+	Repository *repo.DirectRepository
 
 	configDir  string
 	storageDir string
@@ -124,7 +124,7 @@ func (e *Environment) MustReopen(t *testing.T) {
 }
 
 // MustOpenAnother opens another repository backend by the same storage.
-func (e *Environment) MustOpenAnother(t *testing.T) *repo.Repository {
+func (e *Environment) MustOpenAnother(t *testing.T) repo.Repository {
 	rep2, err := repo.Open(testlogging.Context(t), e.configFile(), masterPassword, &repo.Options{})
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/internal/server/api_object_get.go
+++ b/internal/server/api_object_get.go
@@ -22,7 +22,7 @@ func (s *Server) handleObjectGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	obj, err := s.rep.Objects.Open(r.Context(), oid)
+	obj, err := s.rep.OpenObject(r.Context(), oid)
 	if err == object.ErrObjectNotFound {
 		http.Error(w, "object not found", http.StatusNotFound)
 		return

--- a/internal/server/api_repo.go
+++ b/internal/server/api_repo.go
@@ -25,15 +25,22 @@ func (s *Server) handleRepoStatus(ctx context.Context, r *http.Request) (interfa
 		}, nil
 	}
 
+	dr, ok := s.rep.(*repo.DirectRepository)
+	if ok {
+		return &serverapi.StatusResponse{
+			Connected:   true,
+			ConfigFile:  dr.ConfigFile,
+			CacheDir:    dr.Content.CachingOptions.CacheDirectory,
+			Hash:        dr.Content.Format.Hash,
+			Encryption:  dr.Content.Format.Encryption,
+			MaxPackSize: dr.Content.Format.MaxPackSize,
+			Splitter:    dr.Objects.Format.Splitter,
+			Storage:     dr.Blobs.ConnectionInfo().Type,
+		}, nil
+	}
+
 	return &serverapi.StatusResponse{
-		Connected:   true,
-		ConfigFile:  s.rep.ConfigFile,
-		CacheDir:    s.rep.Content.CachingOptions.CacheDirectory,
-		Hash:        s.rep.Content.Format.Hash,
-		Encryption:  s.rep.Content.Format.Encryption,
-		MaxPackSize: s.rep.Content.Format.MaxPackSize,
-		Splitter:    s.rep.Objects.Format.Splitter,
-		Storage:     s.rep.Blobs.ConnectionInfo().Type,
+		Connected: true,
 	}, nil
 }
 

--- a/internal/server/api_sources.go
+++ b/internal/server/api_sources.go
@@ -18,8 +18,8 @@ import (
 func (s *Server) handleSourcesList(ctx context.Context, r *http.Request) (interface{}, *apiError) {
 	resp := &serverapi.SourcesResponse{
 		Sources:       []*serverapi.SourceStatus{},
-		LocalHost:     s.rep.Hostname,
-		LocalUsername: s.rep.Username,
+		LocalHost:     s.rep.Hostname(),
+		LocalUsername: s.rep.Username(),
 	}
 
 	for _, v := range s.sourceManagers {
@@ -58,8 +58,8 @@ func (s *Server) handleSourcesCreate(ctx context.Context, r *http.Request) (inte
 	}
 
 	sourceInfo := snapshot.SourceInfo{
-		UserName: s.rep.Username,
-		Host:     s.rep.Hostname,
+		UserName: s.rep.Username(),
+		Host:     s.rep.Hostname(),
 		Path:     req.Path,
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,7 +26,7 @@ type Server struct {
 	OnShutdown func(ctx context.Context) error
 
 	options   Options
-	rep       *repo.Repository
+	rep       repo.Repository
 	cancelRep context.CancelFunc
 
 	// all API requests run with shared lock on this mutex
@@ -178,7 +178,7 @@ func (s *Server) endUpload(ctx context.Context, src snapshot.SourceInfo) {
 
 // SetRepository sets the repository (nil is allowed and indicates server that is not
 // connected to the repository).
-func (s *Server) SetRepository(ctx context.Context, rep *repo.Repository) error {
+func (s *Server) SetRepository(ctx context.Context, rep repo.Repository) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -223,7 +223,7 @@ func (s *Server) SetRepository(ctx context.Context, rep *repo.Repository) error 
 	return nil
 }
 
-func (s *Server) refreshPeriodically(ctx context.Context, r *repo.Repository) {
+func (s *Server) refreshPeriodically(ctx context.Context, r repo.Repository) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -334,9 +334,9 @@ type Options struct {
 	RefreshInterval time.Duration
 }
 
-// New creates a Server on top of a given Repository.
+// New creates a Server.
 // The server will manage sources for a given username@hostname.
-func New(ctx context.Context, rep *repo.Repository, options Options) (*Server, error) {
+func New(ctx context.Context, options Options) (*Server, error) {
 	s := &Server{
 		options:         options,
 		sourceManagers:  map[snapshot.SourceInfo]*sourceManager{},

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -94,7 +94,7 @@ func (s *sourceManager) run(ctx context.Context) {
 	s.wg.Add(1)
 	defer s.wg.Done()
 
-	if s.server.rep.Hostname == s.src.Host {
+	if s.server.rep.Hostname() == s.src.Host {
 		log(ctx).Debugf("starting local source manager for %v", s.src)
 		s.runLocal(ctx)
 	} else {

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -122,25 +122,11 @@ func (m *Manager) GetMetadata(ctx context.Context, id ID) (*EntryMetadata, error
 
 // Get retrieves the contents of the provided manifest item by deserializing it as JSON to provided object.
 // If the manifest is not found, returns ErrNotFound.
-func (m *Manager) Get(ctx context.Context, id ID, data interface{}) error {
+func (m *Manager) Get(ctx context.Context, id ID, data interface{}) (*EntryMetadata, error) {
 	if err := m.ensureInitialized(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
-	b, err := m.GetRaw(ctx, id)
-	if err != nil {
-		return err
-	}
-
-	if err := json.Unmarshal(b, data); err != nil {
-		return errors.Wrapf(err, "unable to unmashal %q", id)
-	}
-
-	return nil
-}
-
-// GetRaw returns raw contents of the provided manifest (JSON bytes) or ErrNotFound if not found.
-func (m *Manager) GetRaw(ctx context.Context, id ID) ([]byte, error) {
 	if err := m.ensureInitialized(ctx); err != nil {
 		return nil, err
 	}
@@ -157,7 +143,13 @@ func (m *Manager) GetRaw(ctx context.Context, id ID) ([]byte, error) {
 		return nil, ErrNotFound
 	}
 
-	return e.Content, nil
+	if data != nil {
+		if err := json.Unmarshal([]byte(e.Content), data); err != nil {
+			return nil, errors.Wrapf(err, "unable to unmashal %q", id)
+		}
+	}
+
+	return cloneEntryMetadata(e), nil
 }
 
 // Find returns the list of EntryMetadata for manifest entries matching all provided labels.

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -127,10 +127,6 @@ func (m *Manager) Get(ctx context.Context, id ID, data interface{}) (*EntryMetad
 		return nil, err
 	}
 
-	if err := m.ensureInitialized(ctx); err != nil {
-		return nil, err
-	}
-
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"sort"
 	"strings"
@@ -186,9 +187,16 @@ func TestManifestInitCorruptedBlock(t *testing.T) {
 		desc string
 		f    func() error
 	}{
-		{"GetRaw", func() error { _, err := mgr.GetRaw(ctx, "anything"); return err }},
+		{"GetRaw", func() error {
+			var raw json.RawMessage
+			_, err := mgr.Get(ctx, "anything", &raw)
+			return err
+		}},
 		{"GetMetadata", func() error { _, err := mgr.GetMetadata(ctx, "anything"); return err }},
-		{"Get", func() error { return mgr.Get(ctx, "anything", nil) }},
+		{"Get", func() error {
+			_, err := mgr.Get(ctx, "anything", nil)
+			return err
+		}},
 		{"Delete", func() error { return mgr.Delete(ctx, "anything") }},
 		{"Find", func() error { _, err := mgr.Find(ctx, nil); return err }},
 		{"Put", func() error {
@@ -240,7 +248,7 @@ func verifyItem(ctx context.Context, t *testing.T, mgr *Manager, id ID, labels m
 	}
 
 	var d2 map[string]int
-	if err := mgr.Get(ctx, id, &d2); err != nil {
+	if _, err := mgr.Get(ctx, id, &d2); err != nil {
 		t.Errorf("Get failed: %v", err)
 	}
 

--- a/repo/open.go
+++ b/repo/open.go
@@ -32,7 +32,7 @@ type Options struct {
 var ErrInvalidPassword = errors.Errorf("invalid repository password")
 
 // Open opens a Repository specified in the configuration file.
-func Open(ctx context.Context, configFile, password string, options *Options) (rep *Repository, err error) {
+func Open(ctx context.Context, configFile, password string, options *Options) (rep *DirectRepository, err error) {
 	defer func() {
 		if err != nil {
 			log(ctx).Errorf("failed to open repository: %v", err)
@@ -72,15 +72,15 @@ func Open(ctx context.Context, configFile, password string, options *Options) (r
 		return nil, err
 	}
 
-	r.Hostname = lc.Hostname
-	r.Username = lc.Username
+	r.hostname = lc.Hostname
+	r.username = lc.Username
 
-	if r.Hostname == "" {
-		r.Hostname = getDefaultHostName(ctx)
+	if r.hostname == "" {
+		r.hostname = getDefaultHostName(ctx)
 	}
 
-	if r.Username == "" {
-		r.Username = getDefaultUserName(ctx)
+	if r.username == "" {
+		r.username = getDefaultUserName(ctx)
 	}
 
 	r.ConfigFile = configFile
@@ -89,7 +89,7 @@ func Open(ctx context.Context, configFile, password string, options *Options) (r
 }
 
 // OpenWithConfig opens the repository with a given configuration, avoiding the need for a config file.
-func OpenWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, password string, options *Options, caching content.CachingOptions) (*Repository, error) {
+func OpenWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, password string, options *Options, caching content.CachingOptions) (*DirectRepository, error) {
 	// Read format blob, potentially from cache.
 	fb, err := readAndCacheFormatBlobBytes(ctx, st, caching.CacheDirectory)
 	if err != nil {
@@ -145,7 +145,7 @@ func OpenWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 		return nil, errors.Wrap(err, "unable to open manifests")
 	}
 
-	return &Repository{
+	return &DirectRepository{
 		Content:   cm,
 		Objects:   om,
 		Blobs:     st,
@@ -159,7 +159,7 @@ func OpenWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 }
 
 // SetCachingConfig changes caching configuration for a given repository.
-func (r *Repository) SetCachingConfig(ctx context.Context, opt content.CachingOptions) error {
+func (r *DirectRepository) SetCachingConfig(ctx context.Context, opt content.CachingOptions) error {
 	lc, err := loadConfigFromFile(r.ConfigFile)
 	if err != nil {
 		return err

--- a/repo/token.go
+++ b/repo/token.go
@@ -17,7 +17,7 @@ type tokenInfo struct {
 
 // Token returns an opaque token that contains repository connection information
 // and optionally the provided password.
-func (r *Repository) Token(password string) (string, error) {
+func (r *DirectRepository) Token(password string) (string, error) {
 	ti := &tokenInfo{
 		Version:  "1",
 		Storage:  r.Blobs.ConnectionInfo(),

--- a/repo/upgrade.go
+++ b/repo/upgrade.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Upgrade upgrades repository data structures to the latest version.
-func (r *Repository) Upgrade(ctx context.Context) error {
+func (r *DirectRepository) Upgrade(ctx context.Context) error {
 	f := r.formatBlob
 
 	repoConfig, err := f.decryptFormatBytes(r.masterKey)

--- a/snapshot/gc/gc.go
+++ b/snapshot/gc/gc.go
@@ -26,7 +26,7 @@ func oidOf(entry fs.Entry) object.ID {
 	return entry.(object.HasObjectID).ObjectID()
 }
 
-func findInUseContentIDs(ctx context.Context, rep *repo.Repository, used *sync.Map) error {
+func findInUseContentIDs(ctx context.Context, rep repo.Repository, used *sync.Map) error {
 	ids, err := snapshot.ListSnapshotManifests(ctx, rep, nil)
 	if err != nil {
 		return errors.Wrap(err, "unable to list snapshot manifest IDs")
@@ -51,7 +51,7 @@ func findInUseContentIDs(ctx context.Context, rep *repo.Repository, used *sync.M
 
 	w.ObjectCallback = func(entry fs.Entry) error {
 		oid := oidOf(entry)
-		contentIDs, err := rep.Objects.VerifyObject(ctx, oid)
+		contentIDs, err := rep.VerifyObject(ctx, oid)
 
 		if err != nil {
 			return errors.Wrapf(err, "error verifying %v", oid)
@@ -75,7 +75,7 @@ func findInUseContentIDs(ctx context.Context, rep *repo.Repository, used *sync.M
 
 // Run performs garbage collection on all the snapshots in the repository.
 // nolint:gocognit
-func Run(ctx context.Context, rep *repo.Repository, minContentAge time.Duration, gcDelete bool) (Stats, error) {
+func Run(ctx context.Context, rep *repo.DirectRepository, minContentAge time.Duration, gcDelete bool) (Stats, error) {
 	var used sync.Map
 
 	var st Stats

--- a/snapshot/policy/expire.go
+++ b/snapshot/policy/expire.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ApplyRetentionPolicy applies retention policy to a given source by deleting expired snapshots.
-func ApplyRetentionPolicy(ctx context.Context, rep *repo.Repository, sourceInfo snapshot.SourceInfo, reallyDelete bool) ([]*snapshot.Manifest, error) {
+func ApplyRetentionPolicy(ctx context.Context, rep repo.Repository, sourceInfo snapshot.SourceInfo, reallyDelete bool) ([]*snapshot.Manifest, error) {
 	snapshots, err := snapshot.ListSnapshots(ctx, rep, sourceInfo)
 	if err != nil {
 		return nil, err
@@ -22,7 +22,7 @@ func ApplyRetentionPolicy(ctx context.Context, rep *repo.Repository, sourceInfo 
 
 	if reallyDelete {
 		for _, it := range toDelete {
-			if err := rep.Manifests.Delete(ctx, it.ID); err != nil {
+			if err := rep.DeleteManifest(ctx, it.ID); err != nil {
 				return toDelete, err
 			}
 		}
@@ -31,7 +31,7 @@ func ApplyRetentionPolicy(ctx context.Context, rep *repo.Repository, sourceInfo 
 	return toDelete, nil
 }
 
-func getExpiredSnapshots(ctx context.Context, rep *repo.Repository, snapshots []*snapshot.Manifest) ([]*snapshot.Manifest, error) {
+func getExpiredSnapshots(ctx context.Context, rep repo.Repository, snapshots []*snapshot.Manifest) ([]*snapshot.Manifest, error) {
 	var toDelete []*snapshot.Manifest
 
 	for _, snapshotGroup := range snapshot.GroupBySource(snapshots) {
@@ -46,7 +46,7 @@ func getExpiredSnapshots(ctx context.Context, rep *repo.Repository, snapshots []
 	return toDelete, nil
 }
 
-func getExpiredSnapshotsForSource(ctx context.Context, rep *repo.Repository, snapshots []*snapshot.Manifest) ([]*snapshot.Manifest, error) {
+func getExpiredSnapshotsForSource(ctx context.Context, rep repo.Repository, snapshots []*snapshot.Manifest) ([]*snapshot.Manifest, error) {
 	src := snapshots[0].Source
 
 	pol, _, err := GetEffectivePolicy(ctx, rep, src)

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -76,7 +76,7 @@ func TestSnapshotsAPI(t *testing.T) {
 	verifyLoadSnapshots(t, env.Repository, []manifest.ID{id1, id2, id3}, []*snapshot.Manifest{manifest1, manifest2, manifest3})
 }
 
-func verifySnapshotManifestIDs(t *testing.T, rep *repo.Repository, src *snapshot.SourceInfo, expected []manifest.ID) {
+func verifySnapshotManifestIDs(t *testing.T, rep repo.Repository, src *snapshot.SourceInfo, expected []manifest.ID) {
 	t.Helper()
 
 	res, err := snapshot.ListSnapshotManifests(testlogging.Context(t), rep, src)
@@ -98,7 +98,7 @@ func sortManifestIDs(s []manifest.ID) {
 	})
 }
 
-func mustSaveSnapshot(t *testing.T, rep *repo.Repository, man *snapshot.Manifest) manifest.ID {
+func mustSaveSnapshot(t *testing.T, rep repo.Repository, man *snapshot.Manifest) manifest.ID {
 	t.Helper()
 
 	id, err := snapshot.SaveSnapshot(testlogging.Context(t), rep, man)
@@ -109,7 +109,7 @@ func mustSaveSnapshot(t *testing.T, rep *repo.Repository, man *snapshot.Manifest
 	return id
 }
 
-func verifySources(t *testing.T, rep *repo.Repository, sources ...snapshot.SourceInfo) {
+func verifySources(t *testing.T, rep repo.Repository, sources ...snapshot.SourceInfo) {
 	actualSources, err := snapshot.ListSources(testlogging.Context(t), rep)
 	if err != nil {
 		t.Errorf("error listing sources: %v", err)
@@ -120,7 +120,7 @@ func verifySources(t *testing.T, rep *repo.Repository, sources ...snapshot.Sourc
 	}
 }
 
-func verifyListSnapshots(t *testing.T, rep *repo.Repository, src snapshot.SourceInfo, expected []*snapshot.Manifest) {
+func verifyListSnapshots(t *testing.T, rep repo.Repository, src snapshot.SourceInfo, expected []*snapshot.Manifest) {
 	t.Helper()
 
 	got, err := snapshot.ListSnapshots(testlogging.Context(t), rep, src)
@@ -142,7 +142,7 @@ func verifyListSnapshots(t *testing.T, rep *repo.Repository, src snapshot.Source
 	}
 }
 
-func verifyLoadSnapshots(t *testing.T, rep *repo.Repository, ids []manifest.ID, expected []*snapshot.Manifest) {
+func verifyLoadSnapshots(t *testing.T, rep repo.Repository, ids []manifest.ID, expected []*snapshot.Manifest) {
 	got, err := snapshot.LoadSnapshots(testlogging.Context(t), rep, ids)
 	if err != nil {
 		t.Errorf("error loading manifests: %v", err)

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -12,7 +12,7 @@ import (
 )
 
 type repositoryAllSources struct {
-	rep *repo.Repository
+	rep repo.Repository
 }
 
 func (s *repositoryAllSources) Summary() *fs.DirectorySummary {
@@ -76,6 +76,6 @@ func (s *repositoryAllSources) Readdir(ctx context.Context) (fs.Entries, error) 
 }
 
 // AllSourcesEntry returns fs.Directory that contains the list of all snapshot sources found in the repository.
-func AllSourcesEntry(rep *repo.Repository) fs.Directory {
+func AllSourcesEntry(rep repo.Repository) fs.Directory {
 	return &repositoryAllSources{rep: rep}
 }

--- a/snapshot/snapshotfs/restore.go
+++ b/snapshot/snapshotfs/restore.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Restore walks a snapshot root with given snapshot ID and restores it to the local filesystem
-func Restore(ctx context.Context, rep *repo.Repository, targetPath string, snapID manifest.ID, opts localfs.CopyOptions) error {
+func Restore(ctx context.Context, rep repo.Repository, targetPath string, snapID manifest.ID, opts localfs.CopyOptions) error {
 	m, err := snapshot.LoadSnapshot(ctx, rep, snapID)
 	if err != nil {
 		return err
@@ -32,6 +32,6 @@ func Restore(ctx context.Context, rep *repo.Repository, targetPath string, snapI
 }
 
 // RestoreRoot walks a snapshot root with given object ID and restores it to the local filesystem
-func RestoreRoot(ctx context.Context, rep *repo.Repository, targetPath string, oid object.ID, opts localfs.CopyOptions) error {
+func RestoreRoot(ctx context.Context, rep repo.Repository, targetPath string, oid object.ID, opts localfs.CopyOptions) error {
 	return localfs.Copy(ctx, targetPath, DirectoryEntry(rep, oid, nil), opts)
 }

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -11,7 +11,7 @@ import (
 )
 
 type sourceDirectories struct {
-	rep      *repo.Repository
+	rep      repo.Repository
 	userHost string
 }
 

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -15,7 +15,7 @@ import (
 )
 
 type sourceSnapshots struct {
-	rep *repo.Repository
+	rep repo.Repository
 	src snapshot.SourceInfo
 }
 

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -29,7 +29,7 @@ const (
 type uploadTestHarness struct {
 	sourceDir *mockfs.Directory
 	repoDir   string
-	repo      *repo.Repository
+	repo      repo.Repository
 }
 
 var errTest = errors.New("test error")

--- a/tests/repository_stress_test/repository_stress_test.go
+++ b/tests/repository_stress_test/repository_stress_test.go
@@ -155,10 +155,10 @@ func longLivedRepositoryTest(ctx context.Context, t *testing.T, cancel chan stru
 	wg2.Wait()
 }
 
-func repositoryTest(ctx context.Context, t *testing.T, cancel chan struct{}, rep *repo.Repository) {
+func repositoryTest(ctx context.Context, t *testing.T, cancel chan struct{}, rep *repo.DirectRepository) {
 	workTypes := []*struct {
 		name     string
-		fun      func(ctx context.Context, t *testing.T, r *repo.Repository) error
+		fun      func(ctx context.Context, t *testing.T, r *repo.DirectRepository) error
 		weight   int
 		hitCount int
 	}{
@@ -218,7 +218,7 @@ func repositoryTest(ctx context.Context, t *testing.T, cancel chan struct{}, rep
 	}
 }
 
-func writeRandomBlock(ctx context.Context, t *testing.T, r *repo.Repository) error {
+func writeRandomBlock(ctx context.Context, t *testing.T, r *repo.DirectRepository) error {
 	data := make([]byte, 1000)
 	cryptorand.Read(data) //nolint:errcheck
 
@@ -237,7 +237,7 @@ func writeRandomBlock(ctx context.Context, t *testing.T, r *repo.Repository) err
 	return err
 }
 
-func readKnownBlock(ctx context.Context, t *testing.T, r *repo.Repository) error {
+func readKnownBlock(ctx context.Context, t *testing.T, r *repo.DirectRepository) error {
 	knownBlocksMutex.Lock()
 	if len(knownBlocks) == 0 {
 		knownBlocksMutex.Unlock()
@@ -255,7 +255,7 @@ func readKnownBlock(ctx context.Context, t *testing.T, r *repo.Repository) error
 	return err
 }
 
-func listContents(ctx context.Context, t *testing.T, r *repo.Repository) error {
+func listContents(ctx context.Context, t *testing.T, r *repo.DirectRepository) error {
 	return r.Content.IterateContents(
 		ctx,
 		content.IterateOptions{},
@@ -263,7 +263,7 @@ func listContents(ctx context.Context, t *testing.T, r *repo.Repository) error {
 	)
 }
 
-func listAndReadAllContents(ctx context.Context, t *testing.T, r *repo.Repository) error {
+func listAndReadAllContents(ctx context.Context, t *testing.T, r *repo.DirectRepository) error {
 	return r.Content.IterateContents(
 		ctx,
 		content.IterateOptions{},
@@ -282,20 +282,20 @@ func listAndReadAllContents(ctx context.Context, t *testing.T, r *repo.Repositor
 		})
 }
 
-func compact(ctx context.Context, t *testing.T, r *repo.Repository) error {
+func compact(ctx context.Context, t *testing.T, r *repo.DirectRepository) error {
 	return r.Content.CompactIndexes(ctx, content.CompactOptions{MaxSmallBlobs: 1})
 }
 
-func flush(ctx context.Context, t *testing.T, r *repo.Repository) error {
+func flush(ctx context.Context, t *testing.T, r *repo.DirectRepository) error {
 	return r.Flush(ctx)
 }
 
-func refresh(ctx context.Context, t *testing.T, r *repo.Repository) error {
+func refresh(ctx context.Context, t *testing.T, r *repo.DirectRepository) error {
 	return r.Refresh(ctx)
 }
 
-func readRandomManifest(ctx context.Context, t *testing.T, r *repo.Repository) error {
-	manifests, err := r.Manifests.Find(ctx, nil)
+func readRandomManifest(ctx context.Context, t *testing.T, r *repo.DirectRepository) error {
+	manifests, err := r.FindManifests(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -306,12 +306,12 @@ func readRandomManifest(ctx context.Context, t *testing.T, r *repo.Repository) e
 
 	n := rand.Intn(len(manifests))
 
-	_, err = r.Manifests.GetRaw(ctx, manifests[n].ID)
+	_, err = r.GetManifest(ctx, manifests[n].ID, nil)
 
 	return err
 }
 
-func writeRandomManifest(ctx context.Context, t *testing.T, r *repo.Repository) error {
+func writeRandomManifest(ctx context.Context, t *testing.T, r *repo.DirectRepository) error {
 	key1 := fmt.Sprintf("key-%v", rand.Intn(10))
 	key2 := fmt.Sprintf("key-%v", rand.Intn(10))
 	val1 := fmt.Sprintf("val1-%v", rand.Intn(10))
@@ -320,7 +320,7 @@ func writeRandomManifest(ctx context.Context, t *testing.T, r *repo.Repository) 
 	content2 := fmt.Sprintf("content-%v", rand.Intn(10))
 	content1val := fmt.Sprintf("val1-%v", rand.Intn(10))
 	content2val := fmt.Sprintf("val2-%v", rand.Intn(10))
-	_, err := r.Manifests.Put(ctx, map[string]string{
+	_, err := r.PutManifest(ctx, map[string]string{
 		"type": key1,
 		key1:   val1,
 		key2:   val2,


### PR DESCRIPTION
This is 99% mechanical:

Extracted repo.Repository interface that only exposes high-level object and manifest management methods, but not blob nor content management.

Renamed old *repo.Repository to *repo.DirectRepository

Reviewed codebase to only depend on repo.Repository as much as possible, but added way for low-level CLI commands to use DirectRepository.