### PR TITLE
[robustness testing] Implement metadata store for test metadata using kopia

### DIFF
--- a/tests/robustness/snapmeta/kopia_meta.go
+++ b/tests/robustness/snapmeta/kopia_meta.go
@@ -1,0 +1,126 @@
+package snapmeta
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/kopia/kopia/tests/tools/kopiarunner"
+)
+
+var _ Persister = &kopiaMetadata{}
+
+// kopiaMetadata handles metadata persistency of a snapshot store, using a Kopia
+// repository as the persistency mechanism
+type kopiaMetadata struct {
+	*Simple
+	localMetadataDir string
+	snap             *kopiarunner.KopiaSnapshotter
+}
+
+// New instantiates a new Persister and returns it.
+func New() (Persister, error) {
+	localDir, err := ioutil.TempDir("", "kopia-local-metadata-")
+	if err != nil {
+		return nil, err
+	}
+
+	snap, err := kopiarunner.NewKopiaSnapshotter()
+	if err != nil {
+		return nil, err
+	}
+
+	return &kopiaMetadata{
+		localMetadataDir: localDir,
+		Simple:           NewSimple(),
+		snap:             snap,
+	}, nil
+}
+
+// Cleanup cleans up the local temporary files used by a KopiaMetadata
+func (store *kopiaMetadata) Cleanup() {
+	if store.localMetadataDir != "" {
+		os.RemoveAll(store.localMetadataDir) //nolint:errcheck
+	}
+
+	if store.snap != nil {
+		store.snap.Cleanup()
+	}
+}
+
+// ConnectOrCreateS3 implements the RepoManager interface, connects to a repo in an S3
+// bucket or attempts to create one if connection is unsuccessful
+func (store *kopiaMetadata) ConnectOrCreateS3(bucketName, pathPrefix string) error {
+	return store.snap.ConnectOrCreateS3(bucketName, pathPrefix)
+}
+
+// ConnectOrCreateFilesystem implements the RepoManager interface, connects to a repo in the filesystem
+// or attempts to create one if connection is unsuccessful
+func (store *kopiaMetadata) ConnectOrCreateFilesystem(path string) error {
+	return store.snap.ConnectOrCreateFilesystem(path)
+}
+
+// LoadMetadata implements the DataPersister interface, restores the latest
+// snapshot from the kopia repository and decodes its contents, populating
+// its metadata on the snapshots residing in the target test repository.
+func (store *kopiaMetadata) LoadMetadata() error {
+	snapIDs, err := store.snap.ListSnapshots()
+	if err != nil {
+		return err
+	}
+
+	if len(snapIDs) == 0 {
+		return nil // No snapshot IDs fouund in repository
+	}
+
+	lastSnapID := snapIDs[len(snapIDs)-1]
+
+	restorePath := filepath.Join(store.localMetadataDir, "kopia-metadata-latest")
+
+	err = store.snap.RestoreSnapshot(lastSnapID, restorePath)
+	if err != nil {
+		return err
+	}
+
+	defer os.Remove(restorePath) //nolint:errcheck
+
+	f, err := os.Open(restorePath) //nolint:gosec
+	if err != nil {
+		return err
+	}
+
+	err = json.NewDecoder(f).Decode(&(store.Simple.m))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FlushMetadata implements the DataPersister interface, flushing the local
+// metadata on the target test repo's snapshots to the metadata Kopia repository
+// as a snapshot create.
+func (store *kopiaMetadata) FlushMetadata() error {
+	f, err := ioutil.TempFile(store.localMetadataDir, "kopia-metadata-")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		f.Close()           //nolint:errcheck
+		os.Remove(f.Name()) //nolint:errcheck
+	}()
+
+	err = json.NewEncoder(f).Encode(store.Simple.m)
+	if err != nil {
+		return err
+	}
+
+	_, err = store.snap.CreateSnapshot(f.Name())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tests/robustness/snapmeta/simple.go
+++ b/tests/robustness/snapmeta/simple.go
@@ -8,8 +8,8 @@ var _ Store = &Simple{}
 // snapshot metadata as a byte slice in a map in memory.
 // A Simple should not be copied.
 type Simple struct {
-	m map[string][]byte
-	l sync.Mutex
+	m  map[string][]byte
+	mu sync.Mutex
 }
 
 // NewSimple instantiates a new Simple snapstore and
@@ -25,8 +25,8 @@ func (s *Simple) Store(key string, val []byte) error {
 	buf := make([]byte, len(val))
 	_ = copy(buf, val)
 
-	s.l.Lock()
-	defer s.l.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	s.m[key] = buf
 
@@ -35,8 +35,8 @@ func (s *Simple) Store(key string, val []byte) error {
 
 // Load implements the Storer interface Load method
 func (s *Simple) Load(key string) ([]byte, error) {
-	s.l.Lock()
-	defer s.l.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if buf, found := s.m[key]; found {
 		retBuf := make([]byte, len(buf))
@@ -50,16 +50,16 @@ func (s *Simple) Load(key string) ([]byte, error) {
 
 // Delete implements the Storer interface Delete method
 func (s *Simple) Delete(key string) {
-	s.l.Lock()
-	defer s.l.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	delete(s.m, key)
 }
 
 // GetKeys implements the Storer interface GetKeys method
 func (s *Simple) GetKeys() []string {
-	s.l.Lock()
-	defer s.l.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	ret := make([]string, 0, len(s.m))
 

--- a/tests/robustness/snapmeta/simple.go
+++ b/tests/robustness/snapmeta/simple.go
@@ -1,0 +1,71 @@
+package snapmeta
+
+import "sync"
+
+var _ Store = &Simple{}
+
+// Simple is a snapstore implementation that stores
+// snapshot metadata as a byte slice in a map in memory.
+// A Simple should not be copied.
+type Simple struct {
+	m map[string][]byte
+	l sync.Mutex
+}
+
+// NewSimple instantiates a new Simple snapstore and
+// returns its pointer
+func NewSimple() *Simple {
+	return &Simple{
+		m: make(map[string][]byte),
+	}
+}
+
+// Store implements the Storer interface Store method
+func (s *Simple) Store(key string, val []byte) error {
+	buf := make([]byte, len(val))
+	_ = copy(buf, val)
+
+	s.l.Lock()
+	defer s.l.Unlock()
+
+	s.m[key] = buf
+
+	return nil
+}
+
+// Load implements the Storer interface Load method
+func (s *Simple) Load(key string) ([]byte, error) {
+	s.l.Lock()
+	defer s.l.Unlock()
+
+	if buf, found := s.m[key]; found {
+		retBuf := make([]byte, len(buf))
+		_ = copy(retBuf, buf)
+
+		return retBuf, nil
+	}
+
+	return nil, nil
+}
+
+// Delete implements the Storer interface Delete method
+func (s *Simple) Delete(key string) {
+	s.l.Lock()
+	defer s.l.Unlock()
+
+	delete(s.m, key)
+}
+
+// GetKeys implements the Storer interface GetKeys method
+func (s *Simple) GetKeys() []string {
+	s.l.Lock()
+	defer s.l.Unlock()
+
+	ret := make([]string, 0, len(s.m))
+
+	for k := range s.m {
+		ret = append(ret, k)
+	}
+
+	return ret
+}

--- a/tests/robustness/snapmeta/snapmeta.go
+++ b/tests/robustness/snapmeta/snapmeta.go
@@ -1,0 +1,23 @@
+// Package snapmeta describes entities that can accept
+// arbitrary metadata and flush it to a persistent repository.
+package snapmeta
+
+import "github.com/kopia/kopia/tests/robustness/snap"
+
+// Store describes the ability to store and retrieve
+// a buffer of metadata, indexed by a string key.
+type Store interface {
+	Store(key string, val []byte) error
+	Load(key string) ([]byte, error)
+	Delete(key string)
+	GetKeys() []string
+}
+
+// Persister describes the ability to flush metadata
+// to, and load it again, from a repository.
+type Persister interface {
+	Store
+	snap.RepoManager
+	LoadMetadata() error
+	FlushMetadata() error
+}


### PR DESCRIPTION
Add an implementation of the metadata store using Kopia snapshots and restores to manage persistence of walk metadata. Metadata are stored to and retrieved from the store, and a mechanism for persisting the store is implemented using Kopia snapshots.