### PR TITLE
performance: plumbed through output buffer to encryption and hashing,…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,7 @@ ifneq ($(uname),Windows)
 	             -e github.com/kopia/kopia/internal/blobtesting \
 	             -e github.com/kopia/kopia/internal/repotesting \
 	             -e github.com/kopia/kopia/internal/testlogging \
+	             -e github.com/kopia/kopia/internal/bufcache \
 	             -e github.com/kopia/kopia/internal/hmac \
 	             -e github.com/kopia/kopia/internal/faketime \
 	             -e github.com/kopia/kopia/internal/testutil \

--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -53,9 +53,11 @@ func runBenchmarkCryptoAction(ctx *kingpin.ParseContext) error {
 			t0 := time.Now()
 
 			hashCount := *benchmarkCryptoRepeat
+			hashOutput := make([]byte, 0, 64)
+
 			for i := 0; i < hashCount; i++ {
-				contentID := h(data)
-				if _, encerr := e.Encrypt(data, contentID); encerr != nil {
+				contentID := h(hashOutput[:0], data)
+				if _, encerr := e.Encrypt(nil, data, contentID); encerr != nil {
 					printStderr("encryption failed: %v\n", encerr)
 					break
 				}

--- a/internal/bufcache/bufcache.go
+++ b/internal/bufcache/bufcache.go
@@ -1,0 +1,78 @@
+// Package bufcache allocates and recycles byte slices used as buffers.
+package bufcache
+
+import (
+	"sync"
+)
+
+type poolWithCapacity struct {
+	capacity int
+	pool     *sync.Pool
+}
+
+// pools keep track of sync.Pools holding pointers to byte slices of exactly the provided capacity.
+// when allocating, we pick from the smallest pool that fits.
+var pools = []poolWithCapacity{
+	{1 << 8, &sync.Pool{}},  // 256 B
+	{1 << 10, &sync.Pool{}}, // 1 KB
+	{1 << 12, &sync.Pool{}}, // 4 KB
+	{1 << 14, &sync.Pool{}}, // 16 KB
+	{1 << 16, &sync.Pool{}}, // 64 KB
+	{1 << 18, &sync.Pool{}}, // 256 KB
+	{1 << 20, &sync.Pool{}}, // 1 MB
+	{1 << 21, &sync.Pool{}}, // 2 MB
+	{1 << 22, &sync.Pool{}}, // 4 MB
+	{1 << 23, &sync.Pool{}}, // 8 MB
+	{1 << 24, &sync.Pool{}}, // 16 MB
+	{1 << 25, &sync.Pool{}}, // 32 MB
+}
+
+// EmptyBytesWithCapacity returns slice of length 0 with >= given capacity.
+func EmptyBytesWithCapacity(capacity int) []byte {
+	if p, ok := findPoolWithSize(capacity); ok {
+		return getOrAllocate(p.pool, p.capacity)
+	}
+
+	// beyond largest bucket, allocate
+	return make([]byte, 0, capacity)
+}
+
+// Clone clones given slice onto a slice from the cache.
+func Clone(b []byte) []byte {
+	return append(EmptyBytesWithCapacity(len(b)), b...)
+}
+
+// Return returns the given slice back to the pool.
+func Return(b []byte) {
+	if p, ok := findPoolWithSize(cap(b)); ok && p.capacity == cap(b) {
+		p.pool.Put(&b)
+	}
+}
+
+func findPoolWithSize(capacity int) (poolWithCapacity, bool) {
+	// quick binary search to find the right pool bucket
+	l, r := 0, len(pools)
+
+	for l < r {
+		if m := (l + r) >> 1; pools[m].capacity < capacity {
+			l = m + 1
+		} else {
+			r = m
+		}
+	}
+
+	if l < len(pools) {
+		return pools[l], true
+	}
+
+	return poolWithCapacity{}, false
+}
+
+func getOrAllocate(p *sync.Pool, capacity int) []byte {
+	v := p.Get()
+	if v == nil {
+		return make([]byte, 0, capacity)
+	}
+
+	return (*v.(*[]byte))[:0]
+}

--- a/internal/bufcache/bufcache_test.go
+++ b/internal/bufcache/bufcache_test.go
@@ -1,0 +1,31 @@
+package bufcache_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/bufcache"
+)
+
+func TestBufCache(t *testing.T) {
+	cases := []struct {
+		requestCap    int
+		wantResultCap int
+	}{
+		{0, 256},
+		{1, 256},
+		{256, 256},
+		{257, 1024},
+		{1024, 1024},
+		{1025, 4096},
+		{1 << 24, 1 << 24},     // 16 MB
+		{1 << 25, 1 << 25},     // 32 MB
+		{1<<25 + 3, 1<<25 + 3}, // 32 MB + 3, not pooled anymore
+	}
+
+	for _, tc := range cases {
+		result := bufcache.EmptyBytesWithCapacity(tc.requestCap)
+		if got, want := cap(result), tc.wantResultCap; got != want {
+			t.Errorf("got invalid capacity of buffer: %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/hmac/hmac.go
+++ b/internal/hmac/hmac.go
@@ -27,7 +27,9 @@ func VerifyAndStrip(b, secret []byte) ([]byte, error) {
 
 	h := hmac.New(sha256.New, secret)
 	h.Write(data) // nolint:errcheck
-	validSignature := h.Sum(nil)
+
+	var sigBuf [32]byte
+	validSignature := h.Sum(sigBuf[:0])
 
 	if len(signature) != len(validSignature) {
 		return nil, errors.New("invalid signature length")

--- a/repo/content/content_cache_test.go
+++ b/repo/content/content_cache_test.go
@@ -148,7 +148,7 @@ func verifyContentCache(t *testing.T, cache *contentCache) {
 			} else if err != nil && err.Error() != tc.err.Error() {
 				t.Errorf("unexpected error for %v: %+v, wanted %+v", tc.cacheKey, err, tc.err)
 			}
-			if !reflect.DeepEqual(v, tc.expected) {
+			if !bytes.Equal(v, tc.expected) {
 				t.Errorf("unexpected data for %v: %x, wanted %x", tc.cacheKey, v, tc.expected)
 			}
 		}

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	cryptorand "crypto/rand"
 	"crypto/sha1"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -132,8 +131,8 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 			return
 		}
 
-		if got, want := b2, b; !reflect.DeepEqual(got, want) {
-			t.Errorf("content %q data mismatch: got %x (nil:%v), wanted %x (nil:%v)", contentID, got, got == nil, want, want == nil)
+		if got, want := b2, b; !bytes.Equal(got, want) {
+			t.Errorf("content %q data mismatch: got %x, wanted %x", contentID, got, want)
 			return
 		}
 	}

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -68,14 +68,14 @@ func TestFormatters(t *testing.T) {
 						return
 					}
 
-					contentID := h(data)
+					contentID := h(nil, data)
 
-					cipherText, err := e.Encrypt(data, contentID)
+					cipherText, err := e.Encrypt(nil, data, contentID)
 					if err != nil || cipherText == nil {
 						t.Errorf("invalid response from Encrypt: %v %v", cipherText, err)
 					}
 
-					plainText, err := e.Decrypt(cipherText, contentID)
+					plainText, err := e.Decrypt(nil, cipherText, contentID)
 					if err != nil || plainText == nil {
 						t.Errorf("invalid response from Decrypt: %v %v", plainText, err)
 					}

--- a/repo/content/content_index_recovery.go
+++ b/repo/content/content_index_recovery.go
@@ -176,9 +176,9 @@ func (bm *lockFreeManager) appendPackFileIndexRecoveryData(ctx context.Context, 
 		return nil, err
 	}
 
-	localIndexIV := bm.hashData(localIndex)
+	localIndexIV := bm.hashData(nil, localIndex)
 
-	encryptedLocalIndex, err := bm.encryptor.Encrypt(localIndex, localIndexIV)
+	encryptedLocalIndex, err := bm.encryptor.Encrypt(nil, localIndex, localIndexIV)
 	if err != nil {
 		return nil, err
 	}

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -506,10 +506,9 @@ func (bm *Manager) WriteContent(ctx context.Context, data []byte, prefix ID) (ID
 		return "", err
 	}
 
-	hashOutput := bufcache.EmptyBytesWithCapacity(maxHashSize)
-	defer bufcache.Return(hashOutput)
+	var hashOutput [maxHashSize]byte
 
-	contentID := prefix + ID(hex.EncodeToString(bm.hashData(hashOutput, data)))
+	contentID := prefix + ID(hex.EncodeToString(bm.hashData(hashOutput[:0], data)))
 
 	// content already tracked
 	if bi, err := bm.getContentInfo(contentID); err == nil {

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -1245,7 +1245,7 @@ func verifyContentManagerDataSet(ctx context.Context, t *testing.T, mgr *Manager
 			continue
 		}
 
-		if !reflect.DeepEqual(v, originalPayload) {
+		if !bytes.Equal(v, originalPayload) {
 			t.Errorf("payload for %q does not match original: %v", v, originalPayload)
 		}
 	}
@@ -1307,7 +1307,7 @@ func verifyContent(ctx context.Context, t *testing.T, bm *Manager, contentID ID,
 		return
 	}
 
-	if got, want := b2, b; !reflect.DeepEqual(got, want) {
+	if got, want := b2, b; !bytes.Equal(got, want) {
 		t.Errorf("content %q data mismatch: got %x (nil:%v), wanted %x (nil:%v)", contentID, got, got == nil, want, want == nil)
 	}
 

--- a/repo/content/packindex_test.go
+++ b/repo/content/packindex_test.go
@@ -117,11 +117,11 @@ func TestPackIndex(t *testing.T) {
 	data2 := buf2.Bytes()
 	data3 := buf3.Bytes()
 
-	if !reflect.DeepEqual(data1, data2) {
+	if !bytes.Equal(data1, data2) {
 		t.Errorf("builder output not stable: %x vs %x", hex.Dump(data1), hex.Dump(data2))
 	}
 
-	if !reflect.DeepEqual(data2, data3) {
+	if !bytes.Equal(data2, data3) {
 		t.Errorf("builder output not stable: %x vs %x", hex.Dump(data2), hex.Dump(data3))
 	}
 

--- a/repo/encryption/chacha20_poly1305_hmac_sha256_encryptor.go
+++ b/repo/encryption/chacha20_poly1305_hmac_sha256_encryptor.go
@@ -4,43 +4,50 @@ import (
 	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/sha256"
+	"hash"
+	"sync"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
 type chacha20poly1305hmacSha256Encryptor struct {
-	keyDerivationSecret []byte
+	hmacPool *sync.Pool
 }
 
 // aeadForContent returns cipher.AEAD using key derived from a given contentID.
 func (e chacha20poly1305hmacSha256Encryptor) aeadForContent(contentID []byte) (cipher.AEAD, error) {
-	h := hmac.New(sha256.New, e.keyDerivationSecret)
+	h := e.hmacPool.Get().(hash.Hash)
+	defer e.hmacPool.Put(h)
+
+	h.Reset()
+
 	if _, err := h.Write(contentID); err != nil {
 		return nil, errors.Wrap(err, "unable to derive encryption key")
 	}
 
-	key := h.Sum(nil)
+	var hashBuf [32]byte
+	key := h.Sum(hashBuf[:0])
 
 	return chacha20poly1305.New(key)
 }
 
-func (e chacha20poly1305hmacSha256Encryptor) Decrypt(input, contentID []byte) ([]byte, error) {
+func (e chacha20poly1305hmacSha256Encryptor) Decrypt(output, input, contentID []byte) ([]byte, error) {
 	a, err := e.aeadForContent(contentID)
 	if err != nil {
 		return nil, err
 	}
 
-	return aeadOpenPrefixedWithNonce(a, input, contentID)
+	return aeadOpenPrefixedWithNonce(output, a, input, contentID)
 }
 
-func (e chacha20poly1305hmacSha256Encryptor) Encrypt(input, contentID []byte) ([]byte, error) {
+func (e chacha20poly1305hmacSha256Encryptor) Encrypt(output, input, contentID []byte) ([]byte, error) {
 	a, err := e.aeadForContent(contentID)
 	if err != nil {
 		return nil, err
 	}
 
-	return aeadSealWithRandomNonce(a, input, contentID)
+	return aeadSealWithRandomNonce(output, a, input, contentID)
 }
 
 func (e chacha20poly1305hmacSha256Encryptor) IsAuthenticated() bool {
@@ -58,6 +65,12 @@ func init() {
 			return nil, err
 		}
 
-		return chacha20poly1305hmacSha256Encryptor{keyDerivationSecret}, nil
+		hmacPool := &sync.Pool{
+			New: func() interface{} {
+				return hmac.New(sha256.New, keyDerivationSecret)
+			},
+		}
+
+		return chacha20poly1305hmacSha256Encryptor{hmacPool}, nil
 	})
 }

--- a/repo/encryption/deprecated_ctr_encryptor.go
+++ b/repo/encryption/deprecated_ctr_encryptor.go
@@ -12,12 +12,12 @@ type ctrEncryptor struct {
 	createCipher func() (cipher.Block, error)
 }
 
-func (fi ctrEncryptor) Encrypt(plainText, contentID []byte) ([]byte, error) {
-	return symmetricEncrypt(fi.createCipher, contentID, plainText)
+func (fi ctrEncryptor) Encrypt(output, plainText, contentID []byte) ([]byte, error) {
+	return symmetricEncrypt(output, fi.createCipher, contentID, plainText)
 }
 
-func (fi ctrEncryptor) Decrypt(cipherText, contentID []byte) ([]byte, error) {
-	return symmetricEncrypt(fi.createCipher, contentID, cipherText)
+func (fi ctrEncryptor) Decrypt(output, cipherText, contentID []byte) ([]byte, error) {
+	return symmetricEncrypt(output, fi.createCipher, contentID, cipherText)
 }
 
 func (fi ctrEncryptor) IsAuthenticated() bool {
@@ -28,7 +28,7 @@ func (fi ctrEncryptor) IsDeprecated() bool {
 	return true
 }
 
-func symmetricEncrypt(createCipher func() (cipher.Block, error), iv, b []byte) ([]byte, error) {
+func symmetricEncrypt(output []byte, createCipher func() (cipher.Block, error), iv, b []byte) ([]byte, error) {
 	blockCipher, err := createCipher()
 	if err != nil {
 		return nil, err
@@ -39,8 +39,9 @@ func symmetricEncrypt(createCipher func() (cipher.Block, error), iv, b []byte) (
 	}
 
 	ctr := cipher.NewCTR(blockCipher, iv[0:blockCipher.BlockSize()])
-	result := make([]byte, len(b))
-	ctr.XORKeyStream(result, b)
+
+	result, out := sliceForAppend(output, len(b))
+	ctr.XORKeyStream(out, b)
 
 	return result, nil
 }

--- a/repo/encryption/deprecated_salsa_encryptor.go
+++ b/repo/encryption/deprecated_salsa_encryptor.go
@@ -20,7 +20,7 @@ type salsaEncryptor struct {
 	hmacSecret []byte
 }
 
-func (s salsaEncryptor) Decrypt(input, contentID []byte) ([]byte, error) {
+func (s salsaEncryptor) Decrypt(output, input, contentID []byte) ([]byte, error) {
 	if s.hmacSecret != nil {
 		var err error
 
@@ -30,11 +30,11 @@ func (s salsaEncryptor) Decrypt(input, contentID []byte) ([]byte, error) {
 		}
 	}
 
-	return s.encryptDecrypt(input, contentID)
+	return s.encryptDecrypt(output, input, contentID)
 }
 
-func (s salsaEncryptor) Encrypt(input, contentID []byte) ([]byte, error) {
-	v, err := s.encryptDecrypt(input, contentID)
+func (s salsaEncryptor) Encrypt(output, input, contentID []byte) ([]byte, error) {
+	v, err := s.encryptDecrypt(output, input, contentID)
 	if err != nil {
 		return nil, errors.Wrap(err, "decrypt")
 	}
@@ -50,14 +50,14 @@ func (s salsaEncryptor) IsAuthenticated() bool {
 	return s.hmacSecret != nil
 }
 
-func (s salsaEncryptor) encryptDecrypt(input, contentID []byte) ([]byte, error) {
+func (s salsaEncryptor) encryptDecrypt(output, input, contentID []byte) ([]byte, error) {
 	if len(contentID) < s.nonceSize {
 		return nil, errors.Errorf("hash too short, expected >=%v bytes, got %v", s.nonceSize, len(contentID))
 	}
 
-	result := make([]byte, len(input))
+	result, out := sliceForAppend(output, len(input))
 	nonce := contentID[0:s.nonceSize]
-	salsa20.XORKeyStream(result, input, nonce, s.key)
+	salsa20.XORKeyStream(out, input, nonce, s.key)
 
 	return result, nil
 }

--- a/repo/encryption/null_encryptor.go
+++ b/repo/encryption/null_encryptor.go
@@ -4,12 +4,22 @@ package encryption
 type nullEncryptor struct {
 }
 
-func (fi nullEncryptor) Encrypt(plainText, contentID []byte) ([]byte, error) {
-	return cloneBytes(plainText), nil
+var zeroBytes = []byte{}
+
+func (fi nullEncryptor) Encrypt(output, plainText, contentID []byte) ([]byte, error) {
+	if len(plainText) == 0 {
+		return zeroBytes, nil
+	}
+
+	return append(output, plainText...), nil
 }
 
-func (fi nullEncryptor) Decrypt(cipherText, contentID []byte) ([]byte, error) {
-	return cloneBytes(cipherText), nil
+func (fi nullEncryptor) Decrypt(output, cipherText, contentID []byte) ([]byte, error) {
+	if len(cipherText) == 0 {
+		return zeroBytes, nil
+	}
+
+	return append(output, cipherText...), nil
 }
 
 func (fi nullEncryptor) IsAuthenticated() bool {

--- a/repo/encryption/null_encryptor.go
+++ b/repo/encryption/null_encryptor.go
@@ -4,21 +4,11 @@ package encryption
 type nullEncryptor struct {
 }
 
-var zeroBytes = []byte{}
-
 func (fi nullEncryptor) Encrypt(output, plainText, contentID []byte) ([]byte, error) {
-	if len(plainText) == 0 {
-		return zeroBytes, nil
-	}
-
 	return append(output, plainText...), nil
 }
 
 func (fi nullEncryptor) Decrypt(output, cipherText, contentID []byte) ([]byte, error) {
-	if len(cipherText) == 0 {
-		return zeroBytes, nil
-	}
-
 	return append(output, cipherText...), nil
 }
 

--- a/repo/hashing/hashing_test.go
+++ b/repo/hashing/hashing_test.go
@@ -36,12 +36,17 @@ func TestRoundTrip(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			hash1a := f(data1)
-			hash1b := f(data1)
-			hash2 := f(data2)
+			outputBuffer := make([]byte, 0, 256)
+			hash1a := f(nil, data1)
+			hash1b := f(outputBuffer, data1)
+			hash2 := f(nil, data2)
 
 			if !bytes.Equal(hash1a, hash1b) {
 				t.Fatalf("hashing not stable: %x %x", hash1a, hash1b)
+			}
+
+			if !bytes.Equal(hash1a, outputBuffer[0:len(hash1a)]) {
+				t.Fatalf("hash did not populate output buffer")
 			}
 
 			if bytes.Equal(hash1a, hash2) {

--- a/tests/stress_test/stress_test.go
+++ b/tests/stress_test/stress_test.go
@@ -1,11 +1,11 @@
 package stress_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/rand"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -127,7 +127,7 @@ func stressWorker(ctx context.Context, t *testing.T, deadline time.Time, openMgr
 				return
 			}
 
-			if !reflect.DeepEqual(previous.data, d2) {
+			if !bytes.Equal(previous.data, d2) {
 				t.Errorf("invalid previous data for %q %x %x", previous.contentID, d2, previous.data)
 				return
 			}


### PR DESCRIPTION
… so that the caller can pre-allocate/reuse it