### PR TITLE
performance: improvements to object manager

### DIFF
--- a/cli/command_benchmark_compression.go
+++ b/cli/command_benchmark_compression.go
@@ -52,7 +52,7 @@ func runBenchmarkCompressionAction(ctx *kingpin.ParseContext) error {
 
 		cnt := *benchmarkCompressionRepeat
 		for i := 0; i < cnt; i++ {
-			compressed, err := comp.Compress(data)
+			compressed, err := comp.Compress(nil, data)
 			if err != nil {
 				printStderr("compression %q failed: %v\n", name, err)
 				continue

--- a/cli/command_benchmark_compression.go
+++ b/cli/command_benchmark_compression.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"hash/fnv"
 	"io/ioutil"
 	"sort"
@@ -51,17 +52,21 @@ func runBenchmarkCompressionAction(ctx *kingpin.ParseContext) error {
 		var lastHash uint64
 
 		cnt := *benchmarkCompressionRepeat
+
+		var compressed bytes.Buffer
+
 		for i := 0; i < cnt; i++ {
-			compressed, err := comp.Compress(nil, data)
-			if err != nil {
+			compressed.Reset()
+
+			if err := comp.Compress(&compressed, data); err != nil {
 				printStderr("compression %q failed: %v\n", name, err)
 				continue
 			}
 
-			compressedSize = int64(len(compressed))
+			compressedSize = int64(compressed.Len())
 
 			if *benchmarkCompressionVerifyStable {
-				h := hashOf(compressed)
+				h := hashOf(compressed.Bytes())
 
 				if i == 0 {
 					lastHash = h

--- a/repo/compression/compressor.go
+++ b/repo/compression/compressor.go
@@ -16,8 +16,8 @@ type Name string
 // Compressor implements compression and decompression of a byte slice.
 type Compressor interface {
 	HeaderID() HeaderID
-	Compress(b []byte) ([]byte, error)
-	Decompress(b []byte) ([]byte, error)
+	Compress(output, b []byte) ([]byte, error)
+	Decompress(output, b []byte) ([]byte, error)
 }
 
 // maps of registered compressors by header ID and name.

--- a/repo/compression/compressor.go
+++ b/repo/compression/compressor.go
@@ -2,6 +2,7 @@
 package compression
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -16,8 +17,8 @@ type Name string
 // Compressor implements compression and decompression of a byte slice.
 type Compressor interface {
 	HeaderID() HeaderID
-	Compress(output, b []byte) ([]byte, error)
-	Decompress(output, b []byte) ([]byte, error)
+	Compress(output *bytes.Buffer, input []byte) error
+	Decompress(output *bytes.Buffer, input []byte) error
 }
 
 // maps of registered compressors by header ID and name.
@@ -54,4 +55,10 @@ func IDFromHeader(b []byte) (HeaderID, error) {
 	}
 
 	return HeaderID(binary.BigEndian.Uint32(b[0:compressionHeaderSize])), nil
+}
+
+func mustSucceed(err error) {
+	if err != nil {
+		panic("unexpected error: " + err.Error())
+	}
 }

--- a/repo/compression/compressor_gzip.go
+++ b/repo/compression/compressor_gzip.go
@@ -17,14 +17,10 @@ func init() {
 }
 
 func newGZipCompressor(id HeaderID, level int) Compressor {
-	// check that this works, we'll be using this without possibility of returning error below
-	if _, err := gzip.NewWriterLevel(bytes.NewBuffer(nil), level); err != nil {
-		panic("unexpected failure when creting writer")
-	}
-
 	return &gzipCompressor{id, compressionHeader(id), sync.Pool{
 		New: func() interface{} {
-			w, _ := gzip.NewWriterLevel(bytes.NewBuffer(nil), level)
+			w, err := gzip.NewWriterLevel(bytes.NewBuffer(nil), level)
+			mustSucceed(err)
 			return w
 		},
 	}}
@@ -40,48 +36,45 @@ func (c *gzipCompressor) HeaderID() HeaderID {
 	return c.id
 }
 
-func (c *gzipCompressor) Compress(output, b []byte) ([]byte, error) {
-	buf := bytes.NewBuffer(output[:0])
-
-	if _, err := buf.Write(c.header); err != nil {
-		return nil, errors.Wrap(err, "unable to write header")
+func (c *gzipCompressor) Compress(output *bytes.Buffer, input []byte) error {
+	if _, err := output.Write(c.header); err != nil {
+		return errors.Wrap(err, "unable to write header")
 	}
 
 	w := c.pool.Get().(*gzip.Writer)
 	defer c.pool.Put(w)
 
-	w.Reset(buf)
+	w.Reset(output)
 
-	if _, err := w.Write(b); err != nil {
-		return nil, errors.Wrap(err, "compression error")
+	if _, err := w.Write(input); err != nil {
+		return errors.Wrap(err, "compression error")
 	}
 
 	if err := w.Close(); err != nil {
-		return nil, errors.Wrap(err, "compression close error")
+		return errors.Wrap(err, "compression close error")
 	}
 
-	return buf.Bytes(), nil
+	return nil
 }
 
-func (c *gzipCompressor) Decompress(output, b []byte) ([]byte, error) {
+func (c *gzipCompressor) Decompress(output *bytes.Buffer, b []byte) error {
 	if len(b) < compressionHeaderSize {
-		return nil, errors.Errorf("invalid compression header")
+		return errors.Errorf("invalid compression header")
 	}
 
 	if !bytes.Equal(b[0:compressionHeaderSize], c.header) {
-		return nil, errors.Errorf("invalid compression header")
+		return errors.Errorf("invalid compression header")
 	}
 
 	r, err := gzip.NewReader(bytes.NewReader(b[compressionHeaderSize:]))
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to open gzip stream")
+		return errors.Wrap(err, "unable to open gzip stream")
 	}
 	defer r.Close() //nolint:errcheck
 
-	buf := bytes.NewBuffer(output[:0])
-	if _, err := iocopy.Copy(buf, r); err != nil {
-		return nil, errors.Wrap(err, "decompression error")
+	if _, err := iocopy.Copy(output, r); err != nil {
+		return errors.Wrap(err, "decompression error")
 	}
 
-	return buf.Bytes(), nil
+	return nil
 }

--- a/repo/compression/compressor_test.go
+++ b/repo/compression/compressor_test.go
@@ -15,34 +15,37 @@ func TestCompressor(t *testing.T) {
 			// make sure all-zero data is compressed
 			data := make([]byte, 10000)
 
-			cData, err := comp.Compress(nil, data)
-			if err != nil {
+			var cData bytes.Buffer
+
+			if err := comp.Compress(&cData, data); err != nil {
 				t.Fatalf("compression error %v", err)
 				return
 			}
 
-			if len(cData) >= len(data) {
+			if cData.Len() >= len(data) {
 				t.Errorf("compression not effective for all-zero data")
 			}
 
 			for id2, comp2 := range ByHeaderID {
 				if id != id2 {
-					if _, err2 := comp2.Decompress(nil, cData); err2 == nil {
+					var dData bytes.Buffer
+
+					if err2 := comp2.Decompress(&dData, cData.Bytes()); err2 == nil {
 						t.Errorf("compressor %x was able to decompress results of %x", id2, id)
 					}
 				}
 			}
 
-			data2, err := comp.Decompress(nil, cData)
-			if err != nil {
+			var data2 bytes.Buffer
+			if err := comp.Decompress(&data2, cData.Bytes()); err != nil {
 				t.Fatalf("decompression error %v", err)
 			}
 
-			if !bytes.Equal(data, data2) {
+			if !bytes.Equal(data, data2.Bytes()) {
 				t.Errorf("invalid decompressed data %x, wanted %x", data2, data)
 			}
 
-			t.Logf("compressed %v => %v", len(data), len(cData))
+			t.Logf("compressed %v => %v", len(data), cData.Len())
 		})
 
 		t.Run(fmt.Sprintf("non-compressible-data-%x", id), func(t *testing.T) {
@@ -50,26 +53,28 @@ func TestCompressor(t *testing.T) {
 			data := make([]byte, 10000)
 			rand.Read(data) //nolint:errcheck
 
-			cData, err := comp.Compress(nil, data)
+			var cData bytes.Buffer
+
+			err := comp.Compress(&cData, data)
 			if err != nil {
 				t.Fatalf("compression error %v", err)
 				return
 			}
 
-			if len(cData) < len(data) {
+			if cData.Len() < len(data) {
 				t.Errorf("compression magically effective for random data")
 			}
 
-			data2, err := comp.Decompress(nil, cData)
-			if err != nil {
+			var data2 bytes.Buffer
+			if err := comp.Decompress(&data2, cData.Bytes()); err != nil {
 				t.Fatalf("decompression error %v", err)
 			}
 
-			if !bytes.Equal(data, data2) {
+			if !bytes.Equal(data, data2.Bytes()) {
 				t.Errorf("invalid decompressed data %x, wanted %x", data2, data)
 			}
 
-			t.Logf("compressed %v => %v", len(data), len(cData))
+			t.Logf("compressed %v => %v", len(data), cData.Bytes())
 		})
 	}
 }

--- a/repo/compression/compressor_test.go
+++ b/repo/compression/compressor_test.go
@@ -15,7 +15,7 @@ func TestCompressor(t *testing.T) {
 			// make sure all-zero data is compressed
 			data := make([]byte, 10000)
 
-			cData, err := comp.Compress(data)
+			cData, err := comp.Compress(nil, data)
 			if err != nil {
 				t.Fatalf("compression error %v", err)
 				return
@@ -27,13 +27,13 @@ func TestCompressor(t *testing.T) {
 
 			for id2, comp2 := range ByHeaderID {
 				if id != id2 {
-					if _, err2 := comp2.Decompress(cData); err2 == nil {
+					if _, err2 := comp2.Decompress(nil, cData); err2 == nil {
 						t.Errorf("compressor %x was able to decompress results of %x", id2, id)
 					}
 				}
 			}
 
-			data2, err := comp.Decompress(cData)
+			data2, err := comp.Decompress(nil, cData)
 			if err != nil {
 				t.Fatalf("decompression error %v", err)
 			}
@@ -50,7 +50,7 @@ func TestCompressor(t *testing.T) {
 			data := make([]byte, 10000)
 			rand.Read(data) //nolint:errcheck
 
-			cData, err := comp.Compress(data)
+			cData, err := comp.Compress(nil, data)
 			if err != nil {
 				t.Fatalf("compression error %v", err)
 				return
@@ -60,7 +60,7 @@ func TestCompressor(t *testing.T) {
 				t.Errorf("compression magically effective for random data")
 			}
 
-			data2, err := comp.Decompress(cData)
+			data2, err := comp.Decompress(nil, cData)
 			if err != nil {
 				t.Fatalf("decompression error %v", err)
 			}

--- a/repo/splitter/splitter.go
+++ b/repo/splitter/splitter.go
@@ -13,6 +13,8 @@ const (
 // It must return true if the object should be split after byte b is processed.
 type Splitter interface {
 	ShouldSplit(b byte) bool
+	Reset()
+	Close()
 }
 
 // SupportedAlgorithms returns the list of supported splitters.

--- a/repo/splitter/splitter_buzhash32.go
+++ b/repo/splitter/splitter_buzhash32.go
@@ -14,6 +14,14 @@ type buzhash32Splitter struct {
 	maxSize int
 }
 
+func (rs *buzhash32Splitter) Close() {
+}
+
+func (rs *buzhash32Splitter) Reset() {
+	rs.rh.Reset()
+	rs.rh.Write(make([]byte, splitterSlidingWindowSize)) //nolint:errcheck
+}
+
 func (rs *buzhash32Splitter) ShouldSplit(b byte) bool {
 	rs.rh.Roll(b)
 	rs.count++

--- a/repo/splitter/splitter_fixed.go
+++ b/repo/splitter/splitter_fixed.go
@@ -5,6 +5,13 @@ type fixedSplitter struct {
 	chunkLength int
 }
 
+func (s *fixedSplitter) Close() {
+}
+
+func (s *fixedSplitter) Reset() {
+	s.cur = 0
+}
+
 func (s *fixedSplitter) ShouldSplit(b byte) bool {
 	s.cur++
 

--- a/repo/splitter/splitter_pool.go
+++ b/repo/splitter/splitter_pool.go
@@ -1,0 +1,30 @@
+package splitter
+
+import (
+	"sync"
+)
+
+type recyclableSplitter struct {
+	Splitter
+	pool *sync.Pool
+}
+
+func (s recyclableSplitter) Close() {
+	s.Splitter.Reset()
+	s.Splitter.Close()
+	s.pool.Put(s.Splitter)
+}
+
+// Pooled returns a factory that recycles the splitters on Close().
+func Pooled(f Factory) Factory {
+	pool := &sync.Pool{}
+
+	return func() Splitter {
+		s := pool.Get()
+		if s == nil {
+			return recyclableSplitter{f(), pool}
+		}
+
+		return recyclableSplitter{s.(Splitter), pool}
+	}
+}

--- a/repo/splitter/splitter_rabinkarp64.go
+++ b/repo/splitter/splitter_rabinkarp64.go
@@ -1,6 +1,8 @@
 package splitter
 
-import "github.com/chmduquesne/rollinghash/rabinkarp64"
+import (
+	"github.com/chmduquesne/rollinghash/rabinkarp64"
+)
 
 type rabinKarp64Splitter struct {
 	// we're intentionally not using rollinghash.Hash32 interface because doing this in a tight loop
@@ -10,6 +12,14 @@ type rabinKarp64Splitter struct {
 	count   int
 	minSize int
 	maxSize int
+}
+
+func (rs *rabinKarp64Splitter) Close() {
+}
+
+func (rs *rabinKarp64Splitter) Reset() {
+	rs.rh.Reset()
+	rs.rh.Write(make([]byte, splitterSlidingWindowSize)) //nolint:errcheck
 }
 
 func (rs *rabinKarp64Splitter) ShouldSplit(b byte) bool {


### PR DESCRIPTION
- added pooled splitters and ability to reset them without having to recreate
- added support for caller-provided compressor output to be able to pool it
- added pooling of compressor instances, since those are costly