### PR TITLE
Refactor CLI stats

### DIFF
--- a/cli/command_snapshot_gc.go
+++ b/cli/command_snapshot_gc.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 
+	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/snapshot/gc"
 )
@@ -14,7 +15,14 @@ var (
 )
 
 func runSnapshotGCCommand(ctx context.Context, rep *repo.Repository) error {
-	return gc.Run(ctx, rep, *snapshotGCMinContentAge, *snapshotGCDelete)
+	st, err := gc.Run(ctx, rep, *snapshotGCMinContentAge, *snapshotGCDelete)
+
+	log(ctx).Infof("GC found %v unused contents (%v bytes)", st.UnusedCount, units.BytesStringBase2(st.UnusedBytes))
+	log(ctx).Infof("GC found %v unused contents that are too recent to delete (%v bytes)", st.TooRecentCount, units.BytesStringBase2(st.TooRecentBytes))
+	log(ctx).Infof("GC found %v in-use contents (%v bytes)", st.InUseCount, units.BytesStringBase2(st.InUseBytes))
+	log(ctx).Infof("GC found %v in-use system-contents (%v bytes)", st.SystemCount, units.BytesStringBase2(st.SystemBytes))
+
+	return err
 }
 
 func init() {

--- a/internal/stats/countsum.go
+++ b/internal/stats/countsum.go
@@ -1,0 +1,22 @@
+// Package stats provides helpers for simple stats
+package stats
+
+import "sync/atomic"
+
+// CountSum holds sum and count values
+type CountSum struct {
+	sum   int64
+	count uint32
+}
+
+// Add adds size to s and returns approximate values for the current count
+// and total bytes
+func (s *CountSum) Add(size int64) (count uint32, sum int64) {
+	return atomic.AddUint32(&s.count, 1), atomic.AddInt64(&s.sum, size)
+}
+
+// Approximate returns an approximation of the current count and sum values.
+// It is approximate because retrieving both values is not an atomic operation.
+func (s *CountSum) Approximate() (count uint32, sum int64) {
+	return atomic.LoadUint32(&s.count), atomic.LoadInt64(&s.sum)
+}

--- a/snapshot/gc/gc.go
+++ b/snapshot/gc/gc.go
@@ -133,7 +133,7 @@ func Run(ctx context.Context, rep *repo.Repository, minContentAge time.Duration,
 	log(ctx).Infof("found %v in-use system-contents (%v bytes)", systemCount, units.BytesStringBase2(totalSystemBytes))
 
 	if unusedCount > 0 && !gcDelete {
-		return errors.Errorf("Not deleting because '--delete' flag was not set.")
+		return errors.Errorf("not deleting because '--delete' flag was not set")
 	}
 
 	return nil

--- a/snapshot/gc/stats.go
+++ b/snapshot/gc/stats.go
@@ -1,0 +1,10 @@
+package gc
+
+// Stats contains statistics about a GC run
+type Stats struct {
+	// Keep int64 fields first to ensure they get aligned to at least 64-bit
+	// boundaries which is required for atomic access on ARM and x86-32.
+	// Also results in a smaller struct size
+	UnusedBytes, InUseBytes, SystemBytes, TooRecentBytes int64
+	UnusedCount, InUseCount, SystemCount, TooRecentCount uint32
+}


### PR DESCRIPTION
No functional changes.

Add helpers to improve code readability in the CLI commands that collect stats, and leverage those in the `blob gc`, `content list` and `snapshot gc` commands.

Also, minor refactoring in the snapshot/gc.Run function to improve readability. No functional changes. 
