### PR TITLE
cli: pre-allocated buffers for crypto benchmark

### DIFF
--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -31,6 +31,15 @@ func runBenchmarkCryptoAction(ctx *kingpin.ParseContext) error {
 
 	data := make([]byte, *benchmarkCryptoBlockSize)
 
+	const (
+		maxEncryptionOverhead = 1024
+		maxHashSize           = 64
+	)
+
+	var hashOutput [maxHashSize]byte
+
+	encryptOutput := make([]byte, len(data)+maxEncryptionOverhead)
+
 	for _, ha := range hashing.SupportedAlgorithms() {
 		for _, ea := range encryption.SupportedAlgorithms(*benchmarkCryptoDeprecatedAlgorithms) {
 			isEncrypted := ea != encryption.NoneAlgorithm
@@ -53,11 +62,10 @@ func runBenchmarkCryptoAction(ctx *kingpin.ParseContext) error {
 			t0 := time.Now()
 
 			hashCount := *benchmarkCryptoRepeat
-			hashOutput := make([]byte, 0, 64)
 
 			for i := 0; i < hashCount; i++ {
 				contentID := h(hashOutput[:0], data)
-				if _, encerr := e.Encrypt(nil, data, contentID); encerr != nil {
+				if _, encerr := e.Encrypt(encryptOutput[:0], data, contentID); encerr != nil {
 					printStderr("encryption failed: %v\n", encerr)
 					break
 				}


### PR DESCRIPTION
non-optimized (0.5.0)
  0. BLAKE2B-256-128      AES256-GCM-HMAC-SHA256 644.9 MiB / second

before this change:
  0. BLAKE2B-256-128      AES256-GCM-HMAC-SHA256 655.9 MiB / second

after (this change):
  0. BLAKE2B-256-128      AES256-GCM-HMAC-SHA256 781.5 MiB / second
