### PR TITLE
performance: introduced buf.Pool which helps reuse memory buffers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ ifneq ($(uname),Windows)
 	find repo/ -name '*.go' | xargs grep "^\t\"github.com/kopia/kopia" \
 	   | grep -v -e github.com/kopia/kopia/repo \
 	             -e github.com/kopia/kopia/internal/retry \
+	             -e github.com/kopia/kopia/internal/buf \
 	             -e github.com/kopia/kopia/internal/throttle \
 	             -e github.com/kopia/kopia/internal/iocopy \
 	             -e github.com/kopia/kopia/internal/blobtesting \

--- a/internal/buf/pool.go
+++ b/internal/buf/pool.go
@@ -1,0 +1,205 @@
+// Package buf manages allocation of temporary short-term buffers.
+package buf
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	maxAllocAttempts       = 3
+	allocationRetryTimeout = 500 * time.Millisecond
+)
+
+type segment struct {
+	nextUnallocated   int32  // high water mark
+	allocatedBufCount int32  // how many outstanding users of the segment there are
+	data              []byte // the underlying buffer from which we're allocating
+	pool              *Pool
+}
+
+// Buf represents allocated slice of memory pool. At the end of using the buffer, Release() must be called to
+// reclaim memory.
+type Buf struct {
+	nextUnallocated         int32
+	previousNextUnallocated int32
+
+	Data []byte
+
+	segment *segment // segment from which the data was allocated
+}
+
+// IsPooled determines whether data slice is part of a pool.
+func (b *Buf) IsPooled() bool { return b.segment != nil }
+
+// Release returns the slice back to the pool.
+func (b *Buf) Release() {
+	if b.segment == nil {
+		return
+	}
+
+	notify := false
+
+	// best effort compare-and-swap, which will pop the buffer off the stack in its appropriate segment
+	if atomic.CompareAndSwapInt32(&b.segment.nextUnallocated, b.nextUnallocated, b.previousNextUnallocated) {
+		// popped from the stack in the segment
+		notify = true
+	}
+
+	if atomic.AddInt32(&b.segment.allocatedBufCount, -1) == 0 {
+		// last allocated Buf, we can reset 'next' to zero
+		atomic.StoreInt32(&b.segment.nextUnallocated, 0)
+
+		notify = true
+	}
+
+	if notify {
+		// this segment just became free, notify other goroutines doing Allocate()
+		select {
+		case b.segment.pool.segmentReleased <- struct{}{}: // notified
+		default: // nobody is waiting
+		}
+	}
+
+	b.Data = nil
+
+	b.segment = nil
+}
+
+func (s *segment) allocate(count int) (Buf, bool) {
+	n := int32(count)
+
+	for {
+		// see if we have capacity in this segment
+		v := atomic.LoadInt32(&s.nextUnallocated)
+		if v+n > int32(len(s.data)) {
+			// out of space in this segment
+			return Buf{}, false
+		}
+
+		if atomic.CompareAndSwapInt32(&s.nextUnallocated, v, v+n) {
+			atomic.AddInt32(&s.allocatedBufCount, 1)
+
+			return Buf{v + n, v, s.data[v : v+n : v+n], s}, true
+		}
+	}
+}
+
+// Pool manages allocations of short-term data buffers from a pool.
+//
+// Note that buffers managed by the pool are meant to be extremely short lived and are suitable
+// for in-memory operations, such as encryption, compression, etc, but not for I/O buffers of any kind.
+// It is EXTREMELY important to always release memory allocated from the Pool. Failure to do so will
+// result in
+//
+// The pool uses N segments, with each segment tracking its high water mark usage.
+//
+// Allocation simply advances the high water mark within first segment that has capacity
+// and increments per-segment refcount.
+//
+// On Buf.Release() the refcount is decremented and when it hits zero, the entire segment becomes instantly
+// freed.
+//
+// As an extra optimization, when Buf.Release() is called in LIFO order, it will also lower the
+// high water mark making its memory available for immediate reuse.
+//
+// If no segment has available capacity, the pool waits a few times until memory becomes released
+// and falls back to allocating from the heap.
+type Pool struct {
+	maxSegments     int
+	segmentReleased chan struct{} // channel which is notified whenever any segment becomes available for allocations
+
+	// this protects the slice, to be able to atomically replace it
+	mu          sync.Mutex
+	segmentSize int
+	segments    []*segment
+}
+
+// NewPool creates a buffer pool, composed of N fixed-length segments of specified maximum size.
+func NewPool(segmentSize, maxSegments int) *Pool {
+	p := &Pool{
+		segmentSize:     segmentSize,
+		segmentReleased: make(chan struct{}),
+		maxSegments:     maxSegments,
+	}
+
+	return p
+}
+
+func (p *Pool) currentSegments() []*segment {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.segments
+}
+
+// SetSegmentSize sets the segment size for future segments that will be created.
+func (p *Pool) SetSegmentSize(maxSize int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.segmentSize = maxSize
+}
+
+// InitializeSegments initializes n segments up to the maximum number of segments.
+func (p *Pool) InitializeSegments(n int) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	remaining := p.maxSegments - len(p.segments)
+	if n > remaining {
+		n = remaining
+	}
+
+	if n == 0 {
+		return false
+	}
+
+	var newSegments []*segment
+
+	newSegments = append(newSegments, p.segments...)
+
+	for i := 0; i < n; i++ {
+		newSegments = append(newSegments, &segment{
+			data: make([]byte, p.segmentSize),
+			pool: p,
+		})
+	}
+
+	p.segments = newSegments
+
+	return true
+}
+
+// Allocate allocates a slice of the buffer
+func (p *Pool) Allocate(n int) Buf {
+	// requested more than the pool can cache, allocate throw-away buffer.
+	if p == nil || n > p.segmentSize {
+		return Buf{0, 0, make([]byte, n), nil}
+	}
+
+	for i := 0; i < maxAllocAttempts; i++ {
+		// try to allocate
+		for _, s := range p.currentSegments() {
+			buf, ok := s.allocate(n)
+			if ok {
+				return buf
+			}
+		}
+
+		// add one more segment up to specified limit
+		if p.InitializeSegments(1) {
+			continue
+		}
+
+		// wait until some segment becomes free or some time passes, whichever comes first
+		select {
+		case <-p.segmentReleased:
+		case <-time.After(allocationRetryTimeout):
+		}
+	}
+
+	// fall back to heap allocation
+	return Buf{0, 0, make([]byte, n), nil}
+}

--- a/internal/buf/pool_metrics.go
+++ b/internal/buf/pool_metrics.go
@@ -1,0 +1,77 @@
+package buf
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var tagKeyPool = tag.MustNewKey("pool")
+
+// buffer pool metrics
+var (
+	metricPoolAllocatedBuffers = stats.Int64(
+		"kopia/bufferpool/allocated_buffers",
+		"Number of buffers allocated from a pool",
+		stats.UnitDimensionless,
+	)
+
+	metricPoolAllocatedBytes = stats.Int64(
+		"kopia/bufferpool/allocated_bytes",
+		"Number of bytes allocated from a pool",
+		stats.UnitDimensionless,
+	)
+
+	metricPoolReleasedBuffers = stats.Int64(
+		"kopia/bufferpool/released_buffers",
+		"Number of buffers released back to the pool",
+		stats.UnitBytes,
+	)
+
+	metricPoolReleasedBytes = stats.Int64(
+		"kopia/bufferpool/released_bytes",
+		"Number of bytes released from a pool",
+		stats.UnitBytes,
+	)
+
+	metricPoolOutstandingBuffers = stats.Int64(
+		"kopia/bufferpool/outstanding_buffers",
+		"Number of buffers allocated from a pool but not returned yet",
+		stats.UnitBytes,
+	)
+
+	metricPoolOutstandingBytes = stats.Int64(
+		"kopia/bufferpool/outstanding_bytes",
+		"Number of bytes allocated from a pool but not returned yet",
+		stats.UnitBytes,
+	)
+
+	metricPoolNumSegments = stats.Int64(
+		"kopia/bufferpool/num_segments",
+		"Number of segments in the pool",
+		stats.UnitDimensionless,
+	)
+)
+
+func aggregateByPool(m stats.Measure, agg *view.Aggregation) *view.View {
+	return &view.View{
+		Name:        m.Name(),
+		Aggregation: agg,
+		Description: m.Description(),
+		Measure:     m,
+		TagKeys:     []tag.Key{tagKeyPool},
+	}
+}
+func init() {
+	if err := view.Register(
+		aggregateByPool(metricPoolAllocatedBytes, view.LastValue()),
+		aggregateByPool(metricPoolOutstandingBytes, view.LastValue()),
+		aggregateByPool(metricPoolReleasedBytes, view.LastValue()),
+		aggregateByPool(metricPoolAllocatedBuffers, view.LastValue()),
+		aggregateByPool(metricPoolOutstandingBuffers, view.LastValue()),
+		aggregateByPool(metricPoolReleasedBuffers, view.LastValue()),
+		aggregateByPool(metricPoolNumSegments, view.LastValue()),
+	); err != nil {
+		panic("unable to register opencensus views: " + err.Error())
+	}
+}

--- a/internal/buf/pool_test.go
+++ b/internal/buf/pool_test.go
@@ -1,0 +1,78 @@
+package buf
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestPool(t *testing.T) {
+	var wg sync.WaitGroup
+
+	// 20 buffers of 1 MB each
+	var a = NewPool(1000000, 20)
+
+	a.InitializeSegments(20)
+
+	var ms1, ms2 runtime.MemStats
+
+	runtime.ReadMemStats(&ms1)
+
+	// 30 gorouties, each allocating and releasing memory 1 M times
+	for i := 0; i < 30; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for j := 0; j < 1000000; j++ {
+				const allocSize = 100000
+
+				b := a.Allocate(allocSize)
+
+				if got, want := len(b.Data), allocSize; got != want {
+					t.Errorf("unexpected len: %v, want %v", got, want)
+				}
+
+				if got, want := cap(b.Data), allocSize; got != want {
+					t.Errorf("unexpected cap: %v, want %v", got, want)
+				}
+
+				if !b.IsPooled() {
+					t.Errorf("unexpected !IsPooled()")
+				}
+
+				b.Release()
+			}
+		}()
+	}
+
+	wg.Wait()
+	runtime.ReadMemStats(&ms2)
+
+	// amount of memory should be O(kilobytes), not 1 MB because all buffers got preallocated
+	if diff := ms2.TotalAlloc - ms1.TotalAlloc; diff > 1000000 {
+		t.Errorf("too much memory was allocated: %v", diff)
+	}
+}
+
+func TestNilPool(t *testing.T) {
+	var a *Pool
+
+	// allocate from nil pool
+	b := a.Allocate(5)
+
+	if got, want := len(b.Data), 5; got != want {
+		t.Errorf("unexpected len: %v, want %v", got, want)
+	}
+
+	if got, want := cap(b.Data), 5; got != want {
+		t.Errorf("unexpected cap: %v, want %v", got, want)
+	}
+
+	if b.IsPooled() {
+		t.Errorf("unexpected IsPooled()")
+	}
+
+	b.Release()
+}

--- a/internal/buf/pool_test.go
+++ b/internal/buf/pool_test.go
@@ -10,9 +10,10 @@ func TestPool(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// 20 buffers of 1 MB each
-	var a = NewPool(1000000, 20)
+	var a = NewPool(1000000, "testing-pool")
+	defer a.Close()
 
-	a.InitializeSegments(20)
+	a.AddSegments(20)
 
 	var ms1, ms2 runtime.MemStats
 

--- a/internal/buf/pool_test.go
+++ b/internal/buf/pool_test.go
@@ -1,6 +1,7 @@
 package buf
 
 import (
+	"context"
 	"runtime"
 	"sync"
 	"testing"
@@ -9,8 +10,10 @@ import (
 func TestPool(t *testing.T) {
 	var wg sync.WaitGroup
 
+	ctx := context.Background()
+
 	// 20 buffers of 1 MB each
-	var a = NewPool(1000000, "testing-pool")
+	var a = NewPool(ctx, 1000000, "testing-pool")
 	defer a.Close()
 
 	a.AddSegments(20)

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -695,7 +695,7 @@ func newManagerWithOptions(ctx context.Context, st blob.Storage, f *FormattingOp
 			checkInvariantsOnUnlock: os.Getenv("KOPIA_VERIFY_INVARIANTS") != "",
 			writeFormatVersion:      int32(f.Version),
 			committedContents:       contentIndex,
-			encryptionBufferPool:    buf.NewPool(defaultEncryptionBufferPoolSegmentSize+encryptor.MaxOverhead(), "content-manager-encryption"),
+			encryptionBufferPool:    buf.NewPool(ctx, defaultEncryptionBufferPoolSegmentSize+encryptor.MaxOverhead(), "content-manager-encryption"),
 		},
 
 		mu:   mu,

--- a/repo/object/object_manager.go
+++ b/repo/object/object_manager.go
@@ -183,7 +183,7 @@ func NewObjectManager(ctx context.Context, bm contentManager, f Format, opts Man
 
 	om.newSplitter = splitter.Pooled(os)
 
-	om.bufferPool = buf.NewPool(om.newSplitter().MaxSegmentSize()+maxCompressionOverheadPerSegment, "object-manager")
+	om.bufferPool = buf.NewPool(ctx, om.newSplitter().MaxSegmentSize()+maxCompressionOverheadPerSegment, "object-manager")
 
 	if opts.Trace != nil {
 		om.trace = opts.Trace

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/buf"
 	"github.com/kopia/kopia/repo/compression"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/splitter"
@@ -51,12 +52,13 @@ func (t *contentIDTracker) contentIDs() []content.ID {
 }
 
 type objectWriter struct {
-	ctx  context.Context
-	repo *Manager
+	ctx context.Context
+	om  *Manager
 
 	compressor compression.Compressor
 
 	prefix      content.ID
+	buf         buf.Buf
 	buffer      *bytes.Buffer
 	totalLength int64
 
@@ -68,9 +70,13 @@ type objectWriter struct {
 	splitter splitter.Splitter
 }
 
+func (w *objectWriter) initBuffer() {
+	w.buf = w.om.bufferPool.Allocate(w.splitter.MaxSegmentSize())
+	w.buffer = bytes.NewBuffer(w.buf.Data[:0])
+}
+
 func (w *objectWriter) Close() error {
-	w.buffer.Reset()
-	w.repo.bufferPool.Put(w.buffer)
+	w.buf.Release()
 
 	if w.splitter != nil {
 		w.splitter.Close()
@@ -113,9 +119,9 @@ func (w *objectWriter) flushBuffer() error {
 		return errors.Wrap(err, "unable to prepare content bytes")
 	}
 
-	contentID, err := w.repo.contentMgr.WriteContent(w.ctx, contentBytes, w.prefix)
+	contentID, err := w.om.contentMgr.WriteContent(w.ctx, contentBytes, w.prefix)
 	w.buffer.Reset()
-	w.repo.trace("OBJECT_WRITER(%q) stored %v (%v bytes)", w.description, contentID, length)
+	w.om.trace("OBJECT_WRITER(%q) stored %v (%v bytes)", w.description, contentID, length)
 
 	if err != nil {
 		return errors.Wrapf(err, "error when flushing chunk %d of %s", chunkID, w.description)
@@ -159,13 +165,14 @@ func (w *objectWriter) Result() (ID, error) {
 
 	iw := &objectWriter{
 		ctx:         w.ctx,
-		repo:        w.repo,
+		om:          w.om,
 		compressor:  nil,
 		description: "LIST(" + w.description + ")",
-		splitter:    w.repo.newSplitter(),
+		splitter:    w.om.newSplitter(),
 		prefix:      w.prefix,
-		buffer:      w.repo.bufferPool.Get().(*bytes.Buffer),
 	}
+
+	iw.initBuffer()
 
 	defer iw.Close() //nolint:errcheck
 

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -36,6 +36,10 @@ func (r *Repository) Close(ctx context.Context) error {
 		return errors.Wrap(err, "error flushing")
 	}
 
+	if err := r.Objects.Close(); err != nil {
+		return errors.Wrap(err, "error closing object manager")
+	}
+
 	if err := r.Content.Close(ctx); err != nil {
 		return errors.Wrap(err, "error closing content-addressable storage manager")
 	}

--- a/tests/stress_test/stress_test.go
+++ b/tests/stress_test/stress_test.go
@@ -109,6 +109,11 @@ func stressWorker(ctx context.Context, t *testing.T, deadline time.Time, openMgr
 				return
 			}
 
+			if cerr := bm.Close(ctx); cerr != nil {
+				t.Errorf("close error: %v", cerr)
+				return
+			}
+
 			bm, err = openMgr()
 			if err != nil {
 				t.Errorf("error opening: %v", err)


### PR DESCRIPTION
content manager:

Previously we would store special field Payload for contents
that were added but never flushed to the store and it was not
encrypted. This required special handling different for pending
vs flushed contents.

This change maintains pending pack buffer ready to be flushed
and appends encrypted contents to it, which avoids data copying.
The buffers are pooled to avoid allocations.

This change also introduces 'buf.Pool', which allows efficient management of ephemeral in-memory buffer using multiple buffers.

## Impact of this PR:

```
10 GB: 10 dirs x 10 files x 100 mb each:

before: time=50.152      cpu=372.200      memory=824.699     vmem=5841.207
after:  time=45.133      cpu=200.400      memory=725.645     vmem=5659.527

10 GB: 10 dirs x 10000 files x 100 kb each:

before: time=43.130      cpu=545.600      memory=656.676     vmem=5724.605
after:  time=43.108      cpu=603.400      memory=407.422     vmem=5392.953

100 MB: 100 directories x 10000 files x 100 bytes each:

before: time=108.431     cpu=149.100      memory=834.781     vmem=5825.094
after:  time=54.108      cpu=100.000      memory=696.168    vmem= 5747.988
```

Fixes #125
Fixes #93 