### PR TITLE
Kopia 0.5.1 hotfix release

### DIFF
--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -384,10 +384,15 @@ func (bm *lockFreeManager) encryptAndWriteContentNotLocked(ctx context.Context, 
 	hash := bm.hashData(data)
 	blobID := prefix + blob.ID(hex.EncodeToString(hash))
 
+	iv, err := getIndexBlobIV(blobID)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to get IV from index blob")
+	}
+
 	// Encrypt the content in-place.
 	atomic.AddInt64(&bm.stats.EncryptedBytes, int64(len(data)))
 
-	data2, err := bm.encryptor.Encrypt(data, hash)
+	data2, err := bm.encryptor.Encrypt(data, iv)
 	if err != nil {
 		return "", err
 	}

--- a/tests/end_to_end_test/all_formats_test.go
+++ b/tests/end_to_end_test/all_formats_test.go
@@ -1,0 +1,45 @@
+package endtoend_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/repo/encryption"
+	"github.com/kopia/kopia/repo/hashing"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestAllFormatsSmokeTest(t *testing.T) {
+	for _, encryptionAlgo := range encryption.SupportedAlgorithms(false) {
+		encryptionAlgo := encryptionAlgo
+
+		t.Run(encryptionAlgo, func(t *testing.T) {
+			for _, hashAlgo := range hashing.SupportedAlgorithms() {
+
+				hashAlgo := hashAlgo
+				t.Run(hashAlgo, func(t *testing.T) {
+					t.Parallel()
+
+					e := testenv.NewCLITest(t)
+					defer e.Cleanup(t)
+					defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+					e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--block-hash", hashAlgo, "--encryption", encryptionAlgo)
+					e.RunAndExpectSuccess(t, "snap", "create", sharedTestDataDir1)
+
+					sources := e.ListSnapshotsAndExpectSuccess(t)
+					if got, want := len(sources), 1; got != want {
+						t.Errorf("unexpected number of sources: %v, want %v in %#v", got, want, sources)
+					}
+
+					e.RunAndExpectSuccess(t, "repo", "disconnect")
+					e.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", e.RepoDir)
+
+					sources = e.ListSnapshotsAndExpectSuccess(t)
+					if got, want := len(sources), 1; got != want {
+						t.Errorf("unexpected number of sources: %v, want %v in %#v", got, want, sources)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Quick fix for the issue found in 0.5.0 where hash algorithms that are not 128-bits cause corrupted index blobs (`n`) and repository will fail to open:

# To reproduce the problem:

```
$ export KOPIA_PASSWORD=foo
$ rm -rf /tmp/kopia-repo
$ mkdir /tmp/kopia-repo
# create repo using 256-bit hash
$ kopia-0.5.0 repo create filesystem --path /tmp/kopia-repo --block-hash=HMAC-SHA256
$ kopia-0.5.0 snapshot create ~/Projects/Kopia/repo
$ kopia-0.5.0 policy list
$ kopia-0.5.0 snapshot list
$ kopia-0.5.0 repo disconnect
# this fails
$ kopia-0.5.0 repo connect filesystem --path /tmp/kopia-repo
```

# To fix the repository created using 0.5.0:

1. Remove all `n` blobs from the storage. For example in case of the filesystem use `$ rm -rf /tmp/kopia-repo/n*`

2. The repository will connect now, we need to recover all indexes from pack blobs:

```
$ kopia-0.5.1 repo connect filesystem --path /tmp/kopia-repo
$ kopia-0.5.1 index recover --commit
$ kopia-0.5.1 snapshot list
```