### PR TITLE
cli: allow override of snapshot start time and end time

### DIFF
--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -2,6 +2,7 @@ package endtoend_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kopia/kopia/tests/testenv"
 )
@@ -35,4 +36,55 @@ func TestSnapshotCreate(t *testing.T) {
 	if got, want := len(sources), 3; got != want {
 		t.Errorf("unexpected number of sources: %v, want %v in %#v", got, want, sources)
 	}
+}
+
+func TestStartTimeOverride(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+	defer e.Cleanup(t)
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1, "--start-time", "2000-01-01 01:01:00 UTC")
+	sources := e.ListSnapshotsAndExpectSuccess(t)
+
+	gotTime := sources[0].Snapshots[0].Time
+	wantTime, _ := time.Parse("2006-01-02 15:04:05 MST", "2000-01-01 01:01:00 UTC")
+
+	if !gotTime.Equal(wantTime) {
+		t.Errorf("unexpected start time returned: %v, want %v in %#v", gotTime, wantTime, sources)
+	}
+
+	e.RunAndExpectFailure(t, "snapshot", "create", sharedTestDataDir1, "--start-time", "2000-01-01")
+}
+
+func TestEndTimeOverride(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+	defer e.Cleanup(t)
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1, "--end-time", "2000-01-01 01:01:00 UTC")
+	sources := e.ListSnapshotsAndExpectSuccess(t)
+
+	gotTime := sources[0].Snapshots[0].Time
+	wantTime, _ := time.Parse("2006-01-02 15:04:05 MST", "2000-01-01 01:01:00 UTC")
+
+	// If we set the end time then start time should be calculated to be <total snapshot time> seconds before it
+	if !gotTime.Before(wantTime) {
+		t.Errorf("end time unexpectedly before start time: %v, wanted before %v in %#v", gotTime, wantTime, sources)
+	}
+
+	e.RunAndExpectFailure(t, "snapshot", "create", sharedTestDataDir1, "--end-time", "2000-01-01")
+}
+
+func TestInvalidTimeOverride(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+	defer e.Cleanup(t)
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	e.RunAndExpectFailure(t, "snapshot", "create", sharedTestDataDir1, "--start-time", "2000-01-01 01:01:00 UTC", "--end-time", "1999-01-01 01:01:00 UTC")
 }


### PR DESCRIPTION
This PR introduces two new arguments `--start-time` and `--end-time` to the `kopia snapshot create' command` to override the start time and end the end time that the snapshot is created.

If the start time is specified but no end time is, then the end time will be set to the start time so it doesn't look like a backup ran for (potentially) years and vice-versa for end time specified without a start time.

Fixes #354 