### PR TITLE
content: added missing condition variable broadcast

### DIFF
--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -420,6 +420,9 @@ func (bm *Manager) Flush(ctx context.Context) error {
 
 	defer func() {
 		bm.flushing = false
+
+		// we finished flushing, notify goroutines that were waiting for it.
+		bm.cond.Broadcast()
 	}()
 
 	for len(bm.writingPacks) > 0 {


### PR DESCRIPTION
after finishing flushing, fixes timeouts on Travis

This started randomly failing on Travis after we switched to golang 1.14. Could it be that because of pre-emption changes we uncovered the bug that was previously being masked?