### PR TITLE
Add CLI option for disabling tls verification while connecting to s3

### DIFF
--- a/cli/storage_s3.go
+++ b/cli/storage_s3.go
@@ -24,6 +24,7 @@ func init() {
 			cmd.Flag("session-token", "Session token (overrides AWS_SESSION_TOKEN environment variable)").Envar("AWS_SESSION_TOKEN").StringVar(&s3options.SessionToken)
 			cmd.Flag("prefix", "Prefix to use for objects in the bucket").StringVar(&s3options.Prefix)
 			cmd.Flag("disable-tls", "Disable TLS security (HTTPS)").BoolVar(&s3options.DoNotUseTLS)
+			cmd.Flag("disable-tls-verification", "Disable TLS (HTTPS) certificate verification").BoolVar(&s3options.DoNotVerifyTLS)
 			cmd.Flag("max-download-speed", "Limit the download speed.").PlaceHolder("BYTES_PER_SEC").IntVar(&s3options.MaxDownloadSpeedBytesPerSecond)
 			cmd.Flag("max-upload-speed", "Limit the upload speed.").PlaceHolder("BYTES_PER_SEC").IntVar(&s3options.MaxUploadSpeedBytesPerSecond)
 		},

--- a/repo/blob/s3/s3_options.go
+++ b/repo/blob/s3/s3_options.go
@@ -8,8 +8,9 @@ type Options struct {
 	// Prefix specifies additional string to prepend to all objects.
 	Prefix string `json:"prefix,omitempty"`
 
-	Endpoint    string `json:"endpoint"`
-	DoNotUseTLS bool   `json:"doNotUseTLS,omitempty"`
+	Endpoint       string `json:"endpoint"`
+	DoNotUseTLS    bool   `json:"doNotUseTLS,omitempty"`
+	DoNotVerifyTLS bool   `json:"doNotVerifyTLS,omitempty"`
 
 	AccessKeyID     string `json:"accessKeyID"`
 	SecretAccessKey string `json:"secretAccessKey" kopia:"sensitive"`

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -227,6 +227,7 @@ func toBandwidth(bytesPerSecond int) iothrottler.Bandwidth {
 }
 
 func getCustomTransport(insecureSkipVerify bool) (transport *http.Transport) {
+	// nolint:gosec
 	customTransport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}}
 	return customTransport
 }

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -227,10 +227,7 @@ func toBandwidth(bytesPerSecond int) iothrottler.Bandwidth {
 }
 
 func getCustomTransport(insecureSkipVerify bool) (transport *http.Transport) {
-	customTransport := http.DefaultTransport.(*http.Transport).Clone()
-	// nolint:gosec
-	customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecureSkipVerify}
-
+	customTransport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}}
 	return customTransport
 }
 


### PR DESCRIPTION
Introduce a new CLI option for the kopia command. 
"kopia repistory connect s3 --bucket=`<bucket name>` --disable-tls-verification". 
This new option disables tls verification. 


Testing:
1. Manual tests for connecting to an s3 bucket worked. Snapshot creates, snapshot list, snapshot content commands worked.
2. Updated unit tests.



```
 % kopia repository connect s3 --bucket=onkar-kopia-s3-bucket --disable-tls-verification
Enter password to open repository: 

Connected to repository.

NOTICE: Kopia will check for updates on GitHub every 7 days, starting 24 hours after first use.
To disable this behavior, set environment variable KOPIA_CHECK_FOR_UPDATES=false
Alternatively you can remove the file "/Users/onkarbhat/Library/Application Support/kopia/repository.config.update-info.json".
```


```
% kopia snapshot list
onkarbhat@onkars-mbp:/Users/onkarbhat/kasten-workspace/kopia/kopia/kopia-test-dir
  2020-03-18 13:46:27 PDT k348ab6160c6b64d539c7499109802db5 284 B drwxr-xr-x files:3 dirs:1 (latest-4)
  + 1 identical snapshots until 2020-03-18 13:46:33 PDT
  2020-03-18 13:47:23 PDT k1ed9908f6e20c610f6ed24602ce8dda0 320 B drwxr-xr-x files:4 dirs:1 (latest-2)
  2020-03-18 13:50:06 PDT k385c308ea8023bb5e30569c6dd4a5b49 320 B drwxr-xr-x files:4 dirs:2 (latest-1,annual-1,monthly-1,weekly-1,daily-1,hourly-1)
```


```
% kopia snapshot create kopia-test-dir
Snapshotting onkarbhat@onkars-mbp:/Users/onkarbhat/kasten-workspace/kopia/kopia/kopia-test-dir ...
 * 0 hashing, 0 hashed (0 B), 4 cached (320 B), 2 uploaded (4.3 KB) 100.0%
Created snapshot with root k385c308ea8023bb5e30569c6dd4a5b49 and ID 10931ab1e0dd605bf95fed667aafdcba in 0s
```