### PR TITLE
Support for gather writes, where blob.Storage.PutBlob gets a list of slices and writes them sequentially

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,7 @@ ifneq ($(uname),Windows)
 	             -e github.com/kopia/kopia/internal/buf \
 	             -e github.com/kopia/kopia/internal/throttle \
 	             -e github.com/kopia/kopia/internal/iocopy \
+	             -e github.com/kopia/kopia/internal/gather \
 	             -e github.com/kopia/kopia/internal/blobtesting \
 	             -e github.com/kopia/kopia/internal/repotesting \
 	             -e github.com/kopia/kopia/internal/testlogging \

--- a/cli/command_repository_repair.go
+++ b/cli/command_repository_repair.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
@@ -66,7 +67,7 @@ func recoverFormatBlob(ctx context.Context, st blob.Storage, prefixes []string) 
 			log(ctx).Infof("looking for replica of format blob in %v...", bi.BlobID)
 			if b, err := repo.RecoverFormatBlob(ctx, st, bi.BlobID, bi.Length); err == nil {
 				if !*repairDryDrun {
-					if puterr := st.PutBlob(ctx, repo.FormatBlobID, b); puterr != nil {
+					if puterr := st.PutBlob(ctx, repo.FormatBlobID, gather.FromSlice(b)); puterr != nil {
 						return puterr
 					}
 				}

--- a/internal/blobtesting/concurrent.go
+++ b/internal/blobtesting/concurrent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -87,7 +88,7 @@ func VerifyConcurrentAccess(t testingT, st blob.Storage, options ConcurrentAcces
 			for i := 0; i < options.Iterations; i++ {
 				blobID := randomBlobID()
 				data := fmt.Sprintf("%v-%v", blobID, rand.Int63())
-				err := st.PutBlob(ctx, blobID, []byte(data))
+				err := st.PutBlob(ctx, blobID, gather.FromSlice([]byte(data)))
 				switch err {
 				case nil:
 					// clean success

--- a/internal/blobtesting/faulty.go
+++ b/internal/blobtesting/faulty.go
@@ -38,8 +38,8 @@ func (s *FaultyStorage) GetBlob(ctx context.Context, id blob.ID, offset, length 
 }
 
 // PutBlob implements blob.Storage
-func (s *FaultyStorage) PutBlob(ctx context.Context, id blob.ID, data []byte) error {
-	if err := s.getNextFault(ctx, "PutBlob", id, len(data)); err != nil {
+func (s *FaultyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
+	if err := s.getNextFault(ctx, "PutBlob", id); err != nil {
 		return err
 	}
 

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -1,6 +1,7 @@
 package blobtesting
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"sort"
@@ -48,7 +49,7 @@ func (s *mapStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int
 	return nil, blob.ErrBlobNotFound
 }
 
-func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data []byte) error {
+func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -58,7 +59,11 @@ func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data []byte) error
 
 	s.keyTime[id] = s.timeNow()
 
-	s.data[id] = append([]byte{}, data...)
+	var b bytes.Buffer
+
+	data.WriteTo(&b) //nolint:errcheck
+
+	s.data[id] = b.Bytes()
 
 	return nil
 }

--- a/internal/blobtesting/verify.go
+++ b/internal/blobtesting/verify.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -30,7 +31,7 @@ func VerifyStorage(ctx context.Context, t testingT, r blob.Storage) {
 
 	// Now add blocks.
 	for _, b := range blocks {
-		if err := r.PutBlob(ctx, b.blk, b.contents); err != nil {
+		if err := r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents)); err != nil {
 			t.Errorf("can't put blob: %v", err)
 		}
 
@@ -42,7 +43,7 @@ func VerifyStorage(ctx context.Context, t testingT, r blob.Storage) {
 
 	// Overwrite blocks.
 	for _, b := range blocks {
-		if err := r.PutBlob(ctx, b.blk, b.contents); err != nil {
+		if err := r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents)); err != nil {
 			t.Errorf("can't put blob: %v", err)
 		}
 

--- a/internal/gather/gather_bytes.go
+++ b/internal/gather/gather_bytes.go
@@ -1,0 +1,133 @@
+// Package gather implements data structures storing binary data organized
+// in a series of byte slices of fixed size that only gathered together by the user.
+package gather
+
+import (
+	"bytes"
+	"io"
+)
+
+// Bytes represents a sequence of bytes split into slices.
+type Bytes struct {
+	Slices [][]byte
+
+	// for common case where there's one slice, store the slice itself here
+	// to avoid allocation
+	sliceBuf [1][]byte
+}
+
+// GetSection appends the section of the buffer to the provided slice and returns it.
+func (b *Bytes) GetSection(output []byte, offset, size int) []byte {
+	// find the index of starting slice
+	sliceNdx := -1
+
+	for i, p := range b.Slices {
+		if offset < len(p) {
+			sliceNdx = i
+			break
+		}
+
+		offset -= len(p)
+	}
+
+	// not found
+	if sliceNdx == -1 {
+		return nil
+	}
+
+	// first slice, possibly with offset zero
+	var firstChunkSize int
+	if offset+size <= len(b.Slices[sliceNdx]) {
+		firstChunkSize = size
+	} else {
+		// slice shorter
+		firstChunkSize = len(b.Slices[sliceNdx]) - offset
+	}
+
+	output = append(output, b.Slices[sliceNdx][offset:offset+firstChunkSize]...)
+	size -= firstChunkSize
+	sliceNdx++
+
+	// at this point we're staying at offset 0
+	for size > 0 && sliceNdx < len(b.Slices) {
+		s := b.Slices[sliceNdx]
+
+		// l is how many bytes we consume out of the current slice
+		l := size
+		if l > len(s) {
+			l = len(s)
+		}
+
+		output = append(output, s[0:l]...)
+		size -= l
+		sliceNdx++
+	}
+
+	return output
+}
+
+// Length returns the combined length of all slices.
+func (b Bytes) Length() int {
+	l := 0
+
+	for _, data := range b.Slices {
+		l += len(data)
+	}
+
+	return l
+}
+
+// Reader returns a reader for the data.
+func (b Bytes) Reader() io.Reader {
+	switch len(b.Slices) {
+	case 0:
+		return bytes.NewReader(nil)
+
+	case 1:
+		return bytes.NewReader(b.Slices[0])
+
+	default:
+		readers := make([]io.Reader, 0, len(b.Slices))
+
+		for _, v := range b.Slices {
+			readers = append(readers, bytes.NewReader(v))
+		}
+
+		return io.MultiReader(readers...)
+	}
+}
+
+// GetBytes appends all bytes to the provided slice and returns it.
+func (b Bytes) GetBytes(output []byte) []byte {
+	for _, v := range b.Slices {
+		output = append(output, v...)
+	}
+
+	return output
+}
+
+// WriteTo writes contents to the specified writer and returns number of bytes written.
+func (b Bytes) WriteTo(w io.Writer) (int64, error) {
+	var totalN int64
+
+	for _, v := range b.Slices {
+		n, err := w.Write(v)
+
+		totalN += int64(n)
+
+		if err != nil {
+			return totalN, err
+		}
+	}
+
+	return totalN, nil
+}
+
+// FromSlice creates Bytes from the specified slice.
+func FromSlice(b []byte) Bytes {
+	var r Bytes
+	r.sliceBuf[0] = b
+	r.Slices = r.sliceBuf[:]
+
+	return r
+}

--- a/internal/gather/gather_bytes.go
+++ b/internal/gather/gather_bytes.go
@@ -16,8 +16,8 @@ type Bytes struct {
 	sliceBuf [1][]byte
 }
 
-// GetSection appends the section of the buffer to the provided slice and returns it.
-func (b *Bytes) GetSection(output []byte, offset, size int) []byte {
+// AppendSectionTo appends the section of the buffer to the provided slice and returns it.
+func (b *Bytes) AppendSectionTo(output []byte, offset, size int) []byte {
 	// find the index of starting slice
 	sliceNdx := -1
 

--- a/internal/gather/gather_bytes_test.go
+++ b/internal/gather/gather_bytes_test.go
@@ -96,10 +96,10 @@ func TestGatherBytes(t *testing.T) {
 			t.Errorf("unexpected data from GetBytes() %v, want %v", string(all), string(tc.whole))
 		}
 
-		// GetSection - test exhaustively all combinationf os start, length
+		// AppendSectionTo - test exhaustively all combinationf os start, length
 		for i := 0; i <= len(tc.whole); i++ {
 			for j := i; j <= len(tc.whole); j++ {
-				result := b.GetSection(nil, i, j-i)
+				result := b.AppendSectionTo(nil, i, j-i)
 				if !bytes.Equal(result, tc.whole[i:j]) {
 					t.Fatalf("invalid section")
 				}

--- a/internal/gather/gather_bytes_test.go
+++ b/internal/gather/gather_bytes_test.go
@@ -1,0 +1,109 @@
+package gather
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+var sample1 = []byte("hello! how are you? nice to meet you.")
+
+func TestGatherBytes(t *testing.T) {
+	// split the 'whole' into equivalent Bytes slicings in some interesting ways
+	cases := []struct {
+		whole  []byte
+		sliced Bytes
+	}{
+		{
+			whole:  nil,
+			sliced: Bytes{},
+		},
+		{
+			whole: nil,
+			sliced: Bytes{Slices: [][]byte{
+				nil,
+			}},
+		},
+		{
+			whole: nil,
+			sliced: Bytes{Slices: [][]byte{
+				nil,
+				{},
+				nil,
+			}},
+		},
+		{
+			whole:  sample1,
+			sliced: FromSlice(sample1),
+		},
+		{
+			whole: sample1,
+			sliced: Bytes{Slices: [][]byte{
+				nil,
+				sample1,
+				nil,
+			}},
+		},
+		{
+			whole: sample1,
+			sliced: Bytes{Slices: [][]byte{
+				sample1[0:20],
+				sample1[20:],
+			}},
+		},
+		{
+			whole: sample1,
+			sliced: Bytes{Slices: [][]byte{
+				sample1[0:20],
+				nil, // zero-length
+				{},  // zero-length
+				sample1[20:],
+			}},
+		},
+		{
+			whole: sample1,
+			sliced: Bytes{Slices: [][]byte{
+				sample1[0:10],
+				sample1[10:25],
+				sample1[25:30],
+				sample1[30:31],
+				sample1[31:],
+			}},
+		},
+	}
+
+	for _, tc := range cases {
+		b := tc.sliced
+
+		// length
+		if got, want := b.Length(), len(tc.whole); got != want {
+			t.Errorf("unexpected length: %v, want %v", got, want)
+		}
+
+		// reader
+		all, err := ioutil.ReadAll(b.Reader())
+		if err != nil {
+			t.Errorf("unable to read: %v", err)
+		}
+
+		if !bytes.Equal(all, tc.whole) {
+			t.Errorf("unexpected data read %v, want %v", string(all), string(tc.whole))
+		}
+
+		// GetBytes
+		all = b.GetBytes(nil)
+		if !bytes.Equal(all, tc.whole) {
+			t.Errorf("unexpected data from GetBytes() %v, want %v", string(all), string(tc.whole))
+		}
+
+		// GetSection - test exhaustively all combinationf os start, length
+		for i := 0; i <= len(tc.whole); i++ {
+			for j := i; j <= len(tc.whole); j++ {
+				result := b.GetSection(nil, i, j-i)
+				if !bytes.Equal(result, tc.whole[i:j]) {
+					t.Fatalf("invalid section")
+				}
+			}
+		}
+	}
+}

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -21,8 +21,7 @@ func (b *WriteBuffer) Reset() {
 		releaseChunk(s)
 	}
 
-	b.sliceBuf[0] = allocChunk()
-	b.Slices = b.sliceBuf[0:1]
+	b.Slices = nil
 }
 
 // Write implements io.Writer for appending to the buffer.
@@ -60,8 +59,5 @@ func (b *WriteBuffer) Append(data []byte) {
 
 // NewWriteBuffer creates new write buffer.
 func NewWriteBuffer() *WriteBuffer {
-	b := &WriteBuffer{}
-	b.Reset()
-
-	return b
+	return &WriteBuffer{}
 }

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -1,0 +1,67 @@
+package gather
+
+// WriteBuffer is a write buffer for content of unknown size that manages
+// data in a series of byte slices of uniform size.
+type WriteBuffer struct {
+	Bytes
+}
+
+// Close releases all memory allocated by this buffer.
+func (b *WriteBuffer) Close() {
+	for _, s := range b.Slices {
+		releaseChunk(s)
+	}
+
+	b.Slices = nil
+}
+
+// Reset resets buffer back to empty.
+func (b *WriteBuffer) Reset() {
+	for _, s := range b.Slices {
+		releaseChunk(s)
+	}
+
+	b.sliceBuf[0] = allocChunk()
+	b.Slices = b.sliceBuf[0:1]
+}
+
+// Write implements io.Writer for appending to the buffer.
+func (b *WriteBuffer) Write(data []byte) (n int, err error) {
+	b.Append(data)
+	return len(data), nil
+}
+
+// Append appends the specified slice of bytes to the buffer.
+func (b *WriteBuffer) Append(data []byte) {
+	if len(b.Slices) == 0 {
+		b.sliceBuf[0] = allocChunk()
+		b.Slices = b.sliceBuf[0:1]
+	}
+
+	for len(data) > 0 {
+		ndx := len(b.Slices) - 1
+		remaining := cap(b.Slices[ndx]) - len(b.Slices[ndx])
+
+		if remaining == 0 {
+			b.Slices = append(b.Slices, allocChunk())
+			ndx = len(b.Slices) - 1
+			remaining = cap(b.Slices[ndx]) - len(b.Slices[ndx])
+		}
+
+		chunkSize := remaining
+		if chunkSize > len(data) {
+			chunkSize = len(data)
+		}
+
+		b.Slices[ndx] = append(b.Slices[ndx], data[0:chunkSize]...)
+		data = data[chunkSize:]
+	}
+}
+
+// NewWriteBuffer creates new write buffer.
+func NewWriteBuffer() *WriteBuffer {
+	b := &WriteBuffer{}
+	b.Reset()
+
+	return b
+}

--- a/internal/gather/gather_write_buffer_chunk.go
+++ b/internal/gather/gather_write_buffer_chunk.go
@@ -1,0 +1,42 @@
+package gather
+
+import (
+	"sync"
+)
+
+const chunkSize = 1 << 20 // 1MB chunks
+
+var (
+	freeListMutex         sync.Mutex
+	freeList              [][]byte
+	freeListHighWaterMark int
+)
+
+func allocChunk() []byte {
+	freeListMutex.Lock()
+	defer freeListMutex.Unlock()
+
+	l := len(freeList)
+	if l == 0 {
+		return make([]byte, 0, chunkSize)
+	}
+
+	ch := freeList[l-1]
+	freeList = freeList[0 : l-1]
+
+	return ch
+}
+
+func releaseChunk(s []byte) {
+	if cap(s) != chunkSize {
+		return
+	}
+
+	freeListMutex.Lock()
+	defer freeListMutex.Unlock()
+
+	freeList = append(freeList, s[:0])
+	if len(freeList) > freeListHighWaterMark {
+		freeListHighWaterMark = len(freeList)
+	}
+}

--- a/internal/gather/gather_write_buffer_chunk_test.go
+++ b/internal/gather/gather_write_buffer_chunk_test.go
@@ -1,0 +1,58 @@
+package gather
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWriteBufferChunk(t *testing.T) {
+	// reset for testing
+	freeList = nil
+	freeListHighWaterMark = 0
+
+	chunk1 := allocChunk()
+	_ = append(chunk1, []byte("chunk1")...)
+
+	if got, want := len(chunk1), 0; got != want {
+		t.Errorf("invalid chunk len: %v, want %v", got, want)
+	}
+
+	if got, want := cap(chunk1), chunkSize; got != want {
+		t.Errorf("invalid chunk cap: %v, want %v", got, want)
+	}
+
+	if got, want := freeListHighWaterMark, 0; got != want {
+		t.Errorf("unexpected high water mark %v, want %v", got, want)
+	}
+
+	chunk2 := allocChunk()
+	_ = append(chunk2, []byte("chunk2")...)
+
+	if got, want := freeListHighWaterMark, 0; got != want {
+		t.Errorf("unexpected high water mark %v, want %v", got, want)
+	}
+
+	releaseChunk(chunk2)
+
+	if got, want := freeListHighWaterMark, 1; got != want {
+		t.Errorf("unexpected high water mark %v, want %v", got, want)
+	}
+
+	releaseChunk(chunk1)
+
+	if got, want := freeListHighWaterMark, 2; got != want {
+		t.Errorf("unexpected high water mark %v, want %v", got, want)
+	}
+
+	// allocate chunk3 - make sure we got the same slice as chunk1 (LIFO)
+	chunk3 := allocChunk()
+	if got, want := chunk3[0:6], []byte("chunk1"); !bytes.Equal(got, want) {
+		t.Errorf("got wrong chunk data %q, want %q", string(got), string(want))
+	}
+
+	// allocate chunk4 - make sure we got the same slice as chunk1 (LIFO)
+	chunk4 := allocChunk()
+	if got, want := chunk4[0:6], []byte("chunk2"); !bytes.Equal(got, want) {
+		t.Errorf("got wrong chunk data %q, want %q", string(got), string(want))
+	}
+}

--- a/internal/gather/gather_write_buffer_test.go
+++ b/internal/gather/gather_write_buffer_test.go
@@ -1,0 +1,67 @@
+package gather
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestGatherWriteBuffer(t *testing.T) {
+	// reset for testing
+	freeList = nil
+	freeListHighWaterMark = 0
+
+	w := NewWriteBuffer()
+	defer w.Close()
+
+	w.Append([]byte("hello "))
+	fmt.Fprintf(w, "world!")
+
+	if got, want := w.GetBytes(nil), []byte("hello world!"); !bytes.Equal(got, want) {
+		t.Errorf("invaldi bytes %v, want %v", string(got), string(want))
+	}
+
+	if got, want := len(w.Slices), 1; got != want {
+		t.Errorf("invalid number of slices %v, want %v", got, want)
+	}
+
+	w.Append(bytes.Repeat([]byte("x"), chunkSize))
+
+	if got, want := w.Length(), chunkSize+12; got != want {
+		t.Errorf("invalid length: %v, want %v", got, want)
+	}
+
+	// one more slice was allocated
+	if got, want := len(w.Slices), 2; got != want {
+		t.Errorf("invalid number of slices %v, want %v", got, want)
+	}
+
+	// write to fill the remainder of 2nd slice
+	w.Append(bytes.Repeat([]byte("x"), chunkSize-12))
+
+	// still 2 slices
+	if got, want := len(w.Slices), 2; got != want {
+		t.Errorf("invalid number of slices %v, want %v", got, want)
+	}
+
+	// one more byte allocates new slice
+	w.Append([]byte("x"))
+
+	// still 3 slices
+	if got, want := len(w.Slices), 3; got != want {
+		t.Errorf("invalid number of slices %v, want %v", got, want)
+	}
+
+	w.Reset()
+}
+
+func TestGatherDefaultWriteBuffer(t *testing.T) {
+	var w WriteBuffer
+
+	// one more byte allocates new slice
+	w.Append([]byte("x"))
+
+	if got, want := len(w.Slices), 1; got != want {
+		t.Errorf("invalid number of slices %v, want %v", got, want)
+	}
+}

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -2,7 +2,6 @@
 package azure
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -105,11 +104,11 @@ func translateError(err error) error {
 	return err
 }
 
-func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data []byte) error {
+func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	throttled, err := az.uploadThrottler.AddReader(ioutil.NopCloser(bytes.NewReader(data)))
+	throttled, err := az.uploadThrottler.AddReader(ioutil.NopCloser(data.Reader()))
 	if err != nil {
 		return err
 	}

--- a/repo/blob/filesystem/filesystem_storage_test.go
+++ b/repo/blob/filesystem/filesystem_storage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 )
 
@@ -74,11 +75,11 @@ func TestFileStorageTouch(t *testing.T) {
 	}
 
 	fs := r.(*fsStorage)
-	assertNoError(t, fs.PutBlob(ctx, t1, []byte{1}))
+	assertNoError(t, fs.PutBlob(ctx, t1, gather.FromSlice([]byte{1})))
 	time.Sleep(1 * time.Second) // sleep a bit to accommodate Apple filesystems with low timestamp resolution
-	assertNoError(t, fs.PutBlob(ctx, t2, []byte{1}))
+	assertNoError(t, fs.PutBlob(ctx, t2, gather.FromSlice([]byte{1})))
 	time.Sleep(1 * time.Second)
-	assertNoError(t, fs.PutBlob(ctx, t3, []byte{1}))
+	assertNoError(t, fs.PutBlob(ctx, t3, gather.FromSlice([]byte{1})))
 
 	verifyBlobTimestampOrder(t, fs, t1, t2, t3)
 

--- a/repo/blob/logging/logging_storage.go
+++ b/repo/blob/logging/logging_storage.go
@@ -30,11 +30,11 @@ func (s *loggingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length
 	return result, err
 }
 
-func (s *loggingStorage) PutBlob(ctx context.Context, id blob.ID, data []byte) error {
+func (s *loggingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
 	t0 := time.Now()
 	err := s.base.PutBlob(ctx, id, data)
 	dt := time.Since(t0)
-	s.printf(s.prefix+"PutBlob(%q,len=%v)=%#v took %v", id, len(data), err, dt)
+	s.printf(s.prefix+"PutBlob(%q,len=%v)=%#v took %v", id, data.Length(), err, dt)
 
 	return err
 }

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -15,7 +15,7 @@ const minShardedBlobIDLength = 20
 // Impl must be implemented by underlying provided.
 type Impl interface {
 	GetBlobFromPath(ctx context.Context, dirPath, filePath string, offset, length int64) ([]byte, error)
-	PutBlobInPath(ctx context.Context, dirPath, filePath string, data []byte) error
+	PutBlobInPath(ctx context.Context, dirPath, filePath string, dataSlices blob.Bytes) error
 	DeleteBlobInPath(ctx context.Context, dirPath, filePath string) error
 	ReadDir(ctx context.Context, path string) ([]os.FileInfo, error)
 }
@@ -93,7 +93,7 @@ func (s Storage) ListBlobs(ctx context.Context, prefix blob.ID, callback func(bl
 }
 
 // PutBlob implements blob.Storage
-func (s Storage) PutBlob(ctx context.Context, blobID blob.ID, data []byte) error {
+func (s Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes) error {
 	dirPath, filePath := s.GetShardedPathAndFilePath(blobID)
 
 	return s.Impl.PutBlobInPath(ctx, dirPath, filePath, data)

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -2,12 +2,21 @@ package blob
 
 import (
 	"context"
+	"io"
 	"log"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
 )
+
+// Bytes encapsulates
+type Bytes interface {
+	io.WriterTo
+
+	Length() int
+	Reader() io.Reader
+}
 
 // Storage encapsulates API for connecting to blob storage.
 //
@@ -22,8 +31,8 @@ import (
 // The required semantics are provided by existing commercial cloud storage products (Google Cloud, AWS, Azure).
 type Storage interface {
 	// PutBlob uploads the blob with given data to the repository or replaces existing blob with the provided
-	// id with given contents.
-	PutBlob(ctx context.Context, blobID ID, data []byte) error
+	// id with contents gathered from the specified list of slices.
+	PutBlob(ctx context.Context, blobID ID, data Bytes) error
 
 	// DeleteBlob removes the blob from storage. Future Get() operations will fail with ErrNotFound.
 	DeleteBlob(ctx context.Context, blobID ID) error

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -10,7 +10,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Bytes encapsulates
+// Bytes encapsulates a sequence of bytes, possibly stored in a non-contiguous buffers,
+// which can be written sequentially or treated as a io.Reader.
 type Bytes interface {
 	io.WriterTo
 

--- a/repo/blob/storage_test.go
+++ b/repo/blob/storage_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -13,9 +14,9 @@ func TestListAllBlobsConsistent(t *testing.T) {
 	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, time.Now)
-	st.PutBlob(ctx, "foo1", []byte{1, 2, 3}) //nolint:errcheck
-	st.PutBlob(ctx, "foo2", []byte{1, 2, 3}) //nolint:errcheck
-	st.PutBlob(ctx, "foo3", []byte{1, 2, 3}) //nolint:errcheck
+	st.PutBlob(ctx, "foo1", gather.FromSlice([]byte{1, 2, 3})) //nolint:errcheck
+	st.PutBlob(ctx, "foo2", gather.FromSlice([]byte{1, 2, 3})) //nolint:errcheck
+	st.PutBlob(ctx, "foo3", gather.FromSlice([]byte{1, 2, 3})) //nolint:errcheck
 
 	// set up faulty storage that will add a blob while a scan is in progress.
 	f := &blobtesting.FaultyStorage{
@@ -23,7 +24,7 @@ func TestListAllBlobsConsistent(t *testing.T) {
 		Faults: map[string][]*blobtesting.Fault{
 			"ListBlobsItem": {
 				{ErrCallback: func() error {
-					st.PutBlob(ctx, "foo0", []byte{1, 2, 3}) //nolint:errcheck
+					st.PutBlob(ctx, "foo0", gather.FromSlice([]byte{1, 2, 3})) //nolint:errcheck
 					return nil
 				}},
 			},

--- a/repo/content/content_cache.go
+++ b/repo/content/content_cache.go
@@ -12,6 +12,7 @@ import (
 	"go.opencensus.io/stats"
 
 	"github.com/kopia/kopia/internal/ctxutil"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/hmac"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/filesystem"
@@ -87,7 +88,7 @@ func (c *contentCache) getContent(ctx context.Context, cacheKey cacheKey, blobID
 		if puterr := c.cacheStorage.PutBlob(
 			blob.WithUploadProgressCallback(ctx, nil),
 			blob.ID(cacheKey),
-			hmac.Append(b, c.hmacSecret),
+			gather.FromSlice(hmac.Append(b, c.hmacSecret)),
 		); puterr != nil {
 			stats.Record(ctx, metricContentCacheStoreErrors.M(1))
 			log(ctx).Warningf("unable to write cache item %v: %v", cacheKey, puterr)

--- a/repo/content/content_cache_test.go
+++ b/repo/content/content_cache_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -22,8 +23,8 @@ func newUnderlyingStorageForContentCacheTesting(t *testing.T) blob.Storage {
 	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, nil)
-	assertNoError(t, st.PutBlob(ctx, "content-1", []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
-	assertNoError(t, st.PutBlob(ctx, "content-4k", bytes.Repeat([]byte{1, 2, 3, 4}, 1000))) // 4000 bytes
+	assertNoError(t, st.PutBlob(ctx, "content-1", gather.FromSlice([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})))
+	assertNoError(t, st.PutBlob(ctx, "content-4k", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3, 4}, 1000)))) // 4000 bytes
 
 	return st
 }
@@ -166,7 +167,7 @@ func verifyContentCache(t *testing.T, cache *contentCache) {
 		// corrupt the data and write back
 		d[0] ^= 1
 
-		if puterr := cache.cacheStorage.PutBlob(ctx, cacheKey, d); puterr != nil {
+		if puterr := cache.cacheStorage.PutBlob(ctx, cacheKey, gather.FromSlice(d)); puterr != nil {
 			t.Fatalf("unable to write corrupted content: %v", puterr)
 		}
 

--- a/repo/content/content_index_recovery.go
+++ b/repo/content/content_index_recovery.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -166,9 +167,9 @@ func (bm *lockFreeManager) buildLocalIndex(pending packIndexBuilder) ([]byte, er
 }
 
 // writePackFileIndexRecoveryData appends data designed to help with recovery of pack index in case it gets damaged or lost.
-func (bm *lockFreeManager) writePackFileIndexRecoveryData(buf *bytes.Buffer, pending packIndexBuilder) error {
+func (bm *lockFreeManager) writePackFileIndexRecoveryData(buf *gather.WriteBuffer, pending packIndexBuilder) error {
 	// build, encrypt and append local index
-	localIndexOffset := buf.Len()
+	localIndexOffset := buf.Length()
 
 	localIndex, err := bm.buildLocalIndex(pending)
 	if err != nil {
@@ -188,14 +189,14 @@ func (bm *lockFreeManager) writePackFileIndexRecoveryData(buf *bytes.Buffer, pen
 		localIndexLength: uint32(len(encryptedLocalIndex)),
 	}
 
-	writeToBuffer(buf, encryptedLocalIndex)
+	buf.Append(encryptedLocalIndex)
 
 	postambleBytes, err := postamble.toBytes()
 	if err != nil {
 		return err
 	}
 
-	writeToBuffer(buf, postambleBytes)
+	buf.Append(postambleBytes)
 
 	return nil
 }

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -227,7 +227,7 @@ func (bm *lockFreeManager) getContentDataUnlocked(ctx context.Context, pp *pendi
 	var payload []byte
 
 	if pp != nil && pp.packBlobID == bi.PackBlobID {
-		payload = pp.currentPackData.GetSection(nil, int(bi.PackOffset), int(bi.Length))
+		payload = pp.currentPackData.AppendSectionTo(nil, int(bi.PackOffset), int(bi.Length))
 	} else {
 		var err error
 

--- a/repo/format_block.go
+++ b/repo/format_block.go
@@ -1,7 +1,6 @@
 package repo
 
 import (
-	"bytes"
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -155,15 +155,15 @@ func verifyFormatBlobChecksum(b []byte) ([]byte, bool) {
 }
 
 func writeFormatBlob(ctx context.Context, st blob.Storage, f *formatBlob) error {
-	var buf bytes.Buffer
-	e := json.NewEncoder(&buf)
+	buf := gather.NewWriteBuffer()
+	e := json.NewEncoder(buf)
 	e.SetIndent("", "  ")
 
 	if err := e.Encode(f); err != nil {
 		return errors.Wrap(err, "unable to marshal format blob")
 	}
 
-	if err := st.PutBlob(ctx, FormatBlobID, buf.Bytes()); err != nil {
+	if err := st.PutBlob(ctx, FormatBlobID, buf.Bytes); err != nil {
 		return errors.Wrap(err, "unable to write format blob")
 	}
 

--- a/repo/format_block_test.go
+++ b/repo/format_block_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -26,19 +27,19 @@ func TestFormatBlobRecovery(t *testing.T) {
 		t.Errorf("unexpected checksummed length: %v, want %v", got, want)
 	}
 
-	assertNoError(t, st.PutBlob(ctx, "some-blob-by-itself", checksummed))
-	assertNoError(t, st.PutBlob(ctx, "some-blob-suffix", append(append([]byte(nil), 1, 2, 3), checksummed...)))
-	assertNoError(t, st.PutBlob(ctx, "some-blob-prefix", append(append([]byte(nil), checksummed...), 1, 2, 3)))
+	assertNoError(t, st.PutBlob(ctx, "some-blob-by-itself", gather.FromSlice(checksummed)))
+	assertNoError(t, st.PutBlob(ctx, "some-blob-suffix", gather.FromSlice(append(append([]byte(nil), 1, 2, 3), checksummed...))))
+	assertNoError(t, st.PutBlob(ctx, "some-blob-prefix", gather.FromSlice(append(append([]byte(nil), checksummed...), 1, 2, 3))))
 
 	// mess up checksum
 	checksummed[len(checksummed)-3] ^= 1
-	assertNoError(t, st.PutBlob(ctx, "bad-checksum", checksummed))
-	assertNoError(t, st.PutBlob(ctx, "zero-len", []byte{}))
-	assertNoError(t, st.PutBlob(ctx, "one-len", []byte{1}))
-	assertNoError(t, st.PutBlob(ctx, "two-len", []byte{1, 2}))
-	assertNoError(t, st.PutBlob(ctx, "three-len", []byte{1, 2, 3}))
-	assertNoError(t, st.PutBlob(ctx, "four-len", []byte{1, 2, 3, 4}))
-	assertNoError(t, st.PutBlob(ctx, "five-len", []byte{1, 2, 3, 4, 5}))
+	assertNoError(t, st.PutBlob(ctx, "bad-checksum", gather.FromSlice(checksummed)))
+	assertNoError(t, st.PutBlob(ctx, "zero-len", gather.FromSlice([]byte{})))
+	assertNoError(t, st.PutBlob(ctx, "one-len", gather.FromSlice([]byte{1})))
+	assertNoError(t, st.PutBlob(ctx, "two-len", gather.FromSlice([]byte{1, 2})))
+	assertNoError(t, st.PutBlob(ctx, "three-len", gather.FromSlice([]byte{1, 2, 3})))
+	assertNoError(t, st.PutBlob(ctx, "four-len", gather.FromSlice([]byte{1, 2, 3, 4})))
+	assertNoError(t, st.PutBlob(ctx, "five-len", gather.FromSlice([]byte{1, 2, 3, 4, 5})))
 
 	cases := []struct {
 		blobID blob.ID


### PR DESCRIPTION
This amortizes memory allocations when assembling content packs.

This PR only optimizes code paths critical to snapshot creations.