### PR TITLE
Policy set: fix nil pointer dereference #385

### DIFF
--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -82,6 +82,7 @@ func setPolicy(ctx context.Context, rep *repo.Repository) error {
 
 	for _, target := range targets {
 		p, err := policy.GetDefinedPolicy(ctx, rep, target)
+
 		switch {
 		case err == policy.ErrPolicyNotFound:
 			p = &policy.Policy{}

--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -82,8 +82,11 @@ func setPolicy(ctx context.Context, rep *repo.Repository) error {
 
 	for _, target := range targets {
 		p, err := policy.GetDefinedPolicy(ctx, rep, target)
-		if err == policy.ErrPolicyNotFound {
+		switch {
+		case err == policy.ErrPolicyNotFound:
 			p = &policy.Policy{}
+		case err != nil:
+			return errors.Wrap(err, "could not get defined policy")
 		}
 
 		printStderr("Setting policy for %v\n", target)


### PR DESCRIPTION
Fix panic in #385. Only one error type is currently being checked, `policy.ErrPolicyNotFound`. Other errors are allowing execution to continue with the policy set to nil. Instead the error should be returned.