### PR TITLE
policy: deduplicate multiple policies for the same source

### DIFF
--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -123,6 +123,16 @@ func (e *Environment) MustReopen(t *testing.T) {
 	}
 }
 
+// MustOpenAnother opens another repository backend by the same storage.
+func (e *Environment) MustOpenAnother(t *testing.T) *repo.Repository {
+	rep2, err := repo.Open(testlogging.Context(t), e.configFile(), masterPassword, &repo.Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	return rep2
+}
+
 // VerifyBlobCount verifies that the underlying storage contains the specified number of blobs.
 func (e *Environment) VerifyBlobCount(t *testing.T, want int) {
 	var got int

--- a/snapshot/policy/policy_manager_test.go
+++ b/snapshot/policy/policy_manager_test.go
@@ -1,0 +1,52 @@
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kopia/kopia/internal/repotesting"
+)
+
+func TestPolicyManager(t *testing.T) {
+	ctx := context.Background()
+
+	var env repotesting.Environment
+
+	defer env.Setup(t).Close(ctx, t)
+
+	r1 := env.Repository
+	r2 := env.MustOpenAnother(t)
+	sourceInfo := GlobalPolicySourceInfo
+
+	must(t, SetPolicy(ctx, r1, sourceInfo, &Policy{
+		RetentionPolicy: RetentionPolicy{
+			KeepDaily: intPtr(44),
+		},
+	}))
+
+	must(t, SetPolicy(ctx, r2, sourceInfo, &Policy{
+		RetentionPolicy: RetentionPolicy{
+			KeepDaily: intPtr(33),
+		},
+	}))
+
+	must(t, r1.Flush(ctx))
+	must(t, r2.Flush(ctx))
+
+	r3 := env.MustOpenAnother(t)
+
+	pi, err := GetDefinedPolicy(ctx, r3, sourceInfo)
+	must(t, err)
+
+	if got := *pi.RetentionPolicy.KeepDaily; got != 33 && got != 44 {
+		t.Errorf("unexpected policy returned")
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
 in policy manager, fixes #391