### PR TITLE
B2

### DIFF
--- a/cli/storage_b2.go
+++ b/cli/storage_b2.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"context"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/b2"
+)
+
+func init() {
+	var b2options b2.Options
+
+	RegisterStorageConnectFlags(
+		"b2",
+		"a b2 bucket",
+		func(cmd *kingpin.CmdClause) {
+			cmd.Flag("bucket", "Name of the B2 bucket").Required().StringVar(&b2options.BucketName)
+			cmd.Flag("key-id", "Key ID (overrides B2_KEY_ID environment variable)").Required().Envar("B2_KEY_ID").StringVar(&b2options.KeyID)
+			cmd.Flag("key", "Secret key (overrides B2_KEY environment variable)").Required().Envar("B2_KEY").StringVar(&b2options.Key)
+			cmd.Flag("prefix", "Prefix to use for objects in the bucket").StringVar(&b2options.Prefix)
+			cmd.Flag("max-download-speed", "Limit the download speed.").PlaceHolder("BYTES_PER_SEC").IntVar(&b2options.MaxDownloadSpeedBytesPerSecond)
+			cmd.Flag("max-upload-speed", "Limit the upload speed.").PlaceHolder("BYTES_PER_SEC").IntVar(&b2options.MaxUploadSpeedBytesPerSecond)
+		},
+		func(ctx context.Context, isNew bool) (blob.Storage, error) {
+			return b2.New(ctx, &b2options)
+		},
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/golang/protobuf v1.3.5
 	github.com/google/fswalker v0.2.0
+	github.com/google/readahead v0.0.0-20161222183148-eaceba169032 // indirect
 	github.com/google/wire v0.4.0 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/klauspost/compress v1.10.3
@@ -32,6 +33,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/profile v1.4.0
 	github.com/pkg/sftp v1.11.0
+	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 // indirect
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/procfs v0.0.10 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
@@ -52,4 +54,5 @@ require (
 	google.golang.org/grpc v1.28.0 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/ini.v1 v1.55.0 // indirect
+	gopkg.in/kothar/go-backblaze.v0 v0.0.0-20191215213626-7594ed38700f
 )

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,8 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/readahead v0.0.0-20161222183148-eaceba169032 h1:6Be3nkuJFyRfCgr6qTIzmRp8y9QwDIbqy/nYr9WDPos=
+github.com/google/readahead v0.0.0-20161222183148-eaceba169032/go.mod h1:qYysrqQXuV4tzsizt4oOQ6mrBZQ0xnQXP3ylXX8Jk5Y=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
@@ -313,6 +315,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kurin/blazer v0.5.4-0.20190613185654-cf2f27cc0be3 h1:1sl2HmNtqGnDuydLgCJwZIpDLGqZOdwOkcY8WtUl8Cw=
 github.com/kurin/blazer v0.5.4-0.20190613185654-cf2f27cc0be3/go.mod h1:4FCXMUWo9DllR2Do4TtBd377ezyAJ51vB5uTBjt0pGU=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
@@ -412,6 +415,8 @@ github.com/pkg/sftp v1.11.0/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
+github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 h1:D+CiwcpGTW6pL6bv6KI3KbyEyCKyS+1JWS2h8PNDnGA=
@@ -771,6 +776,8 @@ gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eR
 gopkg.in/jcmturner/goidentity.v3 v3.0.0/go.mod h1:oG2kH0IvSYNIu80dVAyu/yoefjq1mNfM5bm88whjWx4=
 gopkg.in/jcmturner/gokrb5.v7 v7.2.3/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
+gopkg.in/kothar/go-backblaze.v0 v0.0.0-20191215213626-7594ed38700f h1:cdE1ou7PeL03MZZ6il83rIcDcK4pDKIccnreJGpztxQ=
+gopkg.in/kothar/go-backblaze.v0 v0.0.0-20191215213626-7594ed38700f/go.mod h1:zJ2QpyDCYo1KvLXlmdnFlQAyF/Qfth0fB8239Qg7BIE=
 gopkg.in/ldap.v3 v3.0.3/go.mod h1:oxD7NyBuxchC+SgJDE1Q5Od05eGt29SDQVBmV+HYbzw=
 gopkg.in/olivere/elastic.v5 v5.0.80/go.mod h1:uhHoB4o3bvX5sorxBU29rPcmBQdV2Qfg0FBrx5D6pV0=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=

--- a/htmlui/src/SetupB2.js
+++ b/htmlui/src/SetupB2.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import Form from 'react-bootstrap/Form';
+import { handleChange, OptionalField, RequiredField, validateRequiredFields } from './forms';
+
+export class SetupB2 extends Component {
+    constructor() {
+        super();
+
+        this.state = {};
+        this.handleChange = handleChange.bind(this);
+    }
+
+    validate() {
+        return validateRequiredFields(this, ["bucket", "keyId", "key"])
+    }
+
+    render() {
+        return <>
+            <Form.Row>
+                {RequiredField(this, "B2 Bucket", "bucket", { placeholder: "enter bucket name" })}
+            </Form.Row>
+            <Form.Row>
+                {RequiredField(this, "Key ID", "keyId", { placeholder: "enter application or account key ID" })}
+                {RequiredField(this, "Key", "key", { placeholder: "enter secret application or account key", type: "password" })}
+            </Form.Row>
+            <Form.Row>
+                {OptionalField(this, "Object Name Prefix", "prefix", { placeholder: "enter object name prefix or leave empty", type: "password" })}
+            </Form.Row>
+        </>;
+    }
+}

--- a/htmlui/src/SetupRepository.js
+++ b/htmlui/src/SetupRepository.js
@@ -8,6 +8,7 @@ import { handleChange, RequiredField, validateRequiredFields } from './forms';
 import { SetupFilesystem } from './SetupFilesystem';
 import { SetupGCS } from './SetupGCS';
 import { SetupS3 } from './SetupS3';
+import { SetupB2 } from "./SetupB2";
 import { SetupAzure } from './SetupAzure';
 import { SetupSFTP } from './SetupSFTP';
 import { SetupToken } from './SetupToken';
@@ -17,11 +18,12 @@ const supportedProviders = [
     { provider: "filesystem", description: "Filesystem", component: SetupFilesystem },
     { provider: "gcs", description: "Google Cloud Storage", component: SetupGCS },
     { provider: "s3", description: "Amazon S3, Minio, Wasabi, etc.", component: SetupS3 },
+    { provider: "b2", description: "Backblaze B2", component: SetupB2 },
     { provider: "azureBlob", description: "Azure Blob Storage", component: SetupAzure },
     { provider: "sftp", description: "SFTP server", component: SetupSFTP },
     { provider: "webdav", description: "WebDAV server", component: SetupWebDAV },
     { provider: "_token", description: "(use token)", component: SetupToken },
-]
+];
 
 export class SetupRepository extends Component {
     constructor() {
@@ -53,7 +55,7 @@ export class SetupRepository extends Component {
     validate() {
         const ed = this.optionsEditor.current;
 
-        let valid = true
+        let valid = true;
 
         if (this.state.provider !== "_token") {
             if (!validateRequiredFields(this, ["password"])) {
@@ -104,7 +106,7 @@ export class SetupRepository extends Component {
                     splitter: this.state.splitter,
                 },
             },
-        }
+        };
 
         axios.post('/api/v1/repo/create', request).then(result => {
             window.location.replace("/");

--- a/repo/blob/b2/b2_options.go
+++ b/repo/blob/b2/b2_options.go
@@ -1,0 +1,16 @@
+package b2
+
+// Options defines options for B2-based storage.
+type Options struct {
+	// BucketName is the name of the bucket where data is stored.
+	BucketName string `json:"bucket"`
+
+	// Prefix specifies additional string to prepend to all objects.
+	Prefix string `json:"prefix,omitempty"`
+
+	KeyID string `json:"keyID"`
+	Key   string `json:"key" kopia:"sensitive"`
+
+	MaxUploadSpeedBytesPerSecond   int `json:"maxUploadSpeedBytesPerSecond,omitempty"`
+	MaxDownloadSpeedBytesPerSecond int `json:"maxDownloadSpeedBytesPerSecond,omitempty"`
+}

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -1,0 +1,258 @@
+// Package b2 implements Storage based on an Backblaze B2 bucket.
+package b2
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/efarrer/iothrottler"
+	"github.com/pkg/errors"
+	"gopkg.in/kothar/go-backblaze.v0"
+
+	"github.com/kopia/kopia/internal/retry"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+const (
+	b2storageType = "b2"
+)
+
+type b2Storage struct {
+	Options
+
+	ctx context.Context
+
+	cli    *backblaze.B2
+	bucket *backblaze.Bucket
+
+	downloadThrottler *iothrottler.IOThrottlerPool
+	uploadThrottler   *iothrottler.IOThrottlerPool
+}
+
+func (s *b2Storage) GetBlob(ctx context.Context, id blob.ID, offset, length int64) ([]byte, error) {
+	fileName := s.getObjectNameString(id)
+
+	attempt := func() (interface{}, error) {
+		var fileRange *backblaze.FileRange
+
+		if length > 0 {
+			fileRange = &backblaze.FileRange{
+				Start: offset,
+				End:   offset + length - 1,
+			}
+		}
+
+		_, r, err := s.bucket.DownloadFileRangeByName(fileName, fileRange)
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close() //nolint:errcheck
+
+		throttled, err := s.downloadThrottler.AddReader(r)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err := ioutil.ReadAll(throttled)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(b) != int(length) && length > 0 {
+			return nil, errors.Errorf("invalid length, got %v bytes, but expected %v", len(b), length)
+		}
+
+		if length == 0 {
+			return []byte{}, nil
+		}
+
+		return b, nil
+	}
+
+	v, err := exponentialBackoff(ctx, fmt.Sprintf("GetBlob(%q,%v,%v)", id, offset, length), attempt)
+	if err != nil {
+		return nil, translateError(err)
+	}
+
+	return v.([]byte), nil
+}
+
+func translateError(err error) error {
+	if b2err, ok := err.(*backblaze.B2Error); ok {
+		if b2err.Status == http.StatusNotFound {
+			// Normal "not found". That's fine.
+			return blob.ErrBlobNotFound
+		}
+
+		if b2err.Status == http.StatusBadRequest && b2err.Code == "already_hidden" {
+			// Special case when hiding a file that is already hidden. It's basically
+			// not found.
+			return blob.ErrBlobNotFound
+		}
+	}
+
+	return err
+}
+
+func exponentialBackoff(ctx context.Context, desc string, att retry.AttemptFunc) (interface{}, error) {
+	return retry.WithExponentialBackoff(ctx, desc, att, isRetriableError)
+}
+
+func isRetriableError(err error) bool {
+	if b2err, ok := err.(*backblaze.B2Error); ok {
+		switch b2err.Status {
+		case http.StatusRequestTimeout:
+			return true
+		case http.StatusTooManyRequests:
+			return true
+		case http.StatusInternalServerError:
+			return true
+		case http.StatusServiceUnavailable:
+			return true
+		case http.StatusGatewayTimeout:
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *b2Storage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
+	throttled, err := s.uploadThrottler.AddReader(ioutil.NopCloser(data.Reader()))
+	if err != nil {
+		return err
+	}
+
+	progressCallback := blob.ProgressCallback(ctx)
+	if progressCallback != nil {
+		progressCallback(string(id), 0, int64(data.Length()))
+		defer progressCallback(string(id), int64(data.Length()), int64(data.Length()))
+	}
+
+	fileName := s.getObjectNameString(id)
+	_, err = s.bucket.UploadFile(fileName, nil, throttled)
+
+	return translateError(err)
+}
+
+func (s *b2Storage) DeleteBlob(ctx context.Context, id blob.ID) error {
+	fileName := s.getObjectNameString(id)
+	_, err := s.bucket.HideFile(fileName)
+	err = translateError(err)
+
+	if err == blob.ErrBlobNotFound {
+		// Deleting failed because it already is deleted? Fine.
+		return nil
+	}
+
+	return err
+}
+
+func (s *b2Storage) getObjectNameString(id blob.ID) string {
+	return s.Prefix + string(id)
+}
+
+func (s *b2Storage) ListBlobs(ctx context.Context, prefix blob.ID, callback func(blob.Metadata) error) error {
+	const maxFileQuery = 1000
+
+	fullPrefix := s.getObjectNameString(prefix)
+	nextFile := ""
+
+	for {
+		resp, err := s.bucket.ListFileNamesWithPrefix(nextFile, maxFileQuery, fullPrefix, "")
+		if err != nil {
+			return err
+		}
+
+		for i := range resp.Files {
+			f := &resp.Files[i]
+			bm := blob.Metadata{
+				BlobID:    blob.ID(f.Name[len(s.Prefix):]),
+				Length:    f.ContentLength,
+				Timestamp: time.Unix(0, f.UploadTimestamp*int64(time.Millisecond)),
+			}
+
+			if err := callback(bm); err != nil {
+				return err
+			}
+		}
+
+		nextFile = resp.NextFileName
+
+		if nextFile == "" {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s *b2Storage) ConnectionInfo() blob.ConnectionInfo {
+	return blob.ConnectionInfo{
+		Type:   b2storageType,
+		Config: &s.Options,
+	}
+}
+
+func (s *b2Storage) Close(ctx context.Context) error {
+	return nil
+}
+
+func (s *b2Storage) String() string {
+	return fmt.Sprintf("b2://%s/%s", s.BucketName, s.Prefix)
+}
+
+func toBandwidth(bytesPerSecond int) iothrottler.Bandwidth {
+	if bytesPerSecond <= 0 {
+		return iothrottler.Unlimited
+	}
+
+	return iothrottler.Bandwidth(bytesPerSecond) * iothrottler.BytesPerSecond
+}
+
+// New creates new B2-backed storage with specified options:
+func New(ctx context.Context, opt *Options) (blob.Storage, error) {
+	if opt.BucketName == "" {
+		return nil, errors.New("bucket name must be specified")
+	}
+
+	cli, err := backblaze.NewB2(backblaze.Credentials{KeyID: opt.KeyID, ApplicationKey: opt.Key})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create client")
+	}
+
+	downloadThrottler := iothrottler.NewIOThrottlerPool(toBandwidth(opt.MaxDownloadSpeedBytesPerSecond))
+	uploadThrottler := iothrottler.NewIOThrottlerPool(toBandwidth(opt.MaxUploadSpeedBytesPerSecond))
+
+	bucket, err := cli.Bucket(opt.BucketName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot open bucket %q", opt.BucketName)
+	}
+
+	if bucket == nil {
+		return nil, fmt.Errorf("bucket not found: %s", opt.BucketName)
+	}
+
+	return &b2Storage{
+		Options:           *opt,
+		ctx:               ctx,
+		cli:               cli,
+		bucket:            bucket,
+		downloadThrottler: downloadThrottler,
+		uploadThrottler:   uploadThrottler,
+	}, nil
+}
+
+func init() {
+	blob.AddSupportedStorage(
+		b2storageType,
+		func() interface{} {
+			return &Options{}
+		},
+		func(ctx context.Context, o interface{}) (blob.Storage, error) {
+			return New(ctx, o.(*Options))
+		})
+}

--- a/repo/blob/b2/b2_storage_test.go
+++ b/repo/blob/b2/b2_storage_test.go
@@ -1,0 +1,129 @@
+package b2_test
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/b2"
+)
+
+const (
+	testBucketEnv = "KOPIA_B2_TEST_BUCKET"
+	testKeyIDEnv  = "KOPIA_B2_TEST_KEY_ID"
+	testKeyEnv    = "KOPIA_B2_TEST_KEY"
+)
+
+func getEnvOrSkip(t *testing.T, name string) string {
+	value, ok := os.LookupEnv(name)
+	if !ok {
+		t.Skip(fmt.Sprintf("%s not provided", name))
+	}
+
+	return value
+}
+
+func TestB2Storage(t *testing.T) {
+	t.Parallel()
+	bucket := getEnvOrSkip(t, testBucketEnv)
+	keyID := getEnvOrSkip(t, testKeyIDEnv)
+	key := getEnvOrSkip(t, testKeyEnv)
+
+	data := make([]byte, 8)
+	rand.Read(data) //nolint:errcheck
+
+	ctx := context.Background()
+	st, err := b2.New(ctx, &b2.Options{
+		BucketName: bucket,
+		KeyID:      keyID,
+		Key:        key,
+		Prefix:     fmt.Sprintf("test-%v-%x-", time.Now().Unix(), data),
+	})
+
+	if err != nil {
+		t.Fatalf("unable to build b2 storage: %v", err)
+	}
+
+	if err := st.ListBlobs(ctx, "", func(bm blob.Metadata) error {
+		return st.DeleteBlob(ctx, bm.BlobID)
+	}); err != nil {
+		t.Fatalf("unable to clear b2 bucket: %v", err)
+	}
+
+	blobtesting.VerifyStorage(ctx, t, st)
+	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
+
+	// delete everything again
+	if err := st.ListBlobs(ctx, "", func(bm blob.Metadata) error {
+		return st.DeleteBlob(ctx, bm.BlobID)
+	}); err != nil {
+		t.Fatalf("unable to clear b2 bucket: %v", err)
+	}
+
+	if err := st.Close(ctx); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestB2StorageInvalidBlob(t *testing.T) {
+	bucket := getEnvOrSkip(t, testBucketEnv)
+	keyID := getEnvOrSkip(t, testKeyIDEnv)
+	key := getEnvOrSkip(t, testKeyEnv)
+
+	ctx := context.Background()
+	st, err := b2.New(ctx, &b2.Options{
+		BucketName: bucket,
+		KeyID:      keyID,
+		Key:        key,
+	})
+
+	if err != nil {
+		t.Fatalf("unable to build b2 storage: %v", err)
+	}
+
+	defer st.Close(ctx)
+
+	_, err = st.GetBlob(ctx, blob.ID(fmt.Sprintf("invalid-blob-%v", time.Now().UnixNano())), 0, 30)
+	if err == nil {
+		t.Errorf("unexpected success when requesting non-existing blob")
+	}
+}
+
+func TestB2StorageInvalidBucket(t *testing.T) {
+	bucket := fmt.Sprintf("invalid-bucket-%v", time.Now().UnixNano())
+	keyID := getEnvOrSkip(t, testKeyIDEnv)
+	key := getEnvOrSkip(t, testKeyEnv)
+
+	ctx := context.Background()
+	_, err := b2.New(ctx, &b2.Options{
+		BucketName: bucket,
+		KeyID:      keyID,
+		Key:        key,
+	})
+
+	if err == nil {
+		t.Errorf("unexpected success building b2 storage, wanted error")
+	}
+}
+
+func TestB2StorageInvalidCreds(t *testing.T) {
+	bucket := getEnvOrSkip(t, testBucketEnv)
+	keyID := "invalid-key-id"
+	key := "invalid-key"
+
+	ctx := context.Background()
+	_, err := b2.New(ctx, &b2.Options{
+		BucketName: bucket,
+		KeyID:      keyID,
+		Key:        key,
+	})
+
+	if err == nil {
+		t.Errorf("unexpected success building b2 storage, wanted error")
+	}
+}


### PR DESCRIPTION
Implements B2 as requested in #312 .

It was bit of back and forth between libraries. It seems the kinda-standard B2 library for Go (blazer) is a tiny bit overengineered and makes it very hard to deal with error cases (since you cannot access any error details without reflection). Also the code has so many layers of indirection that it was quite hard to follow what actually happens for certain requests. Therefore I went with the much simpler (in a good way) [go-backblaze](https://github.com/kothar/go-backblaze). Only downside so far: it doesn't use a `Context` to make requests. I will probably add that to that library soonish (if the author wants that).

One thing to note about B2, which should be also important when you setup a bucket for the integration tests: B2 doesn't easily support deletion of files. By default a bucket works with full versioning. To not undermine their concept, I did not implement any workarounds for real deletion (like iterating the file history and deleting version by version), I only "hide" files. Bucket rules can be set to actually delete hidden files after a specified period of time. You might want to set that for the bucket you intend to use for testing.

I also did not implement bucket creation/deletion as part of the integration test, since this would require the use of admin credentials. I think it's better to use application specific ones that only use a specific bucket. (Together with the retention rules offered by B2 that should be fine.)

Further more, I didn't implement the ability to set a custom API endpoint. I know of a single B2 mock server that could be interesting for tests, but for production usage there is no (known to me) free implementation of the B2 API (like there is with *minio* for S3). So it just doesn't seem to make sense to offer customization there.

Due to that back and forth I squashed my history into backend and UI commits, even though that garbles (well, removes) the actual timeline. But whatever :-)