### PR TITLE
object: ensure that all I objects have a content prefix

### DIFF
--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -146,8 +146,14 @@ func TestWriterCompleteChunkInTwoWrites(t *testing.T) {
 }
 
 func verifyIndirectBlock(ctx context.Context, t *testing.T, r *Manager, oid ID) {
-	for indexBlobID, isIndirect := oid.IndexObjectID(); isIndirect; indexBlobID, isIndirect = indexBlobID.IndexObjectID() {
-		rd, err := r.Open(ctx, indexBlobID)
+	for indexContentID, isIndirect := oid.IndexObjectID(); isIndirect; indexContentID, isIndirect = indexContentID.IndexObjectID() {
+		if c, _, ok := indexContentID.ContentID(); ok {
+			if !c.HasPrefix() {
+				t.Errorf("expected base content ID to be prefixed, was %v", c)
+			}
+		}
+
+		rd, err := r.Open(ctx, indexContentID)
 		if err != nil {
 			t.Errorf("unable to open %v: %v", oid.String(), err)
 			return

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -18,6 +18,8 @@ import (
 
 var log = logging.GetContextLoggerFunc("object")
 
+const indirectContentPrefix = "x"
+
 // Writer allows writing content to the storage and supports automatic deduplication and encryption
 // of written data.
 type Writer interface {
@@ -248,6 +250,11 @@ func (w *objectWriter) Result() (ID, error) {
 		description: "LIST(" + w.description + ")",
 		splitter:    w.om.newSplitter(),
 		prefix:      w.prefix,
+	}
+
+	if iw.prefix == "" {
+		// force a prefix for indirect contents to make sure they get packaged into metadata (q) blobs.
+		iw.prefix = indirectContentPrefix
 	}
 
 	iw.initBuffer()


### PR DESCRIPTION
When prefix is not specified on ObjectWriter, we force
'x' content prefix on intermediate contents, so object IDs
will look like:

Ix{hash}

This ensures the index contents will be stored in `q` blobs,
making `snapshot gc` easier.