### PR TITLE
content: asynchronous cache sweep

### DIFF
--- a/repo/content/content_cache_test.go
+++ b/repo/content/content_cache_test.go
@@ -118,7 +118,7 @@ func TestDiskContentCache(t *testing.T) {
 	verifyContentCache(t, cache)
 }
 
-func verifyContentCache(t *testing.T, cache *contentCache) {
+func verifyContentCache(t *testing.T, cache contentCache) {
 	ctx := testlogging.Context(t)
 
 	t.Run("GetContentContent", func(t *testing.T) {
@@ -154,12 +154,12 @@ func verifyContentCache(t *testing.T, cache *contentCache) {
 			}
 		}
 
-		verifyStorageContentList(t, cache.cacheStorage, "f0f0f1x", "f0f0f2x", "f0f0f5")
+		verifyStorageContentList(t, cache.(*contentCacheWithStorage).cacheStorage, "f0f0f1x", "f0f0f2x", "f0f0f5")
 	})
 
 	t.Run("DataCorruption", func(t *testing.T) {
 		var cacheKey blob.ID = "f0f0f1x"
-		d, err := cache.cacheStorage.GetBlob(ctx, cacheKey, 0, -1)
+		d, err := cache.(*contentCacheWithStorage).cacheStorage.GetBlob(ctx, cacheKey, 0, -1)
 		if err != nil {
 			t.Fatalf("unable to retrieve data from cache: %v", err)
 		}
@@ -167,7 +167,7 @@ func verifyContentCache(t *testing.T, cache *contentCache) {
 		// corrupt the data and write back
 		d[0] ^= 1
 
-		if puterr := cache.cacheStorage.PutBlob(ctx, cacheKey, gather.FromSlice(d)); puterr != nil {
+		if puterr := cache.(*contentCacheWithStorage).cacheStorage.PutBlob(ctx, cacheKey, gather.FromSlice(d)); puterr != nil {
 			t.Fatalf("unable to write corrupted content: %v", puterr)
 		}
 

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -657,7 +657,7 @@ func newManagerWithOptions(ctx context.Context, st blob.Storage, f *FormattingOp
 		return nil, err
 	}
 
-	contentCache, err := newContentCache(ctx, st, caching, caching.MaxCacheSizeBytes, "contents")
+	dataCache, err := newContentCache(ctx, st, caching, caching.MaxCacheSizeBytes, "contents")
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to initialize content cache")
 	}
@@ -691,7 +691,7 @@ func newManagerWithOptions(ctx context.Context, st blob.Storage, f *FormattingOp
 			minPreambleLength:       defaultMinPreambleLength,
 			maxPreambleLength:       defaultMaxPreambleLength,
 			paddingUnit:             defaultPaddingUnit,
-			contentCache:            contentCache,
+			contentCache:            dataCache,
 			metadataCache:           metadataCache,
 			listCache:               listCache,
 			st:                      st,

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -30,8 +30,8 @@ type lockFreeManager struct {
 	Format         FormattingOptions
 	CachingOptions CachingOptions
 
-	contentCache      *contentCache
-	metadataCache     *contentCache
+	contentCache      contentCache
+	metadataCache     contentCache
 	committedContents *committedContentIndex
 
 	checkInvariantsOnUnlock bool
@@ -215,7 +215,7 @@ func validatePrefix(prefix ID) error {
 	return errors.Errorf("invalid prefix, must be a empty or single letter between 'g' and 'z'")
 }
 
-func (bm *lockFreeManager) getCacheForContentID(id ID) *contentCache {
+func (bm *lockFreeManager) getCacheForContentID(id ID) contentCache {
 	if id.HasPrefix() {
 		return bm.metadataCache
 	}


### PR DESCRIPTION
With large cache sizes it takes several seconds to perform the initial
sweep. This change only checks that the cache is functional without
full sweep.

Also cleaned up contentCache by introducing interface and having
two implementations - one which does caching, and one that does not.