### PR TITLE
content: added blob-level metadata cache

### DIFF
--- a/cli/command_cache_sync.go
+++ b/cli/command_cache_sync.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/kopia/kopia/repo"
+)
+
+var (
+	cacheSyncCommand = cacheCommands.Command("sync", "Synchronizes the metadata cache with blobs in storage")
+)
+
+func runCacheSyncCommand(ctx context.Context, rep *repo.DirectRepository) error {
+	return rep.Content.SyncMetadataCache(ctx)
+}
+
+func init() {
+	cacheSyncCommand.Action(directRepositoryAction(runCacheSyncCommand))
+}

--- a/repo/content/content_cache_base.go
+++ b/repo/content/content_cache_base.go
@@ -1,0 +1,187 @@
+package content
+
+import (
+	"container/heap"
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/blob"
+)
+
+const (
+	defaultSweepFrequency = 1 * time.Minute
+	defaultTouchThreshold = 10 * time.Minute
+	mutexAgeCutoff        = 5 * time.Minute
+)
+
+type mutextLRU struct {
+	mu                  *sync.Mutex
+	lastUsedNanoseconds int64
+}
+
+// cacheBase provides common implementation for per-content and per-blob caches
+type cacheBase struct {
+	cacheStorage   blob.Storage
+	maxSizeBytes   int64
+	sweepFrequency time.Duration
+	touchThreshold time.Duration
+
+	asyncWG sync.WaitGroup
+	closed  chan struct{}
+
+	// stores key to *mutexLRU mapping which is periodically garbage-collected
+	// and used to eliminate/minimize concurrent fetches of the same cached item.
+	loadingMap sync.Map
+}
+
+type contentToucher interface {
+	TouchBlob(ctx context.Context, contentID blob.ID, threshold time.Duration) error
+}
+
+func (c *cacheBase) touch(ctx context.Context, blobID blob.ID) {
+	if t, ok := c.cacheStorage.(contentToucher); ok {
+		t.TouchBlob(ctx, blobID, c.touchThreshold) //nolint:errcheck
+	}
+}
+
+func (c *cacheBase) close() {
+	close(c.closed)
+	c.asyncWG.Wait()
+}
+
+func (c *cacheBase) perItemMutex(key interface{}) *sync.Mutex {
+	now := time.Now().UnixNano() // allow:no-inject-time
+
+	v, ok := c.loadingMap.Load(key)
+	if !ok {
+		v, _ = c.loadingMap.LoadOrStore(key, &mutextLRU{
+			mu:                  &sync.Mutex{},
+			lastUsedNanoseconds: now,
+		})
+	}
+
+	m := v.(*mutextLRU)
+	atomic.StoreInt64(&m.lastUsedNanoseconds, now)
+
+	return m.mu
+}
+
+func (c *cacheBase) sweepDirectoryPeriodically(ctx context.Context) {
+	defer c.asyncWG.Done()
+
+	for {
+		select {
+		case <-c.closed:
+			return
+
+		case <-time.After(c.sweepFrequency):
+			c.sweepMutexes()
+
+			if err := c.sweepDirectory(ctx); err != nil {
+				log(ctx).Warningf("cacheBase sweep failed: %v", err)
+			}
+		}
+	}
+}
+
+// A contentMetadataHeap implements heap.Interface and holds blob.Metadata.
+type contentMetadataHeap []blob.Metadata
+
+func (h contentMetadataHeap) Len() int { return len(h) }
+
+func (h contentMetadataHeap) Less(i, j int) bool {
+	return h[i].Timestamp.Before(h[j].Timestamp)
+}
+
+func (h contentMetadataHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *contentMetadataHeap) Push(x interface{}) {
+	*h = append(*h, x.(blob.Metadata))
+}
+
+func (h *contentMetadataHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[0 : n-1]
+
+	return item
+}
+
+func (c *cacheBase) sweepDirectory(ctx context.Context) (err error) {
+	t0 := time.Now() // allow:no-inject-time
+
+	var h contentMetadataHeap
+
+	var totalRetainedSize int64
+
+	err = c.cacheStorage.ListBlobs(ctx, "", func(it blob.Metadata) error {
+		heap.Push(&h, it)
+		totalRetainedSize += it.Length
+
+		if totalRetainedSize > c.maxSizeBytes {
+			oldest := heap.Pop(&h).(blob.Metadata)
+			if delerr := c.cacheStorage.DeleteBlob(ctx, oldest.BlobID); delerr != nil {
+				log(ctx).Warningf("unable to remove %v: %v", oldest.BlobID, delerr)
+			} else {
+				totalRetainedSize -= oldest.Length
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "error listing cache")
+	}
+
+	log(ctx).Debugf("finished sweeping directory in %v and retained %v/%v bytes (%v %%)", time.Since(t0), totalRetainedSize, c.maxSizeBytes, 100*totalRetainedSize/c.maxSizeBytes) // allow:no-inject-time
+
+	return nil
+}
+
+func (c *cacheBase) sweepMutexes() {
+	cutoffTime := time.Now().Add(-mutexAgeCutoff).UnixNano() // allow:no-inject-time
+
+	// remove from loadingMap all items that have not been touched recently.
+	// since the mutexes are only for performance (to avoid loading duplicates)
+	// and not for correctness, it's always safe to remove them.
+	c.loadingMap.Range(func(key, value interface{}) bool {
+		if m := value.(*mutextLRU); m.lastUsedNanoseconds < cutoffTime {
+			c.loadingMap.Delete(key)
+		}
+
+		return true
+	})
+}
+
+func newContentCacheBase(ctx context.Context, cacheStorage blob.Storage, maxSizeBytes int64, touchThreshold, sweepFrequency time.Duration) (*cacheBase, error) {
+	c := &cacheBase{
+		cacheStorage:   cacheStorage,
+		maxSizeBytes:   maxSizeBytes,
+		closed:         make(chan struct{}),
+		touchThreshold: touchThreshold,
+		sweepFrequency: sweepFrequency,
+	}
+
+	// errGood is a marker error to stop blob iteration quickly, does not
+	// indicate any problem.
+	var errGood = errors.Errorf("good")
+
+	// verify that cache storage is functional by listing from it
+	if err := c.cacheStorage.ListBlobs(ctx, "", func(it blob.Metadata) error {
+		return errGood
+	}); err != nil && err != errGood {
+		return nil, errors.Wrap(err, "unable to open cache")
+	}
+
+	c.asyncWG.Add(1)
+
+	go c.sweepDirectoryPeriodically(ctx)
+
+	return c, nil
+}

--- a/repo/content/content_cache_data.go
+++ b/repo/content/content_cache_data.go
@@ -1,0 +1,114 @@
+package content
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
+
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/hmac"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+type contentCacheForData struct {
+	*cacheBase
+
+	st         blob.Storage
+	hmacSecret []byte
+}
+
+func adjustCacheKey(cacheKey cacheKey) cacheKey {
+	// content IDs with odd length have a single-byte prefix.
+	// move the prefix to the end of cache key to make sure the top level shard is spread 256 ways.
+	if len(cacheKey)%2 == 1 {
+		return cacheKey[1:] + cacheKey[0:1]
+	}
+
+	return cacheKey
+}
+
+func (c *contentCacheForData) getContent(ctx context.Context, cacheKey cacheKey, blobID blob.ID, offset, length int64) ([]byte, error) {
+	cacheKey = adjustCacheKey(cacheKey)
+
+	useCache := shouldUseContentCache(ctx)
+	if useCache {
+		if b := c.readAndVerifyCacheContent(ctx, cacheKey); b != nil {
+			stats.Record(ctx,
+				metricContentCacheHitCount.M(1),
+				metricContentCacheHitBytes.M(int64(len(b))),
+			)
+
+			return b, nil
+		}
+	}
+
+	stats.Record(ctx, metricContentCacheMissCount.M(1))
+
+	b, err := c.st.GetBlob(ctx, blobID, offset, length)
+	if err != nil {
+		stats.Record(ctx, metricContentCacheMissErrors.M(1))
+	} else {
+		stats.Record(ctx, metricContentCacheMissBytes.M(int64(len(b))))
+	}
+
+	if err == blob.ErrBlobNotFound {
+		// not found in underlying storage
+		return nil, err
+	}
+
+	if err == nil && useCache {
+		// do not report cache writes as uploads.
+		if puterr := c.cacheStorage.PutBlob(
+			blob.WithUploadProgressCallback(ctx, nil),
+			blob.ID(cacheKey),
+			gather.FromSlice(hmac.Append(b, c.hmacSecret)),
+		); puterr != nil {
+			stats.Record(ctx, metricContentCacheStoreErrors.M(1))
+			log(ctx).Warningf("unable to write cache item %v: %v", cacheKey, puterr)
+		}
+	}
+
+	return b, err
+}
+
+func (c *contentCacheForData) readAndVerifyCacheContent(ctx context.Context, cacheKey cacheKey) []byte {
+	b, err := c.cacheStorage.GetBlob(ctx, blob.ID(cacheKey), 0, -1)
+	if err == nil {
+		b, err = hmac.VerifyAndStrip(b, c.hmacSecret)
+		if err == nil {
+			c.touch(ctx, blob.ID(cacheKey))
+
+			// retrieved from cache and HMAC valid
+			return b
+		}
+
+		// ignore malformed contents
+		log(ctx).Warningf("malformed content %v: %v", cacheKey, err)
+
+		return nil
+	}
+
+	if err != blob.ErrBlobNotFound {
+		log(ctx).Warningf("unable to read cache %v: %v", cacheKey, err)
+	}
+
+	return nil
+}
+
+func newContentCacheForData(ctx context.Context, st, cacheStorage blob.Storage, maxSizeBytes int64, hmacSecret []byte) (contentCache, error) {
+	if cacheStorage == nil {
+		return passthroughContentCache{st}, nil
+	}
+
+	cb, err := newContentCacheBase(ctx, cacheStorage, maxSizeBytes, defaultTouchThreshold, defaultSweepFrequency)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create base cache")
+	}
+
+	return &contentCacheForData{
+		st:         st,
+		hmacSecret: append([]byte(nil), hmacSecret...),
+		cacheBase:  cb,
+	}, nil
+}

--- a/repo/content/content_cache_metadata.go
+++ b/repo/content/content_cache_metadata.go
@@ -1,0 +1,128 @@
+package content
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"go.opencensus.io/stats"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+const metadataCacheSyncParallelism = 16
+
+type contentCacheForMetadata struct {
+	*cacheBase
+
+	st blob.Storage
+}
+
+// sync synchronizes metadata cache with all blobs found in the storage.
+func (c *contentCacheForMetadata) sync(ctx context.Context) error {
+	sem := make(chan struct{}, metadataCacheSyncParallelism)
+
+	log(ctx).Debugf("synchronizing metadata cache...")
+	defer log(ctx).Debugf("finished synchronizing metadata cache.")
+
+	var eg errgroup.Group
+
+	// list all blobs and fetch contents into cache in parallel.
+	if err := c.st.ListBlobs(ctx, PackBlobIDPrefixSpecial, func(bm blob.Metadata) error {
+		// acquire semaphore
+		sem <- struct{}{}
+		eg.Go(func() error {
+			defer func() {
+				<-sem
+			}()
+
+			_, err := c.getContent(ctx, "dummy", bm.BlobID, 0, 1)
+			return err
+		})
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "error listing blobs")
+	}
+
+	return eg.Wait()
+}
+
+func (c *contentCacheForMetadata) getContent(ctx context.Context, cacheKey cacheKey, blobID blob.ID, offset, length int64) ([]byte, error) {
+	m := c.perItemMutex(blobID)
+	m.Lock()
+	defer m.Unlock()
+
+	useCache := shouldUseContentCache(ctx)
+	if useCache {
+		if v, err := c.cacheBase.cacheStorage.GetBlob(ctx, blobID, offset, length); err == nil {
+			// cache hit
+			stats.Record(ctx,
+				metricContentCacheHitCount.M(1),
+				metricContentCacheHitBytes.M(int64(len(v))),
+			)
+
+			return v, nil
+		}
+	}
+
+	stats.Record(ctx, metricContentCacheMissCount.M(1))
+
+	// read the entire blob
+	log(ctx).Debugf("fetching metadata blob %q", blobID)
+	blobData, err := c.st.GetBlob(ctx, blobID, 0, -1)
+
+	if err != nil {
+		stats.Record(ctx, metricContentCacheMissErrors.M(1))
+	} else {
+		stats.Record(ctx, metricContentCacheMissBytes.M(int64(len(blobData))))
+	}
+
+	if err == blob.ErrBlobNotFound {
+		// not found in underlying storage
+		return nil, err
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if useCache {
+		// store the whole blob in the cache, do not report cache writes as uploads.
+		if puterr := c.cacheStorage.PutBlob(
+			blob.WithUploadProgressCallback(ctx, nil),
+			blobID,
+			gather.FromSlice(blobData),
+		); puterr != nil {
+			stats.Record(ctx, metricContentCacheStoreErrors.M(1))
+			log(ctx).Warningf("unable to write cache item %v: %v", blobID, puterr)
+		}
+	}
+
+	if offset == 0 && length == -1 {
+		return blobData, err
+	}
+
+	if offset < 0 || offset+length > int64(len(blobData)) {
+		return nil, errors.Errorf("invalid (offset=%v,length=%v) for blob %q of size %v", offset, length, blobID, len(blobData))
+	}
+
+	return blobData[offset : offset+length], nil
+}
+
+func newContentCacheForMetadata(ctx context.Context, st, cacheStorage blob.Storage, maxSizeBytes int64) (contentCache, error) {
+	if cacheStorage == nil {
+		return passthroughContentCache{st}, nil
+	}
+
+	cb, err := newContentCacheBase(ctx, cacheStorage, maxSizeBytes, defaultTouchThreshold, defaultSweepFrequency)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create base cache")
+	}
+
+	return &contentCacheForMetadata{
+		st:        st,
+		cacheBase: cb,
+	}, nil
+}

--- a/repo/content/content_cache_passthrough.go
+++ b/repo/content/content_cache_passthrough.go
@@ -1,0 +1,18 @@
+package content
+
+import (
+	"context"
+
+	"github.com/kopia/kopia/repo/blob"
+)
+
+// passthroughContentCache is a contentCache which does no caching.
+type passthroughContentCache struct {
+	st blob.Storage
+}
+
+func (c passthroughContentCache) close() {}
+
+func (c passthroughContentCache) getContent(ctx context.Context, cacheKey cacheKey, blobID blob.ID, offset, length int64) ([]byte, error) {
+	return c.st.GetBlob(ctx, blobID, offset, length)
+}

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -321,7 +321,7 @@ func (bm *lockFreeManager) IndexBlobs(ctx context.Context) ([]IndexBlobInfo, err
 }
 
 func (bm *lockFreeManager) getIndexBlobInternal(ctx context.Context, blobID blob.ID) ([]byte, error) {
-	payload, err := bm.contentCache.getContent(ctx, cacheKey(blobID), blobID, 0, -1)
+	payload, err := bm.metadataCache.getContent(ctx, cacheKey(blobID), blobID, 0, -1)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Unlike regular cache, which caches segments of blobs on a per-content
basis, metadata cache will fetch and store the entire metadata blob (q)
when any of the contents in it is accessed.

Given that there are relatively few metadata blobs compared to data (p)
blobs, this will reduce the traffic to the underlying store and improve
performance of Snapshot GC which only relies on metadata contents.