### PR TITLE
app: portability fixes

### DIFF
--- a/app/public/config.js
+++ b/app/public/config.js
@@ -76,9 +76,13 @@ function newConfigForRepo(repoID) {
 
         if (repoID == "default") {
             data.description = "My Repository";
-            data.configFile = "";
         } else {
             data.description = "Unnamed Repository";
+        }
+
+        if (repoID == "default" && !isPortable) {
+            data.configFile = "";
+        } else {
             data.configFile = "./" + repoID + ".config";
         }
 
@@ -164,6 +168,7 @@ module.exports = {
     },
 
     isPortableConfig() {
+        globalConfigDir();
         return isPortable;
     },
 

--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -11,6 +11,11 @@ const { showConfigWindow, isConfigWindowOpen } = require('./config_window');
 
 app.name = 'KopiaUI';
 
+if (isPortableConfig()) {
+  // in portable mode, write cache under 'repositories'
+  app.setPath('userData', path.join(configDir(), 'cache'));
+}
+
 ipcMain.on('config-save', (event, arg) => {
   console.log('saving config', arg);
   configForRepo(arg.repoID).setBulk(arg.config);


### PR DESCRIPTION
- create default config in portable mode
- override userData to make sure cached data is written outside of %APPDATA%

Fixes #428 