### PR TITLE
Fix #360: Leverage Go 1.14 testing.T.Cleanup()

### DIFF
--- a/repo/content/content_index_recovery_test.go
+++ b/repo/content/content_index_recovery_test.go
@@ -14,7 +14,6 @@ func TestContentIndexRecovery(t *testing.T) {
 	data := blobtesting.DataMap{}
 	keyTime := map[blob.ID]time.Time{}
 	bm := newTestContentManager(t, data, keyTime, nil)
-
 	content1 := writeContentAndVerify(ctx, t, bm, seededRandomData(10, 100))
 	content2 := writeContentAndVerify(ctx, t, bm, seededRandomData(11, 100))
 	content3 := writeContentAndVerify(ctx, t, bm, seededRandomData(12, 100))
@@ -29,12 +28,8 @@ func TestContentIndexRecovery(t *testing.T) {
 		return bm.st.DeleteBlob(ctx, bi.BlobID)
 	}))
 
-	bm.Close(ctx)
-
 	// now with index blobs gone, all contents appear to not be found
 	bm = newTestContentManager(t, data, keyTime, nil)
-	defer bm.Close(ctx)
-
 	verifyContentNotFound(ctx, t, bm, content1)
 	verifyContentNotFound(ctx, t, bm, content2)
 	verifyContentNotFound(ctx, t, bm, content3)

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -1647,6 +1647,10 @@ func newTestContentManagerWithStorage(t *testing.T, st blob.Storage, timeFunc fu
 
 	bm.checkInvariantsOnUnlock = true
 
+	t.Cleanup(func() {
+		bm.Close(context.Background())
+	})
+
 	return bm
 }
 


### PR DESCRIPTION
Reverts 06fbaba
Re-applies "testing: ensure cleanup of content managers" commit