### PR TITLE
cosmetic changes to maintenance behavior

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -145,8 +145,10 @@ func maybeRepositoryAction(act func(ctx context.Context, rep repo.Repository) er
 
 			err = act(ctx, rep)
 
-			if err == nil && rep != nil {
-				err = maybeRunMaintenance(ctx, rep)
+			if rep != nil {
+				if merr := maybeRunMaintenance(ctx, rep); merr != nil {
+					log(ctx).Warningf("error running maintenance: %v", merr)
+				}
 			}
 
 			if rep != nil && required {

--- a/cli/cli_progress.go
+++ b/cli/cli_progress.go
@@ -237,6 +237,8 @@ func (p *cliProgress) Finish() {
 	}
 
 	atomic.StoreInt32(&p.uploadFinished, 1)
+	atomic.StoreInt32(&p.uploading, 0)
+
 	p.output(defaultColor, "")
 }
 


### PR DESCRIPTION
- run maintenance even if the command is about to return an error
  (otherwise if folks have persistent error causing snapshots to fail
  they will never run maintenance)
- disable progress output after snapshotting so that
  'kopia snapshot --all' output is clean