### PR TITLE
server: implemented 'flush' and 'refresh' API

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -135,12 +135,18 @@ func (s *Server) handleAPIPossiblyNotConnected(f func(ctx context.Context, r *ht
 }
 
 func (s *Server) handleRefresh(ctx context.Context, r *http.Request) (interface{}, *apiError) {
-	log(ctx).Infof("refreshing")
+	if err := s.rep.Refresh(ctx); err != nil {
+		return nil, internalServerError(err)
+	}
+
 	return &serverapi.Empty{}, nil
 }
 
 func (s *Server) handleFlush(ctx context.Context, r *http.Request) (interface{}, *apiError) {
-	log(ctx).Infof("flushing")
+	if err := s.rep.Flush(ctx); err != nil {
+		return nil, internalServerError(err)
+	}
+
 	return &serverapi.Empty{}, nil
 }
 

--- a/repo/api_server_repository.go
+++ b/repo/api_server_repository.go
@@ -118,7 +118,7 @@ func (r *apiServerRepository) Refresh(ctx context.Context) error {
 }
 
 func (r *apiServerRepository) Flush(ctx context.Context) error {
-	return nil
+	return r.cli.Post(ctx, "flush", nil, nil)
 }
 
 func (r *apiServerRepository) Close(ctx context.Context) error {
@@ -126,7 +126,7 @@ func (r *apiServerRepository) Close(ctx context.Context) error {
 		return errors.Wrap(err, "error closing object manager")
 	}
 
-	return nil
+	return r.Flush(ctx)
 }
 
 func (r *apiServerRepository) ContentInfo(ctx context.Context, contentID content.ID) (content.Info, error) {


### PR DESCRIPTION
Added test that verifies that when client performs Flush (which happens
at the end of each snapshot and when repository is closed), the
server writes new blobs to the storage.

Fixes #464