### PR TITLE
[Robustness] Add first robustness tests

### DIFF
--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -1,0 +1,55 @@
+// +build darwin linux
+
+package robustness
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"testing"
+
+	engine "github.com/kopia/kopia/tests/robustness/test_engine"
+	"github.com/kopia/kopia/tests/tools/fio"
+	"github.com/kopia/kopia/tests/tools/kopiarunner"
+)
+
+var eng *engine.Engine
+
+const (
+	fsDataPath     = "/tmp/robustness-data"
+	fsMetadataPath = "/tmp/robustness-metadata"
+	s3DataPath     = "robustness-data"
+	s3MetadataPath = "robustness-metadata"
+)
+
+func TestMain(m *testing.M) {
+	var err error
+
+	eng, err = engine.NewEngine()
+	if err != nil {
+		log.Println("skipping robustness tests:", err)
+
+		if err == kopiarunner.ErrExeVariableNotSet || errors.Is(err, fio.ErrEnvNotSet) {
+			os.Exit(0)
+		}
+
+		os.Exit(1)
+	}
+
+	switch {
+	case os.Getenv(engine.S3BucketNameEnvKey) != "":
+		eng.InitS3(context.Background(), s3DataPath, s3MetadataPath)
+	default:
+		eng.InitFilesystem(context.Background(), fsDataPath, fsMetadataPath)
+	}
+
+	result := m.Run()
+
+	err = eng.Cleanup()
+	if err != nil {
+		panic(err)
+	}
+
+	os.Exit(result)
+}

--- a/tests/robustness/robustness_test.go
+++ b/tests/robustness/robustness_test.go
@@ -1,0 +1,79 @@
+// +build darwin linux
+
+package robustness
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"path/filepath"
+	"testing"
+
+	"github.com/kopia/kopia/tests/testenv"
+	"github.com/kopia/kopia/tests/tools/fio"
+)
+
+func TestManySmallFiles(t *testing.T) {
+	fileSize := int64(4096)
+	numFiles := 100
+
+	fioOpt := fio.Options{}.WithFileSize(fileSize).WithNumFiles(numFiles).WithBlockSize(4096)
+
+	err := eng.FileWriter.WriteFiles("", fioOpt)
+	testenv.AssertNoError(t, err)
+
+	ctx := context.TODO()
+	snapID, err := eng.Checker.TakeSnapshot(ctx, eng.FileWriter.LocalDataDir)
+	testenv.AssertNoError(t, err)
+
+	output, err := ioutil.TempFile("", t.Name())
+	testenv.AssertNoError(t, err)
+
+	defer output.Close() //nolint:errcheck
+
+	err = eng.Checker.RestoreSnapshot(ctx, snapID, output)
+	testenv.AssertNoError(t, err)
+}
+
+func TestModifyWorkload(t *testing.T) {
+	const (
+		numSnapshots = 10
+		numDirs      = 10
+		maxOpsPerMod = 5
+	)
+
+	numFiles := 10
+	writeSize := int64(65536 * numFiles)
+	fioOpt := fio.Options{}.
+		WithDedupePercentage(35).
+		WithRandRepeat(false).
+		WithBlockSize(4096).
+		WithFileSize(writeSize).
+		WithNumFiles(numFiles)
+
+	var resultIDs []string
+
+	ctx := context.Background()
+
+	for snapNum := 0; snapNum < numSnapshots; snapNum++ {
+		opsThisLoop := rand.Intn(maxOpsPerMod) + 1
+		for mod := 0; mod < opsThisLoop; mod++ {
+			dirIdxToMod := rand.Intn(numDirs)
+			writeToDir := filepath.Join(t.Name(), fmt.Sprintf("dir%d", dirIdxToMod))
+
+			err := eng.FileWriter.WriteFiles(writeToDir, fioOpt)
+			testenv.AssertNoError(t, err)
+		}
+
+		snapID, err := eng.Checker.TakeSnapshot(ctx, eng.FileWriter.LocalDataDir)
+		testenv.AssertNoError(t, err)
+
+		resultIDs = append(resultIDs, snapID)
+	}
+
+	for _, snapID := range resultIDs {
+		err := eng.Checker.RestoreSnapshot(ctx, snapID, nil)
+		testenv.AssertNoError(t, err)
+	}
+}

--- a/tests/tools/fswalker/fswalker_test.go
+++ b/tests/tools/fswalker/fswalker_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/fswalker"
@@ -183,8 +184,19 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 	} {
 		t.Log(tt.name)
 
+		matchers := tt.fields.GlobalFilterMatchers
+
 		chk := &WalkCompare{
-			GlobalFilterMatchers: tt.fields.GlobalFilterMatchers,
+			GlobalFilterFuncs: []func(string, fswalker.ActionData) bool{
+				func(inputStr string, _ fswalker.ActionData) bool {
+					for _, filterStr := range matchers {
+						if strings.Contains(inputStr, filterStr) {
+							return true
+						}
+					}
+					return false
+				},
+			},
 		}
 
 		tmpDir, err := ioutil.TempDir("", "")
@@ -322,9 +334,21 @@ func TestWalkChecker_filterReportDiffs(t *testing.T) {
 	} {
 		t.Log(tt.name)
 
+		matchers := tt.fields.GlobalFilterMatchers
+
 		chk := &WalkCompare{
-			GlobalFilterMatchers: tt.fields.GlobalFilterMatchers,
+			GlobalFilterFuncs: []func(string, fswalker.ActionData) bool{
+				func(inputStr string, _ fswalker.ActionData) bool {
+					for _, filterStr := range matchers {
+						if strings.Contains(inputStr, filterStr) {
+							return true
+						}
+					}
+					return false
+				},
+			},
 		}
+
 		chk.filterReportDiffs(tt.inputReport)
 
 		if want, got := tt.expModCount, len(tt.inputReport.Modified); want != got {


### PR DESCRIPTION
Add two tests:
- TestManySmallFiles: writes 100k files size 4k to a directory. Snapshots the data tree, restores and validates data.
- TestModifyWorkload: Loops over a simple randomized workload. Performs a series of random file writes to some random sub-directories, then takes a snapshot of the data tree. All snapshots taken during this test are restore-verified at the end.

A global test engine is instantiated in main_test.go, to be used in the robustness test suite across tests (saves time loading/saving metadata once per run instead of per test).

Updated https://github.com/kopia/kopia/issues/179 - simple test cases