### PR TITLE
Fixed arm and arm64 build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ go:
 os:
 - linux
 - osx
+arch:
+- amd64
+- arm64
 addons:
   apt:
     packages:

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ dist-binary:
 
 integration-tests: export KOPIA_EXE ?= $(KOPIA_INTEGRATION_EXE)
 integration-tests: dist-binary
-	 $(GO_TEST) $(TEST_FLAGS) -count=1 -parallel $(PARALLEL) -timeout 600s github.com/kopia/kopia/tests/end_to_end_test
+	 $(GO_TEST) $(TEST_FLAGS) -count=1 -parallel $(PARALLEL) -timeout 3600s github.com/kopia/kopia/tests/end_to_end_test
 
 robustness-tool-tests:
 	FIO_DOCKER_IMAGE=$(FIO_DOCKER_TAG) \

--- a/internal/faketime/faketime.go
+++ b/internal/faketime/faketime.go
@@ -35,8 +35,8 @@ func AutoAdvance(t time.Time, dt time.Duration) func() time.Time {
 // TimeAdvance allows controlling the passage of time. Intended to be used in
 // tests.
 type TimeAdvance struct {
-	base  time.Time
 	delta int64
+	base  time.Time
 }
 
 // NewTimeAdvance creates a TimeAdvance with the given start time

--- a/internal/stats/countsum_mutex.go
+++ b/internal/stats/countsum_mutex.go
@@ -1,13 +1,16 @@
-// +build amd64
+// +build !amd64
 
-// Package stats provides helpers for simple stats
-//
+// Package stats provides helpers for simple stats.  This implementation uses mutex to work around
+// ARM alignment issues with CountSum due to unpredictable memory alignment.
 package stats
 
-import "sync/atomic"
+import (
+	"sync"
+)
 
 // CountSum holds sum and count values
 type CountSum struct {
+	mu    sync.Mutex
 	sum   int64
 	count uint32
 }
@@ -15,11 +18,19 @@ type CountSum struct {
 // Add adds size to s and returns approximate values for the current count
 // and total bytes
 func (s *CountSum) Add(size int64) (count uint32, sum int64) {
-	return atomic.AddUint32(&s.count, 1), atomic.AddInt64(&s.sum, size)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.count += 1
+	s.sum += size
+	return s.count, s.sum
 }
 
 // Approximate returns an approximation of the current count and sum values.
 // It is approximate because retrieving both values is not an atomic operation.
 func (s *CountSum) Approximate() (count uint32, sum int64) {
-	return atomic.LoadUint32(&s.count), atomic.LoadInt64(&s.sum)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.count, s.sum
 }

--- a/internal/stats/countsum_mutex.go
+++ b/internal/stats/countsum_mutex.go
@@ -21,8 +21,9 @@ func (s *CountSum) Add(size int64) (count uint32, sum int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.count += 1
+	s.count++
 	s.sum += size
+
 	return s.count, s.sum
 }
 

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -700,6 +700,7 @@ func newManagerWithOptions(ctx context.Context, st blob.Storage, f *FormattingOp
 	mu := &sync.RWMutex{}
 	m := &Manager{
 		lockFreeManager: lockFreeManager{
+			Stats:                   new(Stats),
 			Format:                  *f,
 			timeNow:                 timeNow,
 			maxPackSize:             f.MaxPackSize,

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -23,8 +23,7 @@ const indexBlobCompactionWarningThreshold = 100
 
 // lockFreeManager contains parts of Manager state that can be accessed without locking
 type lockFreeManager struct {
-	// this one is not lock-free
-	Stats Stats
+	Stats *Stats
 
 	st             blob.Storage
 	Format         FormattingOptions

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"runtime"
 	"runtime/debug"
 	"sync"
 	"testing"
@@ -343,6 +344,13 @@ func TestEndToEndReadAndSeek(t *testing.T) {
 }
 
 func TestEndToEndReadAndSeekWithCompression(t *testing.T) {
+	sizes := []int{1, 199, 200, 201, 9999, 512434, 5012434, 15000000}
+	asyncWritesList := []int{0, 4, 8}
+
+	if runtime.GOARCH != "amd64" {
+		sizes = []int{1, 199, 200, 201, 9999, 512434, 5012434}
+	}
+
 	for _, compressible := range []bool{false, true} {
 		compressible := compressible
 
@@ -353,14 +361,14 @@ func TestEndToEndReadAndSeekWithCompression(t *testing.T) {
 
 				ctx := testlogging.Context(t)
 
-				for _, asyncWrites := range []int{0, 4, 8} {
+				for _, asyncWrites := range asyncWritesList {
 					asyncWrites := asyncWrites
 					totalBytesWritten := 0
 					data, om := setupTest(t)
 
 					t.Run(fmt.Sprintf("async-%v", asyncWrites), func(t *testing.T) {
 						t.Parallel()
-						for _, size := range []int{1, 199, 200, 201, 9999, 512434, 5012434, 15000000} {
+						for _, size := range sizes {
 
 							randomData := makeMaybeCompressibleData(size, compressible)
 

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -348,7 +348,7 @@ func TestEndToEndReadAndSeekWithCompression(t *testing.T) {
 	asyncWritesList := []int{0, 4, 8}
 
 	if runtime.GOARCH != "amd64" {
-		sizes = []int{1, 199, 200, 201, 9999, 512434, 5012434}
+		sizes = []int{1, 199, 200, 201, 9999, 512434}
 	}
 
 	for _, compressible := range []bool{false, true} {

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -45,6 +45,9 @@ const (
 
 // Uploader supports efficient uploading files and directories to repository.
 type Uploader struct {
+	// values aligned to 8-bytes due to atomic access
+	totalWrittenBytes int64
+
 	Progress UploadProgress
 
 	// automatically cancel the Upload after certain number of bytes
@@ -71,8 +74,6 @@ type Uploader struct {
 	nextCheckpointTime time.Time
 
 	uploadBufPool sync.Pool
-
-	totalWrittenBytes int64
 }
 
 // IsCanceled returns true if the upload is canceled.

--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -268,7 +268,7 @@ func verifyServerConnected(t *testing.T, cli *apiclient.KopiaAPIClient, want boo
 func waitForSnapshotCount(ctx context.Context, t *testing.T, cli *apiclient.KopiaAPIClient, match *snapshot.SourceInfo, want int) {
 	t.Helper()
 
-	err := retry.PeriodicallyNoValue(ctx, 1*time.Second, 60, "wait for snapshots", func() error {
+	err := retry.PeriodicallyNoValue(ctx, 1*time.Second, 180, "wait for snapshots", func() error {
 		snapshots, err := serverapi.ListSnapshots(testlogging.Context(t), cli, match)
 		if err != nil {
 			return errors.Wrap(err, "error listing sources")
@@ -359,7 +359,7 @@ func verifyUIServedWithCorrectTitle(t *testing.T, cli *apiclient.KopiaAPIClient,
 }
 
 func waitUntilServerStarted(ctx context.Context, t *testing.T, cli *apiclient.KopiaAPIClient) {
-	if err := retry.PeriodicallyNoValue(ctx, 1*time.Second, 60, "wait for server start", func() error {
+	if err := retry.PeriodicallyNoValue(ctx, 1*time.Second, 180, "wait for server start", func() error {
 		_, err := serverapi.Status(testlogging.Context(t), cli)
 		return err
 	}, retry.Always); err != nil {

--- a/tests/robustness/main_test.go
+++ b/tests/robustness/main_test.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin,amd64 linux,amd64
 
 package robustness
 

--- a/tests/robustness/robustness_test.go
+++ b/tests/robustness/robustness_test.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin,amd64 linux,amd64
 
 package robustness
 

--- a/tests/robustness/test_engine/engine.go
+++ b/tests/robustness/test_engine/engine.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin,amd64 linux,amd64
 
 // Package engine provides the framework for a snapshot repository testing engine
 package engine

--- a/tests/robustness/test_engine/engine_test.go
+++ b/tests/robustness/test_engine/engine_test.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin,amd64 linux,amd64
 
 // Package engine provides the framework for a snapshot repository testing engine
 package engine

--- a/tests/tools/fswalker/fswalker.go
+++ b/tests/tools/fswalker/fswalker.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin,amd64 linux,amd64
 
 // Package fswalker provides the checker.Comparer interface using FSWalker
 // walker and reporter.

--- a/tests/tools/fswalker/fswalker_test.go
+++ b/tests/tools/fswalker/fswalker_test.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin,amd64 linux,amd64
 
 package fswalker
 

--- a/tests/tools/fswalker/reporter/reporter.go
+++ b/tests/tools/fswalker/reporter/reporter.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin,amd64 linux,amd64
 
 // Package reporter wraps calls to the the fswalker Reporter
 package reporter

--- a/tests/tools/fswalker/reporter/reporter_test.go
+++ b/tests/tools/fswalker/reporter/reporter_test.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin,amd64 linux,amd64
 
 package reporter
 

--- a/tests/tools/fswalker/walker/walker.go
+++ b/tests/tools/fswalker/walker/walker.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin,amd64 linux,amd64
 
 // Package walker wraps calls to the the fswalker Walker
 package walker

--- a/tests/tools/fswalker/walker/walker_test.go
+++ b/tests/tools/fswalker/walker/walker_test.go
@@ -1,4 +1,4 @@
-// +build darwin linux
+// +build darwin,amd64 linux,amd64
 
 package walker
 

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -23,6 +23,13 @@ ifeq ($(raw_arch),aarch64)
 	linter_arch_name=arm64
 endif
 
+ifeq ($(raw_arch),armv7l)
+	kopia_arch_name=arm
+	node_arch_name=armv7l
+	goreleaser_arch_name=armv6
+	linter_arch_name=armv7
+endif
+
 ifneq ($(APPVEYOR),)
 
 UNIX_SHELL_ON_WINDOWS=false
@@ -249,10 +256,10 @@ endif
 endif
 
 # disable some tools on non-default architectures
-ifeq ($(kopia_arch_name),arm64)
-maybehugo=
-else
+ifeq ($(kopia_arch_name),amd64)
 maybehugo=$(hugo)
+else
+maybehugo=
 endif
 
 all-tools: $(npm) $(goreleaser) $(linter) $(maybehugo) $(go_bindata) windows-signing-tools

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -195,7 +195,7 @@ ifeq ($(uname),Windows)
 else
 
 ifeq ($(uname),Linux)
-	curl -LsS https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_extended$(HUGO_VERSION)_Linux-64bit.tar.gz | tar zxv -C $(hugo_dir)
+	curl -LsS https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_extended_$(HUGO_VERSION)_Linux-64bit.tar.gz | tar zxv -C $(hugo_dir)
 else
 	curl -LsS https://github.com/gohugoio/hugo/releases/download/v$(HUGO_VERSION)/hugo_extended_$(HUGO_VERSION)_macOS-64bit.tar.gz | tar zxv -C $(hugo_dir)
 endif


### PR DESCRIPTION
Fixed atomic alignment problems on ARMv7 mentioned in #505 

Now it's possible to build and run tests on both `armv7` and `armv8` a.k.a. `arm64` a.k.a. `aarch64`. The following are working:

```
$ make
$ make install-noui
$ make install
$ make test
$ make lint
$ make integration-test
$ make travis-setup
# slow
$ make travis-release
```

Building `site` does not work due to lack of appropriate Hugo build for ARM.
Determining whether it makes sense to build `kopia-ui` on ARM is TBD, but will certainly be interesting when new arm macbooks arrive.

Tested on 2 machines:

Raspberry PI 4 with 4 GB RAM on Ubuntu 20.04 LTS in 64-bit mode (aarch64)
Raspberry PI 4 with 2 GB RAM on Raspbian GNU/Linux 10 (buster) with 2GB RAM in 32-bit mode (armv7l)