### PR TITLE
cli: auto-upgrade the repository to 0.6.0

### DIFF
--- a/cli/auto_upgrade.go
+++ b/cli/auto_upgrade.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/maintenance"
+)
+
+func maybeAutoUpgradeRepository(ctx context.Context, r repo.Repository) {
+	if r == nil {
+		return
+	}
+
+	mr, ok := r.(maintenance.MaintainableRepository)
+	if !ok {
+		return
+	}
+
+	has, err := maintenance.HasParams(ctx, mr)
+	if err == nil && !has {
+		_, _ = noticeColor.Printf("Setting default maintenance parameters...\n")
+
+		if err := setDefaultMaintenanceParameters(ctx, mr); err != nil {
+			log(ctx).Warningf("unable to set default maintenance parameters: %v", err)
+		}
+	}
+}
+
+func setDefaultMaintenanceParameters(ctx context.Context, rep maintenance.MaintainableRepository) error {
+	p := maintenance.DefaultParams()
+	p.Owner = rep.Username() + "@" + rep.Hostname()
+
+	if err := maintenance.SetParams(ctx, rep, &p); err != nil {
+		return errors.Wrap(err, "unable to set maintenance params")
+	}
+
+	_, _ = noticeColor.Printf(`
+Kopia will perform quick maintenance of the repository automatically every %v
+when running as %v. This operation never deletes any data.
+
+Full maintenance (which also deletes unreferenced data) is disabled by default.
+
+To run it manually use:
+
+$ kopia maintenance run --full
+
+Alternatively you can schedule full maintenance to run periodically using:
+
+$ kopia maintenance set --enable-full=true --full-interval=4h
+`, p.QuickCycle.Interval, p.Owner)
+
+	return nil
+}

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -105,14 +105,5 @@ func populateRepository(ctx context.Context, password string) error {
 	printStdout("To change the policy use:\n  kopia policy set --global <options>\n")
 	printStdout("or\n  kopia policy set <dir> <options>\n")
 
-	if dr, ok := rep.(*repo.DirectRepository); ok {
-		p := maintenance.DefaultParams()
-		p.Owner = rep.Username() + "@" + rep.Hostname()
-
-		if err := maintenance.SetParams(ctx, dr, &p); err != nil {
-			return errors.Wrap(err, "unable to set maintenance params")
-		}
-	}
-
-	return nil
+	return setDefaultMaintenanceParameters(ctx, rep.(maintenance.MaintainableRepository))
 }

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -52,6 +52,8 @@ func runServer(ctx context.Context, rep repo.Repository) error {
 		return errors.Wrap(err, "unable to initialize server")
 	}
 
+	maybeAutoUpgradeRepository(ctx, rep)
+
 	if err = srv.SetRepository(ctx, rep); err != nil {
 		return errors.Wrap(err, "error connecting to repository")
 	}

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -37,6 +37,8 @@ var (
 func runSnapshotCommand(ctx context.Context, rep repo.Repository) error {
 	sources := *snapshotCreateSources
 
+	maybeAutoUpgradeRepository(ctx, rep)
+
 	if *snapshotCreateAll {
 		local, err := getLocalBackupPaths(ctx, rep)
 		if err != nil {

--- a/repo/maintenance/maintenance_params.go
+++ b/repo/maintenance/maintenance_params.go
@@ -39,8 +39,7 @@ func DefaultParams() Params {
 			Interval: 7 * 24 * time.Hour,
 		},
 		QuickCycle: CycleParams{
-			// TODO: enable this when ready for public consumption
-			// Enabled:  true,
+			Enabled:  true,
 			Interval: 1 * time.Hour,
 		},
 		SnapshotGC: SnapshotGCParams{
@@ -53,6 +52,16 @@ func DefaultParams() Params {
 type CycleParams struct {
 	Enabled  bool          `json:"enabled"`
 	Interval time.Duration `json:"interval"`
+}
+
+// HasParams determines whether repository-wide maintenance parameters have been set.
+func HasParams(ctx context.Context, rep MaintainableRepository) (bool, error) {
+	md, err := manifestIDs(ctx, rep)
+	if err != nil {
+		return false, err
+	}
+
+	return len(md) > 0, nil
 }
 
 // GetParams returns repository-wide maintenance parameters.


### PR DESCRIPTION
On first 'kopia snapshot' or 'kopia server' use where the 'maintenance' manifest cannot be found, we create a default one and display usage note.