### PR TITLE
Fix #516 - Chown not suported on Windows

### DIFF
--- a/snapshot/restore/local_fs_output.go
+++ b/snapshot/restore/local_fs_output.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/natefinch/atomic"
 	"github.com/pkg/errors"
@@ -86,7 +87,9 @@ func (o *FilesystemOutput) setAttributes(targetPath string, e fs.Entry) error {
 	}
 
 	// Set owner user and group from e
-	if le.Owner() != e.Owner() {
+	// On Windows Chown is not supported. fs.OwnerInfo collected on Windows will always
+	// be zero-value for UID and GID, so the Chown operation is not performed.
+	if le.Owner() != e.Owner() && runtime.GOOS != "windows" {
 		if err = os.Chown(targetPath, int(e.Owner().UserID), int(e.Owner().GroupID)); err != nil && !os.IsPermission(err) {
 			return errors.Wrap(err, "could not change owner/group for "+targetPath)
 		}


### PR DESCRIPTION
Proposed fix for #516: Do not attempt to call `os.Chown` on Windows. The
command is unsupported on windows and will always return
`syscall.EWINDOWS`.

Handling for user ID and group ID on Windows already hardcodes
both values to zero. If a snapshot is restored with non-zero UID/GID
values (for instance if the snapshot was created on a different OS),
filesystem entries will be restored without changing UID/GID, resulting
in a state similar to how they would look if the snapshot was
taken on Windows in the first place.