### PR TITLE
fix typo in url

### DIFF
--- a/site/content/docs/Features/_index.md
+++ b/site/content/docs/Features/_index.md
@@ -8,7 +8,7 @@ weight: 30
 
 Kopia uploads directories and files to remote storage called [Repository](../architecture/) and maintains a set of historical point-in-time snapshot records based on defined policies.
 
-Kopia uses [content-addressable storage](https://en.wikipedia.org/wiki/Content-addressable storage) for snapshots, which has many benefits:
+Kopia uses [content-addressable storage](https://en.wikipedia.org/wiki/Content-addressable%20storage) for snapshots, which has many benefits:
 
 * Each snapshot is always incremental, no data included in previous snapshots is ever re-uploaded to the repository based on file content.
 


### PR DESCRIPTION
This makes the link render correctly.

It looks like this on the site presently, at https://kopia.io/docs/features/:

> <img width="667" alt="image" src="https://user-images.githubusercontent.com/19393950/89705076-fcaa2500-d90e-11ea-8c8d-9244d5e3f97b.png">
