### PR TITLE
upload: auto-ignore kopia cache directories when creating snapshots

### DIFF
--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -1,8 +1,13 @@
 package endtoend_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/kopia/kopia/repo"
 
 	"github.com/kopia/kopia/tests/testenv"
 )
@@ -87,4 +92,29 @@ func TestInvalidTimeOverride(t *testing.T) {
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 	e.RunAndExpectFailure(t, "snapshot", "create", sharedTestDataDir1, "--start-time", "2000-01-01 01:01:00 UTC", "--end-time", "1999-01-01 01:01:00 UTC")
+}
+
+func TestSnapshottingCacheDirectory(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+	defer e.Cleanup(t)
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
+	lines := e.RunAndExpectSuccess(t, "cache", "info")
+	cachePath := filepath.Dir(strings.Split(lines[0], ": ")[0])
+
+	// verify cache marker exists
+	if _, err := os.Stat(filepath.Join(cachePath, repo.CacheDirMarkerFile)); err != nil {
+		t.Fatal(err)
+	}
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", cachePath)
+	snapshots := e.ListSnapshotsAndExpectSuccess(t, cachePath)
+
+	rootID := snapshots[0].Snapshots[0].ObjectID
+	if got, want := len(e.RunAndExpectSuccess(t, "ls", rootID)), 0; got != want {
+		t.Errorf("invalid number of files in snapshot of cache dir %v, want %v", got, want)
+	}
 }


### PR DESCRIPTION
This creates a marker file ".kopia-cache" in the directory that's the root of cache. When uploader sees the file it will treat the entire directory as empty.

This allows entire home directory or root to be backed up more easily.