### PR TITLE
Added endurance test which tests kopia over long time scale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ lint-and-log: $(linter)
 
 vet-time-inject:
 ifneq ($(TRAVIS_OS_NAME),windows)
-	! find repo snapshot -name '*.go' -not -path 'repo/blob/logging/*' -not -name '*_test.go' \
+	! find . -name '*.go' \
 	-exec grep -n -e time.Now -e time.Since -e time.Until {} + \
 	| grep -v -e allow:no-inject-time
 endif

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,10 @@ integration-tests: export KOPIA_EXE ?= $(KOPIA_INTEGRATION_EXE)
 integration-tests: dist-binary
 	 $(GO_TEST) $(TEST_FLAGS) -count=1 -parallel $(PARALLEL) -timeout 3600s github.com/kopia/kopia/tests/end_to_end_test
 
+endurance-tests: export KOPIA_EXE ?= $(KOPIA_INTEGRATION_EXE)
+endurance-tests: dist-binary
+	 $(GO_TEST) $(TEST_FLAGS) -count=1 -parallel $(PARALLEL) -timeout 3600s github.com/kopia/kopia/tests/endurance_test
+
 robustness-tool-tests:
 	FIO_DOCKER_IMAGE=$(FIO_DOCKER_TAG) \
 	$(GO_TEST) $(TEST_FLAGS) -count=1 -timeout 90s github.com/kopia/kopia/tests/tools/...

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ vtest:
 	$(GO_TEST) -count=1 -short -v -timeout $(UNIT_TESTS_TIMEOUT) ./...
 
 dist-binary:
-	go build -o $(KOPIA_INTEGRATION_EXE) github.com/kopia/kopia
+	go build -o $(KOPIA_INTEGRATION_EXE) -tags testing github.com/kopia/kopia
 
 integration-tests: export KOPIA_EXE ?= $(KOPIA_INTEGRATION_EXE)
 integration-tests: dist-binary

--- a/cli/cli_progress.go
+++ b/cli/cli_progress.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fatih/color"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
@@ -98,7 +99,7 @@ func (p *cliProgress) Checkpoint() {
 
 	*p = cliProgress{
 		uploading:         1,
-		uploadStartTime:   time.Now(),
+		uploadStartTime:   clock.Now(),
 		previousFileCount: p.previousFileCount,
 		previousTotalSize: p.previousTotalSize,
 		uploadedBytes:     p.uploadedBytes,
@@ -114,7 +115,7 @@ func (p *cliProgress) maybeOutput() {
 	var shouldOutput bool
 
 	nextOutputTimeUnixNano := atomic.LoadInt64(&p.nextOutputTimeUnixNano)
-	if nowNano := time.Now().UnixNano(); nowNano > nextOutputTimeUnixNano {
+	if nowNano := clock.Now().UnixNano(); nowNano > nextOutputTimeUnixNano {
 		if atomic.CompareAndSwapInt64(&p.nextOutputTimeUnixNano, nextOutputTimeUnixNano, nowNano+progressUpdateInterval.Nanoseconds()) {
 			shouldOutput = true
 		}
@@ -204,7 +205,7 @@ func (p *cliProgress) spinnerCharacter() string {
 func (p *cliProgress) StartShared() {
 	*p = cliProgress{
 		uploading:       1,
-		uploadStartTime: time.Now(),
+		uploadStartTime: clock.Now(),
 		shared:          true,
 	}
 }
@@ -222,7 +223,7 @@ func (p *cliProgress) UploadStarted(previousFileCount int, previousTotalSize int
 
 	*p = cliProgress{
 		uploading:         1,
-		uploadStartTime:   time.Now(),
+		uploadStartTime:   clock.Now(),
 		previousFileCount: previousFileCount,
 		previousTotalSize: previousTotalSize,
 	}

--- a/cli/command_benchmark_compression.go
+++ b/cli/command_benchmark_compression.go
@@ -5,10 +5,10 @@ import (
 	"hash/fnv"
 	"io/ioutil"
 	"sort"
-	"time"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo/compression"
 )
@@ -45,7 +45,7 @@ func runBenchmarkCompressionAction(ctx *kingpin.ParseContext) error {
 	for name, comp := range compression.ByName {
 		printStderr("Benchmarking compressor '%v' (%v x %v bytes)\n", name, *benchmarkCompressionRepeat, len(data))
 
-		t0 := time.Now()
+		t0 := clock.Now()
 
 		var compressedSize int64
 
@@ -77,7 +77,7 @@ func runBenchmarkCompressionAction(ctx *kingpin.ParseContext) error {
 			}
 		}
 
-		hashTime := time.Since(t0)
+		hashTime := clock.Since(t0)
 		bytesPerSecond := float64(len(data)) * float64(cnt) / hashTime.Seconds()
 
 		results = append(results, benchResult{compression: name, throughput: bytesPerSecond, compressedSize: compressedSize})

--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -2,10 +2,10 @@ package cli
 
 import (
 	"sort"
-	"time"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/encryption"
@@ -53,7 +53,7 @@ func runBenchmarkCryptoAction(ctx *kingpin.ParseContext) error {
 
 			printStderr("Benchmarking hash '%v' and encryption '%v'... (%v x %v bytes)\n", ha, ea, *benchmarkCryptoRepeat, len(data))
 
-			t0 := time.Now()
+			t0 := clock.Now()
 
 			hashCount := *benchmarkCryptoRepeat
 
@@ -65,7 +65,7 @@ func runBenchmarkCryptoAction(ctx *kingpin.ParseContext) error {
 				}
 			}
 
-			hashTime := time.Since(t0)
+			hashTime := clock.Since(t0)
 			bytesPerSecond := float64(len(data)) * float64(hashCount) / hashTime.Seconds()
 
 			results = append(results, benchResult{hash: ha, encryption: ea, throughput: bytesPerSecond})

--- a/cli/command_benchmark_splitters.go
+++ b/cli/command_benchmark_splitters.go
@@ -7,6 +7,7 @@ import (
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/splitter"
 )
 
@@ -54,7 +55,7 @@ func runBenchmarkSplitterAction(ctx *kingpin.ParseContext) error {
 
 		var segmentLengths []int
 
-		t0 := time.Now()
+		t0 := clock.Now()
 
 		for _, data := range dataBlocks {
 			s := fact()
@@ -74,7 +75,7 @@ func runBenchmarkSplitterAction(ctx *kingpin.ParseContext) error {
 			}
 		}
 
-		dur := time.Since(t0)
+		dur := clock.Since(t0)
 
 		sort.Ints(segmentLengths)
 

--- a/cli/command_index_optimize.go
+++ b/cli/command_index_optimize.go
@@ -2,8 +2,8 @@ package cli
 
 import (
 	"context"
-	"time"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/content"
 )
@@ -24,7 +24,7 @@ func runOptimizeCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	}
 
 	if age := *optimizeDropDeletedOlderThan; age > 0 {
-		opt.DropDeletedBefore = time.Now().Add(-age)
+		opt.DropDeletedBefore = clock.Now().Add(-age)
 	}
 
 	return rep.Content.CompactIndexes(ctx, opt)

--- a/cli/command_maintenance_info.go
+++ b/cli/command_maintenance_info.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/maintenance"
 )
@@ -74,7 +75,7 @@ func displayCycleInfo(c *maintenance.CycleParams, t time.Time, rep *repo.DirectR
 		printStdout("  interval: %v\n", c.Interval)
 
 		if rep.Time().Before(t) {
-			printStdout("  next run: %v (in %v)\n", formatTimestamp(t), time.Until(t).Truncate(time.Second))
+			printStdout("  next run: %v (in %v)\n", formatTimestamp(t), clock.Until(t).Truncate(time.Second))
 		} else {
 			printStdout("  next run: now\n")
 		}

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -14,13 +14,13 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/pkg/errors"
 	prom "github.com/prometheus/client_golang/prometheus"
 	htpasswd "github.com/tg123/go-htpasswd"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/server"
 	"github.com/kopia/kopia/repo"
 )
@@ -185,7 +185,7 @@ func serveIndexFileForKnownUIRoutes(fs http.FileSystem) http.Handler {
 
 		if r.URL.Path == "/" && indexBytes != nil {
 			fmt.Println("serving patched index")
-			http.ServeContent(w, r, "/", time.Now(), bytes.NewReader(indexBytes))
+			http.ServeContent(w, r, "/", clock.Now(), bytes.NewReader(indexBytes))
 			return
 		}
 

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
@@ -145,7 +146,7 @@ func startTimeAfterEndTime(startTime, endTime time.Time) bool {
 func snapshotSingleSource(ctx context.Context, rep repo.Repository, u *snapshotfs.Uploader, sourceInfo snapshot.SourceInfo) error {
 	printStderr("Snapshotting %v ...\n", sourceInfo)
 
-	t0 := time.Now()
+	t0 := clock.Now()
 
 	localEntry, err := getLocalFSEntry(ctx, sourceInfo.Path)
 	if err != nil {
@@ -218,7 +219,7 @@ func snapshotSingleSource(ctx context.Context, rep repo.Repository, u *snapshotf
 		}
 	}
 
-	printStderr("\nCreated%v snapshot with root %v and ID %v in %v\n", maybePartial, manifest.RootObjectID(), snapID, time.Since(t0).Truncate(time.Second))
+	printStderr("\nCreated%v snapshot with root %v and ID %v in %v\n", maybePartial, manifest.RootObjectID(), snapID, clock.Since(t0).Truncate(time.Second))
 
 	return err
 }

--- a/cli/command_snapshot_verify.go
+++ b/cli/command_snapshot_verify.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/parallelwork"
 	"github.com/kopia/kopia/repo"
@@ -43,7 +44,7 @@ type verifier struct {
 }
 
 func (v *verifier) progressCallback(enqueued, active, completed int64) {
-	elapsed := time.Since(v.startTime)
+	elapsed := clock.Since(v.startTime)
 	maybeTimeRemaining := ""
 
 	if elapsed > 1*time.Second && enqueued > 0 && completed > 0 {
@@ -51,7 +52,7 @@ func (v *verifier) progressCallback(enqueued, active, completed int64) {
 		predictedSeconds := elapsed.Seconds() / completedRatio
 		predictedEndTime := v.startTime.Add(time.Duration(predictedSeconds) * time.Second)
 
-		dt := time.Until(predictedEndTime)
+		dt := clock.Until(predictedEndTime)
 		if dt > 0 {
 			maybeTimeRemaining = fmt.Sprintf(" remaining %v (ETA %v)", dt.Truncate(1*time.Second), formatTimestamp(predictedEndTime.Truncate(1*time.Second)))
 		}
@@ -180,7 +181,7 @@ func (v *verifier) readEntireObject(ctx context.Context, oid object.ID, path str
 func runVerifyCommand(ctx context.Context, rep repo.Repository) error {
 	v := &verifier{
 		rep:       rep,
-		startTime: time.Now(),
+		startTime: clock.Now(),
 		workQueue: parallelwork.NewQueue(),
 		seen:      map[object.ID]bool{},
 	}

--- a/cli/update_check.go
+++ b/cli/update_check.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo"
 )
 
@@ -99,8 +100,8 @@ func getUpdateState() (*updateState, error) {
 func maybeInitializeUpdateCheck(ctx context.Context) {
 	if connectCheckForUpdates {
 		us := &updateState{
-			NextCheckTime:  time.Now().Add(*initialUpdateCheckDelay),
-			NextNotifyTime: time.Now().Add(*initialUpdateCheckDelay),
+			NextCheckTime:  clock.Now().Add(*initialUpdateCheckDelay),
+			NextNotifyTime: clock.Now().Add(*initialUpdateCheckDelay),
 		}
 		if err := writeUpdateState(us); err != nil {
 			log(ctx).Debugf("error initializing update state")
@@ -192,8 +193,8 @@ func maybeCheckForUpdates(ctx context.Context) (string, error) {
 		return "", nil
 	}
 
-	if time.Now().After(us.NextNotifyTime) {
-		us.NextNotifyTime = time.Now().Add(*updateAvailableNotifyInterval)
+	if clock.Now().After(us.NextNotifyTime) {
+		us.NextNotifyTime = clock.Now().Add(*updateAvailableNotifyInterval)
 		if err := writeUpdateState(us); err != nil {
 			return "", errors.Wrap(err, "unable to write update state")
 		}
@@ -206,7 +207,7 @@ func maybeCheckForUpdates(ctx context.Context) (string, error) {
 }
 
 func maybeCheckGithub(ctx context.Context, us *updateState) error {
-	if !time.Now().After(us.NextCheckTime) {
+	if !clock.Now().After(us.NextCheckTime) {
 		return nil
 	}
 
@@ -214,7 +215,7 @@ func maybeCheckGithub(ctx context.Context, us *updateState) error {
 
 	// before we check for update, write update state file again, so if this fails
 	// we won't bother GitHub for a while
-	us.NextCheckTime = time.Now().Add(*updateCheckInterval)
+	us.NextCheckTime = clock.Now().Add(*updateCheckInterval)
 	if err := writeUpdateState(us); err != nil {
 		return errors.Wrap(err, "unable to write update state")
 	}

--- a/fs/cachefs/cache.go
+++ b/fs/cachefs/cache.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/logging"
 	"github.com/kopia/kopia/repo/object"
 )
@@ -93,7 +94,7 @@ func (c *Cache) Readdir(ctx context.Context, d fs.Directory) (fs.Entries, error)
 
 func (c *Cache) getEntriesFromCacheLocked(ctx context.Context, id string) fs.Entries {
 	if v, ok := c.data[id]; id != "" && ok {
-		if time.Now().Before(v.expireAfter) {
+		if clock.Now().Before(v.expireAfter) {
 			c.moveToHead(v)
 
 			if c.debug {
@@ -145,7 +146,7 @@ func (c *Cache) getEntries(ctx context.Context, id string, expirationTime time.D
 	entry := &cacheEntry{
 		id:          id,
 		entries:     raw,
-		expireAfter: time.Now().Add(expirationTime),
+		expireAfter: clock.Now().Add(expirationTime),
 	}
 
 	c.addToHead(entry)

--- a/fs/localfs/local_fs_test.go
+++ b/fs/localfs/local_fs_test.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/testlogging"
 )
 
@@ -29,7 +29,7 @@ func TestFiles(t *testing.T) {
 	var dir fs.Directory
 
 	// Try listing directory that does not exist.
-	_, err = Directory(fmt.Sprintf("/no-such-dir-%v", time.Now().Nanosecond()))
+	_, err = Directory(fmt.Sprintf("/no-such-dir-%v", clock.Now().Nanosecond()))
 	if err == nil {
 		t.Errorf("expected error when dir directory that does not exist.")
 	}

--- a/fs/loggingfs/loggingfs.go
+++ b/fs/loggingfs/loggingfs.go
@@ -3,9 +3,9 @@ package loggingfs
 
 import (
 	"context"
-	"time"
 
 	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/internal/clock"
 )
 
 type loggingOptions struct {
@@ -20,9 +20,9 @@ type loggingDirectory struct {
 }
 
 func (ld *loggingDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {
-	t0 := time.Now()
+	t0 := clock.Now()
 	entry, err := ld.Directory.Child(ctx, name)
-	dt := time.Since(t0)
+	dt := clock.Since(t0)
 	ld.options.printf(ld.options.prefix+"Child(%v) took %v and returned %v", ld.relativePath, dt, err)
 
 	if err != nil {
@@ -33,9 +33,9 @@ func (ld *loggingDirectory) Child(ctx context.Context, name string) (fs.Entry, e
 }
 
 func (ld *loggingDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
-	t0 := time.Now()
+	t0 := clock.Now()
 	entries, err := ld.Directory.Readdir(ctx)
-	dt := time.Since(t0)
+	dt := clock.Since(t0)
 	ld.options.printf(ld.options.prefix+"Readdir(%v) took %v and returned %v items", ld.relativePath, dt, len(entries))
 
 	loggingEntries := make(fs.Entries, len(entries))

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -8,10 +8,10 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/tlsutil"
 	"github.com/kopia/kopia/repo/logging"
 )
@@ -175,15 +175,15 @@ type loggingTransport struct {
 }
 
 func (t loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	t0 := time.Now()
+	t0 := clock.Now()
 
 	resp, err := t.base.RoundTrip(req)
 	if err != nil {
-		log(req.Context()).Debugf("%v %v took %v and failed with %v", req.Method, req.URL, time.Since(t0), err)
+		log(req.Context()).Debugf("%v %v took %v and failed with %v", req.Method, req.URL, clock.Since(t0), err)
 		return nil, err
 	}
 
-	log(req.Context()).Debugf("%v %v took %v and returned %v", req.Method, req.URL, time.Since(t0), resp.Status)
+	log(req.Context()).Debugf("%v %v took %v and returned %v", req.Method, req.URL, clock.Since(t0), resp.Status)
 
 	return resp, nil
 }

--- a/internal/blobtesting/eventually_consistent.go
+++ b/internal/blobtesting/eventually_consistent.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -53,7 +54,7 @@ func (c *ecFrontendCache) put(id blob.ID, data []byte) {
 	}
 
 	c.cachedEntries[id] = &ecCacheEntry{
-		accessTime: time.Now(),
+		accessTime: clock.Now(),
 		data:       data,
 	}
 }
@@ -73,7 +74,7 @@ type ecCacheEntry struct {
 }
 
 func (e *ecCacheEntry) isValid() bool {
-	return time.Since(e.accessTime) < ecCacheDuration
+	return clock.Since(e.accessTime) < ecCacheDuration
 }
 
 type eventuallyConsistentStorage struct {

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -165,7 +166,7 @@ func NewMapStorage(data DataMap, keyTime map[blob.ID]time.Time, timeNow func() t
 	}
 
 	if timeNow == nil {
-		timeNow = time.Now
+		timeNow = clock.Now
 	}
 
 	return &mapStorage{data: data, keyTime: keyTime, timeNow: timeNow}

--- a/internal/clock/now.go
+++ b/internal/clock/now.go
@@ -1,0 +1,83 @@
+// Package clock provides indirection for accessing current time.
+package clock
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+const refreshServerTimeEvery = 3 * time.Second
+
+// Now is overridable function that returns current wall clock time.
+var Now = time.Now // allow:no-inject-time
+
+// Since returns time since the given timestamp.
+func Since(t time.Time) time.Duration {
+	return Now().Sub(t)
+}
+
+// Until returns duration of time between now and a given time.
+func Until(t time.Time) time.Duration {
+	return t.Sub(Now())
+}
+
+func init() {
+	fakeTimeServer := os.Getenv("KOPIA_FAKE_CLOCK_ENDPOINT")
+	if fakeTimeServer == "" {
+		return
+	}
+
+	Now = getTimeFromServer(fakeTimeServer)
+}
+
+// getTimeFromServer returns a function that will return timestamp as returned by the server
+// increasing it client-side by certain inteval until maximum is reached, at which point
+// it will ask the server again for new timestamp.
+//
+// The server endpoint must be HTTP and be set using KOPIA_FAKE_CLOCK_ENDPOINT environment
+// variable.
+func getTimeFromServer(endpoint string) func() time.Time {
+	var mu sync.Mutex
+
+	var timeInfo struct {
+		Next  int64 `json:"next"`
+		Step  int64 `json:"step"`
+		Until int64 `json:"until"`
+	}
+
+	nextRefreshRealTime := time.Now() // allow:no-inject-time
+
+	return func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if timeInfo.Next >= timeInfo.Until || time.Now().After(nextRefreshRealTime) { // allow:no-inject-time
+			resp, err := http.Get(endpoint) //nolint:gosec,noctx
+			if err != nil {
+				log.Fatalf("unable to get fake time from server: %v", err)
+			}
+			defer resp.Body.Close() //nolint:errcheck
+
+			if resp.StatusCode != http.StatusOK {
+				log.Fatalf("unable to get fake time from server: %v", resp.Status)
+			}
+
+			if err := json.NewDecoder(resp.Body).Decode(&timeInfo); err != nil {
+				log.Fatalf("invalid time received from fake time server: %v", err)
+			}
+
+			nextRefreshRealTime = time.Now().Add(refreshServerTimeEvery) // allow:no-inject-time
+		}
+
+		v := timeInfo.Next
+		timeInfo.Next += timeInfo.Step
+
+		n := time.Unix(0, v)
+
+		return n
+	}
+}

--- a/internal/clock/now.go
+++ b/internal/clock/now.go
@@ -2,18 +2,8 @@
 package clock
 
 import (
-	"encoding/json"
-	"log"
-	"net/http"
-	"os"
-	"sync"
 	"time"
 )
-
-const refreshServerTimeEvery = 3 * time.Second
-
-// Now is overridable function that returns current wall clock time.
-var Now = time.Now // allow:no-inject-time
 
 // Since returns time since the given timestamp.
 func Since(t time.Time) time.Duration {
@@ -23,61 +13,4 @@ func Since(t time.Time) time.Duration {
 // Until returns duration of time between now and a given time.
 func Until(t time.Time) time.Duration {
 	return t.Sub(Now())
-}
-
-func init() {
-	fakeTimeServer := os.Getenv("KOPIA_FAKE_CLOCK_ENDPOINT")
-	if fakeTimeServer == "" {
-		return
-	}
-
-	Now = getTimeFromServer(fakeTimeServer)
-}
-
-// getTimeFromServer returns a function that will return timestamp as returned by the server
-// increasing it client-side by certain inteval until maximum is reached, at which point
-// it will ask the server again for new timestamp.
-//
-// The server endpoint must be HTTP and be set using KOPIA_FAKE_CLOCK_ENDPOINT environment
-// variable.
-func getTimeFromServer(endpoint string) func() time.Time {
-	var mu sync.Mutex
-
-	var timeInfo struct {
-		Next  int64 `json:"next"`
-		Step  int64 `json:"step"`
-		Until int64 `json:"until"`
-	}
-
-	nextRefreshRealTime := time.Now() // allow:no-inject-time
-
-	return func() time.Time {
-		mu.Lock()
-		defer mu.Unlock()
-
-		if timeInfo.Next >= timeInfo.Until || time.Now().After(nextRefreshRealTime) { // allow:no-inject-time
-			resp, err := http.Get(endpoint) //nolint:gosec,noctx
-			if err != nil {
-				log.Fatalf("unable to get fake time from server: %v", err)
-			}
-			defer resp.Body.Close() //nolint:errcheck
-
-			if resp.StatusCode != http.StatusOK {
-				log.Fatalf("unable to get fake time from server: %v", resp.Status)
-			}
-
-			if err := json.NewDecoder(resp.Body).Decode(&timeInfo); err != nil {
-				log.Fatalf("invalid time received from fake time server: %v", err)
-			}
-
-			nextRefreshRealTime = time.Now().Add(refreshServerTimeEvery) // allow:no-inject-time
-		}
-
-		v := timeInfo.Next
-		timeInfo.Next += timeInfo.Step
-
-		n := time.Unix(0, v)
-
-		return n
-	}
 }

--- a/internal/clock/now_prod.go
+++ b/internal/clock/now_prod.go
@@ -1,0 +1,10 @@
+// +build !testing
+
+package clock
+
+import "time"
+
+// Now returns current wall clock time.
+func Now() time.Time {
+	return time.Now() // allow:no-inject-time
+}

--- a/internal/clock/now_testing.go
+++ b/internal/clock/now_testing.go
@@ -1,0 +1,74 @@
+// +build testing
+
+package clock
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+const refreshServerTimeEvery = 3 * time.Second
+
+// Now is overridable function that returns current wall clock time.
+var Now = time.Now // allow:no-inject-time
+
+func init() {
+	fakeTimeServer := os.Getenv("KOPIA_FAKE_CLOCK_ENDPOINT")
+	if fakeTimeServer == "" {
+		return
+	}
+
+	Now = getTimeFromServer(fakeTimeServer)
+}
+
+// getTimeFromServer returns a function that will return timestamp as returned by the server
+// increasing it client-side by certain inteval until maximum is reached, at which point
+// it will ask the server again for new timestamp.
+//
+// The server endpoint must be HTTP and be set using KOPIA_FAKE_CLOCK_ENDPOINT environment
+// variable.
+func getTimeFromServer(endpoint string) func() time.Time {
+	var mu sync.Mutex
+
+	var timeInfo struct {
+		Next  int64 `json:"next"`
+		Step  int64 `json:"step"`
+		Until int64 `json:"until"`
+	}
+
+	nextRefreshRealTime := time.Now() // allow:no-inject-time
+
+	return func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if timeInfo.Next >= timeInfo.Until || time.Now().After(nextRefreshRealTime) { // allow:no-inject-time
+			resp, err := http.Get(endpoint) //nolint:gosec,noctx
+			if err != nil {
+				log.Fatalf("unable to get fake time from server: %v", err)
+			}
+			defer resp.Body.Close() //nolint:errcheck
+
+			if resp.StatusCode != http.StatusOK {
+				log.Fatalf("unable to get fake time from server: %v", resp.Status)
+			}
+
+			if err := json.NewDecoder(resp.Body).Decode(&timeInfo); err != nil {
+				log.Fatalf("invalid time received from fake time server: %v", err)
+			}
+
+			nextRefreshRealTime = time.Now().Add(refreshServerTimeEvery) // allow:no-inject-time
+		}
+
+		v := timeInfo.Next
+		timeInfo.Next += timeInfo.Step
+
+		n := time.Unix(0, v)
+
+		return n
+	}
+}

--- a/internal/faketime/faketime_test.go
+++ b/internal/faketime/faketime_test.go
@@ -4,12 +4,14 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/kopia/kopia/internal/clock"
 )
 
 func TestFrozen(t *testing.T) {
 	times := []time.Time{
 		time.Date(2015, 1, 3, 0, 0, 0, 0, time.UTC),
-		time.Now(),
+		clock.Now(),
 	}
 
 	for _, tm := range times {

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/cli"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/ospath"
 	repologging "github.com/kopia/kopia/repo/logging"
 )
@@ -63,7 +64,7 @@ func Initialize(ctx *kingpin.ParseContext) error {
 	var shouldSweepLogs bool
 
 	if logFileName == "" && *logDir != "" {
-		logBaseName := fmt.Sprintf("%v%v-%v%v", logFileNamePrefix, time.Now().Format("20060102-150405"), os.Getpid(), logFileNameSuffix)
+		logBaseName := fmt.Sprintf("%v%v-%v%v", logFileNamePrefix, clock.Now().Format("20060102-150405"), os.Getpid(), logFileNameSuffix)
 		logFileName = filepath.Join(*logDir, logBaseName)
 		symlinkName = "kopia.latest.log"
 
@@ -111,7 +112,7 @@ func Initialize(ctx *kingpin.ParseContext) error {
 func sweepLogDir(ctx context.Context, dirname string, maxCount int, maxAge time.Duration) {
 	var timeCutoff time.Time
 	if maxAge > 0 {
-		timeCutoff = time.Now().Add(-maxAge)
+		timeCutoff = clock.Now().Add(-maxAge)
 	}
 
 	if maxCount == 0 {

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -143,7 +143,7 @@ func sweepLogDir(ctx context.Context, dirname string, maxCount int, maxAge time.
 		cnt++
 
 		if cnt > maxCount || e.ModTime().Before(timeCutoff) {
-			if err = os.Remove(filepath.Join(dirname, e.Name())); err != nil {
+			if err = os.Remove(filepath.Join(dirname, e.Name())); err != nil && !os.IsNotExist(err) {
 				log(ctx).Warningf("unable to remove log file: %v", err)
 			}
 		}

--- a/internal/parallelwork/parallel_work_queue.go
+++ b/internal/parallelwork/parallel_work_queue.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+
+	"github.com/kopia/kopia/internal/clock"
 )
 
 // Queue represents a work queue with multiple parallel workers.
@@ -127,11 +129,11 @@ func (v *Queue) maybeReportProgress() {
 		return
 	}
 
-	if time.Now().Before(v.nextReportTime) {
+	if clock.Now().Before(v.nextReportTime) {
 		return
 	}
 
-	v.nextReportTime = time.Now().Add(1 * time.Second)
+	v.nextReportTime = clock.Now().Add(1 * time.Second)
 
 	cb(v.enqueuedWork, v.activeWorkerCount, v.completedWork)
 }

--- a/internal/server/api_object_get.go
+++ b/internal/server/api_object_get.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/object"
 )
 
@@ -35,7 +36,7 @@ func (s *Server) handleObjectGet(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Disposition", "attachment; filename=\""+p+"\"")
 	}
 
-	mtime := time.Now()
+	mtime := clock.Now()
 
 	if p := r.URL.Query().Get("mtime"); p != "" {
 		if m, err := time.Parse(time.RFC3339Nano, p); err == nil {

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/fs/localfs"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
@@ -110,7 +111,7 @@ func (s *sourceManager) runLocal(ctx context.Context) {
 		var waitTime time.Duration
 
 		if s.nextSnapshotTime != nil {
-			waitTime = time.Until(*s.nextSnapshotTime)
+			waitTime = clock.Until(*s.nextSnapshotTime)
 			log(ctx).Debugf("time to next snapshot %v is %v", s.src, waitTime)
 		} else {
 			log(ctx).Debugf("no scheduled snapshot for %v", s.src)
@@ -123,7 +124,7 @@ func (s *sourceManager) runLocal(ctx context.Context) {
 			return
 
 		case <-s.snapshotRequests:
-			nt := time.Now()
+			nt := clock.Now()
 			s.nextSnapshotTime = &nt
 
 			continue
@@ -266,7 +267,7 @@ func (s *sourceManager) findClosestNextSnapshotTime() *time.Time {
 	}
 
 	for _, tod := range s.pol.TimesOfDay {
-		nowLocalTime := time.Now().Local()
+		nowLocalTime := clock.Now().Local()
 		localSnapshotTime := time.Date(nowLocalTime.Year(), nowLocalTime.Month(), nowLocalTime.Day(), tod.Hour, tod.Minute, 0, 0, time.Local)
 
 		if tod.Hour < nowLocalTime.Hour() || (tod.Hour == nowLocalTime.Hour() && tod.Minute < nowLocalTime.Minute()) {

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/logging"
 )
 
@@ -34,7 +35,7 @@ func GenerateServerCertificate(ctx context.Context, keySize int, certValid time.
 		return nil, nil, errors.Wrap(err, "unable to generate RSA key")
 	}
 
-	notBefore := time.Now()
+	notBefore := clock.Now()
 	notAfter := notBefore.Add(certValid)
 
 	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))

--- a/repo/api_server_repository.go
+++ b/repo/api_server_repository.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/apiclient"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/remoterepoapi"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/hashing"
@@ -118,7 +119,7 @@ func (r *apiServerRepository) Username() string {
 }
 
 func (r *apiServerRepository) Time() time.Time {
-	return time.Now() // allow:no-inject-time
+	return clock.Now()
 }
 
 func (r *apiServerRepository) Refresh(ctx context.Context) error {

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/efarrer/iothrottler"
@@ -15,6 +14,7 @@ import (
 	"gocloud.dev/blob/azureblob"
 	"gocloud.dev/gcerrors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/repo/blob"
@@ -266,7 +266,7 @@ func New(ctx context.Context, opt *Options) (blob.Storage, error) {
 
 	// verify Azure connection is functional by listing blobs in a bucket, which will fail if the container
 	// does not exist. We list with a prefix that will not exist, to avoid iterating through any objects.
-	nonExistentPrefix := fmt.Sprintf("kopia-azure-storage-initializing-%v", time.Now().UnixNano()) // allow:no-inject-time
+	nonExistentPrefix := fmt.Sprintf("kopia-azure-storage-initializing-%v", clock.Now().UnixNano())
 	err = az.ListBlobs(ctx, blob.ID(nonExistentPrefix), func(md blob.Metadata) error {
 		return nil
 	})

--- a/repo/blob/azure/azure_storage_test.go
+++ b/repo/blob/azure/azure_storage_test.go
@@ -7,11 +7,11 @@ import (
 	"net/url"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/azure"
 )
@@ -80,7 +80,7 @@ func TestAzureStorage(t *testing.T) {
 		Container:      container,
 		StorageAccount: storageAccount,
 		StorageKey:     storageKey,
-		Prefix:         fmt.Sprintf("test-%v-%x-", time.Now().Unix(), data),
+		Prefix:         fmt.Sprintf("test-%v-%x-", clock.Now().Unix(), data),
 	})
 	if err != nil {
 		t.Fatalf("unable to connect to Azure: %v", err)
@@ -132,7 +132,7 @@ func TestAzureStorageInvalidBlob(t *testing.T) {
 }
 
 func TestAzureStorageInvalidContainer(t *testing.T) {
-	container := fmt.Sprintf("invalid-container-%v", time.Now().UnixNano())
+	container := fmt.Sprintf("invalid-container-%v", clock.Now().UnixNano())
 	storageAccount := getEnvOrSkip(t, testStorageAccountEnv)
 	storageKey := getEnvOrSkip(t, testStorageKeyEnv)
 

--- a/repo/blob/b2/b2_storage_test.go
+++ b/repo/blob/b2/b2_storage_test.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/b2"
@@ -43,7 +43,7 @@ func TestB2Storage(t *testing.T) {
 			BucketName: bucket,
 			KeyID:      keyID,
 			Key:        key,
-			Prefix:     fmt.Sprintf("test-%v-%x-", time.Now().Unix(), data),
+			Prefix:     fmt.Sprintf("test-%v-%x-", clock.Now().Unix(), data),
 		})
 		if err != nil {
 			t.Fatalf("unable to build b2 storage: %v", err)
@@ -89,14 +89,14 @@ func TestB2StorageInvalidBlob(t *testing.T) {
 
 	defer st.Close(ctx)
 
-	_, err = st.GetBlob(ctx, blob.ID(fmt.Sprintf("invalid-blob-%v", time.Now().UnixNano())), 0, 30)
+	_, err = st.GetBlob(ctx, blob.ID(fmt.Sprintf("invalid-blob-%v", clock.Now().UnixNano())), 0, 30)
 	if err == nil {
 		t.Errorf("unexpected success when requesting non-existing blob")
 	}
 }
 
 func TestB2StorageInvalidBucket(t *testing.T) {
-	bucket := fmt.Sprintf("invalid-bucket-%v", time.Now().UnixNano())
+	bucket := fmt.Sprintf("invalid-bucket-%v", clock.Now().UnixNano())
 	keyID := getEnvOrSkip(t, testKeyIDEnv)
 	key := getEnvOrSkip(t, testKeyEnv)
 

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/sharded"
@@ -236,7 +237,7 @@ func (fs *fsStorage) TouchBlob(ctx context.Context, blobID blob.ID, threshold ti
 		return err
 	}
 
-	n := time.Now() // allow:no-inject-time
+	n := clock.Now()
 
 	age := n.Sub(st.ModTime())
 	if age < threshold {

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"time"
 
 	gcsclient "cloud.google.com/go/storage"
 	"github.com/efarrer/iothrottler"
@@ -17,6 +16,7 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/internal/throttle"
@@ -303,7 +303,7 @@ func New(ctx context.Context, opt *Options) (blob.Storage, error) {
 
 	// verify GCS connection is functional by listing blobs in a bucket, which will fail if the bucket
 	// does not exist. We list with a prefix that will not exist, to avoid iterating through any objects.
-	nonExistentPrefix := fmt.Sprintf("kopia-gcs-storage-initializing-%v", time.Now().UnixNano()) // allow:no-inject-time
+	nonExistentPrefix := fmt.Sprintf("kopia-gcs-storage-initializing-%v", clock.Now().UnixNano())
 	err = gcs.ListBlobs(ctx, blob.ID(nonExistentPrefix), func(md blob.Metadata) error {
 		return nil
 	})

--- a/repo/blob/logging/logging_storage.go
+++ b/repo/blob/logging/logging_storage.go
@@ -3,8 +3,8 @@ package logging
 
 import (
 	"context"
-	"time"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -17,9 +17,9 @@ type loggingStorage struct {
 }
 
 func (s *loggingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64) ([]byte, error) {
-	t0 := time.Now()
+	t0 := clock.Now()
 	result, err := s.base.GetBlob(ctx, id, offset, length)
-	dt := time.Since(t0)
+	dt := clock.Since(t0)
 
 	if len(result) < maxLoggedBlobLength {
 		s.printf(s.prefix+"GetBlob(%q,%v,%v)=(%v, %#v) took %v", id, offset, length, result, err, dt)
@@ -31,9 +31,9 @@ func (s *loggingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length
 }
 
 func (s *loggingStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata, error) {
-	t0 := time.Now()
+	t0 := clock.Now()
 	result, err := s.base.GetMetadata(ctx, id)
-	dt := time.Since(t0)
+	dt := clock.Since(t0)
 
 	s.printf(s.prefix+"GetMetadata(%q)=(%v, %#v) took %v", id, result, err, dt)
 
@@ -41,39 +41,39 @@ func (s *loggingStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Meta
 }
 
 func (s *loggingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
-	t0 := time.Now()
+	t0 := clock.Now()
 	err := s.base.PutBlob(ctx, id, data)
-	dt := time.Since(t0)
+	dt := clock.Since(t0)
 	s.printf(s.prefix+"PutBlob(%q,len=%v)=%#v took %v", id, data.Length(), err, dt)
 
 	return err
 }
 
 func (s *loggingStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
-	t0 := time.Now()
+	t0 := clock.Now()
 	err := s.base.DeleteBlob(ctx, id)
-	dt := time.Since(t0)
+	dt := clock.Since(t0)
 	s.printf(s.prefix+"DeleteBlob(%q)=%#v took %v", id, err, dt)
 
 	return err
 }
 
 func (s *loggingStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback func(blob.Metadata) error) error {
-	t0 := time.Now()
+	t0 := clock.Now()
 	cnt := 0
 	err := s.base.ListBlobs(ctx, prefix, func(bi blob.Metadata) error {
 		cnt++
 		return callback(bi)
 	})
-	s.printf(s.prefix+"ListBlobs(%q)=%v returned %v items and took %v", prefix, err, cnt, time.Since(t0))
+	s.printf(s.prefix+"ListBlobs(%q)=%v returned %v items and took %v", prefix, err, cnt, clock.Since(t0))
 
 	return err
 }
 
 func (s *loggingStorage) Close(ctx context.Context) error {
-	t0 := time.Now()
+	t0 := clock.Now()
 	err := s.base.Close(ctx)
-	dt := time.Since(t0)
+	dt := clock.Since(t0)
 	s.printf(s.prefix+"Close()=%#v took %v", err, dt)
 
 	return err

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/minio/minio/pkg/madmin"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
@@ -227,7 +228,7 @@ func testStorage(t *testutil.RetriableT, options *Options) {
 
 	cleanupOldData(ctx, t, options)
 
-	options.Prefix = fmt.Sprintf("test-%v-%x-", time.Now().Unix(), data)
+	options.Prefix = fmt.Sprintf("test-%v-%x-", clock.Now().Unix(), data)
 	attempt := func() (interface{}, error) {
 		return New(testlogging.Context(t), options)
 	}
@@ -365,7 +366,7 @@ func cleanupOldData(ctx context.Context, t *testutil.RetriableT, options *Option
 	}
 
 	_ = st.ListBlobs(ctx, "", func(it blob.Metadata) error {
-		age := time.Since(it.Timestamp)
+		age := clock.Since(it.Timestamp)
 		if age > cleanupAge {
 			if err := st.DeleteBlob(ctx, it.BlobID); err != nil {
 				t.Errorf("warning: unable to delete %q: %v", it.BlobID, err)

--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/exp/mmap"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -151,7 +152,7 @@ func (c *diskCommittedContentIndexCache) expireUnused(ctx context.Context, used 
 	}
 
 	for _, rem := range remaining {
-		if time.Since(rem.ModTime()) > unusedCommittedContentIndexCleanupTime { // allow:no-inject-time
+		if clock.Since(rem.ModTime()) > unusedCommittedContentIndexCleanupTime {
 			log(ctx).Debugf("removing unused %v %v", rem.Name(), rem.ModTime())
 
 			if err := os.Remove(filepath.Join(c.dirname, rem.Name())); err != nil {

--- a/repo/content/content_cache_base.go
+++ b/repo/content/content_cache_base.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -56,7 +57,7 @@ func (c *cacheBase) close() {
 }
 
 func (c *cacheBase) perItemMutex(key interface{}) *sync.Mutex {
-	now := time.Now().UnixNano() // allow:no-inject-time
+	now := clock.Now().UnixNano()
 
 	v, ok := c.loadingMap.Load(key)
 	if !ok {
@@ -117,7 +118,7 @@ func (h *contentMetadataHeap) Pop() interface{} {
 }
 
 func (c *cacheBase) sweepDirectory(ctx context.Context) (err error) {
-	t0 := time.Now() // allow:no-inject-time
+	t0 := clock.Now()
 
 	var h contentMetadataHeap
 
@@ -141,13 +142,13 @@ func (c *cacheBase) sweepDirectory(ctx context.Context) (err error) {
 		return errors.Wrap(err, "error listing cache")
 	}
 
-	log(ctx).Debugf("finished sweeping directory in %v and retained %v/%v bytes (%v %%)", time.Since(t0), totalRetainedSize, c.maxSizeBytes, 100*totalRetainedSize/c.maxSizeBytes) // allow:no-inject-time
+	log(ctx).Debugf("finished sweeping directory in %v and retained %v/%v bytes (%v %%)", clock.Since(t0), totalRetainedSize, c.maxSizeBytes, 100*totalRetainedSize/c.maxSizeBytes)
 
 	return nil
 }
 
 func (c *cacheBase) sweepMutexes() {
-	cutoffTime := time.Now().Add(-mutexAgeCutoff).UnixNano() // allow:no-inject-time
+	cutoffTime := clock.Now().Add(-mutexAgeCutoff).UnixNano()
 
 	// remove from loadingMap all items that have not been touched recently.
 	// since the mutexes are only for performance (to avoid loading duplicates)

--- a/repo/content/content_cache_test.go
+++ b/repo/content/content_cache_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
@@ -32,11 +33,11 @@ func newUnderlyingStorageForContentCacheTesting(t *testing.T) blob.Storage {
 func TestCacheExpiration(t *testing.T) {
 	cacheData := blobtesting.DataMap{}
 
-	// on Windows, the time does not always move forward (sometimes time.Now() returns exactly the same value for consecutive invocations)
-	// this matters here so we return a fake time.Now() function that always moves forward.
+	// on Windows, the time does not always move forward (sometimes clock.Now() returns exactly the same value for consecutive invocations)
+	// this matters here so we return a fake clock.Now() function that always moves forward.
 	var currentTimeMutex sync.Mutex
 
-	currentTime := time.Now()
+	currentTime := clock.Now()
 
 	movingTimeFunc := func() time.Time {
 		currentTimeMutex.Lock()

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/encryption"
@@ -103,7 +104,7 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 		MaxPackSize: maxPackSize,
 		MasterKey:   make([]byte, 32), // zero key, does not matter
 		Version:     1,
-	}, nil, time.Now, nil)
+	}, nil, clock.Now, nil)
 	if err != nil {
 		t.Errorf("can't create content manager with hash %v and encryption %v: %v", hashAlgo, encryptionAlgo, err.Error())
 		return

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -16,6 +16,7 @@ import (
 	"go.opencensus.io/stats"
 
 	"github.com/kopia/kopia/internal/buf"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/logging"
@@ -644,10 +645,10 @@ func (bm *Manager) Refresh(ctx context.Context) (bool, error) {
 
 	log(ctx).Debugf("Refresh started")
 
-	t0 := time.Now() // allow:no-inject-time
+	t0 := clock.Now()
 
 	_, updated, err := bm.loadPackIndexesUnlocked(ctx)
-	log(ctx).Debugf("Refresh completed in %v and updated=%v", time.Since(t0), updated) // allow:no-inject-time
+	log(ctx).Debugf("Refresh completed in %v and updated=%v", clock.Since(t0), updated)
 
 	return updated, err
 }
@@ -678,7 +679,7 @@ type ManagerOptions struct {
 func NewManager(ctx context.Context, st blob.Storage, f *FormattingOptions, caching *CachingOptions, options ManagerOptions) (*Manager, error) {
 	nowFn := options.TimeNow
 	if nowFn == nil {
-		nowFn = time.Now // allow:no-inject-time
+		nowFn = clock.Now
 	}
 
 	return newManagerWithOptions(ctx, st, f, caching, nowFn, options.RepositoryFormatBytes)

--- a/repo/content/index_blob_manager_test.go
+++ b/repo/content/index_blob_manager_test.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/faketime"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
@@ -156,7 +157,7 @@ func pickRandomActionTestIndexBlobManagerStress() action {
 func TestIndexBlobManagerStress(t *testing.T) {
 	t.Parallel()
 
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(clock.Now().UnixNano())
 
 	for i := range actionsTestIndexBlobManagerStress {
 		actionsTestIndexBlobManagerStress[i].weight = rand.Intn(100)
@@ -166,10 +167,10 @@ func TestIndexBlobManagerStress(t *testing.T) {
 	var (
 		fakeTimeFunc      = faketime.AutoAdvance(fakeLocalStartTime, 100*time.Millisecond)
 		deadline          time.Time // when (according to fakeTimeFunc should the test finish)
-		localTimeDeadline time.Time // when (according to time.Now, the test should finish)
+		localTimeDeadline time.Time // when (according to clock.Now, the test should finish)
 	)
 
-	localTimeDeadline = time.Now().Add(30 * time.Second)
+	localTimeDeadline = clock.Now().Add(30 * time.Second)
 
 	if os.Getenv("CI") != "" {
 		// when running on CI, simulate 4 hours, this takes about ~15-20 seconds.
@@ -203,7 +204,7 @@ func TestIndexBlobManagerStress(t *testing.T) {
 			m := newIndexBlobManagerForTesting(t, loggedSt, fakeTimeFunc)
 
 			// run stress test until the deadline, aborting early on any failure
-			for fakeTimeFunc().Before(deadline) && time.Now().Before(localTimeDeadline) {
+			for fakeTimeFunc().Before(deadline) && clock.Now().Before(localTimeDeadline) {
 				switch pickRandomActionTestIndexBlobManagerStress() {
 				case actionRead:
 					if err := verifyFakeContentsWritten(ctx, m, numWritten, contentPrefix, deletedContents); err != nil {
@@ -257,7 +258,7 @@ func TestIndexBlobManagerStress(t *testing.T) {
 }
 
 func TestIndexBlobManagerPreventsResurrectOfDeletedContents(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(clock.Now().UnixNano())
 
 	// the test is randomized and runs very quickly, run it lots of times
 	failed := false
@@ -271,7 +272,7 @@ func TestIndexBlobManagerPreventsResurrectOfDeletedContents(t *testing.T) {
 }
 
 func TestCompactionCreatesPreviousIndex(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(clock.Now().UnixNano())
 
 	storageData := blobtesting.DataMap{}
 
@@ -322,7 +323,7 @@ func TestCompactionCreatesPreviousIndex(t *testing.T) {
 }
 
 func TestIndexBlobManagerPreventsResurrectOfDeletedContents_RandomizedTimings(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(clock.Now().UnixNano())
 
 	// the test is randomized and runs very quickly, run it lots of times
 	for i := 0; i < 1000; i++ {

--- a/repo/content/list_cache.go
+++ b/repo/content/list_cache.go
@@ -12,6 +12,7 @@ import (
 	"github.com/natefinch/atomic"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/hmac"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -28,7 +29,7 @@ func (c *listCache) listBlobs(ctx context.Context, prefix blob.ID) ([]blob.Metad
 		ci, err := c.readBlobsFromCache(ctx, prefix)
 		if err == nil {
 			expirationTime := ci.Timestamp.Add(c.listCacheDuration)
-			if time.Now().Before(expirationTime) { // allow:no-inject-time
+			if clock.Now().Before(expirationTime) {
 				log(ctx).Debugf("retrieved list of %v '%v' index blobs from cache", len(ci.Blobs), prefix)
 				return ci.Blobs, nil
 			}
@@ -41,7 +42,7 @@ func (c *listCache) listBlobs(ctx context.Context, prefix blob.ID) ([]blob.Metad
 	if err == nil {
 		c.saveListToCache(ctx, prefix, &cachedList{
 			Blobs:     blobs,
-			Timestamp: time.Now(), // allow:no-inject-time
+			Timestamp: clock.Now(),
 		})
 	}
 

--- a/repo/maintenance/maintenance_schedule_test.go
+++ b/repo/maintenance/maintenance_schedule_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/kylelemons/godebug/pretty"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/repotesting"
 )
 
@@ -30,11 +30,11 @@ func TestMaintenanceSchedule(t *testing.T) {
 		t.Errorf("unexpected NextQuickMaintenanceTime: %v", s.NextQuickMaintenanceTime)
 	}
 
-	s.NextFullMaintenanceTime = time.Now()
-	s.NextQuickMaintenanceTime = time.Now()
+	s.NextFullMaintenanceTime = clock.Now()
+	s.NextQuickMaintenanceTime = clock.Now()
 	s.ReportRun("foo", RunInfo{
-		Start:   time.Now(),
-		End:     time.Now(),
+		Start:   clock.Now(),
+		End:     clock.Now(),
 		Success: true,
 	})
 

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/logging"
 )
@@ -484,7 +485,7 @@ type ManagerOptions struct {
 func NewManager(ctx context.Context, b contentManager, options ManagerOptions) (*Manager, error) {
 	timeNow := options.TimeNow
 	if timeNow == nil {
-		timeNow = time.Now // allow:no-inject-time
+		timeNow = clock.Now
 	}
 
 	m := &Manager{

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/manifest"
@@ -202,5 +203,5 @@ func defaultTime(f func() time.Time) func() time.Time {
 		return f
 	}
 
-	return time.Now // allow:no-inject-time
+	return clock.Now
 }

--- a/snapshot/policy/retention_policy.go
+++ b/snapshot/policy/retention_policy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/snapshot"
 )
 
@@ -20,7 +21,7 @@ type RetentionPolicy struct {
 // ComputeRetentionReasons computes the reasons why each snapshot is retained, based on
 // the settings in retention policy and stores them in RetentionReason field.
 func (r *RetentionPolicy) ComputeRetentionReasons(manifests []*snapshot.Manifest) {
-	now := time.Now() // allow:no-inject-time
+	now := clock.Now()
 	maxTime := now.Add(365 * 24 * time.Hour)
 
 	cutoffTime := func(setting *int, add func(time.Time, int) time.Time) time.Time {

--- a/tests/end_to_end_test/auto_update_test.go
+++ b/tests/end_to_end_test/auto_update_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -83,7 +84,7 @@ func TestAutoUpdateEnableTest(t *testing.T) {
 				}
 
 				// verify that initial delay is approximately wantInitialDelay from now +/- 1 minute
-				if got, want := time.Now().Add(tc.wantInitialDelay), state.NextCheckTime; absDuration(got.Sub(want)) > 1*time.Minute {
+				if got, want := clock.Now().Add(tc.wantInitialDelay), state.NextCheckTime; absDuration(got.Sub(want)) > 1*time.Minute {
 					t.Errorf("unexpected NextCheckTime: %v, want approx %v", got, want)
 				}
 			}

--- a/tests/endurance_test/endurance_test.go
+++ b/tests/endurance_test/endurance_test.go
@@ -1,0 +1,222 @@
+package endurance_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"golang.org/x/net/webdav"
+
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+const (
+	maxSourcesPerEnduranceRunner = 3
+	enduranceRunnerCount         = 3
+	runnerIterations             = 1000
+)
+
+type webdavDirWithFakeClock struct {
+	webdav.Dir
+
+	fts *testenv.FakeTimeServer
+}
+
+func (d webdavDirWithFakeClock) OpenFile(ctx context.Context, fname string, flags int, mode os.FileMode) (webdav.File, error) {
+	f, err := d.Dir.OpenFile(ctx, fname, flags, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	if flags&os.O_RDONLY != 0 {
+		// file was readonly
+		return f, nil
+	}
+
+	// change file time after creation to simulate fake time scale.
+	osf := f.(*os.File)
+	now := d.fts.Now()
+
+	if err := os.Chtimes(osf.Name(), now, now); err != nil {
+		log.Printf("unable to change file time: %v", err)
+	}
+
+	return f, nil
+}
+
+func TestEndurance(t *testing.T) {
+	e := testenv.NewCLITest(t)
+	defer e.Cleanup(t)
+
+	tmpDir, err := ioutil.TempDir("", "endurance")
+	if err != nil {
+		t.Fatalf("unable to get temp dir: %v", err)
+	}
+
+	defer os.RemoveAll(tmpDir)
+
+	fts := testenv.NewFakeTimeServer(time.Date(2000, 1, 1, 0, 0, 0, 0, time.Local), 100*time.Millisecond)
+
+	ft := httptest.NewServer(fts)
+	defer ft.Close()
+
+	e.Environment = append(e.Environment, "KOPIA_FAKE_CLOCK_ENDPOINT="+ft.URL)
+
+	sts := httptest.NewServer(&webdav.Handler{
+		FileSystem: webdavDirWithFakeClock{webdav.Dir(tmpDir), fts},
+		LockSystem: webdav.NewMemLS(),
+	})
+	defer sts.Close()
+
+	e.RunAndExpectSuccess(t, "repo", "create", "webdav", "--url", sts.URL)
+
+	t.Run("Runners", func(t *testing.T) {
+		for i := 0; i < enduranceRunnerCount; i++ {
+			i := i
+
+			t.Run(fmt.Sprintf("Runner-%v", i), func(t *testing.T) {
+				t.Parallel()
+
+				enduranceRunner(t, i, ft.URL, sts.URL)
+			})
+		}
+	})
+
+	e.RunAndExpectSuccess(t, "snapshot", "list", "-a", "-i")
+	e.RunAndExpectSuccess(t, "blob", "list")
+}
+
+type runnerState struct {
+	dirs                []string
+	snapshottedAnything bool
+}
+
+type action func(t *testing.T, e *testenv.CLITest, s *runnerState)
+
+// actionsTestIndexBlobManagerStress is a set of actionsTestIndexBlobManagerStress by each actor performed in TestIndexBlobManagerStress with weights.
+var actionsTestIndexBlobManagerStress = []struct {
+	a      action
+	weight int
+}{
+	{actionSnapshotExisting, 50},
+	{actionSnapshotAll, 30},
+	{actionAddNewSource, 1},
+	{actionMutateDirectoryTree, 1},
+	{actionSnapshotVerify, 10},
+	{actionContentVerify, 5},
+}
+
+func actionSnapshotExisting(t *testing.T, e *testenv.CLITest, s *runnerState) {
+	randomPath := s.dirs[rand.Intn(len(s.dirs))]
+	e.RunAndExpectSuccess(t, "snapshot", "create", randomPath, "--no-progress")
+
+	s.snapshottedAnything = true
+}
+
+func actionSnapshotAll(t *testing.T, e *testenv.CLITest, s *runnerState) {
+	if !s.snapshottedAnything {
+		return
+	}
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", "--all", "--no-progress")
+}
+
+func actionSnapshotVerify(t *testing.T, e *testenv.CLITest, s *runnerState) {
+	if !s.snapshottedAnything {
+		return
+	}
+
+	e.RunAndExpectSuccess(t, "snapshot", "verify")
+}
+
+func actionContentVerify(t *testing.T, e *testenv.CLITest, s *runnerState) {
+	if !s.snapshottedAnything {
+		return
+	}
+
+	e.RunAndExpectSuccess(t, "content", "verify")
+}
+
+func actionAddNewSource(t *testing.T, e *testenv.CLITest, s *runnerState) {
+	if len(s.dirs) >= maxSourcesPerEnduranceRunner {
+		return
+	}
+
+	srcDir, err := ioutil.TempDir("", "kopiasrc")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	s.dirs = append(s.dirs, srcDir)
+
+	testenv.CreateDirectoryTree(srcDir, testenv.DirectoryTreeOptions{
+		Depth:                  3,
+		MaxSubdirsPerDirectory: 10,
+		MaxFilesPerDirectory:   10,
+		MaxFileSize:            100,
+	}, &testenv.DirectoryTreeCounters{})
+}
+
+func actionMutateDirectoryTree(t *testing.T, e *testenv.CLITest, s *runnerState) {
+	randomPath := s.dirs[rand.Intn(len(s.dirs))]
+
+	testenv.CreateDirectoryTree(randomPath, testenv.DirectoryTreeOptions{
+		Depth:                  2,
+		MaxSubdirsPerDirectory: 10,
+		MaxFilesPerDirectory:   10,
+		MaxFileSize:            100,
+	}, &testenv.DirectoryTreeCounters{})
+}
+
+func pickRandomEnduranceTestAction() action {
+	sum := 0
+	for _, a := range actionsTestIndexBlobManagerStress {
+		sum += a.weight
+	}
+
+	n := rand.Intn(sum)
+	for _, a := range actionsTestIndexBlobManagerStress {
+		if n < a.weight {
+			return a.a
+		}
+
+		n -= a.weight
+	}
+
+	panic("impossible")
+}
+
+func enduranceRunner(t *testing.T, runnerID int, fakeTimeServer, webdavServer string) {
+	e := testenv.NewCLITest(t)
+	defer e.Cleanup(t)
+
+	e.PassthroughStderr = true
+
+	e.Environment = append(e.Environment,
+		"KOPIA_FAKE_CLOCK_ENDPOINT="+fakeTimeServer,
+		"KOPIA_CHECK_FOR_UPDATES=false",
+	)
+
+	e.RunAndExpectSuccess(t, "repo", "connect", "webdav", "--url", webdavServer, "--override-username="+fmt.Sprintf("runner-%v", runnerID))
+
+	if runnerID == 0 {
+		e.RunAndExpectSuccess(t, "gc", "set", "--enable-full=true", "--full-interval=4h", "--owner=me")
+	}
+
+	var s runnerState
+
+	actionAddNewSource(t, e, &s)
+
+	for k := 0; k < runnerIterations; k++ {
+		t.Logf("ITERATION %v / %v", k, runnerIterations)
+
+		act := pickRandomEnduranceTestAction()
+		act(t, e, &s)
+	}
+}

--- a/tests/robustness/checker/checker.go
+++ b/tests/robustness/checker/checker.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/tests/robustness/snap"
 	"github.com/kopia/kopia/tests/robustness/snapmeta"
 )
@@ -151,14 +152,14 @@ func (chk *Checker) TakeSnapshot(ctx context.Context, sourceDir string) (snapID 
 		return "", err
 	}
 
-	ssStart := time.Now()
+	ssStart := clock.Now()
 
 	snapID, err = chk.snapshotIssuer.CreateSnapshot(sourceDir)
 	if err != nil {
 		return snapID, err
 	}
 
-	ssEnd := time.Now()
+	ssEnd := clock.Now()
 
 	ssMeta := &SnapshotMetadata{
 		SnapID:         snapID,
@@ -231,7 +232,7 @@ func (chk *Checker) DeleteSnapshot(ctx context.Context, snapID string) error {
 		return err
 	}
 
-	ssMeta.DeletionTime = time.Now()
+	ssMeta.DeletionTime = clock.Now()
 
 	err = chk.saveSnapshotMetadata(ssMeta)
 	if err != nil {

--- a/tests/stress_test/stress_test.go
+++ b/tests/stress_test/stress_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
@@ -24,7 +25,7 @@ func TestStressBlockManager(t *testing.T) {
 
 	data := blobtesting.DataMap{}
 	keyTimes := map[blob.ID]time.Time{}
-	memst := blobtesting.NewMapStorage(data, keyTimes, time.Now)
+	memst := blobtesting.NewMapStorage(data, keyTimes, clock.Now)
 
 	duration := 3 * time.Second
 	if os.Getenv("KOPIA_LONG_STRESS_TEST") != "" {
@@ -47,11 +48,11 @@ func stressTestWithStorage(t *testing.T, st blob.Storage, duration time.Duration
 		}, nil, content.ManagerOptions{})
 	}
 
-	seed0 := time.Now().Nanosecond()
+	seed0 := clock.Now().Nanosecond()
 
 	t.Logf("running with seed %v", seed0)
 
-	deadline := time.Now().Add(duration)
+	deadline := clock.Now().Add(duration)
 
 	t.Run("workers", func(t *testing.T) {
 		for i := 0; i < goroutineCount; i++ {
@@ -80,7 +81,7 @@ func stressWorker(ctx context.Context, t *testing.T, deadline time.Time, openMgr
 
 	var workerBlocks []writtenBlock
 
-	for time.Now().Before(deadline) {
+	for clock.Now().Before(deadline) {
 		l := rnd.Intn(30000)
 		data := make([]byte, l)
 

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -39,6 +39,8 @@ type CLITest struct {
 
 	fixedArgs   []string
 	Environment []string
+
+	PassthroughStderr bool
 }
 
 // SourceInfo reprents a single source (user@host:/path) with its snapshots.
@@ -209,6 +211,10 @@ func (e *CLITest) Run(t *testing.T, args ...string) (stdout, stderr []string, er
 
 	errOut := &bytes.Buffer{}
 	c.Stderr = errOut
+
+	if e.PassthroughStderr {
+		c.Stderr = os.Stderr
+	}
 
 	o, err := c.Output()
 

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/iocopy"
 )
 
@@ -89,7 +90,7 @@ func NewCLITest(t *testing.T) *CLITest {
 	}
 
 	return &CLITest{
-		startTime:   time.Now(),
+		startTime:   clock.Now(),
 		RepoDir:     RepoDir,
 		ConfigDir:   ConfigDir,
 		Exe:         filepath.FromSlash(exe),
@@ -363,7 +364,7 @@ func createRandomFile(filename string, options DirectoryTreeOptions, counters *D
 
 	length := rand.Int63n(maxFileSize)
 
-	_, err = iocopy.Copy(f, io.LimitReader(rand.New(rand.NewSource(time.Now().UnixNano())), length))
+	_, err = iocopy.Copy(f, io.LimitReader(rand.New(rand.NewSource(clock.Now().UnixNano())), length))
 	if err != nil {
 		return errors.Wrap(err, "file create error")
 	}

--- a/tests/testenv/faketimeserver.go
+++ b/tests/testenv/faketimeserver.go
@@ -1,0 +1,60 @@
+package testenv
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type fakeTimeInfoStruct struct {
+	Next  int64 `json:"next"`
+	Step  int64 `json:"step"`
+	Until int64 `json:"until"`
+}
+
+// FakeTimeServer serves fake time signal to instances of Kopia.
+type FakeTimeServer struct {
+	mu sync.Mutex
+
+	nextTimeChunk   time.Time
+	timeChunkLength time.Duration
+	step            time.Duration
+}
+
+// Now returns current fake time.
+func (s *FakeTimeServer) Now() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	t := s.nextTimeChunk
+	s.nextTimeChunk = s.nextTimeChunk.Add(s.step)
+
+	return t
+}
+
+func (s *FakeTimeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	timeInfo := fakeTimeInfoStruct{
+		Next:  s.nextTimeChunk.UnixNano(),
+		Step:  s.step.Nanoseconds(),
+		Until: s.nextTimeChunk.Add(s.timeChunkLength).UnixNano(),
+	}
+
+	s.nextTimeChunk = s.nextTimeChunk.Add(s.timeChunkLength)
+
+	json.NewEncoder(w).Encode(timeInfo) //nolint:errcheck
+}
+
+// NewFakeTimeServer creates new time server that serves time over HTTP and locally.
+func NewFakeTimeServer(startTime time.Time, step time.Duration) *FakeTimeServer {
+	return &FakeTimeServer{
+		nextTimeChunk:   startTime,
+		timeChunkLength: 100 * step, // nolint:mnd
+		step:            step,
+	}
+}
+
+var _ http.Handler = (*FakeTimeServer)(nil)


### PR DESCRIPTION
This creates kopia repository and simulates usage of Kopia over multiple months (using accelerated fake time) to trigger effects that are visible after long time passage (maintenance, compactions, expirations).

Fake time is injected into `kopia` binary through a HTTP endpoint that runs on localhost.
    
The test is not used part of any test suite yet but will run in post-submit mode only, preferably 24/7.
