### PR TITLE
content: fixed index compaction that would resurrect content entry during full maintenance

### DIFF
--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -347,6 +347,42 @@ func TestContentManagerFailedToWritePack(t *testing.T) {
 	verifyContent(ctx, t, bm, b1, seededRandomData(1, 10))
 }
 
+func TestIndexCompactionDropsContent(t *testing.T) {
+	ctx := testlogging.Context(t)
+	data := blobtesting.DataMap{}
+	keyTime := map[blob.ID]time.Time{}
+	timeFunc := faketime.AutoAdvance(fakeTime.Add(1), 1*time.Second)
+
+	// create record in index #1
+	bm := newTestContentManager(t, data, keyTime, timeFunc)
+	content1 := writeContentAndVerify(ctx, t, bm, seededRandomData(10, 100))
+	bm.Close(ctx)
+
+	timeFunc()
+
+	// create record in index #2
+	bm = newTestContentManager(t, data, keyTime, timeFunc)
+	deleteContent(ctx, t, bm, content1)
+	bm.Close(ctx)
+
+	timeFunc()
+
+	deleteThreshold := timeFunc()
+
+	t.Logf("----- compaction")
+
+	bm = newTestContentManager(t, data, keyTime, timeFunc)
+	// this drops deleted entries, including from index #1
+	must(t, bm.CompactIndexes(ctx, CompactOptions{
+		DropDeletedBefore: deleteThreshold,
+		AllIndexes:        true,
+	}))
+	bm.Close(ctx)
+
+	bm = newTestContentManager(t, data, keyTime, timeFunc)
+	verifyContentNotFound(ctx, t, bm, content1)
+}
+
 func TestContentManagerConcurrency(t *testing.T) {
 	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}


### PR DESCRIPTION
The problem was that while dropping deleted entries from the index
we were looking at index-local and not merged result.

Say index1 has content1 created at t0.
Say index2 has content1 deleted at t1 > t0.

And we're compacting and dropping index entries deleted before t2,
such that t2 > t1.

Because create and delete records are in separate index files, the
compacted file would preserve "created t0" which is wrong.

This fix changes index compaction to always look at resolved content
status.

Fixes #483 (hopefully)