### PR TITLE
Doc: fix create B2 repository cmd

### DIFF
--- a/site/content/docs/Repositories/_index.md
+++ b/site/content/docs/Repositories/_index.md
@@ -95,7 +95,7 @@ $ kopia repository connect s3
 You will need your B2 bucket name, key-id and key.
 
 ```shell
-$ kopia repository connect b2 \
+$ kopia repository create b2 \
         --bucket=... \
         --key-id=... \
         --key=...


### PR DESCRIPTION
Fix command line: "create" instead of "connect"