### PR TITLE
Set BuildVersion during repo initialization.

### DIFF
--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -77,6 +77,7 @@ func formatBlobFromOptions(opt *NewRepositoryOptions) *formatBlob {
 	return &formatBlob{
 		Tool:                   "https://github.com/kopia/kopia",
 		BuildInfo:              BuildInfo,
+		BuildVersion:           BuildVersion,
 		KeyDerivationAlgorithm: defaultKeyDerivationAlgorithm,
 		UniqueID:               applyDefaultRandomBytes(opt.UniqueID, uniqueIDLength),
 		Version:                "1",


### PR DESCRIPTION
I noticed that the `buildVersion` field of the formatBlob is actually left empty.
From a test repo created with the official `v0.6.3` github binary of kopia:
```
{
  "tool": "https://github.com/kopia/kopia",
  "buildVersion": "",
  "buildInfo": "c142598351399336b82bdbe64c687e63d2775788",
  "uniqueID": "fIaHmFEp4HZEJgu1w1aKVTAwpZnFn574uBwuy5uBE4A=",
  "keyAlgo": "scrypt-65536-8-1",
  "version": "1",
  "encryption": "AES256_GCM",
  "encryptedBlockFormat": "..."
}
```
Looks like `BuildVersion` was missing during repo initialization, which I guess was not on purpose.
