### PR TITLE
apt-publish: publish dummy i386 release

### DIFF
--- a/tools/apt-publish.sh
+++ b/tools/apt-publish.sh
@@ -15,7 +15,9 @@ if [ ! -d "$PKGDIR" ]; then
 fi
 
 distributions="stable testing unstable"
-architectures="amd64 arm64 armhf"
+
+# note we don't produce packages for i386 but lack of it confuses some amd64 clients.
+architectures="amd64 arm64 armhf i386"
 
 WORK_DIR=/tmp/apt-publish
 rm -rf "$WORK_DIR"


### PR DESCRIPTION
Ubuntu on amd64 is sometimes confused and tries downloading i386 anyway