### PR TITLE
[Robustness] Add command line parameters for kopia snapshotter

### DIFF
--- a/tests/tools/kopiarunner/kopia_snapshotter.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter.go
@@ -18,10 +18,8 @@ const (
 	noCheckForUpdatesFlag   = "--no-check-for-updates"
 	noProgressFlag          = "--no-progress"
 	parallelFlag            = "--parallel"
-)
 
-// Flag value settings.
-const (
+	// Flag value settings.
 	contentCacheSizeSettingMB  = 500
 	metadataCacheSizeSettingMB = 500
 	parallelSetting            = 8

--- a/tests/tools/kopiarunner/kopia_snapshotter.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter.go
@@ -2,6 +2,7 @@ package kopiarunner
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -10,6 +11,21 @@ import (
 )
 
 var _ snap.Snapshotter = &KopiaSnapshotter{}
+
+const (
+	contentCacheSizeMBFlag  = "--content-cache-size-mb"
+	metadataCacheSizeMBFlag = "--metadata-cache-size-mb"
+	noCheckForUpdatesFlag   = "--no-check-for-updates"
+	noProgressFlag          = "--no-progress"
+	parallelFlag            = "--parallel"
+)
+
+// Flag value settings.
+const (
+	contentCacheSizeSettingMB  = 500
+	metadataCacheSizeSettingMB = 500
+	parallelSetting            = 8
+)
 
 // KopiaSnapshotter implements the Snapshotter interface using Kopia commands.
 type KopiaSnapshotter struct {
@@ -35,20 +51,28 @@ func (ks *KopiaSnapshotter) Cleanup() {
 	}
 }
 
-// CreateRepo creates a kopia repository with the provided arguments.
-func (ks *KopiaSnapshotter) CreateRepo(args ...string) (err error) {
-	args = append([]string{"repo", "create"}, args...)
-	_, _, err = ks.Runner.Run(args...)
+func (ks *KopiaSnapshotter) repoConnectCreate(op string, args ...string) error {
+	args = append([]string{"repo", op}, args...)
+
+	args = append(args,
+		contentCacheSizeMBFlag, strconv.Itoa(contentCacheSizeSettingMB),
+		metadataCacheSizeMBFlag, strconv.Itoa(metadataCacheSizeSettingMB),
+		noCheckForUpdatesFlag,
+	)
+
+	_, _, err := ks.Runner.Run(args...)
 
 	return err
 }
 
+// CreateRepo creates a kopia repository with the provided arguments.
+func (ks *KopiaSnapshotter) CreateRepo(args ...string) (err error) {
+	return ks.repoConnectCreate("create", args...)
+}
+
 // ConnectRepo connects to the repository described by the provided arguments.
 func (ks *KopiaSnapshotter) ConnectRepo(args ...string) (err error) {
-	args = append([]string{"repo", "connect"}, args...)
-	_, _, err = ks.Runner.Run(args...)
-
-	return err
+	return ks.repoConnectCreate("connect", args...)
 }
 
 // ConnectOrCreateRepo attempts to connect to a repo described by the provided
@@ -83,7 +107,7 @@ func (ks *KopiaSnapshotter) ConnectOrCreateFilesystem(repoPath string) error {
 // CreateSnapshot implements the Snapshotter interface, issues a kopia snapshot
 // create command on the provided source path.
 func (ks *KopiaSnapshotter) CreateSnapshot(source string) (snapID string, err error) {
-	_, errOut, err := ks.Runner.Run("snapshot", "create", source)
+	_, errOut, err := ks.Runner.Run("snapshot", "create", parallelFlag, strconv.Itoa(parallelSetting), noProgressFlag, source)
 	if err != nil {
 		return "", err
 	}
@@ -105,15 +129,50 @@ func (ks *KopiaSnapshotter) DeleteSnapshot(snapID string) (err error) {
 	return err
 }
 
+// RunGC implements the Snapshotter interface, issues a gc command to the kopia repo.
+func (ks *KopiaSnapshotter) RunGC() (err error) {
+	_, _, err = ks.Runner.Run("snapshot", "gc")
+	return err
+}
+
 // ListSnapshots implements the Snapshotter interface, issues a kopia snapshot
 // list and parses the snapshot IDs.
 func (ks *KopiaSnapshotter) ListSnapshots() ([]string, error) {
-	stdout, _, err := ks.Runner.Run("manifest", "list")
+	snapIDListMan, err := ks.snapIDsFromManifestList()
 	if err != nil {
 		return nil, err
 	}
 
-	return parseListForSnapshotIDs(stdout), nil
+	// Validate the list against kopia snapshot list --all
+	snapIDListSnap, err := ks.snapIDsFromSnapListAll()
+	if err != nil {
+		return nil, err
+	}
+
+	if got, want := len(snapIDListSnap), len(snapIDListMan); got != want {
+		return nil, errors.Errorf("Snapshot list len (%d) does not match manifest list len (%d)", got, want)
+	}
+
+	return snapIDListMan, nil
+}
+
+func (ks *KopiaSnapshotter) snapIDsFromManifestList() ([]string, error) {
+	stdout, _, err := ks.Runner.Run("manifest", "list")
+	if err != nil {
+		return nil, errors.Wrap(err, "failure during kopia manifest list")
+	}
+
+	return parseManifestListForSnapshotIDs(stdout), nil
+}
+
+func (ks *KopiaSnapshotter) snapIDsFromSnapListAll() ([]string, error) {
+	// Validate the list against kopia snapshot list --all
+	stdout, _, err := ks.Runner.Run("snapshot", "list", "--all", "--manifest-id", "--show-identical")
+	if err != nil {
+		return nil, errors.Wrap(err, "failure during kopia snapshot list")
+	}
+
+	return parseSnapshotListForSnapshotIDs(stdout), nil
 }
 
 // Run implements the Snapshotter interface, issues an arbitrary kopia command and returns
@@ -123,7 +182,7 @@ func (ks *KopiaSnapshotter) Run(args ...string) (stdout, stderr string, err erro
 }
 
 func parseSnapID(lines []string) (string, error) {
-	pattern := regexp.MustCompile(`uploaded snapshot (\S+)`)
+	pattern := regexp.MustCompile(`Created snapshot with root \S+ and ID (\S+)`)
 
 	for _, l := range lines {
 		match := pattern.FindAllStringSubmatch(l, 1)
@@ -135,7 +194,25 @@ func parseSnapID(lines []string) (string, error) {
 	return "", errors.New("snap ID could not be parsed")
 }
 
-func parseListForSnapshotIDs(output string) []string {
+func parseSnapshotListForSnapshotIDs(output string) []string {
+	var ret []string
+
+	lines := strings.Split(output, "\n")
+	for _, l := range lines {
+		fields := strings.Fields(l)
+
+		for _, f := range fields {
+			spl := strings.Split(f, "manifest:")
+			if len(spl) == 2 { //nolint:gomnd
+				ret = append(ret, spl[1])
+			}
+		}
+	}
+
+	return ret
+}
+
+func parseManifestListForSnapshotIDs(output string) []string {
 	var ret []string
 
 	lines := strings.Split(output, "\n")

--- a/tests/tools/kopiarunner/kopia_snapshotter_exe_test.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter_exe_test.go
@@ -1,0 +1,77 @@
+package kopiarunner
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestParseSnapListAllExeTest(t *testing.T) {
+	baseDir, err := ioutil.TempDir("", t.Name())
+	testenv.AssertNoError(t, err)
+
+	defer os.RemoveAll(baseDir)
+
+	repoDir, err := ioutil.TempDir(baseDir, "repo")
+	testenv.AssertNoError(t, err)
+
+	sourceDir, err := ioutil.TempDir(baseDir, "source")
+	testenv.AssertNoError(t, err)
+
+	ks, err := NewKopiaSnapshotter(repoDir)
+	if err == ErrExeVariableNotSet {
+		t.Skip("KOPIA_EXE not set, skipping test")
+	}
+
+	testenv.AssertNoError(t, err)
+
+	err = ks.ConnectOrCreateFilesystem(repoDir)
+	testenv.AssertNoError(t, err)
+
+	// Empty snapshot list
+	snapIDListSnap, err := ks.snapIDsFromSnapListAll()
+	testenv.AssertNoError(t, err)
+
+	if got, want := len(snapIDListSnap), 0; got != want {
+		t.Errorf("Snapshot list (len %d) should be empty", got)
+	}
+
+	fmt.Println(snapIDIsLastInList("asdf", snapIDListSnap))
+
+	const numSnapsToTest = 5
+	for snapCount := 0; snapCount < numSnapsToTest; snapCount++ {
+		snapID, err := ks.CreateSnapshot(sourceDir)
+		testenv.AssertNoError(t, err)
+
+		// Validate the list against kopia snapshot list --all
+		snapIDListSnap, err := ks.snapIDsFromSnapListAll()
+		testenv.AssertNoError(t, err)
+
+		if got, want := len(snapIDListSnap), snapCount+1; got != want {
+			t.Errorf("Snapshot list len (%d) does not match expected number of snapshots (%d)", got, want)
+		}
+
+		if !snapIDIsLastInList(snapID, snapIDListSnap) {
+			t.Errorf("Snapshot ID that was just created %s was not in the snapshot list", snapID)
+		}
+
+		// Validate the list against kopia snapshot list --all
+		snapIDListMan, err := ks.snapIDsFromManifestList()
+		testenv.AssertNoError(t, err)
+
+		if got, want := len(snapIDListMan), snapCount+1; got != want {
+			t.Errorf("Snapshot list len (%d) does not match expected number of snapshots (%d)", got, want)
+		}
+
+		if !snapIDIsLastInList(snapID, snapIDListSnap) {
+			t.Errorf("Snapshot ID that was just created %s was not in the manifest list", snapID)
+		}
+	}
+}
+
+func snapIDIsLastInList(snapID string, snapIDList []string) bool {
+	return len(snapIDList) > 0 && snapIDList[len(snapIDList)-1] == snapID
+}

--- a/tests/tools/kopiarunner/kopia_snapshotter_test.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter_test.go
@@ -1,0 +1,57 @@
+package kopiarunner
+
+import "testing"
+
+func TestSnapListParse(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		input  string
+		expOut []string
+	}{
+		{
+			name:   "No input",
+			input:  "",
+			expOut: []string{},
+		},
+		{
+			name:   "test a real input one line",
+			input:  "2020-04-02 23:58:40 UTC k1fa28ad0d2df85e76bac85d63d274098 128.5 MB drwxr-xr-x manifest:15d40f2e5af68df27951775ccdef1b60 files:9016 dirs:442 (latest-1,annual-1,monthly-1,weekly-1,daily-1,hourly-1)",
+			expOut: []string{"15d40f2e5af68df27951775ccdef1b60"},
+		},
+		{
+			name: "test a real input multiple lines",
+			input: `2020-04-02 23:58:40 UTC k1fa28ad0d2df85e76bac85d63d274098 128.5 MB drwxr-xr-x manifest:15d40f2e5af68df27951775ccdef1b60 files:9016 dirs:442 (latest-1,annual-1,monthly-1,weekly-1,daily-1,hourly-1)
+2020-04-02 23:58:40 UTC k1fa28ad0d2df85e76bac85d63d274098 128.5 MB drwxr-xr-x manifest:123 files:9016 dirs:442 (latest-1,annual-1,monthly-1,weekly-1,daily-1,hourly-1)
+2020-04-02 23:58:40 UTC k1fa28ad0d2df85e76bac85d63d274098 128.5 MB drwxr-xr-x manifest:321 files:9016 dirs:442 (latest-1,annual-1,monthly-1,weekly-1,daily-1,hourly-1)
+			`,
+			expOut: []string{
+				"15d40f2e5af68df27951775ccdef1b60",
+				"123",
+				"321",
+			},
+		},
+		{
+			name:   "Basic input",
+			input:  "manifest:asdf",
+			expOut: []string{"asdf"},
+		},
+		{
+			name:   "Malformed input",
+			input:  "manifust:asdf",
+			expOut: []string{},
+		},
+	} {
+		t.Log(tc.name)
+		gotOut := parseSnapshotListForSnapshotIDs(tc.input)
+
+		if got, want := len(gotOut), len(tc.expOut); got != want {
+			t.Errorf("Output snapshot list length %d does not match expected length %d", got, want)
+		}
+
+		for i := range gotOut {
+			if got, want := gotOut[i], tc.expOut[i]; got != want {
+				t.Errorf("Expected snapshot ID %s but got %s for index %d", want, got, i)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add flags for:
- no-progress
- parallel
- cache sizes
- no update check

Add an integration test to validate snapshotter expected output
against a kopia executable.

Add GC command, and sanity checks on finding snapshot ID from lists.