### PR TITLE
content: fixed index compaction that would resurrect content entry during full maintenance

### DIFF
--- a/repo/content/index.go
+++ b/repo/content/index.go
@@ -11,8 +11,11 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 )
 
-const maxEntrySize = 256
-const maxContentIDSize = maxHashSize + 1
+const (
+	maxEntrySize     = 256
+	maxContentIDSize = maxHashSize + 1
+	unknownKeySize   = 255
+)
 
 // packIndex is a read-only index of packed contents.
 type packIndex interface {
@@ -180,8 +183,14 @@ func (b *index) findEntry(output []byte, contentID ID) ([]byte, error) {
 	var hashBuf [maxContentIDSize]byte
 
 	key := contentIDToBytes(hashBuf[:0], contentID)
+
+	// empty index blob, this is possible when compaction removes exactly everything
+	if b.hdr.keySize == unknownKeySize {
+		return nil, nil
+	}
+
 	if len(key) != b.hdr.keySize {
-		return nil, errors.Errorf("invalid content ID: %q", contentID)
+		return nil, errors.Errorf("invalid content ID: %q (%v vs %v)", contentID, len(key), b.hdr.keySize)
 	}
 
 	stride := b.hdr.keySize + b.hdr.valueSize


### PR DESCRIPTION
(backported from 5e2994b4a905d94fdd9c1b5eb487ddca367c9f8d)

The problem was that while dropping deleted entries from the index
we were looking at index-local and nor merged result.

Say index1 has content1 created at t0.
Say index2 has content1 deleted at t1 > t0.

And we're compacting and dropping index entries deleted before t2,
such that t2 > t1.

Because create and delete records are in separate index files, the
compacted file would preserve "created t0" which is wrong.

This fix changes index compaction to always look at resolved content
status.