### PR TITLE
object: fixed splitter reset on reuse

### DIFF
--- a/repo/splitter/splitter_buzhash32.go
+++ b/repo/splitter/splitter_buzhash32.go
@@ -20,6 +20,7 @@ func (rs *buzhash32Splitter) Close() {
 func (rs *buzhash32Splitter) Reset() {
 	rs.rh.Reset()
 	rs.rh.Write(make([]byte, splitterSlidingWindowSize)) //nolint:errcheck
+	rs.count = 0
 }
 
 func (rs *buzhash32Splitter) ShouldSplit(b byte) bool {

--- a/repo/splitter/splitter_rabinkarp64.go
+++ b/repo/splitter/splitter_rabinkarp64.go
@@ -20,6 +20,7 @@ func (rs *rabinKarp64Splitter) Close() {
 func (rs *rabinKarp64Splitter) Reset() {
 	rs.rh.Reset()
 	rs.rh.Write(make([]byte, splitterSlidingWindowSize)) //nolint:errcheck
+	rs.count = 0
 }
 
 func (rs *rabinKarp64Splitter) ShouldSplit(b byte) bool {


### PR DESCRIPTION
We did not properly reset the splitter state for buzhash32 and
rabinkarp64, so object writer did not achieve perfect deduplication.

Fixes #595