### PR TITLE
Go 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: bionic
 osx_image: xcode11.3
 language: go
 go:
-- 1.14.x
+- 1.15.x
 os:
 - linux
 - osx

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kopia/kopia
 
-go 1.14
+go 1.15
 
 require (
 	bazil.org/fuse v0.0.0-20200117225306-7b5117fecadc


### PR DESCRIPTION
Use Go 1.15 in Travis.
Also require 1.15 to build, although it is only needed for tests.