### PR TITLE
Splitter throughput improvements

### DIFF
--- a/cli/command_benchmark_splitters.go
+++ b/cli/command_benchmark_splitters.go
@@ -59,19 +59,17 @@ func runBenchmarkSplitterAction(ctx *kingpin.ParseContext) error {
 
 		for _, data := range dataBlocks {
 			s := fact()
-			l := 0
 
-			for _, d := range data {
-				l++
-
-				if s.ShouldSplit(d) {
-					segmentLengths = append(segmentLengths, l)
-					l = 0
+			d := data
+			for len(d) > 0 {
+				n := s.NextSplitPoint(d)
+				if n < 0 {
+					segmentLengths = append(segmentLengths, len(d))
+					break
 				}
-			}
 
-			if l > 0 {
-				segmentLengths = append(segmentLengths, l)
+				segmentLengths = append(segmentLengths, n)
+				d = d[n:]
 			}
 		}
 

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -102,22 +102,12 @@ func (w *objectWriter) Close() error {
 	return nil
 }
 
-func nextSplitPoint(data []byte, s splitter.Splitter) int {
-	for i, b := range data {
-		if s.ShouldSplit(b) {
-			return i + 1
-		}
-	}
-
-	return -1
-}
-
 func (w *objectWriter) Write(data []byte) (n int, err error) {
 	dataLen := len(data)
 	w.totalLength += int64(dataLen)
 
 	for len(data) > 0 {
-		n := nextSplitPoint(data, w.splitter)
+		n := w.splitter.NextSplitPoint(data)
 		if n < 0 {
 			// no split points in the buffer
 			w.buffer.Write(data)

--- a/repo/splitter/splitter.go
+++ b/repo/splitter/splitter.go
@@ -71,16 +71,5 @@ func GetFactory(name string) Factory {
 	return splitterFactories[name]
 }
 
-// nextSplitPointHelper implements NextSplitPoint by invoking ShouldSplit on a given splitter.
-func nextSplitPointHelper(data []byte, shouldSplit func(b byte) bool) int {
-	for i, b := range data {
-		if shouldSplit(b) {
-			return i + 1
-		}
-	}
-
-	return -1
-}
-
 // DefaultAlgorithm is the name of the splitter used by default for new repositories.
 const DefaultAlgorithm = "DYNAMIC-4M-BUZHASH"

--- a/repo/splitter/splitter_buzhash32.go
+++ b/repo/splitter/splitter_buzhash32.go
@@ -23,7 +23,11 @@ func (rs *buzhash32Splitter) Reset() {
 	rs.count = 0
 }
 
-func (rs *buzhash32Splitter) ShouldSplit(b byte) bool {
+func (rs *buzhash32Splitter) NextSplitPoint(b []byte) int {
+	return nextSplitPointHelper(b, rs.shouldSplit)
+}
+
+func (rs *buzhash32Splitter) shouldSplit(b byte) bool {
 	rs.rh.Roll(b)
 	rs.count++
 

--- a/repo/splitter/splitter_fixed.go
+++ b/repo/splitter/splitter_fixed.go
@@ -13,18 +13,16 @@ func (s *fixedSplitter) Reset() {
 }
 
 func (s *fixedSplitter) NextSplitPoint(b []byte) int {
-	return nextSplitPointHelper(b, s.shouldSplit)
-}
+	n := s.chunkLength - s.cur
 
-func (s *fixedSplitter) shouldSplit(b byte) bool {
-	s.cur++
-
-	if s.cur >= s.chunkLength {
-		s.cur = 0
-		return true
+	if len(b) < n {
+		s.cur += len(b)
+		return -1
 	}
 
-	return false
+	s.cur = 0
+
+	return n
 }
 
 func (s *fixedSplitter) MaxSegmentSize() int {

--- a/repo/splitter/splitter_fixed.go
+++ b/repo/splitter/splitter_fixed.go
@@ -12,7 +12,11 @@ func (s *fixedSplitter) Reset() {
 	s.cur = 0
 }
 
-func (s *fixedSplitter) ShouldSplit(b byte) bool {
+func (s *fixedSplitter) NextSplitPoint(b []byte) int {
+	return nextSplitPointHelper(b, s.shouldSplit)
+}
+
+func (s *fixedSplitter) shouldSplit(b byte) bool {
 	s.cur++
 
 	if s.cur >= s.chunkLength {

--- a/repo/splitter/splitter_rabinkarp64.go
+++ b/repo/splitter/splitter_rabinkarp64.go
@@ -23,7 +23,11 @@ func (rs *rabinKarp64Splitter) Reset() {
 	rs.count = 0
 }
 
-func (rs *rabinKarp64Splitter) ShouldSplit(b byte) bool {
+func (rs *rabinKarp64Splitter) NextSplitPoint(b []byte) int {
+	return nextSplitPointHelper(b, rs.shouldSplit)
+}
+
+func (rs *rabinKarp64Splitter) shouldSplit(b byte) bool {
 	rs.rh.Roll(b)
 	rs.count++
 

--- a/repo/splitter/splitter_rabinkarp64.go
+++ b/repo/splitter/splitter_rabinkarp64.go
@@ -34,7 +34,16 @@ func (rs *rabinKarp64Splitter) NextSplitPoint(b []byte) int {
 			fastPathBytes = len(b)
 		}
 
-		for i := 0; i < fastPathBytes; i++ {
+		var i int
+
+		for i = 0; i < fastPathBytes-3; i += 4 {
+			rs.rh.Roll(b[i])
+			rs.rh.Roll(b[i+1])
+			rs.rh.Roll(b[i+2])
+			rs.rh.Roll(b[i+3])
+		}
+
+		for ; i < fastPathBytes; i++ {
 			rs.rh.Roll(b[i])
 		}
 

--- a/repo/splitter/splitter_rabinkarp64.go
+++ b/repo/splitter/splitter_rabinkarp64.go
@@ -24,24 +24,66 @@ func (rs *rabinKarp64Splitter) Reset() {
 }
 
 func (rs *rabinKarp64Splitter) NextSplitPoint(b []byte) int {
-	return nextSplitPointHelper(b, rs.shouldSplit)
-}
+	var fastPathBytes int
 
-func (rs *rabinKarp64Splitter) shouldSplit(b byte) bool {
-	rs.rh.Roll(b)
-	rs.count++
+	// simple optimization, if we're below minSize, there's no reason to even
+	// look at the Sum64() or maxSize
+	if left := rs.minSize - rs.count - 1; left > 0 {
+		fastPathBytes = left
+		if fastPathBytes > len(b) {
+			fastPathBytes = len(b)
+		}
 
-	if rs.rh.Sum64()&rs.mask == 0 && rs.count >= rs.minSize {
-		rs.count = 0
-		return true
+		for i := 0; i < fastPathBytes; i++ {
+			rs.rh.Roll(b[i])
+		}
+
+		rs.count += fastPathBytes
+		b = b[fastPathBytes:]
 	}
 
-	if rs.count >= rs.maxSize {
-		rs.count = 0
+	// second optimization, if we're safely below maxSize, there's no reason to check it
+	// in a loop
+	if left := rs.maxSize - rs.count - 1; left > 0 {
+		fp := left
+		if fp >= len(b) {
+			fp = len(b)
+		}
+
+		for i, b := range b[0:fp] {
+			if rs.shouldSplitNoMax(b) {
+				rs.count = 0
+				return fastPathBytes + i + 1
+			}
+		}
+
+		fastPathBytes += fp
+		b = b[fp:]
+	}
+
+	for i, b := range b {
+		if rs.shouldSplitWithMaxCheck(b) {
+			rs.count = 0
+			return fastPathBytes + i + 1
+		}
+	}
+
+	return -1
+}
+
+func (rs *rabinKarp64Splitter) shouldSplitWithMaxCheck(b byte) bool {
+	if rs.shouldSplitNoMax(b) || rs.count >= rs.maxSize {
 		return true
 	}
 
 	return false
+}
+
+func (rs *rabinKarp64Splitter) shouldSplitNoMax(b byte) bool {
+	rs.rh.Roll(b)
+	rs.count++
+
+	return rs.rh.Sum64()&rs.mask == 0
 }
 
 func (rs *rabinKarp64Splitter) MaxSegmentSize() int {


### PR DESCRIPTION
Refactored inner loop inside object writer that performs splitting to feed the splitter the slice of bytes instead of byte-by-byte. 

Splitter now implements `NextSplitPoint(b)` which determines the location of the next split point in the given slice and returns value `n` between `1..len(b)` if the split point happens AFTER byte n. If there is no split point, the splitter returns -1. This allows the splitter to perform internal optimizations which are pretty significant.

# Performance Comparison

Using `kopia benchmark splitter`

`BUZHASH` went from ~3.4s to ~2.4s (~40% throughput improvement)
`RABINKARP` went from ~8.2s to ~7s (~20% throughput improvement)
`FIXED` become free now

## Before

```
  0. FIXED-2M                    1390 ms count:256 min:2097152 10th:2097152 25th:2097152 50th:2097152 75th:2097152 90th:2097152 max:2097152
  1. FIXED-4M                    1411 ms count:128 min:4194304 10th:4194304 25th:4194304 50th:4194304 75th:4194304 90th:4194304 max:4194304
  2. FIXED-1M                    1417 ms count:512 min:1048576 10th:1048576 25th:1048576 50th:1048576 75th:1048576 90th:1048576 max:1048576
  3. FIXED-8M                    1458 ms count:64 min:8388608 10th:8388608 25th:8388608 50th:8388608 75th:8388608 90th:8388608 max:8388608
  4. FIXED                       1563 ms count:128 min:4194304 10th:4194304 25th:4194304 50th:4194304 75th:4194304 90th:4194304 max:4194304
  5. DYNAMIC-8M-BUZHASH          3288 ms count:49 min:677680 10th:5260579 25th:6528562 50th:11102775 75th:16777216 90th:16777216 max:16777216
  6. DYNAMIC-1M-BUZHASH          3463 ms count:428 min:9467 10th:612999 25th:766808 50th:1158068 75th:1744194 90th:2097152 max:2097152
  7. DYNAMIC-4M-BUZHASH          3481 ms count:107 min:9467 10th:2277562 25th:2971794 50th:4747177 75th:7603998 90th:8388608 max:8388608
  8. DYNAMIC-2M-BUZHASH          3500 ms count:204 min:64697 10th:1210184 25th:1638276 50th:2585985 75th:3944217 90th:4194304 max:4194304
  9. DYNAMIC                     3510 ms count:107 min:9467 10th:2277562 25th:2971794 50th:4747177 75th:7603998 90th:8388608 max:8388608
 10. DYNAMIC-8M-RABINKARP        8140 ms count:60 min:1446246 10th:4337385 25th:5293196 50th:8419217 75th:12334953 90th:16777216 max:16777216
 11. DYNAMIC-2M-RABINKARP        8199 ms count:204 min:535925 10th:1235674 25th:1675441 50th:2525341 75th:3658905 90th:4194304 max:4194304
 12. DYNAMIC-1M-RABINKARP        8229 ms count:391 min:213638 10th:623062 25th:813953 50th:1328673 75th:2097152 90th:2097152 max:2097152
 13. DYNAMIC-4M-RABINKARP        8604 ms count:110 min:535925 10th:2242307 25th:2767610 50th:4400962 75th:6813401 90th:8388608 max:8388608
```

## After

```
  0. FIXED-8M                       0 ms count:64 min:8388608 10th:8388608 25th:8388608 50th:8388608 75th:8388608 90th:8388608 max:8388608
  1. FIXED-4M                       0 ms count:128 min:4194304 10th:4194304 25th:4194304 50th:4194304 75th:4194304 90th:4194304 max:4194304
  2. FIXED-2M                       0 ms count:256 min:2097152 10th:2097152 25th:2097152 50th:2097152 75th:2097152 90th:2097152 max:2097152
  3. FIXED-1M                       0 ms count:512 min:1048576 10th:1048576 25th:1048576 50th:1048576 75th:1048576 90th:1048576 max:1048576
  4. FIXED                          0 ms count:128 min:4194304 10th:4194304 25th:4194304 50th:4194304 75th:4194304 90th:4194304 max:4194304
  5. DYNAMIC-4M-BUZHASH          2407 ms count:107 min:9467 10th:2277562 25th:2971794 50th:4747177 75th:7603998 90th:8388608 max:8388608
  6. DYNAMIC-2M-BUZHASH          2415 ms count:204 min:64697 10th:1210184 25th:1638276 50th:2585985 75th:3944217 90th:4194304 max:4194304
  7. DYNAMIC-1M-BUZHASH          2459 ms count:428 min:9467 10th:612999 25th:766808 50th:1158068 75th:1744194 90th:2097152 max:2097152
  8. DYNAMIC-8M-BUZHASH          2525 ms count:49 min:677680 10th:5260579 25th:6528562 50th:11102775 75th:16777216 90th:16777216 max:16777216
  9. DYNAMIC                     2765 ms count:107 min:9467 10th:2277562 25th:2971794 50th:4747177 75th:7603998 90th:8388608 max:8388608
 10. DYNAMIC-2M-RABINKARP        6769 ms count:204 min:535925 10th:1235674 25th:1675441 50th:2525341 75th:3658905 90th:4194304 max:4194304
 11. DYNAMIC-4M-RABINKARP        7001 ms count:110 min:535925 10th:2242307 25th:2767610 50th:4400962 75th:6813401 90th:8388608 max:8388608
 12. DYNAMIC-8M-RABINKARP        7222 ms count:60 min:1446246 10th:4337385 25th:5293196 50th:8419217 75th:12334953 90th:16777216 max:16777216
 13. DYNAMIC-1M-RABINKARP        7346 ms count:391 min:213638 10th:623062 25th:813953 50th:1328673 75th:2097152 90th:2097152 max:2097152
```