### PR TITLE
object: implemented fast concatenation of objects

### DIFF
--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -261,13 +261,8 @@ func (w *objectWriter) Result() (ID, error) {
 
 	defer iw.Close() //nolint:errcheck
 
-	ind := indirectObject{
-		StreamID: "kopia:indirect",
-		Entries:  w.indirectIndex,
-	}
-
-	if err := json.NewEncoder(iw).Encode(ind); err != nil {
-		return "", errors.Wrap(err, "unable to write indirect object index")
+	if err := writeIndirectObject(iw, w.indirectIndex); err != nil {
+		return "", err
 	}
 
 	oid, err := iw.Result()
@@ -276,6 +271,19 @@ func (w *objectWriter) Result() (ID, error) {
 	}
 
 	return IndirectObjectID(oid), nil
+}
+
+func writeIndirectObject(w io.Writer, entries []indirectObjectEntry) error {
+	ind := indirectObject{
+		StreamID: "kopia:indirect",
+		Entries:  entries,
+	}
+
+	if err := json.NewEncoder(w).Encode(ind); err != nil {
+		return errors.Wrap(err, "unable to write indirect object index")
+	}
+
+	return nil
 }
 
 // WriterOptions can be passed to Repository.NewWriter().


### PR DESCRIPTION
This is primarily to facilitate efficient parallel uploads of very large files (>1GB). Due to bottleneck of splitting which is inherently sequential, we can only one use CPU core for each Writer, which limits throughput.