### PR TITLE
cli: ensure advanced commands are not accidentally used

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -188,12 +188,9 @@ func advancedCommand() {
 	if os.Getenv("KOPIA_ADVANCED_COMMANDS") != "enabled" {
 		//nolint:errcheck
 		errorColor.Printf(`
-This command is meant for advanced users only and could be dangerous or lead to
-repository corruption when used improperly.
+This command could be dangerous or lead to repository corruption when used improperly.
 
-Most users of Kopia should not have the need to run this command and instead should rely on
-periodic repository maintenance. See https://kopia.io/docs/maintenance/ for more information.
-
+Running this command is not needed for using Kopia. Instead, most users should rely on periodic repository maintenance. See https://kopia.io/docs/maintenance/ for more information.
 To run this command despite the warning, set KOPIA_ADVANCED_COMMANDS=enabled
 
 `)

--- a/cli/app.go
+++ b/cli/app.go
@@ -184,6 +184,23 @@ func maybeRunMaintenance(ctx context.Context, rep repo.Repository) error {
 	return err
 }
 
+func advancedCommand() {
+	if os.Getenv("KOPIA_ADVANCED_COMMANDS") != "enabled" {
+		//nolint:errcheck
+		errorColor.Printf(`
+This command is meant for advanced users only and could be dangerous or lead to
+repository corruption when used improperly.
+
+Most users of Kopia should not have the need to run this command and instead should rely on
+periodic repository maintenance. See https://kopia.io/docs/maintenance/ for more information.
+
+To run this command despite the warning, set KOPIA_ADVANCED_COMMANDS=enabled
+
+`)
+		os.Exit(1)
+	}
+}
+
 // App returns an instance of command-line application object.
 func App() *kingpin.Application {
 	return app

--- a/cli/command_blob_delete.go
+++ b/cli/command_blob_delete.go
@@ -15,6 +15,8 @@ var (
 )
 
 func runDeleteBlobs(ctx context.Context, rep *repo.DirectRepository) error {
+	advancedCommand()
+
 	for _, b := range *blobDeleteBlobIDs {
 		err := rep.Blobs.DeleteBlob(ctx, blob.ID(b))
 		if err != nil {

--- a/cli/command_blob_gc.go
+++ b/cli/command_blob_gc.go
@@ -17,6 +17,8 @@ var (
 )
 
 func runBlobGarbageCollectCommand(ctx context.Context, rep *repo.DirectRepository) error {
+	advancedCommand()
+
 	opts := maintenance.DeleteUnreferencedBlobsOptions{
 		DryRun:   *blobGarbageCollectCommandDelete != "yes",
 		MinAge:   *blobGarbageCollectMinAge,

--- a/cli/command_content_rewrite.go
+++ b/cli/command_content_rewrite.go
@@ -22,6 +22,8 @@ var (
 )
 
 func runContentRewriteCommand(ctx context.Context, rep *repo.DirectRepository) error {
+	advancedCommand()
+
 	return maintenance.RewriteContents(ctx, rep, &maintenance.RewriteContentsOptions{
 		ContentIDRange: contentIDRange(),
 		ContentIDs:     toContentIDs(*contentRewriteIDs),

--- a/cli/command_content_rm.go
+++ b/cli/command_content_rm.go
@@ -13,6 +13,8 @@ var (
 )
 
 func runContentRemoveCommand(ctx context.Context, rep *repo.DirectRepository) error {
+	advancedCommand()
+
 	for _, contentID := range toContentIDs(*contentRemoveIDs) {
 		if err := rep.Content.DeleteContent(ctx, contentID); err != nil {
 			return err

--- a/cli/command_index_optimize.go
+++ b/cli/command_index_optimize.go
@@ -17,6 +17,8 @@ var (
 )
 
 func runOptimizeCommand(ctx context.Context, rep *repo.DirectRepository) error {
+	advancedCommand()
+
 	opt := content.CompactOptions{
 		MaxSmallBlobs: *optimizeMaxSmallBlobs,
 		AllIndexes:    *optimizeAllIndexes,

--- a/cli/command_index_recover.go
+++ b/cli/command_index_recover.go
@@ -17,6 +17,8 @@ var (
 )
 
 func runRecoverBlockIndexesAction(ctx context.Context, rep *repo.DirectRepository) error {
+	advancedCommand()
+
 	var totalCount int
 
 	defer func() {

--- a/cli/command_manifest_rm.go
+++ b/cli/command_manifest_rm.go
@@ -12,6 +12,8 @@ var (
 )
 
 func runManifestRemoveCommand(ctx context.Context, rep repo.Repository) error {
+	advancedCommand()
+
 	for _, it := range toManifestIDs(*manifestRemoveItems) {
 		if err := rep.DeleteManifest(ctx, it); err != nil {
 			return err

--- a/cli/command_snapshot_gc.go
+++ b/cli/command_snapshot_gc.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	snapshotGCCommand       = snapshotCommands.Command("gc", "Remove contents not used by any snapshot")
+	snapshotGCCommand       = snapshotCommands.Command("gc", "Mark contents as deleted which are not used by any snapshot").Hidden()
 	snapshotGCMinContentAge = snapshotGCCommand.Flag("min-age", "Minimum content age to allow deletion").Default("24h").Duration()
 	snapshotGCDelete        = snapshotGCCommand.Flag("delete", "Delete unreferenced contents").Bool()
 )

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -92,12 +92,15 @@ func NewCLITest(t *testing.T) *CLITest {
 	}
 
 	return &CLITest{
-		startTime:   clock.Now(),
-		RepoDir:     RepoDir,
-		ConfigDir:   ConfigDir,
-		Exe:         filepath.FromSlash(exe),
-		fixedArgs:   fixedArgs,
-		Environment: []string{"KOPIA_PASSWORD=" + repoPassword},
+		startTime: clock.Now(),
+		RepoDir:   RepoDir,
+		ConfigDir: ConfigDir,
+		Exe:       filepath.FromSlash(exe),
+		fixedArgs: fixedArgs,
+		Environment: []string{
+			"KOPIA_PASSWORD=" + repoPassword,
+			"KOPIA_ADVANCED_COMMANDS=enabled",
+		},
 	}
 }
 


### PR DESCRIPTION
This prints an error when a dangerous command is used without
first setting KOPIA_ADVANCED_COMMANDS=enabled environment variable.