### PR TITLE
logging: revamped logs from content manager to be machine parseable

### DIFF
--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -58,7 +58,10 @@ const (
 func Initialize(ctx *kingpin.ParseContext) error {
 	now := clock.Now()
 
-	suffix := strings.ReplaceAll(ctx.SelectedCommand.FullCommand(), " ", "-")
+	suffix := "unknown"
+	if c := ctx.SelectedCommand; c != nil {
+		suffix = strings.ReplaceAll(c.FullCommand(), " ", "-")
+	}
 
 	// activate backends
 	logging.SetBackend(

--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -101,8 +101,6 @@ func (b *committedContentIndex) use(ctx context.Context, packFiles []blob.ID) (b
 		return false, nil
 	}
 
-	log(ctx).Debugf("set of index files has changed (had %v, now %v)", len(b.inUse), len(packFiles))
-
 	var newMerged mergedIndex
 
 	newInUse := map[blob.ID]packIndex{}

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -24,13 +24,15 @@ import (
 
 var (
 	log       = logging.GetContextLoggerFunc("kopia/content")
-	formatLog = logging.GetContextLoggerFunc("kopia/content/format")
+	formatLog = logging.GetContextLoggerFunc(FormatLogModule)
 )
 
 // Prefixes for pack blobs.
 const (
 	PackBlobIDPrefixRegular blob.ID = "p"
 	PackBlobIDPrefixSpecial blob.ID = "q"
+
+	FormatLogModule = "kopia/format"
 
 	maxHashSize                            = 64
 	defaultEncryptionBufferPoolSegmentSize = 8 << 20 // 8 MB
@@ -104,7 +106,7 @@ func (bm *Manager) DeleteContent(ctx context.Context, contentID ID) error {
 	bm.lock()
 	defer bm.unlock()
 
-	log(ctx).Debugf("DeleteContent(%q)", contentID)
+	formatLog(ctx).Debugf("delete-content %v", contentID)
 
 	// remove from all pending packs
 	for _, pp := range bm.pendingPacks {
@@ -161,7 +163,7 @@ func (bm *Manager) addToPackUnlocked(ctx context.Context, contentID ID, data []b
 
 	// do not start new uploads while flushing
 	for bm.flushing {
-		formatLog(ctx).Debugf("waiting before flush completes")
+		formatLog(ctx).Debugf("wait-before-flush")
 		bm.cond.Wait()
 	}
 
@@ -378,10 +380,11 @@ func (bm *Manager) prepareAndWritePackInternal(ctx context.Context, pp *pendingP
 
 	if pp.currentPackData.Length() > 0 {
 		if err := bm.writePackFileNotLocked(ctx, pp.packBlobID, pp.currentPackData.Bytes); err != nil {
+			formatLog(ctx).Debugf("failed-pack %v %v", pp.packBlobID, err)
 			return nil, errors.Wrap(err, "can't save pack data content")
 		}
 
-		formatLog(ctx).Debugf("wrote pack file: %v (%v bytes)", pp.packBlobID, pp.currentPackData.Length())
+		formatLog(ctx).Debugf("wrote-pack %v %v", pp.packBlobID, pp.currentPackData.Length())
 	}
 
 	return packFileIndex, nil
@@ -423,6 +426,8 @@ func (bm *Manager) Flush(ctx context.Context) error {
 	bm.lock()
 	defer bm.unlock()
 
+	formatLog(ctx).Debugf("flush")
+
 	bm.flushing = true
 
 	defer func() {
@@ -453,7 +458,7 @@ func (bm *Manager) Flush(ctx context.Context) error {
 
 // RewriteContent causes reads and re-writes a given content using the most recent format.
 func (bm *Manager) RewriteContent(ctx context.Context, contentID ID) error {
-	log(ctx).Debugf("RewriteContent(%q)", contentID)
+	formatLog(ctx).Debugf("rewrite-content %v", contentID)
 
 	pp, bi, err := bm.getContentInfo(contentID)
 	if err != nil {
@@ -543,8 +548,13 @@ func (bm *Manager) WriteContent(ctx context.Context, data []byte, prefix ID) (ID
 	// content already tracked
 	if _, bi, err := bm.getContentInfo(contentID); err == nil {
 		if !bi.Deleted {
+			formatLog(ctx).Debugf("write-content %v already-exists", contentID)
 			return contentID, nil
 		}
+
+		formatLog(ctx).Debugf("write-content %v previously-deleted", contentID)
+	} else {
+		formatLog(ctx).Debugf("write-content %v new", contentID)
 	}
 
 	err := bm.addToPackUnlocked(ctx, contentID, data, false)

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -197,7 +197,7 @@ func (bm *lockFreeManager) unprocessedIndexBlobsUnlocked(ctx context.Context, co
 		}
 
 		if has {
-			log(ctx).Debugf("index blob %q already in cache, skipping", c.BlobID)
+			formatLog(ctx).Debugf("index-already-cached %v", c.BlobID)
 			continue
 		}
 
@@ -280,8 +280,6 @@ func (bm *lockFreeManager) decryptAndVerify(encrypted, iv []byte) ([]byte, error
 }
 
 func (bm *lockFreeManager) preparePackDataContent(ctx context.Context, pp *pendingPackInfo) (packIndexBuilder, error) {
-	formatLog(ctx).Debugf("preparing content data with %v items (contents %v)", len(pp.currentPackItems), pp.currentPackData.Length())
-
 	packFileIndex := packIndexBuilder{}
 	haveContent := false
 
@@ -289,6 +287,8 @@ func (bm *lockFreeManager) preparePackDataContent(ctx context.Context, pp *pendi
 		if info.PackBlobID == pp.packBlobID {
 			haveContent = true
 		}
+
+		formatLog(ctx).Debugf("add-to-pack %v %v p:%v %v d:%v", pp.packBlobID, info.ID, info.PackBlobID, info.Length, info.Deleted)
 
 		packFileIndex.Add(info)
 	}

--- a/repo/content/content_manager_own_writes.go
+++ b/repo/content/content_manager_own_writes.go
@@ -73,7 +73,7 @@ func (n *memoryOwnWritesCache) merge(ctx context.Context, prefix blob.ID, source
 		if age := n.timeNow().Sub(md.Timestamp); age < ownWritesCacheRetention {
 			result = append(result, md)
 		} else {
-			formatLog(ctx).Debugf("own-writes-cache-expired %v", key, age)
+			formatLog(ctx).Debugf("own-writes-cache-expired %v %v", key, age)
 
 			n.entries.Delete(key)
 		}

--- a/repo/content/content_manager_own_writes.go
+++ b/repo/content/content_manager_own_writes.go
@@ -47,7 +47,7 @@ type memoryOwnWritesCache struct {
 }
 
 func (n *memoryOwnWritesCache) add(ctx context.Context, mb blob.Metadata) error {
-	log(ctx).Debugf("adding %v to own-writes cache", mb.BlobID)
+	formatLog(ctx).Debugf("own-writes-cache-add %v", mb)
 	n.entries.Store(mb.BlobID, mb)
 
 	return nil
@@ -73,7 +73,7 @@ func (n *memoryOwnWritesCache) merge(ctx context.Context, prefix blob.ID, source
 		if age := n.timeNow().Sub(md.Timestamp); age < ownWritesCacheRetention {
 			result = append(result, md)
 		} else {
-			log(ctx).Debugf("deleting stale own writes cache entry: %v (%v)", key, age)
+			formatLog(ctx).Debugf("own-writes-cache-expired %v", key, age)
 
 			n.entries.Delete(key)
 		}
@@ -81,7 +81,7 @@ func (n *memoryOwnWritesCache) merge(ctx context.Context, prefix blob.ID, source
 		return true
 	})
 
-	return mergeOwnWrites(ctx, source, result), nil
+	return mergeOwnWrites(source, result), nil
 }
 
 // persistentOwnWritesCache is an implementation of ownWritesCache that caches entries to strongly consistent blob storage.
@@ -123,7 +123,7 @@ func (d *persistentOwnWritesCache) merge(ctx context.Context, prefix blob.ID, so
 		if age := d.timeNow().Sub(md.Timestamp); age < ownWritesCacheRetention {
 			myWrites = append(myWrites, originalMD)
 		} else {
-			log(ctx).Debugf("deleting blob %v from own-write cache because it's too old: %v (%v)", md.BlobID, age, originalMD.Timestamp)
+			log(ctx).Debugf("own-writes-cache-expired: %v (%v)", md, age)
 
 			if err := d.st.DeleteBlob(ctx, md.BlobID); err != nil && !errors.Is(err, blob.ErrBlobNotFound) {
 				return errors.Wrap(err, "error deleting stale blob")
@@ -133,7 +133,7 @@ func (d *persistentOwnWritesCache) merge(ctx context.Context, prefix blob.ID, so
 		return nil
 	})
 
-	return mergeOwnWrites(ctx, source, myWrites), err
+	return mergeOwnWrites(source, myWrites), err
 }
 
 func (d *persistentOwnWritesCache) delete(ctx context.Context, blobID blob.ID) error {
@@ -144,7 +144,7 @@ func (d *persistentOwnWritesCache) delete(ctx context.Context, blobID blob.ID) e
 	})
 }
 
-func mergeOwnWrites(ctx context.Context, source, own []blob.Metadata) []blob.Metadata {
+func mergeOwnWrites(source, own []blob.Metadata) []blob.Metadata {
 	m := map[blob.ID]blob.Metadata{}
 
 	for _, v := range source {
@@ -164,8 +164,6 @@ func mergeOwnWrites(ctx context.Context, source, own []blob.Metadata) []blob.Met
 	for _, v := range m {
 		s = append(s, v)
 	}
-
-	log(ctx).Debugf("merged %v backend blobs and %v local blobs into %v", source, own, s)
 
 	return s
 }

--- a/repo/content/list_cache.go
+++ b/repo/content/list_cache.go
@@ -30,7 +30,7 @@ func (c *listCache) listBlobs(ctx context.Context, prefix blob.ID) ([]blob.Metad
 		if err == nil {
 			expirationTime := ci.Timestamp.Add(c.listCacheDuration)
 			if clock.Now().Before(expirationTime) {
-				log(ctx).Debugf("retrieved list of %v '%v' index blobs from cache", len(ci.Blobs), prefix)
+				formatLog(ctx).Debugf("list-from-cache '%v' found %v", prefix, len(ci.Blobs))
 				return ci.Blobs, nil
 			}
 		} else if !errors.Is(err, blob.ErrBlobNotFound) {

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -41,6 +41,8 @@ type CLITest struct {
 	Environment []string
 
 	PassthroughStderr bool
+
+	LogsDir string
 }
 
 // SourceInfo reprents a single source (user@host:/path) with its snapshots.
@@ -76,9 +78,15 @@ func NewCLITest(t *testing.T) *CLITest {
 		t.Fatalf("can't create temp directory: %v", err)
 	}
 
+	logsDir, err := ioutil.TempDir("", "kopia-logs")
+	if err != nil {
+		t.Fatalf("can't create temp directory: %v", err)
+	}
+
 	fixedArgs := []string{
 		// use per-test config file, to avoid clobbering current user's setup.
 		"--config-file", filepath.Join(ConfigDir, ".kopia.config"),
+		"--log-dir", logsDir,
 	}
 
 	// disable the use of keyring
@@ -97,6 +105,7 @@ func NewCLITest(t *testing.T) *CLITest {
 		ConfigDir: ConfigDir,
 		Exe:       filepath.FromSlash(exe),
 		fixedArgs: fixedArgs,
+		LogsDir:   logsDir,
 		Environment: []string{
 			"KOPIA_PASSWORD=" + repoPassword,
 			"KOPIA_ADVANCED_COMMANDS=enabled",
@@ -107,7 +116,7 @@ func NewCLITest(t *testing.T) *CLITest {
 // Cleanup cleans up the test Environment unless the test has failed.
 func (e *CLITest) Cleanup(t *testing.T) {
 	if t.Failed() {
-		t.Logf("skipped cleanup for failed test, examine repository: %v", e.RepoDir)
+		t.Logf("skipped cleanup for failed test, examine repository: %v and logs %v", e.RepoDir, e.LogsDir)
 		return
 	}
 
@@ -117,6 +126,10 @@ func (e *CLITest) Cleanup(t *testing.T) {
 
 	if e.ConfigDir != "" {
 		os.RemoveAll(e.ConfigDir)
+	}
+
+	if e.LogsDir != "" {
+		os.RemoveAll(e.LogsDir)
 	}
 }
 


### PR DESCRIPTION
Logs from the content manager (except reads) are sent to separate log
file that is always free from personally-identifiable information
(e.g. no file names, just content IDs and blob IDs).

Also moved CLI logs to a subdirectory (`cli-logs`) and put content logs
in a parallel directory (`content-logs`) with separate retention rules.

Also, the log file name will now include the type of the command that
was invoked:

   kopia-20200913-134157-16110-snapshot-create.log

Fixes #588