### PR TITLE
testing: added performance benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules/
 *_bindata.go
 .tmp.*
 .boto
+*.log

--- a/tests/perf_benchmark/perf-benchmark-setup.sh
+++ b/tests/perf_benchmark/perf-benchmark-setup.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# install tools
+sudo apt install -y fio python3-pip
+sudo pip3 install psrecord
+
+# format /mnt/data partition
+sudo mkfs.ext4 -F /dev/nvme0n1
+sudo mkdir /mnt/data
+sudo mount /dev/nvme0n1 /mnt/data
+sudo chown $USER /mnt/data

--- a/tests/perf_benchmark/perf-benchmark.sh
+++ b/tests/perf_benchmark/perf-benchmark.sh
@@ -13,7 +13,7 @@ fio_opts="--size=$TOTAL_SIZE --bs=256k --iodepth=32 --dedupe_percentage=40 --buf
 
 set -e
 
-echo Running performance test againt version $VERSION from channel $CHANNEL with total data size $TOTAL_SIZE
+echo Running performance test against version $VERSION from channel $CHANNEL with total data size $TOTAL_SIZE
 
 # Install Kopia from APT repository...
 curl -s https://kopia.io/signing-key | sudo apt-key add -

--- a/tests/perf_benchmark/perf-benchmark.sh
+++ b/tests/perf_benchmark/perf-benchmark.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+VERSION=$1
+
+# stable,testing,unstable
+CHANNEL=$2
+
+# total size of source data to backup (e.g. 10Gi)
+TOTAL_SIZE=$3
+
+# we always setup files the same way, the only thing that varies is the number of files
+
+fio_opts="--size=$TOTAL_SIZE --bs=256k --iodepth=32 --dedupe_percentage=40 --buffer_compress_percentage=60 --numjobs=1 --rw=write --name=/mnt/data/source/kopia-test"
+
+set -e
+
+echo Running performance test againt version $VERSION from channel $CHANNEL with total data size $TOTAL_SIZE
+
+# Install Kopia from APT repository...
+curl -s https://kopia.io/signing-key | sudo apt-key add -
+echo "deb http://packages.kopia.io/apt/ $CHANNEL main" | sudo tee /etc/apt/sources.list.d/kopia.list
+sudo apt update
+sudo apt install -y --allow-downgrades kopia=$VERSION
+
+sudo chown -R $USER /mnt/data
+
+for scenario in 1000-compressed 100-compressed 10-compressed 1000-uncompressed 100-uncompressed 10-uncompressed; do
+    echo Cleaning up directories...
+    rm -rfv /mnt/data/{repo,cache,source}
+    mkdir -p /mnt/data/{repo,cache,source}
+
+    # create 100 x 2 GB files
+    echo Preparing files...
+
+    export KOPIA_PASSWORD=super-secure
+    kopia repo create filesystem --path=/mnt/data/repo --cache-directory=/mnt/data/cache
+
+    case $scenario in
+        1000-compressed)
+            fio --nrfiles=1000 $fio_opts
+            kopia policy set --global --compression=s2-default
+            ;;
+        100-compressed)
+            fio --nrfiles=100 $fio_opts
+            kopia policy set --global --compression=s2-default
+            ;;
+        10-compressed)
+            fio --nrfiles=10 $fio_opts
+            kopia policy set --global --compression=s2-default
+            ;;
+        1000-uncompressed)
+            fio --nrfiles=1000 $fio_opts
+            ;;
+        100-uncompressed)
+            fio --nrfiles=100 $fio_opts
+            ;;
+        10-uncompressed)
+            fio --nrfiles=10 $fio_opts
+            ;;
+            *)
+            echo Unhandled scenario $scenario
+            exit 1
+            ;;
+    esac
+
+    psrecord --interval 1 --include-children --log psrecord-$VERSION-initial-$scenario.log "kopia snap create /mnt/data/source"
+
+    # clear cache
+    rm -rfv /mnt/data/cache}
+    mkdir -p /mnt/data/cache}
+
+    # reconnect to repository
+    kopia repo connect filesystem --path=/mnt/data/repo --cache-directory=/mnt/data/cache
+    psrecord --interval 1 --include-children --log psrecord-$VERSION-second-$scenario.log "kopia snap create /mnt/data/source"
+
+    # dump repo size
+    du -bs /mnt/data/repo/ > repo-size-$VERSION-$scenario.log
+done

--- a/tests/perf_benchmark/process_results.go
+++ b/tests/perf_benchmark/process_results.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	psrecordRegex = regexp.MustCompile(`psrecord-(.*)-(initial|second)-(.*).log`)
+	reposizeRegex = regexp.MustCompile(`repo-size-(.*?)-(.*).log`)
+)
+
+type processStats struct {
+	duration float64
+	avgCPU   float64
+	avgRAM   float64
+	maxCPU   float64
+	maxRAM   float64
+}
+
+var (
+	processStatsByScenarioAndVersion = map[string]map[string]processStats{}
+	repoSizeByScenarioArndVersion    = map[string]map[string]int64{}
+)
+
+// getProcessStats parses psrecord log file and computes statistics.
+func getProcessStats(fname string) (processStats, error) {
+	f, err := os.Open(fname) //nolint:gosec
+	if err != nil {
+		return processStats{}, err
+	}
+	defer f.Close() //nolint:errcheck,gosec
+
+	s := bufio.NewScanner(f)
+
+	s.Scan() // skip first line
+
+	var (
+		ps            processStats
+		totalCPUUsage float64
+		totalRAMUsage float64
+		maxCPUUsage   float64
+		maxRAMUsage   float64
+		sampleCount   float64
+	)
+
+	for s.Scan() {
+		fields := strings.Fields(s.Text())
+
+		ts, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil {
+			return ps, errors.Wrap(err, "error parsing time")
+		}
+
+		cpuUsage, err := strconv.ParseFloat(fields[1], 64)
+		if err != nil {
+			return ps, errors.Wrap(err, "error parsing cpu")
+		}
+
+		totalCPUUsage += cpuUsage
+
+		if cpuUsage > maxCPUUsage {
+			maxCPUUsage = cpuUsage
+		}
+
+		ramUsage, err := strconv.ParseFloat(fields[2], 64)
+		if err != nil {
+			return ps, errors.Wrap(err, "error parsing ram")
+		}
+
+		totalRAMUsage += ramUsage
+
+		if ramUsage > maxRAMUsage {
+			maxRAMUsage = ramUsage
+		}
+
+		sampleCount++
+
+		ps.duration = ts
+	}
+
+	if sampleCount > 0 {
+		ps.maxCPU = maxCPUUsage
+		ps.maxRAM = maxRAMUsage
+		ps.avgCPU = totalCPUUsage / sampleCount
+		ps.avgRAM = totalRAMUsage / sampleCount
+	}
+
+	return ps, nil
+}
+
+func parseRepoSize(fname string) (int64, error) {
+	f, err := os.Open(fname) //nolint:gosec
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close() //nolint:errcheck,gosec
+
+	s := bufio.NewScanner(f)
+	s.Scan()
+
+	fields := strings.Fields(s.Text())
+	if len(fields) != 2 { // nolint:gomnd
+		return 0, errors.Errorf("unvalid repo size format")
+	}
+
+	return strconv.ParseInt(fields[0], 10, 64)
+}
+
+func main() {
+	files, err := ioutil.ReadDir(".")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, f := range files {
+		if m := psrecordRegex.FindStringSubmatch(f.Name()); m != nil {
+			version := m[1]
+			phase := m[2]
+			scenario := m[3]
+
+			ps, err := getProcessStats(f.Name())
+			if err != nil {
+				log.Fatalf("err: %v", err)
+			}
+
+			if phase == "initial" {
+				ss := processStatsByScenarioAndVersion[scenario]
+				if ss == nil {
+					ss = map[string]processStats{}
+					processStatsByScenarioAndVersion[scenario] = ss
+				}
+
+				ss[version] = ps
+			}
+		}
+
+		if m := reposizeRegex.FindStringSubmatch(f.Name()); m != nil {
+			version := m[1]
+			scenario := m[2]
+
+			rs, err := parseRepoSize(f.Name())
+			if err != nil {
+				log.Fatalf("unable to parse repo size: %v", err)
+			}
+
+			ss := repoSizeByScenarioArndVersion[scenario]
+			if ss == nil {
+				ss = map[string]int64{}
+				repoSizeByScenarioArndVersion[scenario] = ss
+			}
+
+			ss[version] = rs
+		}
+	}
+
+	for scenario, results := range processStatsByScenarioAndVersion {
+		for ver, ps := range results {
+			rs := repoSizeByScenarioArndVersion[scenario][ver]
+			fmt.Printf("%v,%v,%v,%v,%v,%v,%v,%v\n", scenario, ver, ps.duration, ps.avgCPU, ps.maxCPU, ps.avgRAM, ps.maxRAM, rs)
+		}
+	}
+}


### PR DESCRIPTION
The benchmarks creates 20 GB of files in different configurations

* 10 x 2 GB files
* 100 x 200 MB files
* 1000 x 20 MB files

and backs them up to a local filesystem repository measuring latency, CPU and RAM usage plus repository size.

The script also creates both compressed (s2-default) and uncompressed repositories.

The benchmarking script uses GCP instance (n1-standard-8) with fast NVME
flash to eliminate local filesystem latency.

Current performance numbers show major improvement in latency in
0.7.0-rc1 due to splitter throughput optimization (#606).

See current numbers in https://docs.google.com/spreadsheets/d/1ExNZuYiXgz7CSR65M8Uk6ELk78NsOv6uusuqzW1lS-Q/edit#gid=0