### PR TITLE
upload: scan the directory to be uploaded in parallel to estimate the amount of data to be uploaded

### DIFF
--- a/cli/cli_progress.go
+++ b/cli/cli_progress.go
@@ -47,8 +47,8 @@ type cliProgress struct {
 	spinPhase       int
 	uploadStartTime time.Time
 
-	previousFileCount int
-	previousTotalSize int64
+	estimatedFileCount  int
+	estimatedTotalBytes int64
 
 	// indicates shared instance that does not reset counters at the beginning of upload.
 	shared bool
@@ -152,13 +152,29 @@ func (p *cliProgress) output(col *color.Color, msg string) {
 		return
 	}
 
-	if p.previousTotalSize > 0 {
-		percent := (float64(hashedBytes+cachedBytes) * hundredPercent / float64(p.previousTotalSize))
-		if percent > hundredPercent {
-			percent = hundredPercent
+	if p.estimatedTotalBytes > 0 {
+		line += fmt.Sprintf(", estimated %v", units.BytesStringBase10(p.estimatedTotalBytes))
+
+		ratio := float64(hashedBytes+cachedBytes) / float64(p.estimatedTotalBytes)
+		if ratio > 1 {
+			ratio = 1
 		}
 
-		line += fmt.Sprintf(" %.1f%%", percent)
+		timeSoFarSeconds := clock.Since(p.uploadStartTime).Seconds()
+		estimatedTotalTime := time.Second * time.Duration(timeSoFarSeconds/ratio)
+		estimatedEndTime := p.uploadStartTime.Add(estimatedTotalTime)
+
+		remaining := clock.Until(estimatedEndTime)
+		if remaining < 0 {
+			remaining = 0
+		}
+
+		remaining = remaining.Round(time.Second)
+
+		line += fmt.Sprintf(" (%.1f%%)", ratio*hundredPercent)
+		line += fmt.Sprintf(" %v left", remaining)
+	} else {
+		line += ", estimating..."
 	}
 
 	var extraSpaces string
@@ -197,18 +213,29 @@ func (p *cliProgress) FinishShared() {
 	p.output(defaultColor, "")
 }
 
-func (p *cliProgress) UploadStarted(previousFileCount int, previousTotalSize int64) {
+func (p *cliProgress) UploadStarted() {
 	if p.shared {
 		// do nothing
 		return
 	}
 
 	*p = cliProgress{
-		uploading:         1,
-		uploadStartTime:   clock.Now(),
-		previousFileCount: previousFileCount,
-		previousTotalSize: previousTotalSize,
+		uploading:       1,
+		uploadStartTime: clock.Now(),
 	}
+}
+
+func (p *cliProgress) EstimatedDataSize(fileCount int, totalBytes int64) {
+	if p.shared {
+		// do nothing
+		return
+	}
+
+	p.outputMutex.Lock()
+	defer p.outputMutex.Unlock()
+
+	p.estimatedFileCount = fileCount
+	p.estimatedTotalBytes = totalBytes
 }
 
 func (p *cliProgress) UploadFinished() {

--- a/htmlui/src/SourcesTable.js
+++ b/htmlui/src/SourcesTable.js
@@ -203,8 +203,10 @@ export class SourcesTable extends Component {
                     const totalBytes = u.hashedBytes + u.cachedBytes;
 
                     totals = sizeDisplayName(totalBytes);
-                    if (x.row.original.lastSnapshot) {
-                        const percent = Math.round(totalBytes * 1000.0 / x.row.original.lastSnapshot.stats.totalSize) / 10.0;
+                    if (u.estimatedBytes) {
+                        totals += "/" + sizeDisplayName(u.estimatedBytes);
+
+                        const percent = Math.round(totalBytes * 1000.0 / u.estimatedBytes) / 10.0;
                         if (percent <= 100) {
                             totals += " " + percent + "%";
                         }
@@ -212,7 +214,7 @@ export class SourcesTable extends Component {
                 }
 
                 return <>
-                    <Spinner animation="border" variant="primary" size="sm" title={title} />&nbsp;Snapshotting {totals}
+                    <Spinner animation="border" variant="primary" size="sm" title={title} />&nbsp;Uploading {totals}
                     &nbsp;
                     <Button variant="danger" size="sm" onClick={() => {
                         parent.cancelSnapshot(x.row.original.source);

--- a/snapshot/snapshotfs/upload_scan.go
+++ b/snapshot/snapshotfs/upload_scan.go
@@ -1,0 +1,51 @@
+package snapshotfs
+
+import (
+	"context"
+
+	"github.com/kopia/kopia/fs"
+)
+
+type scanResults struct {
+	numFiles      int
+	totalFileSize int64
+}
+
+// scanDirectory computes the number of files and their total size in a given directory recursively descending
+// into subdirectories. The scan teminates early as soon as the provided context is canceled.
+func (u *Uploader) scanDirectory(ctx context.Context, dir fs.Directory) (scanResults, error) {
+	var res scanResults
+
+	if u.disableEstimation {
+		return res, nil
+	}
+
+	entries, err := dir.Readdir(ctx)
+	if err != nil {
+		return res, err
+	}
+
+	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			// terminate early if context got canceled
+			return res, err
+		}
+
+		switch e := e.(type) {
+		case fs.Directory:
+			dr, err := u.scanDirectory(ctx, e)
+			res.numFiles += dr.numFiles
+			res.totalFileSize += dr.totalFileSize
+
+			if err != nil {
+				return res, err
+			}
+
+		case fs.File:
+			res.numFiles++
+			res.totalFileSize += e.Size()
+		}
+	}
+
+	return res, nil
+}

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -299,6 +299,7 @@ func TestUploadWithCheckpointing(t *testing.T) {
 
 	// create a channel that will be sent to whenever checkpoint completes.
 	u.checkpointFinished = make(chan struct{})
+	u.disableEstimation = true
 
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 


### PR DESCRIPTION
This allows better progress indicator in the CLI and UI.
The percentage completed is not displayed until estimate is available.

Quick demo: https://asciinema.org/a/O7ktcWSgaGUPfJwhzc65mMWM1

Fixes #514 