### PR TITLE
webdav: work around client race condition

### DIFF
--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/studio-b12/gowebdav"
 
@@ -201,7 +202,7 @@ func New(ctx context.Context, opts *Options) (blob.Storage, error) {
 		cli.SetTransport(tlsutil.TransportTrustingSingleCertificate(opts.TrustedServerCertificateFingerprint))
 	}
 
-	return &davStorage{
+	s := &davStorage{
 		sharded.Storage{
 			Impl: &davStorageImpl{
 				Options: *opts,
@@ -211,7 +212,16 @@ func New(ctx context.Context, opts *Options) (blob.Storage, error) {
 			Suffix:   fsStorageChunkSuffix,
 			Shards:   opts.shards(),
 		},
-	}, nil
+	}
+
+	// temporary workaround to a race condition problem in https://github.com/studio-b12/gowebdav/issues/36
+	// the race condition is only during first request to the server, so to fix it we force the first request
+	// to read a non-existent blob, which sets the authentication method.
+	if _, err := s.GetBlob(ctx, blob.ID(uuid.New().String()), 0, -1); !errors.Is(err, blob.ErrBlobNotFound) {
+		return nil, errors.Errorf("unexpected error when initializing webdav: %v", err)
+	}
+
+	return s, nil
 }
 
 func init() {


### PR DESCRIPTION
The race is described in https://github.com/studio-b12/gowebdav/issues/36

We need this workaround until the fix is merged upstream, to avoid maintaining a webdav client fork.

Fixes #624