### PR TITLE
Trivial: update git attributes for Makefile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.go	text eol=lf whitespace=trailing-space,space-before-tab,indent-with-non-tab diff=golang
 go.mod	text eol=lf whitespace=trailing-space,space-before-tab,indent-with-non-tab
 go.sum	text eol=lf whitespace=trailing-space,space-before-tab,indent-with-non-tab
+Makefile text eol=lf whitespace=trailing-space,space-before-tab,indent-with-non-tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-*.go	whitespace=trailing-space,space-before-tab,indent-with-non-tab
-go.mod	whitespace=trailing-space,space-before-tab,indent-with-non-tab
+*.go	text eol=lf whitespace=trailing-space,space-before-tab,indent-with-non-tab diff=golang
+go.mod	text eol=lf whitespace=trailing-space,space-before-tab,indent-with-non-tab
+go.sum	text eol=lf whitespace=trailing-space,space-before-tab,indent-with-non-tab


### PR DESCRIPTION
Add .gitattributes entry for Makefiles
Update .gitattributes for Go files:
- Mark go source files as text, with LF line ending.
- Set git diff language mode for `*.go` files to `golang`
- Add attributes for `go.sum`

