### PR TITLE
Add support for Blake3 hashing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/studio-b12/gowebdav v0.0.0-20200303150724-9380631c29a1
 	github.com/tg123/go-htpasswd v1.0.0
 	github.com/zalando/go-keyring v0.1.0
+	github.com/zeebo/blake3 v0.0.4
 	go.opencensus.io v0.22.4
 	gocloud.dev v0.20.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a

--- a/go.sum
+++ b/go.sum
@@ -675,6 +675,13 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zalando/go-keyring v0.1.0 h1:ffq972Aoa4iHNzBlUHgK5Y+k8+r/8GvcGd80/OFZb/k=
 github.com/zalando/go-keyring v0.1.0/go.mod h1:RaxNwUITJaHVdQ0VC7pELPZ3tOWn13nr0gZMZEhpVU0=
+github.com/zeebo/assert v0.0.0-20181109011804-10f827ce2ed6/go.mod h1:yssERNPivllc1yU3BvpjYI5BUW+zglcz6QWqeVRL5t0=
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/blake3 v0.0.4 h1:vtZ4X8B2lKXZFg2Xyg6Wo36mvmnJvc2VQYTtA4RDCkI=
+github.com/zeebo/blake3 v0.0.4/go.mod h1:YOZo8A49yNqM0X/Y+JmDUZshJWLt1laHsNSn5ny2i34=
+github.com/zeebo/pcg v0.0.0-20181207190024-3cdc6b625a05 h1:4pW5fMvVkrgkMXdvIsVRRTs69DWYA8uNNQsu1stfVKU=
+github.com/zeebo/pcg v0.0.0-20181207190024-3cdc6b625a05/go.mod h1:Gr+78ptB0MwXxm//LBaEvBiaXY7hXJ6KGe2V32X2F6E=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd/v3 v3.3.0-rc.0.0.20200707003333-58bb8ae09f8e/go.mod h1:UENlOa05tkNvLx9VnNziSerG4Ro74upGK6Apd4v6M/Y=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=

--- a/repo/hashing/blake3_hashes.go
+++ b/repo/hashing/blake3_hashes.go
@@ -1,0 +1,26 @@
+package hashing
+
+import (
+	"hash"
+
+	"github.com/zeebo/blake3"
+)
+
+const blake3KeySize = 32
+
+func newBlake3(key []byte) (hash.Hash, error) {
+	// Does the key need to be stretched?
+	if len(key) < blake3KeySize {
+		var xKey [blake3KeySize]byte
+
+		blake3.DeriveKey("kopia blake3 derived key v1", key, xKey[:blake3KeySize])
+		key = xKey[:blake3KeySize]
+	}
+
+	return blake3.NewKeyed(key[:blake3KeySize])
+}
+
+func init() {
+	Register("BLAKE3-256", truncatedKeyedHashFuncFactory(newBlake3, 32))
+	Register("BLAKE3-256-128", truncatedKeyedHashFuncFactory(newBlake3, 16))
+}


### PR DESCRIPTION
Hash info at https://github.com/BLAKE3-team/BLAKE3

Uses https://github.com/zeebo/blake3 optimized implementation

Micro benchmarks show ~2X speedup for hashing+encryption.
- Caveat: not fully controlled environment, etc.

```
     Hash                 Encryption           Throughput
-----------------------------------------------------------------
  0. BLAKE3-256           AES256-GCM-HMAC-SHA256 1.3 GiB / second
  1. BLAKE3-256-128       AES256-GCM-HMAC-SHA256 1.3 GiB / second
  2. BLAKE3-256-128       CHACHA20-POLY1305-HMAC-SHA256 1 GiB / second
  3. BLAKE3-256           CHACHA20-POLY1305-HMAC-SHA256 1 GiB / second
  4. BLAKE2B-256-128      AES256-GCM-HMAC-SHA256 641.5 MiB / second
  5. BLAKE2B-256          AES256-GCM-HMAC-SHA256 621.7 MiB / second
  6. BLAKE2B-256-128      CHACHA20-POLY1305-HMAC-SHA256 572.9 MiB / second
  7. BLAKE2B-256          CHACHA20-POLY1305-HMAC-SHA256 550.5 MiB / second
  8. BLAKE2S-256          AES256-GCM-HMAC-SHA256 497.9 MiB / second
  9. BLAKE2S-128          AES256-GCM-HMAC-SHA256 494.4 MiB / second
 10. BLAKE2S-256          CHACHA20-POLY1305-HMAC-SHA256 456.1 MiB / second
 11. BLAKE2S-128          CHACHA20-POLY1305-HMAC-SHA256 448.6 MiB / second
 12. HMAC-SHA256          AES256-GCM-HMAC-SHA256 313.2 MiB / second
 13. HMAC-SHA256-128      AES256-GCM-HMAC-SHA256 301.8 MiB / second
 14. HMAC-SHA224          AES256-GCM-HMAC-SHA256 300 MiB / second
 15. HMAC-SHA224          CHACHA20-POLY1305-HMAC-SHA256 291.4 MiB / second
 16. HMAC-SHA256-128      CHACHA20-POLY1305-HMAC-SHA256 287.7 MiB / second
 17. HMAC-SHA256          CHACHA20-POLY1305-HMAC-SHA256 287.1 MiB / second
 18. HMAC-SHA3-224        AES256-GCM-HMAC-SHA256 272.6 MiB / second
 19. HMAC-SHA3-256        AES256-GCM-HMAC-SHA256 265 MiB / second
 20. HMAC-SHA3-224        CHACHA20-POLY1305-HMAC-SHA256 259.6 MiB / second
 21. HMAC-SHA3-256        CHACHA20-POLY1305-HMAC-SHA256 245.8 MiB / second
```
