### PR TITLE
cli: When listing directory that had errors, print error summary at the end.

### DIFF
--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -194,7 +194,7 @@ func outputManifestFromSingleSource(ctx context.Context, rep repo.Repository, ma
 			continue
 		}
 
-		bits, col := entryBits(m, ent, lastTotalFileSize)
+		bits, col := entryBits(ctx, m, ent, lastTotalFileSize)
 
 		oid := ent.(object.HasObjectID).ObjectID()
 		if !*snapshotListShowIdentical && oid == previousOID {
@@ -224,7 +224,7 @@ func outputManifestFromSingleSource(ctx context.Context, rep repo.Repository, ma
 	return nil
 }
 
-func entryBits(m *snapshot.Manifest, ent fs.Entry, lastTotalFileSize int64) (bits []string, col *color.Color) {
+func entryBits(ctx context.Context, m *snapshot.Manifest, ent fs.Entry, lastTotalFileSize int64) (bits []string, col *color.Color) {
 	col = color.New() // default color
 
 	if m.IncompleteReason != "" {
@@ -252,9 +252,8 @@ func entryBits(m *snapshot.Manifest, ent fs.Entry, lastTotalFileSize int64) (bit
 		bits = append(bits, deltaBytes(ent.Size()-lastTotalFileSize))
 	}
 
-	if d, ok := ent.(fs.Directory); ok {
-		s := d.Summary()
-		if s != nil {
+	if dws, ok := ent.(fs.DirectoryWithSummary); ok {
+		if s, _ := dws.Summary(ctx); s != nil {
 			bits = append(bits,
 				fmt.Sprintf("files:%v", s.TotalFileCount),
 				fmt.Sprintf("dirs:%v", s.TotalDirCount))

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -43,7 +43,11 @@ type Directory interface {
 	Entry
 	Child(ctx context.Context, name string) (Entry, error)
 	Readdir(ctx context.Context) (Entries, error)
-	Summary() *DirectorySummary
+}
+
+// DirectoryWithSummary is optionally implemented by Directory that provide summary.
+type DirectoryWithSummary interface {
+	Summary(ctx context.Context) (*DirectorySummary, error)
 }
 
 // ErrEntryNotFound is returned when an entry is not found.

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -102,10 +102,6 @@ func (fsd *filesystemDirectory) Size() int64 {
 	return 0
 }
 
-func (fsd *filesystemDirectory) Summary() *fs.DirectorySummary {
-	return nil
-}
-
 func (fsd *filesystemDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {
 	fullPath := fsd.fullPath()
 

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -73,11 +73,6 @@ type Directory struct {
 	onReaddir    func()
 }
 
-// Summary returns summary of a directory.
-func (imd *Directory) Summary() *fs.DirectorySummary {
-	return nil
-}
-
 // AddFileLines adds a mock file with the specified name, text content and permissions.
 func (imd *Directory) AddFileLines(name string, lines []string, permissions os.FileMode) *File {
 	return imd.AddFile(name, []byte(strings.Join(lines, "\n")), permissions)

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -15,10 +15,6 @@ type repositoryAllSources struct {
 	rep repo.Repository
 }
 
-func (s *repositoryAllSources) Summary() *fs.DirectorySummary {
-	return nil
-}
-
 func (s *repositoryAllSources) IsDir() bool {
 	return true
 }

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -83,8 +83,23 @@ type repositorySymlink struct {
 	repositoryEntry
 }
 
-func (rd *repositoryDirectory) Summary() *fs.DirectorySummary {
-	return rd.summary
+func (rd *repositoryDirectory) Summary(ctx context.Context) (*fs.DirectorySummary, error) {
+	if rd.summary != nil {
+		return rd.summary, nil
+	}
+
+	r, err := rd.repo.OpenObject(ctx, rd.metadata.ObjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close() //nolint:errcheck
+
+	_, summ, err := readDirEntries(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return summ, nil
 }
 
 func (rd *repositoryDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -35,10 +35,6 @@ func (s *sourceDirectories) Sys() interface{} {
 	return nil
 }
 
-func (s *sourceDirectories) Summary() *fs.DirectorySummary {
-	return nil
-}
-
 func (s *sourceDirectories) Size() int64 {
 	return 0
 }

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -52,10 +52,6 @@ func safeName(path string) string {
 	return strings.Replace(path, "/", "_", -1)
 }
 
-func (s *sourceSnapshots) Summary() *fs.DirectorySummary {
-	return nil
-}
-
 func (s *sourceSnapshots) Child(ctx context.Context, name string) (fs.Entry, error) {
 	return fs.ReadDirAndFindChild(ctx, s, name)
 }


### PR DESCRIPTION
Can be disabled with `--no-error-summary`.
Quick demo: https://asciinema.org/a/2rma0sx2mD6HoIPy6VL0QEFeP

Also refactored fs.Directory to provide Summary optionally.

Fixes #642