### PR TITLE
Fixed empty object IDs in checkpoints

### DIFF
--- a/internal/buf/pool_test.go
+++ b/internal/buf/pool_test.go
@@ -22,14 +22,22 @@ func TestPool(t *testing.T) {
 
 	runtime.ReadMemStats(&ms1)
 
+	repeat := 1000000
+	numGoRoutines := 30
+
+	if runtime.GOARCH != "amd64" {
+		repeat = 10000
+		numGoRoutines = 10
+	}
+
 	// 30 gorouties, each allocating and releasing memory 1 M times
-	for i := 0; i < 30; i++ {
+	for i := 0; i < numGoRoutines; i++ {
 		wg.Add(1)
 
 		go func() {
 			defer wg.Done()
 
-			for j := 0; j < 1000000; j++ {
+			for j := 0; j < repeat; j++ {
 				const allocSize = 100000
 
 				b := a.Allocate(allocSize)

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -218,8 +218,13 @@ func TestObjectWriterRaceBetweenCheckpointAndResult(t *testing.T) {
 	}
 
 	allZeroes := make([]byte, 1<<20-5)
+	repeat := 100
 
-	for i := 0; i < 100; i++ {
+	if runtime.GOARCH == "arm" {
+		repeat = 10
+	}
+
+	for i := 0; i < repeat; i++ {
 		w := om.NewWriter(ctx, WriterOptions{
 			AsyncWrites: 1,
 		})

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -15,8 +15,10 @@ import (
 	"runtime/debug"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
@@ -187,9 +189,75 @@ func TestCheckpointing(t *testing.T) {
 		t.Errorf("unexpected checkpoint2: %v err: %v", checkpoint2, err)
 	}
 
+	result2, err := writer.Checkpoint()
+	verifyNoError(t, err)
+
+	if result2 != result {
+		t.Errorf("invalid checkpoint after result: %v vs %v", result2, result)
+	}
+
 	verifyFull(ctx, t, om, checkpoint3, allZeroes)
 	verifyFull(ctx, t, om, checkpoint4, make([]byte, 2<<20))
 	verifyFull(ctx, t, om, result, make([]byte, 2<<20+50))
+}
+
+func TestObjectWriterRaceBetweenCheckpointAndResult(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	ctx := testlogging.Context(t)
+	data := map[content.ID][]byte{}
+	fcm := &fakeContentManager{
+		data: data,
+	}
+
+	om, err := NewObjectManager(testlogging.Context(t), fcm, Format{
+		Splitter: "FIXED-1M",
+	}, ManagerOptions{})
+	if err != nil {
+		t.Fatalf("can't create object manager: %v", err)
+	}
+
+	allZeroes := make([]byte, 1<<20-5)
+
+	for i := 0; i < 100; i++ {
+		w := om.NewWriter(ctx, WriterOptions{
+			AsyncWrites: 1,
+		})
+
+		w.Write(allZeroes)
+		w.Write(allZeroes)
+		w.Write(allZeroes)
+
+		var eg errgroup.Group
+
+		eg.Go(func() error {
+			_, rerr := w.Result()
+
+			return rerr
+		})
+
+		eg.Go(func() error {
+			cpID, cperr := w.Checkpoint()
+			if cperr == nil && cpID != "" {
+				ids, verr := om.VerifyObject(ctx, cpID)
+				if verr != nil {
+					return errors.Wrapf(err, "Checkpoint() returned invalid object %v", cpID)
+				}
+
+				for _, id := range ids {
+					if id == "" {
+						return errors.Errorf("checkpoint returned empty id")
+					}
+				}
+			}
+
+			return nil
+		})
+
+		if err := eg.Wait(); err != nil {
+			t.Fatal(err)
+		}
+	}
 }
 
 func verifyFull(ctx context.Context, t *testing.T, om *Manager, oid ID, want []byte) {

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -15,11 +15,11 @@ import (
 	"runtime/debug"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/compression"
@@ -202,7 +202,7 @@ func TestCheckpointing(t *testing.T) {
 }
 
 func TestObjectWriterRaceBetweenCheckpointAndResult(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(clock.Now().UnixNano())
 
 	ctx := testlogging.Context(t)
 	data := map[content.ID][]byte{}

--- a/snapshot/snapshotfs/checkpoint_registry.go
+++ b/snapshot/snapshotfs/checkpoint_registry.go
@@ -51,6 +51,11 @@ func (r *checkpointRegistry) runCheckpoints(checkpointBuilder *dirManifestBuilde
 			return errors.Wrapf(err, "error checkpointing %v", n)
 		}
 
+		if de == nil {
+			// no checkpoint.
+			continue
+		}
+
 		if de.Type != snapshot.EntryTypeDirectory {
 			de.Name = ".checkpointed." + de.Name + "." + uuid.New().String()
 		}

--- a/snapshot/snapshotfs/checkpoint_registry_test.go
+++ b/snapshot/snapshotfs/checkpoint_registry_test.go
@@ -18,6 +18,7 @@ func TestCheckpointRegistry(t *testing.T) {
 	f1 := d.AddFile("f1", []byte{1, 2, 3}, os.FileMode(0o755))
 	f2 := d.AddFile("f2", []byte{2, 3, 4}, os.FileMode(0o755))
 	f3 := d.AddFile("f3", []byte{2, 3, 4}, os.FileMode(0o755))
+	f4 := d.AddFile("f3", []byte{2, 3, 4}, os.FileMode(0o755))
 
 	cp.addCheckpointCallback(dir1, func() (*snapshot.DirEntry, error) {
 		return &snapshot.DirEntry{
@@ -42,6 +43,10 @@ func TestCheckpointRegistry(t *testing.T) {
 		return &snapshot.DirEntry{
 			Name: "other",
 		}, nil
+	})
+
+	cp.addCheckpointCallback(f4, func() (*snapshot.DirEntry, error) {
+		return nil, nil
 	})
 
 	// remove callback before it has a chance of firing

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -127,6 +127,10 @@ func (u *Uploader) uploadFileInternal(ctx context.Context, parentCheckpointRegis
 			return nil, err
 		}
 
+		if checkpointID == "" {
+			return nil, nil
+		}
+
 		return newDirEntry(f, checkpointID)
 	})
 


### PR DESCRIPTION
This was observed by 2 users and reported on Slack.

Fixes #648 

Also added protection to ensure we never save empty object ID in a checkpoint.