### PR TITLE
Eliminated busy loop after snapshot failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 
 include tools/tools.mk
 
-GO_TEST=$(gotestsum) --format=pkgname-and-test-fails --
+GO_TEST=$(gotestsum) --format=pkgname-and-test-fails --no-summary=skipped --
 
 LINTER_DEADLINE=300s
 UNIT_TESTS_TIMEOUT=300s


### PR DESCRIPTION
When a snapshot is due and we fail to create it (for example because the server is unavailable), we immediately retry it. This change delays the retry by 5 minutes. At the same time we keep polling for status update (every 15s or so), which if the repository comes back online will restart the snapshot sooner.

Fixes #657 