### PR TITLE
fshasher: truncate timestamps to full seconds to accommodate filesystems that lose precision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ endif
 
 include tools/tools.mk
 
-GO_TEST=$(gotestsum) --format=pkgname-and-test-fails --no-summary=skipped --
+GOTESTSUM_FORMAT=pkgname-and-test-fails
+GO_TEST=$(gotestsum) --format=$(GOTESTSUM_FORMAT) --no-summary=skipped --
 
 LINTER_DEADLINE=300s
 UNIT_TESTS_TIMEOUT=300s

--- a/internal/fshasher/fshasher.go
+++ b/internal/fshasher/fshasher.go
@@ -92,7 +92,10 @@ func header(ctx context.Context, fullpath string, e os.FileInfo) (*tar.Header, e
 		h.ModTime = time.Time{}
 	}
 
-	h.ModTime = h.ModTime.UTC()
+	// when hashing, compare time to within a second resolution because of
+	// filesystems that don't preserve full timestamp fidelity.
+	// https://travis-ci.org/github/kopia/kopia/jobs/732592885
+	h.ModTime = h.ModTime.Truncate(time.Second).UTC()
 	h.AccessTime = h.ModTime
 	h.ChangeTime = h.ModTime
 


### PR DESCRIPTION
context: https://travis-ci.community/t/weird-filesystem-timestamps-behavior-on-linux-arm64-workers/10053