### PR TITLE
testing: use shorter RSA keys to speed up server tests

### DIFF
--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -73,6 +73,7 @@ func TestServerStart(t *testing.T) {
 		"--address=localhost:0",
 		"--random-password",
 		"--tls-generate-cert",
+		"--tls-generate-rsa-key-size=2048", // use shorter key size to speed up generation
 		"--auto-shutdown=180s",
 		"--override-hostname=fake-hostname",
 		"--override-username=fake-username",
@@ -203,7 +204,13 @@ func TestServerCreateAndConnectViaAPI(t *testing.T) {
 		},
 	}
 
-	e.RunAndProcessStderr(t, sp.ProcessOutput, "server", "start", "--ui", "--address=localhost:0", "--random-password", "--tls-generate-cert", "--auto-shutdown=180s")
+	e.RunAndProcessStderr(t, sp.ProcessOutput,
+		"server", "start", "--ui",
+		"--address=localhost:0", "--random-password",
+		"--tls-generate-cert",
+		"--tls-generate-rsa-key-size=2048", // use shorter key size to speed up generation,
+		"--auto-shutdown=180s",
+	)
 	t.Logf("detected server parameters %#v", sp)
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
@@ -269,7 +276,12 @@ func TestConnectToExistingRepositoryViaAPI(t *testing.T) {
 	}
 
 	// at this point repository is not connected, start the server
-	e.RunAndProcessStderr(t, sp.ProcessOutput, "server", "start", "--ui", "--address=localhost:0", "--random-password", "--tls-generate-cert", "--auto-shutdown=180s", "--override-hostname=fake-hostname", "--override-username=fake-username")
+	e.RunAndProcessStderr(t, sp.ProcessOutput, "server", "start",
+		"--ui", "--address=localhost:0", "--random-password",
+		"--tls-generate-cert",
+		"--tls-generate-rsa-key-size=2048", // use shorter key size to speed up generation
+		"--auto-shutdown=180s",
+		"--override-hostname=fake-hostname", "--override-username=fake-username")
 	t.Logf("detected server parameters %#v", sp)
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{


### PR DESCRIPTION
turns out 4096-bit RSA key generation uses a lot of CPU and takes >30s on ARM. 2048 bit is much faster.
