### PR TITLE
Fixed symlink restore behavior on macOS

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -46,14 +46,18 @@ directory ID and optionally a sub-directory path. For example,
 )
 
 var (
-	restoreCommand              = app.Command("restore", restoreCommandHelp)
-	restoreSourceID             = ""
-	restoreTargetPath           = ""
-	restoreOverwriteDirectories = true
-	restoreOverwriteFiles       = true
-	restoreConsistentAttributes = false
-	restoreMode                 = restoreModeAuto
-	restoreParallel             = 8
+	restoreCommand                = app.Command("restore", restoreCommandHelp)
+	restoreSourceID               = ""
+	restoreTargetPath             = ""
+	restoreOverwriteDirectories   = true
+	restoreOverwriteFiles         = true
+	restoreConsistentAttributes   = false
+	restoreMode                   = restoreModeAuto
+	restoreParallel               = 8
+	restoreIgnorePermissionErrors = true
+	restoreSkipTimes              = false
+	restoreSkipOwners             = false
+	restoreSkipPermissions        = false
 )
 
 const (
@@ -73,6 +77,10 @@ func addRestoreFlags(cmd *kingpin.CmdClause) {
 	cmd.Flag("consistent-attributes", "When multiple snapshots match, fail if they have inconsistent attributes").Envar("KOPIA_RESTORE_CONSISTENT_ATTRIBUTES").BoolVar(&restoreConsistentAttributes)
 	cmd.Flag("mode", "Override restore mode").EnumVar(&restoreMode, restoreModeAuto, restoreModeLocal, restoreModeZip, restoreModeZipNoCompress, restoreModeTar, restoreModeTgz)
 	cmd.Flag("parallel", "Restore parallelism (1=disable)").IntVar(&restoreParallel)
+	cmd.Flag("skip-owners", "Skip owners during restore").BoolVar(&restoreSkipOwners)
+	cmd.Flag("skip-permissions", "Skip permissions during restore").BoolVar(&restoreSkipPermissions)
+	cmd.Flag("skip-times", "Skip times during restore").BoolVar(&restoreSkipTimes)
+	cmd.Flag("ignore-permission-errors", "Ignore permission errors").BoolVar(&restoreIgnorePermissionErrors)
 }
 
 func restoreOutput() (restore.Output, error) {
@@ -85,9 +93,13 @@ func restoreOutput() (restore.Output, error) {
 	switch m {
 	case restoreModeLocal:
 		return &restore.FilesystemOutput{
-			TargetPath:           p,
-			OverwriteDirectories: restoreOverwriteDirectories,
-			OverwriteFiles:       restoreOverwriteFiles,
+			TargetPath:             p,
+			OverwriteDirectories:   restoreOverwriteDirectories,
+			OverwriteFiles:         restoreOverwriteFiles,
+			IgnorePermissionErrors: restoreIgnorePermissionErrors,
+			SkipOwners:             restoreSkipOwners,
+			SkipPermissions:        restoreSkipPermissions,
+			SkipTimes:              restoreSkipTimes,
 		}, nil
 
 	case restoreModeZip, restoreModeZipNoCompress:

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -80,11 +80,12 @@ type EntryWithError struct {
 
 // DirectorySummary represents summary information about a directory.
 type DirectorySummary struct {
-	TotalFileSize    int64     `json:"size"`
-	TotalFileCount   int64     `json:"files"`
-	TotalDirCount    int64     `json:"dirs"`
-	MaxModTime       time.Time `json:"maxTime"`
-	IncompleteReason string    `json:"incomplete,omitempty"`
+	TotalFileSize     int64     `json:"size"`
+	TotalFileCount    int64     `json:"files"`
+	TotalSymlinkCount int64     `json:"symlinks"`
+	TotalDirCount     int64     `json:"dirs"`
+	MaxModTime        time.Time `json:"maxTime"`
+	IncompleteReason  string    `json:"incomplete,omitempty"`
 
 	// number of failed files
 	NumFailed int `json:"numFailed"`

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -105,7 +105,7 @@ func (fsd *filesystemDirectory) Size() int64 {
 func (fsd *filesystemDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {
 	fullPath := fsd.fullPath()
 
-	st, err := os.Stat(filepath.Join(fullPath, name))
+	st, err := os.Lstat(filepath.Join(fullPath, name))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fs.ErrEntryNotFound

--- a/snapshot/restore/local_fs_output_linux.go
+++ b/snapshot/restore/local_fs_output_linux.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 package restore
 
 import (
@@ -14,7 +12,8 @@ func symlinkChown(path string, uid, gid int) error {
 }
 
 func symlinkChmod(path string, mode os.FileMode) error {
-	return unix.Fchmodat(unix.AT_FDCWD, path, uint32(mode), unix.AT_SYMLINK_NOFOLLOW)
+	// linux does not support permissions on symlinks
+	return nil
 }
 
 func symlinkChtimes(linkPath string, atime, mtime time.Time) error {

--- a/snapshot/restore/local_fs_output_windows.go
+++ b/snapshot/restore/local_fs_output_windows.go
@@ -1,14 +1,22 @@
 package restore
 
 import (
-	"context"
+	"os"
 	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 
-func symlinkChtimes(ctx context.Context, linkPath string, atime, mtime time.Time) error {
+func symlinkChown(path string, uid, gid int) error {
+	return nil
+}
+
+func symlinkChmod(path string, mode os.FileMode) error {
+	return nil
+}
+
+func symlinkChtimes(linkPath string, atime, mtime time.Time) error {
 	fta := windows.NsecToFiletime(atime.UnixNano())
 	ftw := windows.NsecToFiletime(mtime.UnixNano())
 

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -479,15 +479,18 @@ func (b *dirManifestBuilder) addEntry(de *snapshot.DirEntry) {
 
 	b.entries = append(b.entries, de)
 
+	if de.ModTime.After(b.summary.MaxModTime) {
+		b.summary.MaxModTime = de.ModTime
+	}
+
 	// nolint:exhaustive
 	switch de.Type {
+	case snapshot.EntryTypeSymlink:
+		b.summary.TotalSymlinkCount++
+
 	case snapshot.EntryTypeFile:
 		b.summary.TotalFileCount++
 		b.summary.TotalFileSize += de.FileSize
-
-		if de.ModTime.After(b.summary.MaxModTime) {
-			b.summary.MaxModTime = de.ModTime
-		}
 
 	case snapshot.EntryTypeDirectory:
 		if childSummary := de.DirSummary; childSummary != nil {


### PR DESCRIPTION
On macOS (unlike Linux and Windows) symbolic links can have separate owners and attributes and to set them on restore we need to use different APIs, otherwise we'd be trying to modify the properties of target and not the link itself and if the link points to a non-existing file/dir we would fail with not found.

Fixes #672 