### PR TITLE
Added support for scanning only one filesystem via files policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules/
 .tmp.*
 .boto
 *.log
+*~

--- a/cli/command_policy_edit.go
+++ b/cli/command_policy_edit.go
@@ -40,6 +40,7 @@ const policyEditFilesHelpText = `
   #   "maxFileSize": number
   #   "noParentDotFiles": true
   #   "noParentIgnore": true
+  #   "oneFileSystem": false
 `
 
 const policyEditSchedulingHelpText = `

--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -60,6 +60,9 @@ var (
 	policySetClearDotIgnore  = policySetCommand.Flag("clear-dot-ignore", "Clear list of paths in the dot-ignore list").Bool()
 	policySetMaxFileSize     = policySetCommand.Flag("max-file-size", "Exclude files above given size").PlaceHolder("N").String()
 
+	// Ignore other mounted fileystems.
+	policyOneFileSystem = policySetCommand.Flag("one-file-system", "Stay in parent filesystem when finding files ('true', 'false', 'inherit')").Enum(booleanEnumValues...)
+
 	// Error handling behavior.
 	policyIgnoreFileErrors      = policySetCommand.Flag("ignore-file-errors", "Ignore errors reading files while traversing ('true', 'false', 'inherit')").Enum(booleanEnumValues...)
 	policyIgnoreDirectoryErrors = policySetCommand.Flag("ignore-dir-errors", "Ignore errors reading directories while traversing ('true', 'false', 'inherit").Enum(booleanEnumValues...)
@@ -187,6 +190,28 @@ func setFilesPolicyFromFlags(fp *policy.FilesPolicy, changeCount *int) error {
 		fp.IgnoreCacheDirs = &val
 
 		printStderr(" - setting ignore cache dirs to %v\n", val)
+	}
+
+	switch {
+	case *policyOneFileSystem == "":
+	case *policyOneFileSystem == inheritPolicyString:
+		*changeCount++
+
+		fp.OneFileSystem = nil
+
+		printStderr(" - inherit one file system from parent\n")
+
+	default:
+		val, err := strconv.ParseBool(*policyOneFileSystem)
+		if err != nil {
+			return err
+		}
+
+		*changeCount++
+
+		fp.OneFileSystem = &val
+
+		printStderr(" - setting one file system to %v\n", val)
 	}
 
 	return nil

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -160,6 +160,12 @@ func printFilesPolicy(p *policy.Policy, parents []*policy.Policy) {
 				return pol.FilesPolicy.MaxFileSize != 0
 			}))
 	}
+
+	printStdout("  Scan one filesystem only:       %5v       %v\n",
+		p.FilesPolicy.OneFileSystemOrDefault(false),
+		getDefinitionPoint(parents, func(pol *policy.Policy) bool {
+			return pol.FilesPolicy.OneFileSystem != nil
+		}))
 }
 
 func printErrorHandlingPolicy(p *policy.Policy, parents []*policy.Policy) {

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -13,12 +13,19 @@ import (
 type Entry interface {
 	os.FileInfo
 	Owner() OwnerInfo
+	Device() DeviceInfo
 }
 
 // OwnerInfo describes owner of a filesystem entry.
 type OwnerInfo struct {
 	UserID  uint32
 	GroupID uint32
+}
+
+// DeviceInfo describes the device this filesystem entry is on.
+type DeviceInfo struct {
+	Dev  uint64
+	Rdev uint64
 }
 
 // Entries is a list of entries sorted by name.

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -36,6 +36,7 @@ type filesystemEntry struct {
 	mtimeNanos int64
 	mode       os.FileMode
 	owner      fs.OwnerInfo
+	device     fs.DeviceInfo
 
 	parentDir string
 }
@@ -72,6 +73,10 @@ func (e *filesystemEntry) Owner() fs.OwnerInfo {
 	return e.owner
 }
 
+func (e *filesystemEntry) Device() fs.DeviceInfo {
+	return e.device
+}
+
 var _ os.FileInfo = (*filesystemEntry)(nil)
 
 func newEntry(fi os.FileInfo, parentDir string) filesystemEntry {
@@ -81,6 +86,7 @@ func newEntry(fi os.FileInfo, parentDir string) filesystemEntry {
 		fi.ModTime().UnixNano(),
 		fi.Mode(),
 		platformSpecificOwnerInfo(fi),
+		platformSpecificDeviceInfo(fi),
 		parentDir,
 	}
 }

--- a/fs/localfs/local_fs_32bit.go
+++ b/fs/localfs/local_fs_32bit.go
@@ -1,0 +1,8 @@
+// +build !windows
+// +build !amd64,!arm64,!arm darwin
+
+package localfs
+
+func platformSpecificWidenDev(dev int32) uint64 {
+	return uint64(dev)
+}

--- a/fs/localfs/local_fs_64bit.go
+++ b/fs/localfs/local_fs_64bit.go
@@ -1,0 +1,9 @@
+// +build !windows
+// +build !darwin
+// +build amd64 arm64 arm
+
+package localfs
+
+func platformSpecificWidenDev(dev uint64) uint64 {
+	return dev
+}

--- a/fs/localfs/local_fs_nonwindows.go
+++ b/fs/localfs/local_fs_nonwindows.go
@@ -18,3 +18,14 @@ func platformSpecificOwnerInfo(fi os.FileInfo) fs.OwnerInfo {
 
 	return oi
 }
+
+func platformSpecificDeviceInfo(fi os.FileInfo) fs.DeviceInfo {
+	var oi fs.DeviceInfo
+	if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+		// not making a separate type for 32-bit platforms here..
+		oi.Dev = platformSpecificWidenDev(stat.Dev)
+		oi.Rdev = platformSpecificWidenDev(stat.Rdev)
+	}
+
+	return oi
+}

--- a/fs/localfs/local_fs_windows.go
+++ b/fs/localfs/local_fs_windows.go
@@ -9,3 +9,7 @@ import (
 func platformSpecificOwnerInfo(fi os.FileInfo) fs.OwnerInfo {
 	return fs.OwnerInfo{}
 }
+
+func platformSpecificDeviceInfo(fi os.FileInfo) fs.DeviceInfo {
+	return fs.DeviceInfo{}
+}

--- a/htmlui/src/PolicyEditor.js
+++ b/htmlui/src/PolicyEditor.js
@@ -182,6 +182,9 @@ export class PolicyEditor extends Component {
                         <Form.Row>
                             {OptionalBoolean(this, "Ignore Well-Known Cache Directories", "policy.files.ignoreCacheDirs", "inherit from parent")}
                         </Form.Row>
+                        <Form.Row>
+                            {OptionalBoolean(this, "Scan only one filesystem", "policy.files.oneFileSystem", "inherit from parent")}
+                        </Form.Row>
                     </div>
                 </Tab>
                 <Tab eventKey="errors" title="Errors">

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -191,6 +191,8 @@ func compareEntry(e1, e2 fs.Entry, fullpath string, out io.Writer) bool {
 		fmt.Fprintln(out, fullpath, "owner groups differ: ", o1.GroupID, o2.GroupID)
 	}
 
+	// don't compare filesystem boundaries (e1.Device()), it's pretty useless and is not stored in backups
+
 	return equal
 }
 

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -102,6 +102,26 @@ func (imd *Directory) AddFile(name string, content []byte, permissions os.FileMo
 	return file
 }
 
+// AddFileDevice adds a mock file with the specified name, content, permissions, and device info.
+func (imd *Directory) AddFileDevice(name string, content []byte, permissions os.FileMode, deviceInfo fs.DeviceInfo) *File {
+	imd, name = imd.resolveSubdir(name)
+	file := &File{
+		entry: entry{
+			name:   name,
+			mode:   permissions,
+			size:   int64(len(content)),
+			device: deviceInfo,
+		},
+		source: func() (ReaderSeekerCloser, error) {
+			return readerSeekerCloser{bytes.NewReader(content)}, nil
+		},
+	}
+
+	imd.addChild(file)
+
+	return file
+}
+
 // AddDir adds a fake directory with a given name and permissions.
 func (imd *Directory) AddDir(name string, permissions os.FileMode) *Directory {
 	imd, name = imd.resolveSubdir(name)
@@ -110,6 +130,23 @@ func (imd *Directory) AddDir(name string, permissions os.FileMode) *Directory {
 		entry: entry{
 			name: name,
 			mode: permissions | os.ModeDir,
+		},
+	}
+
+	imd.addChild(subdir)
+
+	return subdir
+}
+
+// AddDirDevice adds a fake directory with a given name and permissions.
+func (imd *Directory) AddDirDevice(name string, permissions os.FileMode, deviceInfo fs.DeviceInfo) *Directory {
+	imd, name = imd.resolveSubdir(name)
+
+	subdir := &Directory{
+		entry: entry{
+			name:   name,
+			mode:   permissions | os.ModeDir,
+			device: deviceInfo,
 		},
 	}
 

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -37,31 +37,31 @@ type entry struct {
 	device  fs.DeviceInfo
 }
 
-func (e entry) Name() string {
+func (e *entry) Name() string {
 	return e.name
 }
 
-func (e entry) IsDir() bool {
+func (e *entry) IsDir() bool {
 	return e.mode.IsDir()
 }
 
-func (e entry) Mode() os.FileMode {
+func (e *entry) Mode() os.FileMode {
 	return e.mode
 }
 
-func (e entry) ModTime() time.Time {
+func (e *entry) ModTime() time.Time {
 	return e.modTime
 }
 
-func (e entry) Size() int64 {
+func (e *entry) Size() int64 {
 	return e.size
 }
 
-func (e entry) Sys() interface{} {
+func (e *entry) Sys() interface{} {
 	return nil
 }
 
-func (e entry) Owner() fs.OwnerInfo {
+func (e *entry) Owner() fs.OwnerInfo {
 	return e.owner
 }
 

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -34,6 +34,7 @@ type entry struct {
 	size    int64
 	modTime time.Time
 	owner   fs.OwnerInfo
+	device  fs.DeviceInfo
 }
 
 func (e entry) Name() string {
@@ -62,6 +63,10 @@ func (e entry) Sys() interface{} {
 
 func (e entry) Owner() fs.OwnerInfo {
 	return e.owner
+}
+
+func (e *entry) Device() fs.DeviceInfo {
+	return e.device
 }
 
 // Directory is mock in-memory implementation of fs.Directory.

--- a/snapshot/policy/files_policy.go
+++ b/snapshot/policy/files_policy.go
@@ -11,6 +11,8 @@ type FilesPolicy struct {
 	IgnoreCacheDirs *bool `json:"ignoreCacheDirs,omitempty"`
 
 	MaxFileSize int64 `json:"maxFileSize,omitempty"`
+
+	OneFileSystem *bool `json:"oneFileSystem,omitempty"`
 }
 
 // Merge applies default values from the provided policy.
@@ -31,6 +33,10 @@ func (p *FilesPolicy) Merge(src FilesPolicy) {
 	if p.IgnoreCacheDirs == nil {
 		p.IgnoreCacheDirs = src.IgnoreCacheDirs
 	}
+
+	if p.OneFileSystem == nil {
+		p.OneFileSystem = src.OneFileSystem
+	}
 }
 
 // IgnoreCacheDirectoriesOrDefault gets the value of IgnoreCacheDirs or the provided default if not set.
@@ -40,6 +46,15 @@ func (p *FilesPolicy) IgnoreCacheDirectoriesOrDefault(def bool) bool {
 	}
 
 	return *p.IgnoreCacheDirs
+}
+
+// OneFileSystemOrDefault gets the value of OneFileSystem or the provided default if not set.
+func (p *FilesPolicy) OneFileSystemOrDefault(def bool) bool {
+	if p.OneFileSystem == nil {
+		return def
+	}
+
+	return *p.OneFileSystem
 }
 
 // defaultFilesPolicy is the default file ignore policy.

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -39,6 +39,10 @@ func (s *repositoryAllSources) Owner() fs.OwnerInfo {
 	return fs.OwnerInfo{}
 }
 
+func (s *repositoryAllSources) Device() fs.DeviceInfo {
+	return fs.DeviceInfo{}
+}
+
 func (s *repositoryAllSources) Sys() interface{} {
 	return nil
 }

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -71,6 +71,10 @@ func (e *repositoryEntry) Owner() fs.OwnerInfo {
 	}
 }
 
+func (e *repositoryEntry) Device() fs.DeviceInfo {
+	return fs.DeviceInfo{}
+}
+
 func (e *repositoryEntry) DirEntry() *snapshot.DirEntry {
 	return e.metadata
 }

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -43,6 +43,10 @@ func (s *sourceDirectories) Owner() fs.OwnerInfo {
 	return fs.OwnerInfo{}
 }
 
+func (s *sourceDirectories) Device() fs.DeviceInfo {
+	return fs.DeviceInfo{}
+}
+
 func (s *sourceDirectories) Child(ctx context.Context, name string) (fs.Entry, error) {
 	return fs.ReadDirAndFindChild(ctx, s, name)
 }

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -47,6 +47,10 @@ func (s *sourceSnapshots) Owner() fs.OwnerInfo {
 	return fs.OwnerInfo{}
 }
 
+func (s *sourceSnapshots) Device() fs.DeviceInfo {
+	return fs.DeviceInfo{}
+}
+
 func safeName(path string) string {
 	path = strings.TrimLeft(path, "/")
 	return strings.Replace(path, "/", "_", -1)


### PR DESCRIPTION
So this is my very first Go development ever.. :) And as this change appeared to span more files than I originally expected, I suggest actually reading if I've done something silly there. Or possibly proposing another way of doing this if a better one exists.

I tested a couple scenarios, seemed to work as expected! Sadly I didn't find a test system for ignore scenarios, soo I didn't add any automatic tests for this. Also I did not test the HTML ui, I only blindly did the change that seemed like the same thing with another boolean policy.

The new files policy `oneFileSystem` ignores files that are mounted to other filesystems similarly to `tar`'s `--one-file-system` switch. For example, if this is enabled, backing up / should now automatically ignore `/dev`, `/proc`, etc, so the directory entries themselves don't appear in the backup. The value of the policy is `false` by default.

This is implemented by adding a non-windows-field `Device` (of type `DeviceInfo`, reflecting the implementation of `Owner`) to the `Entry` interface. `DeviceInfo` holds the `dev` and `rdev` acquired with stat (same way as with `Owner`), but in addition to that it also holds the same values for the parent directory. It would seem that doing this in some other way, ie. in `ReadDir`, would require modifying the `ReadDir` interface which seems a too large modification for a feature this small.

This change introduces a duplication of `stat` call to the files, as the `Owner` feature already does a separate call. I doubt the performance implications are noticeable, though with some refactoring both `Owner` and `Device` fields could be filled in in one go.

Filling in the field has been placed in `fs/localfs/localfs.go` where `entryFromChildFileInfo` has acquired a third parameter giving the the parent entry. From that information the `Device` of the parent is retrieved, to be passed off to `platformSpecificDeviceInfo` which does the rest of the paperwork. Other fs implementations just put in the default values.

Finally the actual check of the condition is in `ignorefs.go` function `shouldIncludeByDevice` which is analoguous to the other similarly named functions.
