### PR TITLE
cli: added support for copying (or moving) snapshot history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,3 +337,5 @@ perf-benchmark-results:
 	gcloud compute scp $(PERF_BENCHMARK_INSTANCE):psrecord-* tests/perf_benchmark --zone=$(PERF_BENCHMARK_INSTANCE_ZONE) 
 	gcloud compute scp $(PERF_BENCHMARK_INSTANCE):repo-size-* tests/perf_benchmark --zone=$(PERF_BENCHMARK_INSTANCE_ZONE)
 	(cd tests/perf_benchmark && go run process_results.go)
+
+

--- a/cli/app.go
+++ b/cli/app.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/internal/apiclient"
 	"github.com/kopia/kopia/repo"

--- a/cli/command_content_range_flags.go
+++ b/cli/command_content_range_flags.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 
 	"github.com/kopia/kopia/repo/content"
 )

--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"

--- a/cli/command_repository_connect_from_config.go
+++ b/cli/command_repository_connect_from_config.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"os"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"

--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/units"

--- a/cli/command_snapshot_copy.go
+++ b/cli/command_snapshot_copy.go
@@ -1,0 +1,190 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/snapshot"
+)
+
+var (
+	snapshotCopyCommand     = snapshotCommands.Command("copy", "Copy snapshot history from another user or host").Alias("cp")
+	snapshotCopyDryRun      = snapshotCopyCommand.Flag("dry-run", "Do not actually copy snapshots, only print what would happen").Short('n').Bool()
+	snapshotCopyMove        = snapshotCopyCommand.Flag("move", "Delete original copied snapshots").Bool()
+	snapshotCopySource      = snapshotCopyCommand.Arg("source", "Source (user@host or user@host:path)").Required().String()
+	snapshotCopyDestination = snapshotCopyCommand.Arg("destination", "Destination (defaults to current user@host)").String()
+)
+
+// runSnapshotCopyCommand copies snapshot manifests of the specified source
+// to the respective destination. This is typically used when renaming a host,
+// switching username or moving directory around to maintain snapshot history.
+//
+// Both source and destination can be specified using user@host, @host or user@host:/path
+// where destination values override the corresponding parts of the source, so both targeted
+// and mass copying is supported.
+//
+// Source:             Destination         Behavior
+// ---------------------------------------------------
+// @host1              @host2              copy snapshots from all users of host1
+// @host1              user2@host2         (disallowed as it would potentially collapse users)
+// @host1              user2@host2:/path2  (disallowed as it would potentially collapse paths)
+//
+// user1@host1         @host2              copy all snapshots to user1@host2
+// user1@host1         user2@host2         copy all snapshots to user2@host2
+// user1@host1         user2@host2:/path2  (disallowed as it would potentially collapse paths)
+//
+// user1@host1:/path1  @host2              copy to user1@host2:/path1
+// user1@host1:/path1  user2@host2         copy to user2@host2:/path1
+// user1@host1:/path1  user2@host2:/path2  copy snapshots from single path.
+func runSnapshotCopyCommand(ctx context.Context, rep repo.Repository) error {
+	si, di, err := getCopySourceAndDestination(rep)
+	if err != nil {
+		return err
+	}
+
+	// At this point si and di are possibly incomplete snapshot.SourceInfo
+	// could be hostname, user@hostname or user@hostname:/path
+
+	srcSnapshots, err := snapshot.ListSnapshots(ctx, rep, si)
+	if err != nil {
+		return errors.Wrap(err, "error listing source snapshots")
+	}
+
+	dstSnapshots, err := snapshot.ListSnapshots(ctx, rep, di)
+	if err != nil {
+		return errors.Wrap(err, "error listing destination snapshots")
+	}
+
+	for _, manifest := range srcSnapshots {
+		dstSource := getCopyDestination(manifest.Source, di)
+
+		if dstSource == manifest.Source {
+			log(ctx).Debugf("%v is the same as destination, ignoring", dstSource)
+			continue
+		}
+
+		if snapshotExists(dstSnapshots, dstSource, manifest.StartTime) {
+			if *snapshotCopyMove && !*snapshotCopyDryRun {
+				log(ctx).Infof("%v (%v) already exists - deleting source", dstSource, formatTimestamp(manifest.StartTime))
+
+				if err := rep.DeleteManifest(ctx, manifest.ID); err != nil {
+					return errors.Wrap(err, "unable to delete source manifest")
+				}
+			} else {
+				log(ctx).Infof("%v (%v) already exists", dstSource, formatTimestamp(manifest.StartTime))
+			}
+
+			continue
+		}
+
+		srcID := manifest.ID
+
+		log(ctx).Infof("%v %v (%v) => %v", getCopySnapshotAction(), manifest.Source, formatTimestamp(manifest.StartTime), dstSource)
+
+		if *snapshotCopyDryRun {
+			continue
+		}
+
+		manifest.ID = ""
+		manifest.Source = dstSource
+
+		if _, err := snapshot.SaveSnapshot(ctx, rep, manifest); err != nil {
+			return errors.Wrap(err, "unable to save snapshot")
+		}
+
+		if *snapshotCopyMove {
+			if err := rep.DeleteManifest(ctx, srcID); err != nil {
+				return errors.Wrap(err, "unable to delete source manifest")
+			}
+		}
+	}
+
+	return nil
+}
+
+func getCopySnapshotAction() string {
+	action := "copying"
+	if *snapshotCopyMove {
+		action = "moving"
+	}
+
+	if *snapshotCopyDryRun {
+		action += " (dry run)"
+	}
+
+	return action
+}
+
+func getCopySourceAndDestination(rep repo.Repository) (si, di snapshot.SourceInfo, err error) {
+	si, err = snapshot.ParseSourceInfo(*snapshotCopySource, rep.ClientOptions().Hostname, rep.ClientOptions().Username)
+	if err != nil {
+		return si, di, errors.Wrap(err, "invalid source")
+	}
+
+	if *snapshotCopyDestination == "" {
+		// no destination - assume current user@hostname
+		di.UserName = rep.ClientOptions().Username
+		di.Host = rep.ClientOptions().Hostname
+	} else {
+		di, err = snapshot.ParseSourceInfo(*snapshotCopyDestination, rep.ClientOptions().Hostname, rep.ClientOptions().Username)
+		if err != nil {
+			return si, di, errors.Wrap(err, "invalid destination")
+		}
+	}
+
+	if di.Path != "" && si.Path == "" {
+		// it is illegal to specify source without path, but destination with a path
+		// as it would result in multiple individual paths being squished together.
+		return si, di, errors.Errorf("path specified on destination but not source")
+	}
+
+	if di.UserName != "" && si.UserName == "" {
+		// it is illegal to specify source without username, but destination with a username
+		// as it would result in multiple individual paths being squished together.
+		return si, di, errors.Errorf("username specified on destination but not source")
+	}
+
+	return si, di, nil
+}
+
+func snapshotExists(snaps []*snapshot.Manifest, src snapshot.SourceInfo, startTime time.Time) bool {
+	for _, s := range snaps {
+		if !startTime.Equal(s.StartTime) {
+			continue
+		}
+
+		if src != s.Source {
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}
+
+// getCopyDestination returns the source modified by applying non-empty fields specified in the overrides.
+func getCopyDestination(source, overrides snapshot.SourceInfo) snapshot.SourceInfo {
+	dst := source
+
+	if overrides.Host != "" {
+		dst.Host = overrides.Host
+	}
+
+	if overrides.UserName != "" {
+		dst.UserName = overrides.UserName
+	}
+
+	if overrides.Path != "" {
+		dst.Path = overrides.Path
+	}
+
+	return dst
+}
+
+func init() {
+	snapshotCopyCommand.Action(repositoryAction(runSnapshotCopyCommand))
+}

--- a/cli/command_snapshot_copy_move_history.go
+++ b/cli/command_snapshot_copy_move_history.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	snapshotCopyCommand = snapshotCommands.Command("copy", snapshotCopyMoveHelp("copy"))
-	snapshotMoveCommand = snapshotCommands.Command("move", snapshotCopyMoveHelp("move"))
+	snapshotCopyCommand = snapshotCommands.Command("copy-history", snapshotCopyMoveHelp("copy"))
+	snapshotMoveCommand = snapshotCommands.Command("move-history", snapshotCopyMoveHelp("move"))
 
 	snapshotCopyOrMoveDryRun      bool
 	snapshotCopyOrMoveSource      string

--- a/cli/fscache.go
+++ b/cli/fscache.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 
 	"github.com/kopia/kopia/fs/cachefs"
 )

--- a/cli/show_utils.go
+++ b/cli/show_utils.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/units"

--- a/cli/storage_azure.go
+++ b/cli/storage_azure.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/azure"

--- a/cli/storage_b2.go
+++ b/cli/storage_b2.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/b2"

--- a/cli/storage_filesystem.go
+++ b/cli/storage_filesystem.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/filesystem"

--- a/cli/storage_gcs.go
+++ b/cli/storage_gcs.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/gcs"

--- a/cli/storage_providers.go
+++ b/cli/storage_providers.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"context"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"

--- a/cli/storage_rclone.go
+++ b/cli/storage_rclone.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/rclone"

--- a/cli/storage_s3.go
+++ b/cli/storage_s3.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/s3"

--- a/cli/storage_sftp.go
+++ b/cli/storage_sftp.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"io/ioutil"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/sftp"

--- a/cli/storage_webdav.go
+++ b/cli/storage_webdav.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin"
 
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/webdav"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,8 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.2.0
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
 	github.com/Azure/azure-storage-blob-go v0.10.0
-	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/alecthomas/kingpin v0.0.0-20200323085623-b6657d9477a6
+	github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 // indirect
 	github.com/aws/aws-sdk-go v1.34.29
 	github.com/bgentry/speakeasy v0.1.0
 	github.com/chmduquesne/rollinghash v4.0.0+incompatible
@@ -52,6 +53,5 @@ require (
 	golang.org/x/sys v0.0.0-20200922070232-aee5d888a860
 	google.golang.org/api v0.32.0
 	google.golang.org/protobuf v1.25.0
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/kothar/go-backblaze.v0 v0.0.0-20191215213626-7594ed38700f
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.2.0
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
 	github.com/Azure/azure-storage-blob-go v0.10.0
-	github.com/alecthomas/kingpin v0.0.0-20200323085623-b6657d9477a6
+	github.com/alecthomas/kingpin v0.0.0-20200323085623-b6657d9477a6 // this is pulling master, which is newer than v2
 	github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 // indirect
 	github.com/aws/aws-sdk-go v1.34.29
 	github.com/bgentry/speakeasy v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/Shopify/sarama v1.24.1/go.mod h1:fGP8eQ6PugKEI0iUETYYtnP6d1pH/bdDMTel
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/alecthomas/kingpin v0.0.0-20200323085623-b6657d9477a6 h1:0fwkEPHxb5V+KZZLxWmOknl4oHWo60+TnhmKOi4BIkU=
+github.com/alecthomas/kingpin v0.0.0-20200323085623-b6657d9477a6/go.mod h1:b6br6/pDFSfMkBgC96TbpOji05q5pa+v5rIlS0Y6XtI=
 github.com/alecthomas/participle v0.2.1 h1:4AVLj1viSGa4LG5HDXKXrm5xRx19SB/rS/skPQB1Grw=
 github.com/alecthomas/participle v0.2.1/go.mod h1:SW6HZGeZgSIpcUWX3fXpfZhuaWHnmoD5KCVaqSaNTkk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -136,8 +138,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4 h1:EBTWhcAX7rNQ80RLwLCpHZBBrJuzallFHnF+yMXo928=
+github.com/alecthomas/units v0.0.0-20201120081800-1786d5ef83d4/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/fatih/color"
 	logging "github.com/op/go-logging"
 	"github.com/pkg/errors"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/cli"
 	"github.com/kopia/kopia/internal/clock"

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ package main
 import (
 	"os"
 
+	"github.com/alecthomas/kingpin"
 	gologging "github.com/op/go-logging"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/cli"
 	"github.com/kopia/kopia/internal/logfile"
@@ -68,11 +68,15 @@ Commands (use --help-full to list all commands):
 func main() {
 	app := cli.App()
 
+	kingpin.EnableFileExpansion = false
+
 	logging.SetDefault(func(module string) logging.Logger {
 		return gologging.MustGetLogger(module)
 	})
+
 	app.Version(repo.BuildVersion + " build: " + repo.BuildInfo)
 	app.PreAction(logfile.Initialize)
 	app.UsageTemplate(usageTemplate)
+
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }

--- a/site/cli2md/cli2md.go
+++ b/site/cli2md/cli2md.go
@@ -10,8 +10,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
-	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/kopia/kopia/cli"
 	_ "github.com/kopia/kopia/internal/logfile"

--- a/snapshot/manager.go
+++ b/snapshot/manager.go
@@ -53,12 +53,20 @@ func sourceInfoFromLabels(labels map[string]string) SourceInfo {
 }
 
 func sourceInfoToLabels(si SourceInfo) map[string]string {
-	return map[string]string{
+	m := map[string]string{
 		typeKey:    ManifestType,
 		"hostname": si.Host,
-		"username": si.UserName,
-		"path":     si.Path,
 	}
+
+	if si.UserName != "" {
+		m["username"] = si.UserName
+	}
+
+	if si.Path != "" {
+		m["path"] = si.Path
+	}
+
+	return m
 }
 
 // ListSnapshots lists all snapshots for a given source.

--- a/tests/end_to_end_test/snapshot_copy_move_history_test.go
+++ b/tests/end_to_end_test/snapshot_copy_move_history_test.go
@@ -23,7 +23,7 @@ func TestSnapshotCopy(t *testing.T) {
 	})
 
 	// copy user1@host1 to user2@host1
-	e.RunAndExpectSuccess(t, "snapshot", "copy", "user1@host1", "user2@host1")
+	e.RunAndExpectSuccess(t, "snapshot", "copy-history", "user1@host1", "user2@host1")
 
 	// copy user1@host1 to user2@host1
 	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
@@ -32,7 +32,7 @@ func TestSnapshotCopy(t *testing.T) {
 	})
 
 	// copy @host1 to @host2
-	e.RunAndExpectSuccess(t, "snapshot", "copy", "@host1", "@host2")
+	e.RunAndExpectSuccess(t, "snapshot", "copy-history", "@host1", "@host2")
 	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
 		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
 		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
@@ -41,7 +41,7 @@ func TestSnapshotCopy(t *testing.T) {
 	})
 
 	// move user1@host2 to user3@host3
-	e.RunAndExpectSuccess(t, "snapshot", "move", "user1@host2", "user1@host3")
+	e.RunAndExpectSuccess(t, "snapshot", "move-history", "user1@host2", "user1@host3")
 	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
 		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
 		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
@@ -50,7 +50,7 @@ func TestSnapshotCopy(t *testing.T) {
 	})
 
 	// move user1@host2 to @host4
-	e.RunAndExpectSuccess(t, "snapshot", "move", "user1@host3", "@host4")
+	e.RunAndExpectSuccess(t, "snapshot", "move-history", "user1@host3", "@host4")
 	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
 		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
 		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
@@ -59,7 +59,7 @@ func TestSnapshotCopy(t *testing.T) {
 	})
 
 	// copy user1@host1:sharedTestDataDir1 to @host5
-	e.RunAndExpectSuccess(t, "snapshot", "copy", "user1@host1:"+sharedTestDataDir1, "@host5")
+	e.RunAndExpectSuccess(t, "snapshot", "copy-history", "user1@host1:"+sharedTestDataDir1, "@host5")
 	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
 		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
 		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
@@ -69,7 +69,7 @@ func TestSnapshotCopy(t *testing.T) {
 	})
 
 	// copy user1@host1:sharedTestDataDir1 to another@host6:sharedTestDataDir2
-	e.RunAndExpectSuccess(t, "snapshot", "copy", "user1@host1:"+sharedTestDataDir1, "user3@host6:"+sharedTestDataDir2)
+	e.RunAndExpectSuccess(t, "snapshot", "copy-history", "user1@host1:"+sharedTestDataDir1, "user3@host6:"+sharedTestDataDir2)
 	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
 		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
 		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,

--- a/tests/end_to_end_test/snapshot_copy_test.go
+++ b/tests/end_to_end_test/snapshot_copy_test.go
@@ -41,7 +41,7 @@ func TestSnapshotCopy(t *testing.T) {
 	})
 
 	// move user1@host2 to user3@host3
-	e.RunAndExpectSuccess(t, "snapshot", "copy", "--move", "user1@host2", "user1@host3")
+	e.RunAndExpectSuccess(t, "snapshot", "move", "user1@host2", "user1@host3")
 	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
 		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
 		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
@@ -50,7 +50,7 @@ func TestSnapshotCopy(t *testing.T) {
 	})
 
 	// move user1@host2 to @host4
-	e.RunAndExpectSuccess(t, "snapshot", "copy", "--move", "user1@host3", "@host4")
+	e.RunAndExpectSuccess(t, "snapshot", "move", "user1@host3", "@host4")
 	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
 		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
 		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,

--- a/tests/end_to_end_test/snapshot_copy_test.go
+++ b/tests/end_to_end_test/snapshot_copy_test.go
@@ -1,0 +1,111 @@
+package endtoend_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestSnapshotCopy(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+	e.PassthroughStderr = true
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-hostname=host1", "--override-username=user1")
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
+	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
+		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
+	})
+
+	// copy user1@host1 to user2@host1
+	e.RunAndExpectSuccess(t, "snapshot", "copy", "user1@host1", "user2@host1")
+
+	// copy user1@host1 to user2@host1
+	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
+		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
+	})
+
+	// copy @host1 to @host2
+	e.RunAndExpectSuccess(t, "snapshot", "copy", "@host1", "@host2")
+	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
+		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
+		{Host: "host2", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host2", UserName: "user2", Path: sharedTestDataDir1}: 2,
+	})
+
+	// move user1@host2 to user3@host3
+	e.RunAndExpectSuccess(t, "snapshot", "copy", "--move", "user1@host2", "user1@host3")
+	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
+		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
+		{Host: "host3", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host2", UserName: "user2", Path: sharedTestDataDir1}: 2,
+	})
+
+	// move user1@host2 to @host4
+	e.RunAndExpectSuccess(t, "snapshot", "copy", "--move", "user1@host3", "@host4")
+	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
+		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
+		{Host: "host4", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host2", UserName: "user2", Path: sharedTestDataDir1}: 2,
+	})
+
+	// copy user1@host1:sharedTestDataDir1 to @host5
+	e.RunAndExpectSuccess(t, "snapshot", "copy", "user1@host1:"+sharedTestDataDir1, "@host5")
+	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
+		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
+		{Host: "host4", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host2", UserName: "user2", Path: sharedTestDataDir1}: 2,
+		{Host: "host5", UserName: "user1", Path: sharedTestDataDir1}: 2,
+	})
+
+	// copy user1@host1:sharedTestDataDir1 to another@host6:sharedTestDataDir2
+	e.RunAndExpectSuccess(t, "snapshot", "copy", "user1@host1:"+sharedTestDataDir1, "user3@host6:"+sharedTestDataDir2)
+	assertSnapshotCount(t, e, map[snapshot.SourceInfo]int{
+		{Host: "host1", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host1", UserName: "user2", Path: sharedTestDataDir1}: 2,
+		{Host: "host4", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host2", UserName: "user2", Path: sharedTestDataDir1}: 2,
+		{Host: "host5", UserName: "user1", Path: sharedTestDataDir1}: 2,
+		{Host: "host6", UserName: "user3", Path: sharedTestDataDir2}: 2,
+	})
+}
+
+func assertSnapshotCount(t *testing.T, e *testenv.CLITest, wantSnapshotCounts map[snapshot.SourceInfo]int) {
+	t.Helper()
+
+	gotSnapshots := e.ListSnapshotsAndExpectSuccess(t, "-a")
+
+	for si, wantCnt := range wantSnapshotCounts {
+		found := false
+
+		for _, v := range gotSnapshots {
+			if v.Host == si.Host && v.User == si.UserName && v.Path == si.Path {
+				found = true
+
+				t.Logf("found %v snapshots for %v", len(v.Snapshots), si)
+
+				if got, want := len(v.Snapshots), wantCnt; got != want {
+					t.Fatalf("invalid number of snapshots for %v: %v, want %v", si, got, want)
+				}
+			}
+		}
+
+		if !found {
+			t.Fatalf("snapshots not found for %v", si)
+		}
+	}
+
+	if got, want := len(gotSnapshots), len(wantSnapshotCounts); got != want {
+		t.Fatalf("unexpected number of sources: %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Both source and destination can be specified using `user@host`, `@host` or `user@host:/path` where destination values override the corresponding parts of the source, so both targeted and mass copying is supported.

Supported combinations are:

```
Source:             Destination         Behavior
---------------------------------------------------
@host1              @host2              copy snapshots from all users of host1
user1@host1         @host2              copy all snapshots to user1@host2
user1@host1         user2@host2         copy all snapshots to user2@host2
user1@host1:/path1  @host2              copy to user1@host2:/path1
user1@host1:/path1  user2@host2         copy to user2@host2:/path1
user1@host1:/path1  user2@host2:/path2  copy snapshots from single path
```

When `--move` is specified, the matching source snapshots are also deleted.