### PR TITLE
build(deps-dev): bump electron from 7.1.14 to 7.2.4 in /app

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3127,9 +3127,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boolean": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
-      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
+      "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g==",
       "dev": true,
       "optional": true
     },
@@ -5126,9 +5126,9 @@
       }
     },
     "electron": {
-      "version": "7.1.14",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.14.tgz",
-      "integrity": "sha512-y9Nbja4rl+5fPVw9e/lFudwRax3a+jenzS7WXzUkjF7GI8YFxNH2eH9K9PZFNuSwc/OOCja2ul70+D44tKTQEw==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-7.2.4.tgz",
+      "integrity": "sha512-Z+R692uTzXgP8AHrabE+kkrMlQJ6pnAYoINenwj9QSqaD2YbO8IuXU9DMCcUY0+VpA91ee09wFZJNUKYPMnCKg==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -5137,9 +5137,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.54",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-          "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==",
+          "version": "12.19.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
+          "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg==",
           "dev": true
         }
       }
@@ -7026,11 +7026,14 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -12412,13 +12415,13 @@
       }
     },
     "roarr": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.3.tgz",
-      "integrity": "sha512-AEjYvmAhlyxOeB9OqPUzQCo3kuAkNfuDk/HqWbZdFsqDFpapkTjiw+p4svNEoRLvuqNTxqfL+s+gtD4eDgZ+CA==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "dev": true,
       "optional": true,
       "requires": {
-        "boolean": "^3.0.0",
+        "boolean": "^3.0.1",
         "detect-node": "^2.0.4",
         "globalthis": "^1.0.1",
         "json-stringify-safe": "^5.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -113,7 +113,7 @@
   "devDependencies": {
     "asar": "^2.1.0",
     "concurrently": "^5.2.0",
-    "electron": "^7.1.14",
+    "electron": "^7.2.4",
     "electron-builder": "^22.7.0",
     "electron-notarize": "^0.2.1"
   },


### PR DESCRIPTION
This was showing up as a vulnerability with `high severity`

Bumps [electron](https://github.com/electron/electron) from 7.1.14 to 7.2.4.
- [Release notes](https://github.com/electron/electron/releases)
- [Changelog](https://github.com/electron/electron/blob/master/docs/breaking-changes.md)
- [Commits](https://github.com/electron/electron/compare/v7.1.14...v7.2.4)

Signed-off-by: dependabot[bot] <support@github.com>