### PR TITLE
cli: improvements to 'snapshot verify'

### DIFF
--- a/tests/end_to_end_test/snapshot_gc_test.go
+++ b/tests/end_to_end_test/snapshot_gc_test.go
@@ -48,7 +48,7 @@ how are you
 	expectedContentCount++
 
 	// run verification
-	e.RunAndExpectSuccess(t, "snapshot", "verify", "--all-sources")
+	e.RunAndExpectSuccess(t, "snapshot", "verify")
 
 	// garbage-collect in dry run mode
 	e.RunAndExpectSuccess(t, "snapshot", "gc")

--- a/tests/end_to_end_test/snapshot_verify_test.go
+++ b/tests/end_to_end_test/snapshot_verify_test.go
@@ -1,0 +1,31 @@
+package endtoend_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestSnapshotVerifyTest(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	e.RunAndExpectSuccess(t, "snap", "create", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "snap", "verify")
+
+	// list blobs and remove the first 'p', don't remove 'q' or anything else since
+	// we may delete the record of snapshot itself.
+	for _, line := range e.RunAndExpectSuccess(t, "blob", "ls") {
+		blobID := strings.Fields(line)[0]
+		if strings.HasPrefix(blobID, "p") {
+			e.RunAndExpectSuccess(t, "blob", "rm", blobID)
+			break
+		}
+	}
+
+	e.RunAndExpectFailure(t, "snap", "verify")
+}


### PR DESCRIPTION
* When running against direct repository, it will verify that all backing blobs exist based on results of listing.
* Deprecated annoying `--all-sources` flag which is now default if no sources are provided.
* Added e2e test.