### PR TITLE
actions: Added --enable-actions flag

### DIFF
--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -24,6 +24,7 @@ var (
 	connectCheckForUpdates        bool
 	connectReadonly               bool
 	connectDescription            string
+	connectEnableActions          bool
 )
 
 func setupConnectOptions(cmd *kingpin.CmdClause) {
@@ -39,6 +40,7 @@ func setupConnectOptions(cmd *kingpin.CmdClause) {
 	cmd.Flag("check-for-updates", "Periodically check for Kopia updates on GitHub").Default("true").Envar(checkForUpdatesEnvar).BoolVar(&connectCheckForUpdates)
 	cmd.Flag("readonly", "Make repository read-only to avoid accidental changes").BoolVar(&connectReadonly)
 	cmd.Flag("description", "Human-readable description of the repository").StringVar(&connectDescription)
+	cmd.Flag("enable-actions", "Allow snapshot actions").BoolVar(&connectEnableActions)
 }
 
 func connectOptions() *repo.ConnectOptions {
@@ -51,10 +53,11 @@ func connectOptions() *repo.ConnectOptions {
 			MaxListCacheDurationSec:   int(connectMaxListCacheDuration.Seconds()),
 		},
 		ClientOptions: repo.ClientOptions{
-			Hostname:    connectHostname,
-			Username:    connectUsername,
-			ReadOnly:    connectReadonly,
-			Description: connectDescription,
+			Hostname:      connectHostname,
+			Username:      connectUsername,
+			ReadOnly:      connectReadonly,
+			Description:   connectDescription,
+			EnableActions: connectEnableActions,
 		},
 	}
 }

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -32,6 +32,8 @@ var (
 	snapshotCreateParallelUploads         = snapshotCreateCommand.Flag("parallel", "Upload N files in parallel").PlaceHolder("N").Default("0").Int()
 	snapshotCreateStartTime               = snapshotCreateCommand.Flag("start-time", "Override snapshot start timestamp.").String()
 	snapshotCreateEndTime                 = snapshotCreateCommand.Flag("end-time", "Override snapshot end timestamp.").String()
+	snapshotCreateForceEnableActions      = snapshotCreateCommand.Flag("force-enable-actions", "Enable snapshot actions even if globally disabled on this client").Hidden().Bool()
+	snapshotCreateForceDisableActions     = snapshotCreateCommand.Flag("force-disable-actions", "Disable snapshot actions even if globally enabled on this client").Hidden().Bool()
 )
 
 func runSnapshotCommand(ctx context.Context, rep repo.Repository) error {
@@ -114,6 +116,14 @@ func validateStartEndTime(st, et string) error {
 func setupUploader(rep repo.Repository) *snapshotfs.Uploader {
 	u := snapshotfs.NewUploader(rep)
 	u.MaxUploadBytes = *snapshotCreateCheckpointUploadLimitMB << 20 //nolint:gomnd
+
+	if *snapshotCreateForceEnableActions {
+		u.EnableActions = true
+	}
+
+	if *snapshotCreateForceDisableActions {
+		u.EnableActions = false
+	}
 
 	if interval := *snapshotCreateCheckpointInterval; interval != 0 {
 		u.CheckpointInterval = interval

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -20,6 +20,8 @@ type ClientOptions struct {
 
 	// Description is human-readable description of the repository to use in the UI.
 	Description string `json:"description,omitempty"`
+
+	EnableActions bool `json:"enableActions"`
 }
 
 // ApplyDefaults returns a copy of ClientOptions with defaults filled out.

--- a/tests/end_to_end_test/snapshot_actions_test.go
+++ b/tests/end_to_end_test/snapshot_actions_test.go
@@ -302,7 +302,7 @@ func TestSnapshotActionsEnable(t *testing.T) {
 
 			envFile := filepath.Join(e.LogsDir, "env1.txt")
 
-			// set a action before-snapshot-root that fails and which saves the environment to a file.
+			// set an action before-snapshot-root that fails and which saves the environment to a file.
 			e.RunAndExpectSuccess(t,
 				"policy", "set",
 				sharedTestDataDir1,

--- a/tests/end_to_end_test/snapshot_actions_test.go
+++ b/tests/end_to_end_test/snapshot_actions_test.go
@@ -25,7 +25,7 @@ func TestSnapshotActionsBeforeSnapshotRoot(t *testing.T) {
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
-	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-hostname=foo", "--override-username=foo")
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-hostname=foo", "--override-username=foo", "--enable-actions")
 	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir2)
 
 	envFile1 := filepath.Join(e.LogsDir, "env1.txt")
@@ -157,7 +157,7 @@ func TestSnapshotActionsBeforeAfterFolder(t *testing.T) {
 
 	e := testenv.NewCLITest(t)
 
-	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--enable-actions")
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
 	// create directory structure
@@ -225,7 +225,7 @@ func TestSnapshotActionsEmbeddedScript(t *testing.T) {
 
 	e := testenv.NewCLITest(t)
 
-	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--enable-actions")
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
 	var (
@@ -263,6 +263,61 @@ func TestSnapshotActionsEmbeddedScript(t *testing.T) {
 
 	e.RunAndExpectSuccess(t, "policy", "set", sharedTestDataDir1, "--before-folder-action", failingScript, "--persist-action-script")
 	e.RunAndExpectFailure(t, "snapshot", "create", sharedTestDataDir1)
+}
+
+func TestSnapshotActionsEnable(t *testing.T) {
+	t.Parallel()
+
+	th := os.Getenv("TESTING_ACTION_EXE")
+	if th == "" {
+		t.Skip("TESTING_ACTION_EXE verifyNoError be set")
+	}
+
+	cases := []struct {
+		desc          string
+		connectFlags  []string
+		snapshotFlags []string
+		wantRun       bool
+	}{
+		{desc: "defaults", connectFlags: nil, snapshotFlags: nil, wantRun: false},
+		{desc: "override-connect-disable", connectFlags: []string{"--enable-actions"}, snapshotFlags: nil, wantRun: true},
+		{desc: "override-connect-disable", connectFlags: []string{"--no-enable-actions"}, snapshotFlags: nil, wantRun: false},
+		{desc: "override-snapshot-enable", connectFlags: nil, snapshotFlags: []string{"--force-enable-actions"}, wantRun: true},
+		{desc: "override-snapshot-disable", connectFlags: nil, snapshotFlags: []string{"--force-disable-actions"}, wantRun: false},
+		{desc: "snapshot-takes-precedence-enable", connectFlags: []string{"--no-enable-actions"}, snapshotFlags: []string{"--force-enable-actions"}, wantRun: true},
+		{desc: "snapshot-takes-precedence-disable", connectFlags: []string{"--enable-actions"}, snapshotFlags: []string{"--force-disable-actions"}, wantRun: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			e := testenv.NewCLITest(t)
+
+			defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+			e.RunAndExpectSuccess(t, append([]string{"repo", "create", "filesystem", "--path", e.RepoDir}, tc.connectFlags...)...)
+
+			envFile := filepath.Join(e.LogsDir, "env1.txt")
+
+			// set a action before-snapshot-root that fails and which saves the environment to a file.
+			e.RunAndExpectSuccess(t,
+				"policy", "set",
+				sharedTestDataDir1,
+				"--before-snapshot-root-action",
+				th+" --save-env="+envFile)
+
+			e.RunAndExpectSuccess(t, append([]string{"snapshot", "create", sharedTestDataDir1}, tc.snapshotFlags...)...)
+
+			_, err := os.Stat(envFile)
+			didRun := err == nil
+			if didRun != tc.wantRun {
+				t.Errorf("unexpected behavior. did run: %v want run: %v", didRun, tc.wantRun)
+			}
+		})
+	}
 }
 
 func tmpfileWithContents(t *testing.T, contents string) string {


### PR DESCRIPTION
This can be specified at `repo create` or `repo connect` to enable
actions. By default actions are disabled to avoid security risks
associated with executing code.

Alternatively during `snapshot create` one can specify
`--force-enable-actions` or `--force-disable-actions`