### PR TITLE
cli: only fetch the persisted password from keychain/keyring if one was not provided on the command line

### DIFF
--- a/tests/end_to_end_test/api_server_repository_test.go
+++ b/tests/end_to_end_test/api_server_repository_test.go
@@ -75,6 +75,11 @@ func TestAPIServerRepository(t *testing.T) {
 		"--password", "baz",
 	)
 
+	// we are providing custom password to connect, make sure we won't be providing
+	// (different) default password via environment variable, as command-line password
+	// takes precedence over persisted password.
+	e2.RemoveDefaultPassword()
+
 	// should see one snapshot
 	snapshots := e2.ListSnapshotsAndExpectSuccess(t)
 	if got, want := len(snapshots), 1; got != want {

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -129,6 +129,19 @@ func NewCLITest(t *testing.T) *CLITest {
 	}
 }
 
+// RemoveDefaultPassword prevents KOPIA_PASSWORD from being passed to kopia.
+func (e *CLITest) RemoveDefaultPassword() {
+	var newEnv []string
+
+	for _, s := range e.Environment {
+		if !strings.HasPrefix(s, "KOPIA_PASSWORD=") {
+			newEnv = append(newEnv, s)
+		}
+	}
+
+	e.Environment = newEnv
+}
+
 // RunAndExpectSuccess runs the given command, expects it to succeed and returns its output lines.
 func (e *CLITest) RunAndExpectSuccess(t *testing.T, args ...string) []string {
 	t.Helper()


### PR DESCRIPTION
This also fixed a test bug where the test was incorrectly passing password via environment variable and it was (incorrectly) expected to be ignored.

Password is determined in the following order:

- flag/environment variable (highest priority)
- persistent storage
- asking user (lowest priority)
 
Fixes #741 