### PR TITLE
fixed cases where nil was passed to errors.Wrap() causing nil to be returned

### DIFF
--- a/repo/maintenance/maintenance_schedule.go
+++ b/repo/maintenance/maintenance_schedule.go
@@ -87,7 +87,7 @@ func GetSchedule(ctx context.Context, rep MaintainableRepository) (*Schedule, er
 	}
 
 	if len(v) < c.NonceSize() {
-		return nil, errors.Wrap(err, "invalid schedule blob")
+		return nil, errors.Errorf("invalid schedule blob")
 	}
 
 	j, err := c.Open(nil, v[0:c.NonceSize()], v[c.NonceSize():], maintenanceScheduleAEADExtraData)

--- a/repo/object/object_manager.go
+++ b/repo/object/object_manager.go
@@ -354,7 +354,7 @@ func (om *Manager) newRawReader(ctx context.Context, objectID ID, assertLength i
 	}
 
 	if assertLength != -1 && int64(len(payload)) != assertLength {
-		return nil, errors.Wrapf(err, "unexpected chunk length %v, expected %v", len(payload), assertLength)
+		return nil, errors.Errorf("unexpected chunk length %v, expected %v", len(payload), assertLength)
 	}
 
 	return newObjectReaderWithData(payload), nil

--- a/repo/open.go
+++ b/repo/open.go
@@ -214,7 +214,7 @@ func writeCacheMarker(cacheDir string) error {
 		return nil
 	}
 
-	if !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "unexpected cache marker error")
 	}
 


### PR DESCRIPTION
This is for #746 (there is likely a deeper issue here)