### PR TITLE
Preliminary support for sessions

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -45,6 +45,7 @@ var (
 	indexCommands       = app.Command("index", "Commands to manipulate content index.").Hidden()
 	benchmarkCommands   = app.Command("benchmark", "Commands to test performance of algorithms.").Hidden()
 	maintenanceCommands = app.Command("maintenance", "Maintenance commands.").Hidden().Alias("gc")
+	sessionCommands     = app.Command("session", "Session commands.").Hidden()
 )
 
 func helpFullAction(ctx *kingpin.ParseContext) error {

--- a/cli/command_blob_gc.go
+++ b/cli/command_blob_gc.go
@@ -11,21 +11,23 @@ import (
 )
 
 var (
-	blobGarbageCollectCommand       = blobCommands.Command("gc", "Garbage-collect unused blobs")
-	blobGarbageCollectCommandDelete = blobGarbageCollectCommand.Flag("delete", "Whether to delete unused blobs").String()
-	blobGarbageCollectParallel      = blobGarbageCollectCommand.Flag("parallel", "Number of parallel blob scans").Default("16").Int()
-	blobGarbageCollectMinAge        = blobGarbageCollectCommand.Flag("min-age", "Garbage-collect blobs with minimum age").Default("24h").Duration()
-	blobGarbageCollectPrefix        = blobGarbageCollectCommand.Flag("prefix", "Only GC blobs with given prefix").String()
+	blobGarbageCollectCommand              = blobCommands.Command("gc", "Garbage-collect unused blobs")
+	blobGarbageCollectCommandDelete        = blobGarbageCollectCommand.Flag("delete", "Whether to delete unused blobs").String()
+	blobGarbageCollectParallel             = blobGarbageCollectCommand.Flag("parallel", "Number of parallel blob scans").Default("16").Int()
+	blobGarbageCollectMinAge               = blobGarbageCollectCommand.Flag("min-age", "Garbage-collect blobs with minimum age").Default("24h").Duration()
+	blobGarbageCollectSessionExpirationAge = blobGarbageCollectCommand.Flag("session-expiration-age", "Garbage-collect blobs belonging to sessions that have not been updated recently").Default("96h").Duration()
+	blobGarbageCollectPrefix               = blobGarbageCollectCommand.Flag("prefix", "Only GC blobs with given prefix").String()
 )
 
 func runBlobGarbageCollectCommand(ctx context.Context, rep *repo.DirectRepository) error {
 	advancedCommand(ctx)
 
 	opts := maintenance.DeleteUnreferencedBlobsOptions{
-		DryRun:   *blobGarbageCollectCommandDelete != "yes",
-		MinAge:   *blobGarbageCollectMinAge,
-		Parallel: *blobGarbageCollectParallel,
-		Prefix:   blob.ID(*blobGarbageCollectPrefix),
+		DryRun:               *blobGarbageCollectCommandDelete != "yes",
+		MinAge:               *blobGarbageCollectMinAge,
+		SessionExpirationAge: *blobGarbageCollectSessionExpirationAge,
+		Parallel:             *blobGarbageCollectParallel,
+		Prefix:               blob.ID(*blobGarbageCollectPrefix),
 	}
 
 	n, err := maintenance.DeleteUnreferencedBlobs(ctx, rep, opts)

--- a/cli/command_session_list.go
+++ b/cli/command_session_list.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+)
+
+var sessionListCommand = sessionCommands.Command("list", "List sessions").Alias("ls")
+
+func runSessionList(ctx context.Context, rep *repo.DirectRepository) error {
+	sessions, err := rep.ListActiveSessions(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error listing sessions")
+	}
+
+	for _, s := range sessions {
+		printStdout("%v %v@%v %v %v\n", s.ID, s.User, s.Host, formatTimestamp(s.StartTime), formatTimestamp(s.CheckpointTime))
+	}
+
+	return nil
+}
+
+func init() {
+	sessionListCommand.Action(directRepositoryAction(runSessionList))
+}

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -129,11 +129,6 @@ func (fs *fsImpl) GetBlobFromPath(ctx context.Context, dirPath, path string, off
 func (fs *fsImpl) GetMetadataFromPath(ctx context.Context, dirPath, path string) (blob.Metadata, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
-		// nolint:wrapcheck
-		return blob.Metadata{}, err
-	}
-
-	if err != nil {
 		if os.IsNotExist(err) {
 			return blob.Metadata{}, blob.ErrBlobNotFound
 		}

--- a/repo/content/blob_crypto.go
+++ b/repo/content/blob_crypto.go
@@ -14,12 +14,12 @@ import (
 )
 
 func getIndexBlobIV(s blob.ID) ([]byte, error) {
-	if len(s) < 2*aes.BlockSize {
-		return nil, errors.Errorf("blob id too short: %v", s)
-	}
-
 	if p := strings.Index(string(s), "-"); p >= 0 { // nolint:gocritic
 		s = s[0:p]
+	}
+
+	if len(s) < 2*aes.BlockSize {
+		return nil, errors.Errorf("blob id too short: %v", s)
 	}
 
 	return hex.DecodeString(string(s[len(s)-(aes.BlockSize*2):]))
@@ -68,14 +68,14 @@ func decryptFullBlob(h hashing.HashFunc, enc encryption.Encryptor, payload []byt
 	return payload, nil
 }
 
-func verifyChecksum(h hashing.HashFunc, data, contentID []byte) error {
+func verifyChecksum(h hashing.HashFunc, data, iv []byte) error {
 	var hashOutput [maxHashSize]byte
 
 	expected := h(hashOutput[:0], data)
 	expected = expected[len(expected)-aes.BlockSize:]
 
-	if !bytes.HasSuffix(contentID, expected) {
-		return errors.Errorf("invalid checksum for blob %x, expected %x", contentID, expected)
+	if !bytes.HasSuffix(iv, expected) {
+		return errors.Errorf("invalid checksum for blob %x, expected %x", iv, expected)
 	}
 
 	return nil

--- a/repo/content/blob_crypto.go
+++ b/repo/content/blob_crypto.go
@@ -1,0 +1,82 @@
+package content
+
+import (
+	"bytes"
+	"crypto/aes"
+	"encoding/hex"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/encryption"
+	"github.com/kopia/kopia/repo/hashing"
+)
+
+func getIndexBlobIV(s blob.ID) ([]byte, error) {
+	if len(s) < 2*aes.BlockSize {
+		return nil, errors.Errorf("blob id too short: %v", s)
+	}
+
+	if p := strings.Index(string(s), "-"); p >= 0 { // nolint:gocritic
+		s = s[0:p]
+	}
+
+	return hex.DecodeString(string(s[len(s)-(aes.BlockSize*2):]))
+}
+
+func encryptFullBlob(h hashing.HashFunc, enc encryption.Encryptor, data []byte, prefix blob.ID, sessionID SessionID) (blob.ID, []byte, error) {
+	var hashOutput [maxHashSize]byte
+
+	hash := h(hashOutput[:0], data)
+	blobID := prefix + blob.ID(hex.EncodeToString(hash))
+
+	if sessionID != "" {
+		blobID += blob.ID("-" + sessionID)
+	}
+
+	iv, err := getIndexBlobIV(blobID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	data2, err := enc.Encrypt(nil, data, iv)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "error encrypting blob %v", blobID)
+	}
+
+	return blobID, data2, nil
+}
+
+func decryptFullBlob(h hashing.HashFunc, enc encryption.Encryptor, payload []byte, blobID blob.ID) ([]byte, error) {
+	iv, err := getIndexBlobIV(blobID)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get index blob IV")
+	}
+
+	payload, err = enc.Decrypt(nil, payload, iv)
+	if err != nil {
+		return nil, errors.Wrap(err, "decrypt error")
+	}
+
+	// Since the encryption key is a function of data, we must be able to generate exactly the same key
+	// after decrypting the content. This serves as a checksum.
+	if err := verifyChecksum(h, payload, iv); err != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}
+
+func verifyChecksum(h hashing.HashFunc, data, contentID []byte) error {
+	var hashOutput [maxHashSize]byte
+
+	expected := h(hashOutput[:0], data)
+	expected = expected[len(expected)-aes.BlockSize:]
+
+	if !bytes.HasSuffix(contentID, expected) {
+		return errors.Errorf("invalid checksum for blob %x, expected %x", contentID, expected)
+	}
+
+	return nil
+}

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/blobtesting"
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/encryption"
@@ -104,7 +103,7 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 		MaxPackSize: maxPackSize,
 		MasterKey:   make([]byte, 32), // zero key, does not matter
 		Version:     1,
-	}, nil, &ManagerOptions{TimeNow: clock.Now})
+	}, nil, nil)
 	if err != nil {
 		t.Errorf("can't create content manager with hash %v and encryption %v: %v", hashAlgo, encryptionAlgo, err.Error())
 		return

--- a/repo/content/content_manager_indexes.go
+++ b/repo/content/content_manager_indexes.go
@@ -109,7 +109,7 @@ func (bm *Manager) compactIndexBlobs(ctx context.Context, indexBlobs []IndexBlob
 		return errors.Wrap(err, "unable to build an index")
 	}
 
-	compactedIndexBlob, err := bm.indexBlobManager.writeIndexBlob(ctx, buf.Bytes())
+	compactedIndexBlob, err := bm.indexBlobManager.writeIndexBlob(ctx, buf.Bytes(), "")
 	if err != nil {
 		return errors.Wrap(err, "unable to write compacted indexes")
 	}

--- a/repo/content/index_blob_manager_test.go
+++ b/repo/content/index_blob_manager_test.go
@@ -605,7 +605,7 @@ func writeFakeIndex(ctx context.Context, m indexBlobManager, ndx map[string]fake
 		return blob.Metadata{}, errors.Wrap(err, "json error")
 	}
 
-	bm, err := m.writeIndexBlob(ctx, j)
+	bm, err := m.writeIndexBlob(ctx, j, "")
 	if err != nil {
 		return blob.Metadata{}, errors.Wrap(err, "error writing blob")
 	}
@@ -702,7 +702,7 @@ func mustRegisterCompaction(t *testing.T, m indexBlobManager, inputs, outputs []
 func mustWriteIndexBlob(t *testing.T, m indexBlobManager, data string) blob.Metadata {
 	t.Logf("writing index blob %q", data)
 
-	blobMD, err := m.writeIndexBlob(testlogging.Context(t), []byte(data))
+	blobMD, err := m.writeIndexBlob(testlogging.Context(t), []byte(data), "")
 	if err != nil {
 		t.Fatalf("failed to write index blob: %v", err)
 	}

--- a/repo/content/sessions.go
+++ b/repo/content/sessions.go
@@ -1,0 +1,179 @@
+package content
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+// BlobIDPrefixSession is the prefix for blob IDs indicating active sessions.
+// Each blob ID will consist of {sessionID}.{suffix}.
+const BlobIDPrefixSession blob.ID = "s"
+
+// SessionID represents identifier of a session.
+type SessionID string
+
+// SessionInfo describes a particular session and is persisted in Session blob.
+type SessionInfo struct {
+	ID             SessionID `json:"id"`
+	StartTime      time.Time `json:"startTime"`
+	CheckpointTime time.Time `json:"checkpointTime"`
+	User           string    `json:"username"`
+	Host           string    `json:"hostname"`
+}
+
+var (
+	sessionIDEpochStartTime   = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	sessionIDEpochGranularity = 30 * 24 * time.Hour
+)
+
+// generateSessionID generates a random session identifier.
+func generateSessionID(now time.Time) (SessionID, error) {
+	// generate session ID as {random-64-bit}{epoch-number}
+	// where epoch number is roughly the number of months since 2020-01-01
+	// so our 64-bit number only needs to be unique per month.
+	// Given number of seconds per month, this allows >1000 sessions per
+	// second before significant probability of collision while keeping the
+	// session identifiers relatively short.
+	r := make([]byte, 8)
+	if _, err := cryptorand.Read(r); err != nil {
+		return "", errors.Wrap(err, "unable to read crypto bytes")
+	}
+
+	epochNumber := int(now.Sub(sessionIDEpochStartTime) / sessionIDEpochGranularity)
+
+	return SessionID(fmt.Sprintf("%v%016x%x", BlobIDPrefixSession, r, epochNumber)), nil
+}
+
+func (bm *Manager) getOrStartSessionLocked(ctx context.Context) (SessionID, error) {
+	if bm.currentSessionInfo.ID != "" {
+		return bm.currentSessionInfo.ID, nil
+	}
+
+	id, err := generateSessionID(bm.timeNow())
+	if err != nil {
+		return "", errors.Wrap(err, "unable to generate session ID")
+	}
+
+	bm.currentSessionInfo = SessionInfo{
+		ID:        id,
+		StartTime: bm.timeNow(),
+		User:      bm.sessionUser,
+		Host:      bm.sessionHost,
+	}
+
+	bm.sessionMarkerBlobIDs = nil
+	if err := bm.writeSessionMarkerLocked(ctx); err != nil {
+		return "", errors.Wrap(err, "unable to write session marker")
+	}
+
+	return id, nil
+}
+
+// commitSession commits the current session by deleting all session marker blobs
+// that got written.
+func (bm *Manager) commitSession(ctx context.Context) error {
+	for _, b := range bm.sessionMarkerBlobIDs {
+		if err := bm.st.DeleteBlob(ctx, b); err != nil && !errors.Is(err, blob.ErrBlobNotFound) {
+			return errors.Wrapf(err, "failed to delete session marker %v", b)
+		}
+	}
+
+	bm.currentSessionInfo.ID = ""
+	bm.sessionMarkerBlobIDs = nil
+
+	return nil
+}
+
+// writeSessionMarkerLocked writes a session marker indicating last time the session
+// was known to be alive.
+// TODO(jkowalski): write this periodically when sessions span the duration of an upload.
+func (bm *Manager) writeSessionMarkerLocked(ctx context.Context) error {
+	cp := bm.currentSessionInfo
+	cp.CheckpointTime = bm.timeNow()
+
+	js, err := json.Marshal(cp)
+	if err != nil {
+		return errors.Wrap(err, "unable to serialize session marker payload")
+	}
+
+	sessionBlobID, encrypted, err := encryptFullBlob(bm.hasher, bm.encryptor, js, BlobIDPrefixSession, bm.currentSessionInfo.ID)
+	if err != nil {
+		return errors.Wrap(err, "unable to encrypt session marker")
+	}
+
+	if err := bm.st.PutBlob(ctx, sessionBlobID, gather.FromSlice(encrypted)); err != nil {
+		return errors.Wrapf(err, "unable to write session marker: %v", string(sessionBlobID))
+	}
+
+	bm.sessionMarkerBlobIDs = append(bm.sessionMarkerBlobIDs, sessionBlobID)
+
+	return nil
+}
+
+// SessionIDFromBlobID returns session ID from a given blob ID or empty string if it's not a session blob ID.
+func SessionIDFromBlobID(b blob.ID) SessionID {
+	parts := strings.Split(string(b), "-")
+	if len(parts) == 1 {
+		return ""
+	}
+
+	for _, sid := range parts[1:] {
+		if strings.HasPrefix(sid, string(BlobIDPrefixSession)) {
+			return SessionID(sid)
+		}
+	}
+
+	return ""
+}
+
+// ListActiveSessions returns a set of all active sessions in a given storage.
+func (bm *Manager) ListActiveSessions(ctx context.Context) (map[SessionID]*SessionInfo, error) {
+	blobs, err := blob.ListAllBlobs(ctx, bm.st, BlobIDPrefixSession)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list session blobs")
+	}
+
+	m := map[SessionID]*SessionInfo{}
+
+	for _, b := range blobs {
+		sid := SessionIDFromBlobID(b.BlobID)
+		if sid == "" {
+			return nil, errors.Errorf("found invalid session blob %v", b.BlobID)
+		}
+
+		si := &SessionInfo{}
+
+		payload, err := bm.st.GetBlob(ctx, b.BlobID, 0, -1)
+		if err != nil {
+			if errors.Is(err, blob.ErrBlobNotFound) {
+				continue
+			}
+
+			return nil, errors.Wrapf(err, "error loading session: %v", b.BlobID)
+		}
+
+		payload, err = decryptFullBlob(bm.hasher, bm.encryptor, payload, b.BlobID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error decrypting session: %v", b.BlobID)
+		}
+
+		if err := json.Unmarshal(payload, si); err != nil {
+			return nil, errors.Wrapf(err, "error parsing session: %v", b.BlobID)
+		}
+
+		if old := m[sid]; old == nil || si.CheckpointTime.After(old.CheckpointTime) {
+			m[sid] = si
+		}
+	}
+
+	return m, nil
+}

--- a/repo/content/sessions.go
+++ b/repo/content/sessions.go
@@ -38,7 +38,7 @@ var (
 // generateSessionID generates a random session identifier.
 func generateSessionID(now time.Time) (SessionID, error) {
 	// generate session ID as {random-64-bit}{epoch-number}
-	// where epoch number is roughly the number of months since 2020-01-01
+	// where epoch number is roughly the number of months since 2000-01-01
 	// so our 64-bit number only needs to be unique per month.
 	// Given number of seconds per month, this allows >1000 sessions per
 	// second before significant probability of collision while keeping the

--- a/repo/content/sessions_test.go
+++ b/repo/content/sessions_test.go
@@ -1,0 +1,57 @@
+package content
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+func TestGenerateSessionID(t *testing.T) {
+	n := clock.Now()
+
+	s1, err := generateSessionID(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s2, err := generateSessionID(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s3, err := generateSessionID(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := map[SessionID]bool{
+		s1: true,
+		s2: true,
+		s3: true,
+	}
+
+	if len(m) != 3 {
+		t.Fatalf("session IDs were not unique: %v", m)
+	}
+}
+
+func TestSessionIDFromBlobID(t *testing.T) {
+	cases := []struct {
+		blobID    blob.ID
+		sessionID SessionID
+	}{
+		{"pdeadbeef", ""},
+		{"pdeadbeef-", ""},
+		{"pdeadbeef-whatever", ""},
+		{"pdeadbeef-s01", "s01"},
+		{"pdeadbeef-s01", "s01"},
+		{"sdeadbeef-s01", "s01"},
+	}
+
+	for _, tc := range cases {
+		if got, want := SessionIDFromBlobID(tc.blobID), tc.sessionID; got != want {
+			t.Errorf("invalid result for %v: %v, want %v", tc.blobID, got, want)
+		}
+	}
+}

--- a/repo/maintenance/blob_gc_test.go
+++ b/repo/maintenance/blob_gc_test.go
@@ -1,0 +1,207 @@
+package maintenance
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/faketime"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/repo/object"
+)
+
+var testHMACSecret = []byte{1, 2, 3}
+
+func TestDeleteUnreferencedBlobs(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	var env repotesting.Environment
+
+	ta := faketime.NewTimeAdvance(time.Now(), 1*time.Second)
+
+	// setup repository without encryption and without HMAC so we can implant session blobs
+	defer env.Setup(t, repotesting.Options{
+		OpenOptions: func(o *repo.Options) {
+			o.TimeNowFunc = ta.NowFunc()
+		},
+		NewRepositoryOptions: func(nro *repo.NewRepositoryOptions) {
+			nro.BlockFormat.Encryption = "NONE"
+			nro.BlockFormat.Hash = "HMAC-SHA256"
+			nro.BlockFormat.HMACSecret = testHMACSecret
+		},
+	}).Close(ctx, t)
+
+	w := env.Repository.NewObjectWriter(ctx, object.WriterOptions{})
+	io.WriteString(w, "hello world!")
+	w.Result()
+	w.Close()
+
+	env.Repository.Flush(ctx)
+
+	blobsBefore, err := blob.ListAllBlobs(ctx, env.Repository.Blobs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(blobsBefore), 3; got != want {
+		t.Fatalf("unexpected number of blobs after writing: %v", blobsBefore)
+	}
+
+	// add some more unreferenced blobs
+	const (
+		extraBlobID1 blob.ID = "pdeadbeef1"
+		extraBlobID2 blob.ID = "pdeadbeef2"
+	)
+
+	mustPutDummyBlob(t, env.Repository.Blobs, extraBlobID1)
+	mustPutDummyBlob(t, env.Repository.Blobs, extraBlobID2)
+	verifyBlobExists(t, env.Repository.Blobs, extraBlobID1)
+	verifyBlobExists(t, env.Repository.Blobs, extraBlobID2)
+
+	// new blobs not will be deleted because of minimum age requirement
+	if _, err = DeleteUnreferencedBlobs(ctx, env.Repository, DeleteUnreferencedBlobsOptions{
+		MinAge: 1 * time.Hour,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyBlobExists(t, env.Repository.Blobs, extraBlobID1)
+	verifyBlobExists(t, env.Repository.Blobs, extraBlobID2)
+
+	// new blobs will be deleted
+	if _, err = DeleteUnreferencedBlobs(ctx, env.Repository, DeleteUnreferencedBlobsOptions{
+		MinAge: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyBlobNotFound(t, env.Repository.Blobs, extraBlobID1)
+	verifyBlobNotFound(t, env.Repository.Blobs, extraBlobID2)
+
+	// add blobs again and
+	const (
+		extraBlobIDWithSession1 blob.ID = "pdeadbeef1-s01"
+		extraBlobIDWithSession2 blob.ID = "pdeadbeef2-s01"
+		extraBlobIDWithSession3 blob.ID = "pdeadbeef3-s02"
+	)
+
+	mustPutDummyBlob(t, env.Repository.Blobs, extraBlobIDWithSession1)
+	mustPutDummyBlob(t, env.Repository.Blobs, extraBlobIDWithSession2)
+	mustPutDummyBlob(t, env.Repository.Blobs, extraBlobIDWithSession3)
+
+	session1Marker := mustPutDummySessionBlob(t, env.Repository.Blobs, "s01", &content.SessionInfo{
+		CheckpointTime: ta.NowFunc()(),
+	})
+	session2Marker := mustPutDummySessionBlob(t, env.Repository.Blobs, "s02", &content.SessionInfo{
+		CheckpointTime: ta.NowFunc()(),
+	})
+
+	if _, err = DeleteUnreferencedBlobs(ctx, env.Repository, DeleteUnreferencedBlobsOptions{
+		MinAge: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyBlobExists(t, env.Repository.Blobs, extraBlobIDWithSession1)
+	verifyBlobExists(t, env.Repository.Blobs, extraBlobIDWithSession2)
+	verifyBlobExists(t, env.Repository.Blobs, extraBlobIDWithSession3)
+	verifyBlobExists(t, env.Repository.Blobs, session1Marker)
+	verifyBlobExists(t, env.Repository.Blobs, session2Marker)
+
+	// now finish session 2
+	env.Repository.Blobs.DeleteBlob(ctx, session2Marker)
+
+	if _, err = DeleteUnreferencedBlobs(ctx, env.Repository, DeleteUnreferencedBlobsOptions{
+		MinAge: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyBlobExists(t, env.Repository.Blobs, extraBlobIDWithSession1)
+	verifyBlobExists(t, env.Repository.Blobs, extraBlobIDWithSession2)
+	verifyBlobNotFound(t, env.Repository.Blobs, extraBlobIDWithSession3)
+	verifyBlobExists(t, env.Repository.Blobs, session1Marker)
+	verifyBlobNotFound(t, env.Repository.Blobs, session2Marker)
+
+	// now move time into the future making session 1 timed out
+	ta.Advance(7 * 24 * time.Hour)
+
+	if _, err = DeleteUnreferencedBlobs(ctx, env.Repository, DeleteUnreferencedBlobsOptions{
+		MinAge: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyBlobNotFound(t, env.Repository.Blobs, extraBlobIDWithSession1)
+	verifyBlobNotFound(t, env.Repository.Blobs, extraBlobIDWithSession2)
+	verifyBlobNotFound(t, env.Repository.Blobs, extraBlobIDWithSession3)
+	verifyBlobNotFound(t, env.Repository.Blobs, session1Marker)
+	verifyBlobNotFound(t, env.Repository.Blobs, session2Marker)
+
+	// make sure we're back to the starting point.
+
+	blobsAfter, err := blob.ListAllBlobs(ctx, env.Repository.Blobs, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(blobsBefore, blobsAfter); diff != "" {
+		t.Errorf("unexpected diff: %v", diff)
+	}
+}
+
+func verifyBlobExists(t *testing.T, st blob.Storage, blobID blob.ID) {
+	t.Helper()
+
+	if _, err := st.GetMetadata(testlogging.Context(t), blobID); err != nil {
+		t.Fatalf("expected blob %v to exist, got %v", blobID, err)
+	}
+}
+
+func verifyBlobNotFound(t *testing.T, st blob.Storage, blobID blob.ID) {
+	t.Helper()
+
+	if _, err := st.GetMetadata(testlogging.Context(t), blobID); !errors.Is(err, blob.ErrBlobNotFound) {
+		t.Fatalf("expected blob %v to be not found, got %v", blobID, err)
+	}
+}
+
+func mustPutDummyBlob(t *testing.T, st blob.Storage, blobID blob.ID) {
+	t.Helper()
+
+	if err := st.PutBlob(testlogging.Context(t), blobID, gather.FromSlice([]byte{1, 2, 3})); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustPutDummySessionBlob(t *testing.T, st blob.Storage, sessionIDSuffix blob.ID, si *content.SessionInfo) blob.ID {
+	t.Helper()
+
+	j, err := json.Marshal(si)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := hmac.New(sha256.New, testHMACSecret)
+	h.Write(j)
+
+	blobID := blob.ID(fmt.Sprintf("s%x-%v", h.Sum(nil)[16:32], sessionIDSuffix))
+
+	if err := st.PutBlob(testlogging.Context(t), blobID, gather.FromSlice(j)); err != nil {
+		t.Fatal(err)
+	}
+
+	return blobID
+}

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -42,6 +42,8 @@ type MaintainableRepository interface {
 	repo.Writer
 
 	DeriveKey(purpose []byte, keyLength int) []byte
+
+	ListActiveSessions(ctx context.Context) (map[content.SessionID]*content.SessionInfo, error)
 }
 
 // Supported maintenance modes.

--- a/repo/open.go
+++ b/repo/open.go
@@ -164,6 +164,8 @@ func OpenWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 	cmOpts := &content.ManagerOptions{
 		RepositoryFormatBytes: fb,
 		TimeNow:               defaultTime(options.TimeNowFunc),
+		SessionUser:           lc.ClientOptions.Username,
+		SessionHost:           lc.ClientOptions.Hostname,
 	}
 
 	cm, err := content.NewManager(ctx, st, fo, caching, cmOpts)

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -133,6 +133,11 @@ func (r *DirectRepository) DeleteManifest(ctx context.Context, id manifest.ID) e
 	return r.Manifests.Delete(ctx, id)
 }
 
+// ListActiveSessions returns the map of active sessions.
+func (r *DirectRepository) ListActiveSessions(ctx context.Context) (map[content.SessionID]*content.SessionInfo, error) {
+	return r.Content.ListActiveSessions(ctx)
+}
+
 // UpdateDescription updates the description of a connected repository.
 func (r *DirectRepository) UpdateDescription(d string) {
 	r.cliOpts.Description = d

--- a/tests/end_to_end_test/restore_fail_test.go
+++ b/tests/end_to_end_test/restore_fail_test.go
@@ -69,7 +69,7 @@ func TestRestoreFail(t *testing.T) {
 func findPackBlob(blobIDs []string) string {
 	// Pattern to match "p" followed by hexadecimal digits
 	// Ex) "pd4c69d72b75a9d3d7d9da21096c6b60a"
-	patternStr := fmt.Sprintf("^%s[0-9a-f]+$", content.PackBlobIDPrefixRegular)
+	patternStr := fmt.Sprintf("^%s[0-9a-f]+", content.PackBlobIDPrefixRegular)
 	pattern := regexp.MustCompile(patternStr)
 
 	for _, blobID := range blobIDs {


### PR DESCRIPTION
Sessions allow blob GC to ignore `p` and `q` blobs that are in the process of being written but don't have a corresponding index `n` blob yet.

Content manager will write `s<hash>-<session-id>` blob first before writing any `p`, `q` or `n` blobs (which will all share the same random session id). Only after successfully writing `n` blob, we will delete the `s` blob.

The reader (blob GC) will ignore `p` and `q` blobs if there's a corresponding `s` blob with the same session ID.

This is somewhat functional now, but there's no real way to control for session lifetime (it's implicit from first content write to a subsequent Flush()) so if two logical sessions share the same content manager they will be entangled (such as in `kopia server`)

Future PRs will allow creation of much longer session lifetimes for the duration of the entire upload, so that we can create per-snapshot session and make snapshots effectively atomic even when running inside `kopia server`

Related #731