### PR TITLE
Fix bug that empty log directories are created on any command with --help argument

### DIFF
--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -57,6 +57,10 @@ const (
 
 // Initialize is invoked as part of command execution to create log file just before it's needed.
 func Initialize(ctx *kingpin.ParseContext) error {
+	if *logDir == "" {
+		return nil
+	}
+
 	now := clock.Now()
 
 	suffix := "unknown"


### PR DESCRIPTION
More detail in https://github.com/kopia/kopia/issues/715