### PR TITLE
Add potential cause of specific mount command error on Windows

### DIFF
--- a/internal/mount/mount_net_use.go
+++ b/internal/mount/mount_net_use.go
@@ -49,7 +49,7 @@ func netUse(ctx context.Context, args ...string) (string, error) {
 func netUseMount(ctx context.Context, driveLetter, webdavURL string) (string, error) {
 	out, err := netUse(ctx, driveLetter, webdavURL)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to run 'net use' (%v)", out)
+		return "", errors.Wrapf(err, "unable to run 'net use' (%v), see https://kopia.io/docs/mounting/#windows for more information", out)
 	}
 
 	if driveLetter != "*" {

--- a/site/content/docs/Getting started/_index.md
+++ b/site/content/docs/Getting started/_index.md
@@ -5,13 +5,13 @@ linkTitle: "Getting Started"
 weight: 10
 ---
 
-This guide will walk you through installing Kopia, creating, managing and restoring snapshots and defining snapshot policies. 
+This guide will walk you through installing Kopia, creating, managing and restoring snapshots and defining snapshot policies.
 
 Make sure to familiarize yourself with Kopia [features](../features/) before following along.
 
 ## Installation
 
-Kopia is distributed as a single command-line (CLI) binary called `kopia`. 
+Kopia is distributed as a single command-line (CLI) binary called `kopia`.
 
 To install it follow the [Installation Guide](../installation/).
 
@@ -28,7 +28,7 @@ The Kopia UI is new and experimental. See the tutorial on Youtube:
 
 Repository is a place where Kopia stores all its snapshot data. It's typically remote storage, such as [Google Cloud Storage](https://cloud.google.com/storage/), [Amazon S3](https://aws.amazon.com/s3/) (or copmatible such as Minio.io, Wasabi, B2), [Azure](https://azure.microsoft.com/services/storage/), sftp, http/s, webdav or similar. You can also use any locally-mounted storage (using SMB, NFS or similar). For more details about repository see [Architecture](../architecture/) and [Repositories](../repositories).
 
-To create a repository use one of the subcommands of `kopia repository create`. 
+To create a repository use one of the subcommands of `kopia repository create`.
 
 > NOTE: This guide focuses on simple scenarios, more command-line features are described in the [Command-Line Reference](../reference/command-line/).
 
@@ -94,7 +94,7 @@ $ kopia repository connect google --bucket kopia-test-123
 
 ## Creating Initial Snapshot
 
-Let's create our first snapshot. That's as simple as `kopia snapshot create`. 
+Let's create our first snapshot. That's as simple as `kopia snapshot create`.
 We will create the snapshot of the source code of Kopia itself:
 
 ```shell
@@ -104,7 +104,7 @@ $ kopia snapshot create $HOME/Projects/github.com/kopia/kopia
 After completion, Kopia prints the identifier of the root of the snapshot, which starts with `k`:
 
 ```
-uploaded snapshot 9a622e33ab134ef440f76ed755f79c2f 
+uploaded snapshot 9a622e33ab134ef440f76ed755f79c2f
   (root kfe997567fb1cf8a13341e4ca11652f70) in 1m42.044883302s
 ```
 
@@ -226,7 +226,7 @@ Which returns:
 
 ## Mounting Snapshots
 
-We can mount the directory in a local filesystem and examine it using regular file commands to examine the contents.
+We can [mount](../mounting/) the directory in a local filesystem and examine it using regular file commands to examine the contents.
 This is currently the recommended way of restoring files from snapshots.
 
 ```shell

--- a/site/content/docs/Mounting/_index.md
+++ b/site/content/docs/Mounting/_index.md
@@ -1,0 +1,108 @@
+---
+title: "Mounting"
+linkTitle: "Mounting"
+weight: 50
+---
+
+Mounting allows you to map a content in Kopia repository into a directory in local filesystem and examine it using regular file commands or browser. This is currently the recommended way of restoring files from snapshots.
+
+Mounting can be done repository-wise or content-wise.
+
+When the special path `all` is used, the whole repository with its latest snapshot version is mounted:
+
+```shell
+$ mkdir /tmp/mnt
+$ kopia mount all /tmp/mnt &
+$ ls -l /tmp/mnt/
+total 119992
+-rw-r--r--  1 jarek  staff      1101 May  9 22:33 CONTRIBUTING.md
+-rw-r--r--  1 jarek  staff     11357 May  9 22:33 LICENSE
+-rw-r--r--  1 jarek  staff      1613 Jun 22 19:01 Makefile
+-rw-r--r--  1 jarek  staff      2286 May  9 22:33 README.md
+drwxr-xr-x  1 jarek  staff     11264 May  9 22:33 assets
+drwxr-xr-x  1 jarek  staff      6275 Jun  2 23:08 cli2md
+-rw-r--r--  1 jarek  staff      3749 May 14 19:00 config.toml
+drwxr-xr-x  1 jarek  staff    879721 Jun 22 20:15 content
+-rwxr-xr-x  1 jarek  staff       727 May  9 22:33 deploy.sh
+drwxr-xr-x  1 jarek  staff      1838 May 14 19:00 layouts
+drwxr-xr-x  1 jarek  staff  13682567 Jun 22 18:57 node_modules
+-rw-r--r--  1 jarek  staff     94056 Jun 22 18:57 package-lock.json
+-rw-r--r--  1 jarek  staff       590 May  9 22:33 package.json
+drwxr-xr-x  1 jarek  staff   7104710 Jun 22 19:01 public
+drwxr-xr-x  1 jarek  staff    904965 Jun 22 20:13 resources
+drwxr-xr-x  1 jarek  staff  38701570 Jun  1 20:11 themes
+$ umount /tmp/mnt
+```
+
+If the whole repository is not needed, you could mount a specific directory only:
+
+```shell
+$ kopia snapshot list
+foo@bar:/home/foo/kopia
+  2020-05-01 00:00:00 UTC kb9a8420bf6b8ea280d6637ad1adbd4c5 85.2 MB drwxrwxrwx files:75 dirs:2 (daily-3)
+  + 2 identical snapshots until 2020-05-01 00:00:00 UTC
+...
+
+$ mkdir /tmp/mnt
+$ kopia mount kb9a8420bf6b8ea280d6637ad1adbd4c5 /tmp/mnt &
+$ ls -l /tmp/mnt/
+total 119992
+-rw-r--r--  1 foo  staff      1101 May  9 22:33 CONTRIBUTING.md
+-rw-r--r--  1 foo  staff     11357 May  9 22:33 LICENSE
+-rw-r--r--  1 foo  staff      1613 Jun 22 19:01 Makefile
+-rw-r--r--  1 foo  staff      2286 May  9 22:33 README.md
+drwxr-xr-x  1 foo  staff     11264 May  9 22:33 assets
+drwxr-xr-x  1 foo  staff      6275 Jun  2 23:08 cli2md
+-rw-r--r--  1 foo  staff      3749 May 14 19:00 config.toml
+drwxr-xr-x  1 foo  staff    879721 Jun 22 20:15 content
+-rwxr-xr-x  1 foo  staff       727 May  9 22:33 deploy.sh
+drwxr-xr-x  1 foo  staff      1838 May 14 19:00 layouts
+drwxr-xr-x  1 foo  staff  13682567 Jun 22 18:57 node_modules
+-rw-r--r--  1 foo  staff     94056 Jun 22 18:57 package-lock.json
+-rw-r--r--  1 foo  staff       590 May  9 22:33 package.json
+drwxr-xr-x  1 foo  staff   7104710 Jun 22 19:01 public
+drwxr-xr-x  1 foo  staff    904965 Jun 22 20:13 resources
+drwxr-xr-x  1 foo  staff  38701570 Jun  1 20:11 themes
+$ umount /tmp/mnt
+```
+
+## Windows
+
+On Windows, the mounting is done with `net use` on a WebDAV server. To unmount, press Ctrl-C at the prompt:
+
+```shell
+PS> kopia mount all Z:
+Mounted 'all' on Z:
+Press Ctrl-C to unmount.
+
+(Press Ctrl-C)
+
+Unmounting...
+Unmounted.
+```
+
+If for some reason you lost the prompt, unmounting can be done by using the "Disconnect" command in Explorer drive menu, or a `net use` command:
+
+```shell
+PS> net use Z: /delete
+Z: was deleted successfully.
+```
+
+If you encounter an error with status "2", one possible cause is the "WebClient" service being unable to start. It could be disabled, or its dependencies have problem to start, etc. You can check the service status in the "Services" administrative tool.
+
+```shell
+PS> kopia mount all Z:  # unable to mount
+kopia.exe: error: mount error: unable to mount webdav server as drive letter: unable to run 'net use' (): error running 'net use': exit status 2, try --help
+
+PS> sc start WebClient  # attempt to start the service failed
+[SC] StartService FAILED 1058:
+
+The service cannot be started, either because it is disabled or because it has no enabled devices associated with it.
+
+PS> sc config WebClient start= demand  # change the service from Disabled to Demand start. can also be done in "Services"
+[SC] ChangeServiceConfig SUCCESS
+
+PS> kopia mount all Z:  # mount successful
+Mounted 'all' on Z:
+Press Ctrl-C to unmount.
+```


### PR DESCRIPTION
Before this change, error message looks like:
```
error: mount error: unable to mount webdav server as drive letter: unable to run 'net use' (): error running 'net use': exit status 2, try --help
```
After this change, when error code 2:
```
error: mount error: unable to mount webdav server as drive letter: this error is often caused by but not limited to the 'WebClient' service being unable to start: exit status 2, try --help
```
When error code other than 2:
```
error: mount error: unable to mount webdav server as drive letter: error running 'net use': exit status 123, try --help
```

This change fixes the duplicate short message about 'net use'. It removes the empty `()`, because output is empty in case of error. It adds potential cause for error code 2. Otherwise, the error message is mostly untouched.