### PR TITLE
performance: improve performance of fragmented index lookups

### DIFF
--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -12,7 +12,7 @@ import (
 )
 
 // smallIndexEntryCountThreshold is the threshold to determine whether an
-// index is small. Any index with fewer entries than this threshold 
+// index is small. Any index with fewer entries than this threshold
 // will be combined in-memory to reduce the number of segments and speed up
 // large index operations (such as verification of all contents).
 const smallIndexEntryCountThreshold = 100

--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -11,10 +11,11 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 )
 
-// combineSmallIndexThreshold is the count threshold below which indexes
+// smallIndexEntryCountThreshold is the threshold to determine whether an
+// index is small. Any index with fewer entries than this threshold 
 // will be combined in-memory to reduce the number of segments and speed up
 // large index operations (such as verification of all contents).
-const combineSmallIndexThreshold = 100
+const smallIndexEntryCountThreshold = 100
 
 type committedContentIndex struct {
 	cache committedContentIndexCache
@@ -148,7 +149,7 @@ func combineSmallIndexes(m mergedIndex) (mergedIndex, error) {
 	var toKeep, toMerge mergedIndex
 
 	for _, ndx := range m {
-		if ndx.ApproximateCount() < combineSmallIndexThreshold {
+		if ndx.ApproximateCount() < smallIndexEntryCountThreshold {
 			toMerge = append(toMerge, ndx)
 		} else {
 			toKeep = append(toKeep, ndx)

--- a/repo/content/index.go
+++ b/repo/content/index.go
@@ -21,6 +21,8 @@ const (
 type packIndex interface {
 	io.Closer
 
+	ApproximateCount() int
+
 	GetInfo(contentID ID) (*Info, error)
 
 	// invoked the provided callback for all entries such that entry.ID >= startID and entry.ID < endID
@@ -87,6 +89,10 @@ func readHeader(readerAt io.ReaderAt) (headerInfo, error) {
 	}
 
 	return hi, nil
+}
+
+func (b *index) ApproximateCount() int {
+	return b.hdr.entryCount
 }
 
 // Iterate invokes the provided callback function for a range of contents in the index, sorted alphabetically.

--- a/repo/content/merged.go
+++ b/repo/content/merged.go
@@ -11,6 +11,16 @@ const iterateParallelism = 16
 // mergedIndex is an implementation of Index that transparently merges returns from underlying Indexes.
 type mergedIndex []packIndex
 
+func (m mergedIndex) ApproximateCount() int {
+	c := 0
+
+	for _, ndx := range m {
+		c += ndx.ApproximateCount()
+	}
+
+	return c
+}
+
 // Close closes all underlying indexes.
 func (m mergedIndex) Close() error {
 	for _, ndx := range m {


### PR DESCRIPTION
In a typical repository there will be many small indexes and few large
ones. If the number gets above ~100 or so, things get very slow.

It helps to pre-merge very small indexes in memory to reduce the number
of binary searches and mmaped IO to perform. In some extreme cases
where we have many uncompacted index segments (each with just 1-2
entries), the savings are as quite dramatic.

In one case with >100 index segments the time to run
`kopia snapshot verify` went from 10m to 0.5m after this change.

In another well-maintained repository with 1.2M contents and
about 25 segments, the time to run `kopia snapshot verify` went from
48s to 35s.