### PR TITLE
Add support for kopia diff --json

### DIFF
--- a/cli/command_diff.go
+++ b/cli/command_diff.go
@@ -17,6 +17,7 @@ var (
 	diffCommand          = app.Command("diff", "Displays differences between two repository objects (files or directories)").Alias("compare")
 	diffFirstObjectPath  = diffCommand.Arg("object-path1", "First object/path").Required().String()
 	diffSecondObjectPath = diffCommand.Arg("object-path2", "Second object/path").Required().String()
+	diffJSON             = diffCommand.Flag("json", "Use JSON formatted output").Bool()
 	diffCompareFiles     = diffCommand.Flag("files", "Compare files by launching diff command for all pairs of (old,new)").Short('f').Bool()
 	diffCommandCommand   = diffCommand.Flag("diff-command", "Displays differences between two repository objects (files or directories)").Default(defaultDiffCommand()).Envar("KOPIA_DIFF").String()
 )
@@ -39,7 +40,12 @@ func runDiffCommand(ctx context.Context, rep repo.Reader) error {
 		return errors.New("arguments do diff must both be directories or both non-directories")
 	}
 
-	d, err := diff.NewComparer(os.Stdout)
+	outputFormat := diff.OutputText
+	if *diffJSON {
+		outputFormat = diff.OutputJSON
+	}
+
+	d, err := diff.NewComparer(os.Stdout, outputFormat)
 	if err != nil {
 		return errors.Wrap(err, "error creating comparer")
 	}

--- a/internal/diff/comparer_output.go
+++ b/internal/diff/comparer_output.go
@@ -1,0 +1,58 @@
+package diff
+
+import (
+	"os"
+	"os/exec"
+	"time"
+)
+
+// ComparerOutput is the interface for displaying results.
+type ComparerOutput interface {
+	// A directory was added.
+	AddDirectory(path string)
+
+	// A directory was removed.
+	RemoveDirectory(path string)
+
+	// A directory was replaced by a non-directory.
+	ChangeDirNondir(path string)
+
+	// A non-directory was replaced by a directory.
+	ChangeNondirDir(path string)
+
+	// A file of certain size was added.
+	AddFile(path string, size int64)
+
+	// A file of certain size was removed.
+	RemoveFile(path string, size int64)
+
+	// The properties of a file were changed.
+	ChangeFile(path string, modTime time.Time, size1 int64, size2 int64)
+
+	// Path does not exist in the source, but exists in the destination.
+	NotExistSource(path string)
+
+	// Path does not exist in the destination, but exists in the source.
+	NotExistDest(path string)
+
+	// Permission flags of the path differ.
+	ModesDiffer(path string, mode1 os.FileMode, mode2 os.FileMode)
+
+	// Size of the file differs.
+	SizesDiffer(path string, size1 int64, size2 int64)
+
+	// Modification time of the path differs.
+	ModTimeDiffer(path string, modtime1 time.Time, modtime2 time.Time)
+
+	// Owner user id of the path differs.
+	OwnerDiffer(path string, userID1 uint32, userID2 uint32)
+
+	// Owner group of the path differs.
+	GroupDiffer(path string, groupID1 uint32, groupID2 uint32)
+
+	// Runs a prepared diff command and handles its output.
+	RunDiffCommand(path1 string, path2 string, cmd *exec.Cmd)
+
+	// Close the output; no further calls shall be issued.
+	Close()
+}

--- a/internal/diff/comparer_output_json.go
+++ b/internal/diff/comparer_output_json.go
@@ -1,0 +1,140 @@
+package diff
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// ComparerOutputJSON is a basic standard output compare output.
+type ComparerOutputJSON struct {
+	out     io.Writer
+	entries []interface{}
+}
+
+func (coj *ComparerOutputJSON) add(entryType string, data map[string]interface{}) {
+	entry := map[string]interface{}{
+		"type": entryType,
+	}
+
+	for k, v := range data {
+		entry[k] = v
+	}
+
+	coj.entries = append(coj.entries, entry)
+}
+
+// AddDirectory is called when a directory was added.
+func (coj *ComparerOutputJSON) AddDirectory(path string) {
+	coj.add("add_directory", map[string]interface{}{"path": path})
+}
+
+// RemoveDirectory is called when a directory was removed.
+func (coj *ComparerOutputJSON) RemoveDirectory(path string) {
+	coj.add("remove_directory", map[string]interface{}{"path": path})
+}
+
+// ChangeDirNondir is called when a directory was replaced by a non-directory.
+func (coj *ComparerOutputJSON) ChangeDirNondir(path string) {
+	coj.add("change_dir_nondir", map[string]interface{}{"path": path})
+}
+
+// ChangeNondirDir is called when a non-directory was replaced by a directory.
+func (coj *ComparerOutputJSON) ChangeNondirDir(path string) {
+	coj.add("change_nondir_dir", map[string]interface{}{"path": path})
+}
+
+// ChangeFile is called when the properties of a file were changed.
+func (coj *ComparerOutputJSON) ChangeFile(path string, modTime time.Time, size1, size2 int64) {
+	coj.add("change_file", map[string]interface{}{"path": path, "size1": size1, "size2": size2})
+}
+
+// AddFile is called when a file of certain size was added.
+func (coj *ComparerOutputJSON) AddFile(path string, size int64) {
+	coj.add("add_file", map[string]interface{}{"path": path, "size": size})
+}
+
+// RemoveFile is called when a file of certain size was removed.
+func (coj *ComparerOutputJSON) RemoveFile(path string, size int64) {
+	coj.add("remove_file", map[string]interface{}{"path": path, "size": size})
+}
+
+// RunDiffCommand runs the given prepared command for the purpose of comparing two files.
+func (coj *ComparerOutputJSON) RunDiffCommand(path1, path2 string, cmd *exec.Cmd) {
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			// this is the only kind of error cmd.Output() returns
+			coj.add("diff", map[string]interface{}{
+				"path1":     path1,
+				"path2":     path2,
+				"exit_code": exitError.ExitCode(),
+				"output":    fmt.Sprintf("%v", string(out)),
+			})
+		} else {
+			coj.add("diff", map[string]interface{}{
+				"path1":  path1,
+				"path2":  path2,
+				"error":  fmt.Sprintf("%v", err),
+				"output": fmt.Sprintf("%v", string(out)),
+			})
+		}
+	} else {
+		coj.add("diff", map[string]interface{}{
+			"path1":     path1,
+			"path2":     path2,
+			"exit_code": 0,
+			"output":    fmt.Sprintf("%v", string(out)),
+		})
+	}
+}
+
+// NotExistSource is called when the path does not exist in the source, but exists in the destination.
+func (coj *ComparerOutputJSON) NotExistSource(path string) {
+	coj.add("not_exist_source", map[string]interface{}{"path": path})
+}
+
+// NotExistDest is called when the path does not exist in the destination, but exists in the source.
+func (coj *ComparerOutputJSON) NotExistDest(path string) {
+	coj.add("not_exist_dest", map[string]interface{}{"path": path})
+}
+
+// ModesDiffer is called when the permission flags of the path differ.
+func (coj *ComparerOutputJSON) ModesDiffer(path string, mode1, mode2 os.FileMode) {
+	coj.add("modes_differ", map[string]interface{}{"path": path, "mode1": mode1, "mode2": mode2})
+}
+
+// SizesDiffer is called when the size of the file differs.
+func (coj *ComparerOutputJSON) SizesDiffer(path string, size1, size2 int64) {
+	coj.add("sizes_differ", map[string]interface{}{"path": path, "size1": size1, "size2": size2})
+}
+
+// ModTimeDiffer is called when the modification time of the path differs.
+func (coj *ComparerOutputJSON) ModTimeDiffer(path string, modtime1, modtime2 time.Time) {
+	coj.add("mod_time_differ", map[string]interface{}{"path": path, "modtime1": modtime1, "modtime2": modtime2})
+}
+
+// OwnerDiffer is called when the owner user id of the path differs.
+func (coj *ComparerOutputJSON) OwnerDiffer(path string, userID1, userID2 uint32) {
+	coj.add("owner_differ", map[string]interface{}{"path": path, "user_id1": userID1, "useR_id2": userID2})
+}
+
+// GroupDiffer is called when the owner group of the path differs.
+func (coj *ComparerOutputJSON) GroupDiffer(path string, groupID1, groupID2 uint32) {
+	coj.add("group_differ", map[string]interface{}{"path": path, "group_id1": groupID1, "group_id2": groupID2})
+}
+
+// Close the output; no further calls shall be issued.
+func (coj *ComparerOutputJSON) Close() {
+	jsonRoot := map[string]interface{}{"entries": coj.entries}
+	if err := json.NewEncoder(coj.out).Encode(jsonRoot); err != nil {
+		fmt.Fprintf(coj.out, "{\"error\": 1}")
+	}
+}

--- a/internal/diff/comparer_output_text.go
+++ b/internal/diff/comparer_output_text.go
@@ -1,0 +1,96 @@
+package diff
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// ComparerOutputText is a basic standard output compare output.
+type ComparerOutputText struct {
+	out io.Writer
+}
+
+// AddDirectory is called when a directory was added.
+func (cot *ComparerOutputText) AddDirectory(path string) {
+	fmt.Fprintf(cot.out, "added directory %v\n", path)
+}
+
+// RemoveDirectory is called when a directory was removed.
+func (cot *ComparerOutputText) RemoveDirectory(path string) {
+	fmt.Fprintf(cot.out, "removed directory %v\n", path)
+}
+
+// ChangeDirNondir is called when a directory was replaced by a non-directory.
+func (cot *ComparerOutputText) ChangeDirNondir(path string) {
+	fmt.Fprintf(cot.out, "changed %v from directory to non-directory\n", path)
+}
+
+// ChangeNondirDir is called when a non-directory was replaced by a directory.
+func (cot *ComparerOutputText) ChangeNondirDir(path string) {
+	fmt.Fprintf(cot.out, "changed %v from non-directory to a directory\n", path)
+}
+
+// ChangeFile is called when the properties of a file were changed.
+func (cot *ComparerOutputText) ChangeFile(path string, modTime time.Time, size1, size2 int64) {
+	fmt.Fprintf(cot.out, "changed %v at %v (size %v -> %v)\n", path, modTime.String(), size1, size2)
+}
+
+// AddFile is called when a file of certain size was added.
+func (cot *ComparerOutputText) AddFile(path string, size int64) {
+	fmt.Fprintf(cot.out, "added file %v (%v bytes)\n", path, size)
+}
+
+// RemoveFile is called when a file of certain size was removed.
+func (cot *ComparerOutputText) RemoveFile(path string, size int64) {
+	fmt.Fprintf(cot.out, "removed file %v (%v bytes)\n", path, size)
+}
+
+// RunDiffCommand runs the given prepared command for the purpose of comparing two files.
+func (cot *ComparerOutputText) RunDiffCommand(path1, path2 string, cmd *exec.Cmd) {
+	cmd.Stdout = cot.out
+	cmd.Stderr = cot.out
+	cmd.Run() //nolint:errcheck
+}
+
+// NotExistSource is called when the path does not exist in the source, but exists in the destination.
+func (cot *ComparerOutputText) NotExistSource(path string) {
+	fmt.Fprintf(cot.out, "%v does not exist in source directory\n", path)
+}
+
+// NotExistDest is called when the path does not exist in the destination, but exists in the source.
+func (cot *ComparerOutputText) NotExistDest(path string) {
+	fmt.Fprintf(cot.out, "%v does not exist in destination directory\n", path)
+}
+
+// ModesDiffer is called when the permission flags of the path differ.
+func (cot *ComparerOutputText) ModesDiffer(path string, mode1, mode2 os.FileMode) {
+	fmt.Fprintf(cot.out, "%v modes differ: %v %v\n", path, mode1, mode2)
+}
+
+// SizesDiffer is called when the size of the file differs.
+func (cot *ComparerOutputText) SizesDiffer(path string, size1, size2 int64) {
+	fmt.Fprintf(cot.out, "%v sizes differ: %v %v\n", path, size1, size2)
+}
+
+// ModTimeDiffer is called when the modification time of the path differs.
+func (cot *ComparerOutputText) ModTimeDiffer(path string, modtime1, modtime2 time.Time) {
+	fmt.Fprintf(cot.out, "%v modification times differ: %v %v\n", path, modtime1, modtime2)
+}
+
+// OwnerDiffer is called when the owner user id of the path differs.
+func (cot *ComparerOutputText) OwnerDiffer(path string, userID1, userID2 uint32) {
+	fmt.Fprintf(cot.out, "%v owner users differ: %v %v\n", path, userID1, userID2)
+}
+
+// GroupDiffer is called when the owner group of the path differs.
+func (cot *ComparerOutputText) GroupDiffer(path string, groupID1, groupID2 uint32) {
+	fmt.Fprintf(cot.out, "%v owner groups differ: %v %v\n", path, groupID1, groupID2)
+}
+
+// Close the output; no further calls shall be issued.
+func (cot *ComparerOutputText) Close() {
+	// no particular operations on close
+}

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -110,7 +110,7 @@ func compareDirs(t *testing.T, source, restoreDir string) {
 	testenv.AssertNoError(t, err)
 
 	if !assert.Equal(t, wantHash, gotHash, "restored directory hash does not match source's hash") {
-		cmp, err := diff.NewComparer(os.Stderr)
+		cmp, err := diff.NewComparer(os.Stderr, diff.OutputText)
 		testenv.AssertNoError(t, err)
 
 		cmp.DiffCommand = "cmp"


### PR DESCRIPTION
This produces a basic JSON version of the textual content provided by the `kopia diff` command; most useful when combined with the use of `jq`.

Activated with a `diff`-specific `--json`-switch, so it does not try to be general in any way and the mapping from the old output to the JSON is pretty much 1:1—so there's maybe some amount of redundancy and it does not try to collect output e.g. per-file or anything. And definitely nothing as all-encompassing as what https://github.com/kopia/kopia/issues/272 aims for.

But it's still probably quite useful for analyzing the changes in the repo.
