### PR TITLE
mechanical refactoring of content manager to extract CommittedReadManager

### DIFF
--- a/repo/content/caching_options.go
+++ b/repo/content/caching_options.go
@@ -7,8 +7,6 @@ type CachingOptions struct {
 	MaxMetadataCacheSizeBytes int64  `json:"maxMetadataCacheSize,omitempty"`
 	MaxListCacheDurationSec   int    `json:"maxListCacheDuration,omitempty"`
 	HMACSecret                []byte `json:"-"`
-
-	ownWritesCache ownWritesCache
 }
 
 // CloneOrDefault returns a clone of the caching options or empty options for nil.

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -104,7 +104,7 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 		MaxPackSize: maxPackSize,
 		MasterKey:   make([]byte, 32), // zero key, does not matter
 		Version:     1,
-	}, nil, clock.Now, nil)
+	}, nil, &ManagerOptions{TimeNow: clock.Now})
 	if err != nil {
 		t.Errorf("can't create content manager with hash %v and encryption %v: %v", hashAlgo, encryptionAlgo, err.Error())
 		return

--- a/repo/content/content_index_recovery.go
+++ b/repo/content/content_index_recovery.go
@@ -167,7 +167,7 @@ func (bm *lockFreeManager) buildLocalIndex(pending packIndexBuilder) ([]byte, er
 }
 
 // writePackFileIndexRecoveryData appends data designed to help with recovery of pack index in case it gets damaged or lost.
-func (bm *lockFreeManager) writePackFileIndexRecoveryData(buf *gather.WriteBuffer, pending packIndexBuilder) error {
+func (bm *Manager) writePackFileIndexRecoveryData(buf *gather.WriteBuffer, pending packIndexBuilder) error {
 	// build, encrypt and append local index
 	localIndexOffset := buf.Length()
 
@@ -201,7 +201,7 @@ func (bm *lockFreeManager) writePackFileIndexRecoveryData(buf *gather.WriteBuffe
 	return nil
 }
 
-func (bm *lockFreeManager) readPackFileLocalIndex(ctx context.Context, packFile blob.ID, packFileLength int64) ([]byte, error) {
+func (bm *CommittedReadManager) readPackFileLocalIndex(ctx context.Context, packFile blob.ID, packFileLength int64) ([]byte, error) {
 	// TODO(jkowalski): optimize read when packFileLength is provided
 	_ = packFileLength
 

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -20,8 +20,7 @@ const indexBlobCompactionWarningThreshold = 100
 
 // lockFreeManager contains parts of Manager state that can be accessed without locking.
 type lockFreeManager struct {
-	Format         FormattingOptions
-	CachingOptions CachingOptions
+	Format FormattingOptions
 
 	checkInvariantsOnUnlock bool
 

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -1,14 +1,11 @@
 package content
 
 import (
-	"bytes"
 	"context"
 	"crypto/aes"
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"io"
-	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -75,129 +72,6 @@ func writeRandomBytesToBuffer(b *gather.WriteBuffer, count int) error {
 	return nil
 }
 
-func (bm *CommittedReadManager) loadPackIndexesUnlocked(ctx context.Context) ([]IndexBlobInfo, bool, error) {
-	nextSleepTime := 100 * time.Millisecond //nolint:gomnd
-
-	for i := 0; i < indexLoadAttempts; i++ {
-		if err := ctx.Err(); err != nil {
-			// nolint:wrapcheck
-			return nil, false, err
-		}
-
-		if i > 0 {
-			bm.indexBlobManager.flushCache()
-			log(ctx).Debugf("encountered NOT_FOUND when loading, sleeping %v before retrying #%v", nextSleepTime, i)
-			time.Sleep(nextSleepTime)
-			nextSleepTime *= 2
-		}
-
-		indexBlobs, err := bm.indexBlobManager.listIndexBlobs(ctx, false)
-		if err != nil {
-			return nil, false, errors.Wrap(err, "error listing index blobs")
-		}
-
-		err = bm.tryLoadPackIndexBlobsUnlocked(ctx, indexBlobs)
-		if err == nil {
-			var indexBlobIDs []blob.ID
-			for _, b := range indexBlobs {
-				indexBlobIDs = append(indexBlobIDs, b.BlobID)
-			}
-
-			var updated bool
-
-			updated, err = bm.committedContents.use(ctx, indexBlobIDs)
-			if err != nil {
-				return nil, false, err
-			}
-
-			if len(indexBlobs) > indexBlobCompactionWarningThreshold {
-				log(ctx).Warningf("Found too many index blobs (%v), this may result in degraded performance.\n\nPlease ensure periodic repository maintenance is enabled or run 'kopia maintenance'.", len(indexBlobs))
-			}
-
-			return indexBlobs, updated, nil
-		}
-
-		if !errors.Is(err, blob.ErrBlobNotFound) {
-			return nil, false, err
-		}
-	}
-
-	return nil, false, errors.Errorf("unable to load pack indexes despite %v retries", indexLoadAttempts)
-}
-
-func (bm *CommittedReadManager) tryLoadPackIndexBlobsUnlocked(ctx context.Context, indexBlobs []IndexBlobInfo) error {
-	ch, unprocessedIndexesSize, err := bm.unprocessedIndexBlobsUnlocked(ctx, indexBlobs)
-	if err != nil {
-		return err
-	}
-
-	if len(ch) == 0 {
-		return nil
-	}
-
-	log(ctx).Debugf("downloading %v new index blobs (%v bytes)...", len(ch), unprocessedIndexesSize)
-
-	var wg sync.WaitGroup
-
-	errch := make(chan error, parallelFetches)
-
-	for i := 0; i < parallelFetches; i++ {
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-
-			for indexBlobID := range ch {
-				data, err := bm.indexBlobManager.getIndexBlob(ctx, indexBlobID)
-				if err != nil {
-					errch <- err
-					return
-				}
-
-				if err := bm.committedContents.addContent(ctx, indexBlobID, data, false); err != nil {
-					errch <- errors.Wrap(err, "unable to add to committed content cache")
-					return
-				}
-			}
-		}()
-	}
-
-	wg.Wait()
-	close(errch)
-
-	// Propagate async errors, if any.
-	for err := range errch {
-		return err
-	}
-
-	log(ctx).Debugf("Index contents downloaded.")
-
-	return nil
-}
-
-// unprocessedIndexBlobsUnlocked returns a closed channel filled with content IDs that are not in committedContents cache.
-func (bm *CommittedReadManager) unprocessedIndexBlobsUnlocked(ctx context.Context, contents []IndexBlobInfo) (resultCh <-chan blob.ID, totalSize int64, err error) {
-	ch := make(chan blob.ID, len(contents))
-	defer close(ch)
-
-	for _, c := range contents {
-		has, err := bm.committedContents.cache.hasIndexBlobID(ctx, c.BlobID)
-		if err != nil {
-			return nil, 0, errors.Wrapf(err, "error determining whether index blob %v has been downloaded", c.BlobID)
-		}
-
-		if has {
-			formatLog(ctx).Debugf("index-already-cached %v", c.BlobID)
-			continue
-		}
-
-		ch <- c.BlobID
-		totalSize += c.Length
-	}
-
-	return ch, totalSize, nil
-}
-
 // ValidatePrefix returns an error if a given prefix is invalid.
 func ValidatePrefix(prefix ID) error {
 	switch len(prefix) {
@@ -210,14 +84,6 @@ func ValidatePrefix(prefix ID) error {
 	}
 
 	return errors.Errorf("invalid prefix, must be a empty or single letter between 'g' and 'z'")
-}
-
-func (bm *CommittedReadManager) getCacheForContentID(id ID) contentCache {
-	if id.HasPrefix() {
-		return bm.metadataCache
-	}
-
-	return bm.contentCache
 }
 
 func (bm *Manager) getContentDataUnlocked(ctx context.Context, pp *pendingPackInfo, bi *Info) ([]byte, error) {
@@ -235,42 +101,6 @@ func (bm *Manager) getContentDataUnlocked(ctx context.Context, pp *pendingPackIn
 	}
 
 	return bm.decryptContentAndVerify(payload, bi)
-}
-
-func (bm *CommittedReadManager) decryptContentAndVerify(payload []byte, bi *Info) ([]byte, error) {
-	bm.Stats.readContent(len(payload))
-
-	var hashBuf [maxHashSize]byte
-
-	iv, err := getPackedContentIV(hashBuf[:], bi.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	decrypted, err := bm.decryptAndVerify(payload, iv)
-	if err != nil {
-		return nil, errors.Wrapf(err, "invalid checksum at %v offset %v length %v", bi.PackBlobID, bi.PackOffset, len(payload))
-	}
-
-	return decrypted, nil
-}
-
-func (bm *CommittedReadManager) decryptAndVerify(encrypted, iv []byte) ([]byte, error) {
-	decrypted, err := bm.encryptor.Decrypt(nil, encrypted, iv)
-	if err != nil {
-		return nil, errors.Wrap(err, "decrypt")
-	}
-
-	bm.Stats.decrypted(len(decrypted))
-
-	if bm.encryptor.IsAuthenticated() {
-		// already verified
-		return decrypted, nil
-	}
-
-	// Since the encryption key is a function of data, we must be able to generate exactly the same key
-	// after decrypting the content. This serves as a checksum.
-	return decrypted, bm.verifyChecksum(decrypted, iv)
 }
 
 func (bm *Manager) preparePackDataContent(ctx context.Context, pp *pendingPackInfo) (packIndexBuilder, error) {
@@ -316,11 +146,6 @@ func (bm *Manager) preparePackDataContent(ctx context.Context, pp *pendingPackIn
 	return packFileIndex, err
 }
 
-// IndexBlobs returns the list of active index blobs.
-func (bm *CommittedReadManager) IndexBlobs(ctx context.Context, includeInactive bool) ([]IndexBlobInfo, error) {
-	return bm.indexBlobManager.listIndexBlobs(ctx, includeInactive)
-}
-
 func getPackedContentIV(output []byte, contentID ID) ([]byte, error) {
 	n, err := hex.Decode(output, []byte(contentID[len(contentID)-(aes.BlockSize*2):]))
 	if err != nil {
@@ -342,22 +167,6 @@ func (bm *Manager) hashData(output, data []byte) []byte {
 	bm.Stats.hashedContent(len(data))
 
 	return contentID
-}
-
-func (bm *CommittedReadManager) verifyChecksum(data, contentID []byte) error {
-	var hashOutput [maxHashSize]byte
-
-	expected := bm.hasher(hashOutput[:0], data)
-	expected = expected[len(expected)-aes.BlockSize:]
-
-	if !bytes.HasSuffix(contentID, expected) {
-		bm.Stats.foundInvalidContent()
-		return errors.Errorf("invalid checksum for blob %x, expected %x", contentID, expected)
-	}
-
-	bm.Stats.foundValidContent()
-
-	return nil
 }
 
 // CreateHashAndEncryptor returns new hashing and encrypting functions based on

--- a/repo/content/content_read_manager.go
+++ b/repo/content/content_read_manager.go
@@ -1,0 +1,22 @@
+package content
+
+import (
+	"time"
+
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/encryption"
+	"github.com/kopia/kopia/repo/hashing"
+)
+
+// CommittedReadManager is responsible for read-only access to committed data.
+type CommittedReadManager struct {
+	Stats             *Stats
+	st                blob.Storage
+	indexBlobManager  indexBlobManager
+	contentCache      contentCache
+	metadataCache     contentCache
+	committedContents *committedContentIndex
+	hasher            hashing.HashFunc
+	encryptor         encryption.Encryptor
+	timeNow           func() time.Time
+}

--- a/repo/content/content_read_manager.go
+++ b/repo/content/content_read_manager.go
@@ -1,7 +1,13 @@
 package content
 
 import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/encryption"
@@ -19,4 +25,224 @@ type CommittedReadManager struct {
 	hasher            hashing.HashFunc
 	encryptor         encryption.Encryptor
 	timeNow           func() time.Time
+}
+
+func (rm *CommittedReadManager) readPackFileLocalIndex(ctx context.Context, packFile blob.ID, packFileLength int64) ([]byte, error) {
+	// TODO(jkowalski): optimize read when packFileLength is provided
+	_ = packFileLength
+
+	payload, err := rm.st.GetBlob(ctx, packFile, 0, -1)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error getting blob %v", packFile)
+	}
+
+	postamble := findPostamble(payload)
+	if postamble == nil {
+		return nil, errors.Errorf("unable to find valid postamble in file %v", packFile)
+	}
+
+	if uint64(postamble.localIndexOffset+postamble.localIndexLength) > uint64(len(payload)) {
+		// invalid offset/length
+		return nil, errors.Errorf("unable to find valid local index in file %v", packFile)
+	}
+
+	encryptedLocalIndexBytes := payload[postamble.localIndexOffset : postamble.localIndexOffset+postamble.localIndexLength]
+	if encryptedLocalIndexBytes == nil {
+		return nil, errors.Errorf("unable to find valid local index in file %v", packFile)
+	}
+
+	localIndexBytes, err := rm.decryptAndVerify(encryptedLocalIndexBytes, postamble.localIndexIV)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to decrypt local index")
+	}
+
+	return localIndexBytes, nil
+}
+
+func (rm *CommittedReadManager) loadPackIndexesUnlocked(ctx context.Context) ([]IndexBlobInfo, bool, error) {
+	nextSleepTime := 100 * time.Millisecond //nolint:gomnd
+
+	for i := 0; i < indexLoadAttempts; i++ {
+		if err := ctx.Err(); err != nil {
+			// nolint:wrapcheck
+			return nil, false, err
+		}
+
+		if i > 0 {
+			rm.indexBlobManager.flushCache()
+			log(ctx).Debugf("encountered NOT_FOUND when loading, sleeping %v before retrying #%v", nextSleepTime, i)
+			time.Sleep(nextSleepTime)
+			nextSleepTime *= 2
+		}
+
+		indexBlobs, err := rm.indexBlobManager.listIndexBlobs(ctx, false)
+		if err != nil {
+			return nil, false, errors.Wrap(err, "error listing index blobs")
+		}
+
+		err = rm.tryLoadPackIndexBlobsUnlocked(ctx, indexBlobs)
+		if err == nil {
+			var indexBlobIDs []blob.ID
+			for _, b := range indexBlobs {
+				indexBlobIDs = append(indexBlobIDs, b.BlobID)
+			}
+
+			var updated bool
+
+			updated, err = rm.committedContents.use(ctx, indexBlobIDs)
+			if err != nil {
+				return nil, false, err
+			}
+
+			if len(indexBlobs) > indexBlobCompactionWarningThreshold {
+				log(ctx).Warningf("Found too many index blobs (%v), this may result in degraded performance.\n\nPlease ensure periodic repository maintenance is enabled or run 'kopia maintenance'.", len(indexBlobs))
+			}
+
+			return indexBlobs, updated, nil
+		}
+
+		if !errors.Is(err, blob.ErrBlobNotFound) {
+			return nil, false, err
+		}
+	}
+
+	return nil, false, errors.Errorf("unable to load pack indexes despite %v retries", indexLoadAttempts)
+}
+
+func (rm *CommittedReadManager) tryLoadPackIndexBlobsUnlocked(ctx context.Context, indexBlobs []IndexBlobInfo) error {
+	ch, unprocessedIndexesSize, err := rm.unprocessedIndexBlobsUnlocked(ctx, indexBlobs)
+	if err != nil {
+		return err
+	}
+
+	if len(ch) == 0 {
+		return nil
+	}
+
+	log(ctx).Debugf("downloading %v new index blobs (%v bytes)...", len(ch), unprocessedIndexesSize)
+
+	var wg sync.WaitGroup
+
+	errch := make(chan error, parallelFetches)
+
+	for i := 0; i < parallelFetches; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for indexBlobID := range ch {
+				data, err := rm.indexBlobManager.getIndexBlob(ctx, indexBlobID)
+				if err != nil {
+					errch <- err
+					return
+				}
+
+				if err := rm.committedContents.addContent(ctx, indexBlobID, data, false); err != nil {
+					errch <- errors.Wrap(err, "unable to add to committed content cache")
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errch)
+
+	// Propagate async errors, if any.
+	for err := range errch {
+		return err
+	}
+
+	log(ctx).Debugf("Index contents downloaded.")
+
+	return nil
+}
+
+// unprocessedIndexBlobsUnlocked returns a closed channel filled with content IDs that are not in committedContents cache.
+func (rm *CommittedReadManager) unprocessedIndexBlobsUnlocked(ctx context.Context, contents []IndexBlobInfo) (resultCh <-chan blob.ID, totalSize int64, err error) {
+	ch := make(chan blob.ID, len(contents))
+	defer close(ch)
+
+	for _, c := range contents {
+		has, err := rm.committedContents.cache.hasIndexBlobID(ctx, c.BlobID)
+		if err != nil {
+			return nil, 0, errors.Wrapf(err, "error determining whether index blob %v has been downloaded", c.BlobID)
+		}
+
+		if has {
+			formatLog(ctx).Debugf("index-already-cached %v", c.BlobID)
+			continue
+		}
+
+		ch <- c.BlobID
+		totalSize += c.Length
+	}
+
+	return ch, totalSize, nil
+}
+
+func (rm *CommittedReadManager) getCacheForContentID(id ID) contentCache {
+	if id.HasPrefix() {
+		return rm.metadataCache
+	}
+
+	return rm.contentCache
+}
+
+func (rm *CommittedReadManager) decryptContentAndVerify(payload []byte, bi *Info) ([]byte, error) {
+	rm.Stats.readContent(len(payload))
+
+	var hashBuf [maxHashSize]byte
+
+	iv, err := getPackedContentIV(hashBuf[:], bi.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	decrypted, err := rm.decryptAndVerify(payload, iv)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid checksum at %v offset %v length %v", bi.PackBlobID, bi.PackOffset, len(payload))
+	}
+
+	return decrypted, nil
+}
+
+func (rm *CommittedReadManager) decryptAndVerify(encrypted, iv []byte) ([]byte, error) {
+	decrypted, err := rm.encryptor.Decrypt(nil, encrypted, iv)
+	if err != nil {
+		return nil, errors.Wrap(err, "decrypt")
+	}
+
+	rm.Stats.decrypted(len(decrypted))
+
+	if rm.encryptor.IsAuthenticated() {
+		// already verified
+		return decrypted, nil
+	}
+
+	// Since the encryption key is a function of data, we must be able to generate exactly the same key
+	// after decrypting the content. This serves as a checksum.
+	return decrypted, rm.verifyChecksum(decrypted, iv)
+}
+
+// IndexBlobs returns the list of active index blobs.
+func (rm *CommittedReadManager) IndexBlobs(ctx context.Context, includeInactive bool) ([]IndexBlobInfo, error) {
+	return rm.indexBlobManager.listIndexBlobs(ctx, includeInactive)
+}
+
+func (rm *CommittedReadManager) verifyChecksum(data, contentID []byte) error {
+	var hashOutput [maxHashSize]byte
+
+	expected := rm.hasher(hashOutput[:0], data)
+	expected = expected[len(expected)-aes.BlockSize:]
+
+	if !bytes.HasSuffix(contentID, expected) {
+		rm.Stats.foundInvalidContent()
+		return errors.Errorf("invalid checksum for blob %x, expected %x", contentID, expected)
+	}
+
+	rm.Stats.foundValidContent()
+
+	return nil
 }

--- a/repo/content/content_read_manager.go
+++ b/repo/content/content_read_manager.go
@@ -306,3 +306,26 @@ func (rm *CommittedReadManager) setupReadManagerCaches(ctx context.Context, cach
 
 	return nil
 }
+
+func newReadManager(ctx context.Context, st blob.Storage, f *FormattingOptions, caching *CachingOptions, timeNow func() time.Time) (*CommittedReadManager, error) {
+	hasher, encryptor, err := CreateHashAndEncryptor(f)
+	if err != nil {
+		return nil, err
+	}
+
+	rm := &CommittedReadManager{
+		st:        st,
+		encryptor: encryptor,
+		hasher:    hasher,
+		Stats:     new(Stats),
+		timeNow:   timeNow,
+	}
+
+	caching = caching.CloneOrDefault()
+
+	if err := rm.setupReadManagerCaches(ctx, caching); err != nil {
+		return nil, errors.Wrap(err, "error setting up read manager caches")
+	}
+
+	return rm, nil
+}

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -149,7 +149,7 @@ func TestManifestInitCorruptedBlock(t *testing.T) {
 	}
 
 	// write some data to storage
-	bm, err := content.NewManager(ctx, st, f, nil, content.ManagerOptions{})
+	bm, err := content.NewManager(ctx, st, f, nil, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestManifestInitCorruptedBlock(t *testing.T) {
 	}
 
 	// make a new content manager based on corrupted data.
-	bm, err = content.NewManager(ctx, st, f, nil, content.ManagerOptions{})
+	bm, err = content.NewManager(ctx, st, f, nil, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -306,7 +306,7 @@ func newManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.Da
 		Encryption:  encryption.DefaultAlgorithm,
 		MaxPackSize: 100000,
 		Version:     1,
-	}, nil, content.ManagerOptions{})
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("can't create content manager: %v", err)
 	}

--- a/repo/open.go
+++ b/repo/open.go
@@ -162,7 +162,7 @@ func OpenWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 		fo.MaxPackSize = 20 << 20 // nolint:gomnd
 	}
 
-	cmOpts := content.ManagerOptions{
+	cmOpts := &content.ManagerOptions{
 		RepositoryFormatBytes: fb,
 		TimeNow:               defaultTime(options.TimeNowFunc),
 	}

--- a/tests/stress_test/stress_test.go
+++ b/tests/stress_test/stress_test.go
@@ -45,7 +45,7 @@ func stressTestWithStorage(t *testing.T, st blob.Storage, duration time.Duration
 			Encryption:  "AES-256-CTR",
 			MaxPackSize: 20000000,
 			MasterKey:   []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
-		}, nil, content.ManagerOptions{})
+		}, nil, nil)
 	}
 
 	seed0 := clock.Now().Nanosecond()


### PR DESCRIPTION
CommittedReadManager supports reading of committed contents only

(note commits are not necessarily pretty but should be easy to review)