### PR TITLE
Created end-to-end tests verifying .kopiaignore behavior.

### DIFF
--- a/fs/ignorefs/ignorefs_test.go
+++ b/fs/ignorefs/ignorefs_test.go
@@ -20,26 +20,29 @@ var (
 	notSoLargeFileContents = tooLargeFileContents[0 : len(tooLargeFileContents)-1]
 )
 
-func setupFilesystem() *mockfs.Directory {
+func setupFilesystem(skipDefaultFiles bool) *mockfs.Directory {
 	root := mockfs.NewDirectory()
-	root.AddFile("file1", dummyFileContents, 0)
-	root.AddFile("file2", dummyFileContents, 0)
-	root.AddFile("file3", notSoLargeFileContents, 0)
-	root.AddFile("ignored-by-rule", dummyFileContents, 0)
-	root.AddFile("largefile1", tooLargeFileContents, 0)
 
-	dev1 := fs.DeviceInfo{Dev: 1, Rdev: 0}
-	dev2 := fs.DeviceInfo{Dev: 2, Rdev: 0}
+	if !skipDefaultFiles {
+		root.AddFile("file1", dummyFileContents, 0)
+		root.AddFile("file2", dummyFileContents, 0)
+		root.AddFile("file3", notSoLargeFileContents, 0)
+		root.AddFile("ignored-by-rule", dummyFileContents, 0)
+		root.AddFile("largefile1", tooLargeFileContents, 0)
 
-	d1 := root.AddDir("bin", 0)
-	d2 := root.AddDirDevice("pkg", 0, dev1)
-	d3 := root.AddDirDevice("src", 0, dev2)
+		dev1 := fs.DeviceInfo{Dev: 1, Rdev: 0}
+		dev2 := fs.DeviceInfo{Dev: 2, Rdev: 0}
 
-	d1.AddFile("some-bin", dummyFileContents, 0)
-	d2.AddFileDevice("some-pkg", dummyFileContents, 0, dev1)
+		d1 := root.AddDir("bin", 0)
+		d2 := root.AddDirDevice("pkg", 0, dev1)
+		d3 := root.AddDirDevice("src", 0, dev2)
 
-	d4 := d3.AddDirDevice("some-src", 0, dev2)
-	d4.AddFileDevice("f1", dummyFileContents, 0, dev2)
+		d1.AddFile("some-bin", dummyFileContents, 0)
+		d2.AddFileDevice("some-pkg", dummyFileContents, 0, dev1)
+
+		d4 := d3.AddDirDevice("some-src", 0, dev2)
+		d4.AddFileDevice("f1", dummyFileContents, 0, dev2)
+	}
 
 	return root
 }
@@ -93,11 +96,12 @@ var oneFileSystemPolicy = policy.BuildTree(map[string]*policy.Policy{
 }, policy.DefaultPolicy)
 
 var cases = []struct {
-	desc         string
-	policyTree   *policy.Tree
-	setup        func(root *mockfs.Directory)
-	addedFiles   []string
-	ignoredFiles []string
+	desc             string
+	policyTree       *policy.Tree
+	setup            func(root *mockfs.Directory)
+	skipDefaultFiles bool
+	addedFiles       []string
+	ignoredFiles     []string
 }{
 	{desc: "null policy, missing dotignore"},
 	{
@@ -303,6 +307,191 @@ var cases = []struct {
 	// 		"./src/sub/ignore.foo",
 	// 	},
 	// },
+	// {
+	// 	desc:       "exclude all but specific wildcard",
+	// 	policyTree: defaultPolicy,
+	// 	setup: func(root *mockfs.Directory) {
+	// 		root.AddFileLines(".kopiaignore", []string{
+	// 			"*",
+	// 			"!*.txt  ",
+	// 			"!*/",
+	// 		}, 0)
+	// 		root.AddDir("foo", 0).AddDir("subfoo", 0)
+	// 		root.AddDir("bar", 0).AddDir("subbar", 0)
+	// 		root.AddFile("a.png", dummyFileContents, 0)
+	// 		root.AddFile("a.txt", dummyFileContents, 0)
+	// 		root.Subdir("bar").AddFile("a.txt", dummyFileContents, 0)
+	// 		root.Subdir("bar").AddFile("a.bmp", dummyFileContents, 0)
+	// 		root.Subdir("bar").Subdir("subbar").AddFile("a.txt", dummyFileContents, 0)
+	// 	},
+	// 	addedFiles: []string{
+	// 		"./a.txt",
+	// 		"./bar/",
+	// 		"./bar/a.txt",
+	// 		"./bar/subbar/",
+	// 		"./bar/subbar/a.txt",
+	// 		// Note: Preferably we probably would not want these empty subdirectories since all their contents are ignored. But this is how
+	// 		//       .gitignore works, with the difference of course that git does not commit directories, only files.
+	// 		"./bin/",
+	// 		"./foo/",
+	// 		"./foo/subfoo/",
+	// 	},
+	// 	ignoredFiles: []string{
+	// 		"./ignored-by-rule",
+	// 		"./largefile1",
+	// 		"./file1",
+	// 		"./file2",
+	// 		"./file3",
+	// 		"./pkg/some-pkg",
+	// 		"./bin/some-bin",
+	// 		"./src/some-src/f1",
+	// 	},
+	// },
+	// {
+	// 	desc:             "overlapping exclude files with negate in previous file #1",
+	// 	policyTree:       defaultPolicy,
+	// 	skipDefaultFiles: true,
+	// 	setup: func(root *mockfs.Directory) {
+	// 		root.AddFileLines(".kopiaignore", []string{
+	// 			"*",
+	// 			"!*.txt",
+	// 			"!*/",
+	// 			"AB/",
+	// 		}, 0)
+
+	// 		root.AddDir("A", 0).AddDir("AA", 0)
+	// 		root.Subdir("A").AddDir("AB", 0)
+	// 		root.Subdir("A").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("A").AddFile("file.go", dummyFileContents, 0)
+	// 		root.Subdir("A").Subdir("AA").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("A").Subdir("AA").AddFile("file.go", dummyFileContents, 0)
+	// 		root.Subdir("A").Subdir("AB").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("A").Subdir("AB").AddFile("file.go", dummyFileContents, 0)
+	// 		root.Subdir("A").AddFileLines(".kopiaignore", []string{
+	// 			"*.txt",
+	// 			"!*.go",
+	// 		}, 0)
+
+	// 		root.AddDir("B", 0).AddDir("AA", 0)
+	// 		root.Subdir("B").AddDir("AB", 0)
+	// 		root.Subdir("B").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("B").AddFile("file.go", dummyFileContents, 0)
+	// 		root.Subdir("B").Subdir("AA").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("B").Subdir("AA").AddFile("file.go", dummyFileContents, 0)
+	// 		root.Subdir("B").Subdir("AB").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("B").Subdir("AB").AddFile("file.go", dummyFileContents, 0)
+	// 	},
+	// 	addedFiles: []string{
+	// 		"./A/",
+	// 		"./B/",
+	// 		"./A/AA/",
+	// 		"./B/AA/",
+	// 		"./A/file.go",
+	// 		"./A/AA/file.go",
+	// 		"./B/file.txt",
+	// 		"./B/AA/file.txt",
+	// 	},
+	// 	ignoredFiles: []string{},
+	// },
+	// {
+	// 	desc:             "overlapping exclude files with negate in previous file #2",
+	// 	policyTree:       defaultPolicy,
+	// 	skipDefaultFiles: true,
+	// 	setup: func(root *mockfs.Directory) {
+	// 		root.AddFileLines(".kopiaignore", []string{
+	// 			"*",
+	// 			"!*.txt",
+	// 			"!*/",
+	// 			"AB/",
+	// 		}, 0)
+
+	// 		root.AddDir("A", 0).AddDir("AA", 0)
+	// 		root.Subdir("A").AddDir("AB", 0)
+	// 		root.Subdir("A").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("A").AddFile("file.go", dummyFileContents, 0)
+	// 		root.Subdir("A").Subdir("AA").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("A").Subdir("AA").AddFile("file.go", dummyFileContents, 0)
+	// 		root.Subdir("A").Subdir("AB").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("A").Subdir("AB").AddFile("file.go", dummyFileContents, 0)
+	// 		root.Subdir("A").Subdir("AB").AddFileLines(".kopiaignore", []string{
+	// 			"!*.txt",
+	// 		}, 0)
+
+	// 		root.Subdir("A").AddFileLines(".kopiaignore", []string{
+	// 			"*.txt",
+	// 			"!*.go",
+	// 			"!/AB/",
+	// 		}, 0)
+
+	// 		root.AddDir("B", 0).AddDir("AA", 0)
+	// 		root.Subdir("B").AddDir("AB", 0)
+	// 		root.Subdir("B").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("B").AddFile("file.go", dummyFileContents, 0)
+	// 		root.Subdir("B").Subdir("AA").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("B").Subdir("AA").AddFile("file.go", dummyFileContents, 0)
+	// 		root.Subdir("B").Subdir("AB").AddFile("file.txt", dummyFileContents, 0)
+	// 		root.Subdir("B").Subdir("AB").AddFile("file.go", dummyFileContents, 0)
+	// 	},
+	// 	addedFiles: []string{
+	// 		"./A/",
+	// 		"./B/",
+	// 		"./A/AA/",
+	// 		"./A/AB/",
+	// 		"./B/AA/",
+	// 		"./A/file.go",
+	// 		"./A/AA/file.go",
+	// 		"./A/AB/file.go",
+	// 		"./A/AB/file.txt",
+	// 		"./B/file.txt",
+	// 		"./B/AA/file.txt",
+	// 	},
+	// 	ignoredFiles: []string{},
+	// },
+	{
+		desc:             "multiple ignore files with none in root",
+		policyTree:       defaultPolicy,
+		skipDefaultFiles: true,
+		setup: func(root *mockfs.Directory) {
+			root.AddDir("A", 0).AddDir("AA", 0)
+			root.Subdir("A").AddDir("AB", 0)
+			root.Subdir("A").AddFile("file.txt", dummyFileContents, 0)
+			root.Subdir("A").AddFile("file.go", dummyFileContents, 0)
+			root.Subdir("A").Subdir("AA").AddFile("file.txt", dummyFileContents, 0)
+			root.Subdir("A").Subdir("AA").AddFile("file.go", dummyFileContents, 0)
+			root.Subdir("A").Subdir("AB").AddFile("file.txt", dummyFileContents, 0)
+			root.Subdir("A").Subdir("AB").AddFile("file.go", dummyFileContents, 0)
+			root.Subdir("A").AddFileLines(".kopiaignore", []string{
+				"AB/",
+				"*.go",
+			}, 0)
+
+			root.AddDir("B", 0).AddDir("AA", 0)
+			root.Subdir("B").AddDir("AB", 0)
+			root.Subdir("B").AddFile("file.txt", dummyFileContents, 0)
+			root.Subdir("B").AddFile("file.go", dummyFileContents, 0)
+			root.Subdir("B").Subdir("AA").AddFile("file.txt", dummyFileContents, 0)
+			root.Subdir("B").Subdir("AA").AddFile("file.go", dummyFileContents, 0)
+			root.Subdir("B").Subdir("AB").AddFile("file.txt", dummyFileContents, 0)
+			root.Subdir("B").Subdir("AB").AddFile("file.go", dummyFileContents, 0)
+			root.Subdir("B").AddFileLines(".kopiaignore", []string{
+				"AA/",
+				"*.txt",
+			}, 0)
+		},
+		addedFiles: []string{
+			"./A/",
+			"./A/.kopiaignore",
+			"./A/file.txt",
+			"./A/AA/",
+			"./A/AA/file.txt",
+			"./B/",
+			"./B/.kopiaignore",
+			"./B/file.go",
+			"./B/AB/",
+			"./B/AB/file.go",
+		},
+		ignoredFiles: []string{},
+	},
 	//  Not supported according to spec: https://git-scm.com/docs/gitignore#_pattern_format
 	// {
 	// 	desc: "exclude include wildcard",
@@ -345,7 +534,7 @@ func TestIgnoreFS(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			root := setupFilesystem()
+			root := setupFilesystem(tc.skipDefaultFiles)
 			originalFiles := walkTree(t, root)
 
 			if tc.setup != nil {
@@ -387,6 +576,8 @@ func addAndSubtractFiles(original, added, removed []string) []string {
 }
 
 func walkTree(t *testing.T, dir fs.Directory) []string {
+	t.Helper()
+
 	var output []string
 
 	var walk func(path string, d fs.Directory) error

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -143,34 +143,34 @@ func TestSnapshotCreateWithIgnore(t *testing.T) {
 			},
 			expected: []string{},
 		},
-		{
-			desc: "ignore_all_but_text_files",
-			files: []testFileEntry{
-				{
-					Name: "/.kopiaignore",
-					Content: []string{
-						"*",
-						"!*.txt",
-						"!*/",
-					},
-				},
-				{Name: "foo/bar/file.txt"},
-				{Name: "foo/bar/file.png"},
-				{Name: "foo/file.txt"},
-				{Name: "foo/file.jpg"},
-				{Name: "car/car.jpg"},
-				{Name: "file.txt"},
-				{Name: "file.bmp"},
-			},
-			expected: []string{
-				"foo/",
-				"foo/bar/",
-				"car/", // all files in this are ignored, but the directory is still included.
-				"foo/bar/file.txt",
-				"foo/file.txt",
-				"file.txt",
-			},
-		},
+		// {
+		// 	desc: "ignore_all_but_text_files",
+		// 	files: []testFileEntry{
+		// 		{
+		// 			Name: "/.kopiaignore",
+		// 			Content: []string{
+		// 				"*",
+		// 				"!*.txt",
+		// 				"!*/",
+		// 			},
+		// 		},
+		// 		{Name: "foo/bar/file.txt"},
+		// 		{Name: "foo/bar/file.png"},
+		// 		{Name: "foo/file.txt"},
+		// 		{Name: "foo/file.jpg"},
+		// 		{Name: "car/car.jpg"},
+		// 		{Name: "file.txt"},
+		// 		{Name: "file.bmp"},
+		// 	},
+		// 	expected: []string{
+		// 		"foo/",
+		// 		"foo/bar/",
+		// 		"car/", // all files in this are ignored, but the directory is still included.
+		// 		"foo/bar/file.txt",
+		// 		"foo/file.txt",
+		// 		"file.txt",
+		// 	},
+		// },
 		{
 			desc: "ignore_rooted_vs_unrooted_1",
 			files: []testFileEntry{
@@ -285,24 +285,24 @@ func TestSnapshotCreateWithIgnore(t *testing.T) {
 				"B/",   // directory is empty because all contents are ignored, but the empty directory is still included.
 			},
 		},
-		{
-			desc: "ignore_rooted_vs_unrooted_6",
-			files: []testFileEntry{
-				{
-					Name: "/.kopiaignore",
-					Content: []string{
-						"# This is a comment  ",
-						"test1",
-					},
-				},
-				{Name: "A/test1"},
-				{Name: "test1"},
-			},
-			expected: []string{
-				".kopiaignore",
-				"A/test1",
-			},
-		},
+		// {
+		// 	desc: "ignore_rooted_vs_unrooted_6",
+		// 	files: []testFileEntry{
+		// 		{
+		// 			Name: "/.kopiaignore",
+		// 			Content: []string{
+		// 				"# This is a comment  ",
+		// 				"/test1",
+		// 			},
+		// 		},
+		// 		{Name: "A/test1"},
+		// 		{Name: "test1"},
+		// 	},
+		// 	expected: []string{
+		// 		".kopiaignore",
+		// 		"A/test1",
+		// 	},
+		// },
 	}
 
 	for _, tc := range cases {

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -303,6 +303,97 @@ func TestSnapshotCreateWithIgnore(t *testing.T) {
 		// 		"A/test1",
 		// 	},
 		// },
+		// {
+		// 	desc: "multiple_ignore_files_1",
+		// 	files: []testFileEntry{
+		// 		{
+		// 			Name: "/.kopiaignore",
+		// 			Content: []string{
+		// 				"# Exclude everything except *.txt files anywhere.",
+		// 				"*",
+		// 				"!*.txt  ", // trailing spaces intentional
+		// 				"!*/",
+		// 				"AB/",
+		// 			},
+		// 		},
+		// 		{
+		// 			Name: "A/.kopiaignore",
+		// 			Content: []string{
+		// 				"*.txt",
+		// 				"# Negate *.go from the file above in the hierarchy.",
+		// 				"!*.go",
+		// 			},
+		// 		},
+		// 		{Name: "A/file.txt"},
+		// 		{Name: "A/file.go"},
+		// 		{Name: "A/AA/file.txt"},
+		// 		{Name: "A/AA/file.go"},
+		// 		{Name: "A/AB/file.txt"},
+		// 		{Name: "A/AB/file.go"},
+		// 		{Name: "B/file.txt"},
+		// 		{Name: "B/file.go"},
+		// 		{Name: "B/AA/file.txt"},
+		// 		{Name: "B/AA/file.go"},
+		// 		{Name: "B/AB/file.txt"},
+		// 		{Name: "B/AB/file.go"},
+		// 	},
+		// 	expected: []string{
+		// 		"A/file.go",
+		// 		"A/AA/file.go",
+		// 		"B/file.txt",
+		// 		"B/AA/file.txt",
+		// 	},
+		// },
+		// {
+		// 	desc: "multiple_ignore_files_2",
+		// 	files: []testFileEntry{
+		// 		{
+		// 			Name: "/.kopiaignore",
+		// 			Content: []string{
+		// 				"# Exclude everything except *.txt files anywhere.",
+		// 				"*",
+		// 				"!*.txt  ", // trailing spaces intentional
+		// 				"!*/",
+		// 				"AB/",
+		// 			},
+		// 		},
+		// 		{
+		// 			Name: "A/.kopiaignore",
+		// 			Content: []string{
+		// 				"*.txt",
+		// 				"# Negate *.go from the file above in the hierarchy.",
+		// 				"!*.go",
+		// 				"!/AB/",
+		// 			},
+		// 		},
+		// 		{
+		// 			Name: "A/AB/.kopiaignore",
+		// 			Content: []string{
+		// 				"!*.txt",
+		// 			},
+		// 		},
+		// 		{Name: "A/file.txt"},
+		// 		{Name: "A/file.go"},
+		// 		{Name: "A/AA/file.txt"},
+		// 		{Name: "A/AA/file.go"},
+		// 		{Name: "A/AB/file.txt"},
+		// 		{Name: "A/AB/file.go"},
+		// 		{Name: "B/file.txt"},
+		// 		{Name: "B/file.go"},
+		// 		{Name: "B/AA/file.txt"},
+		// 		{Name: "B/AA/file.go"},
+		// 		{Name: "B/AB/file.txt"},
+		// 		{Name: "B/AB/file.go"},
+		// 	},
+		// 	expected: []string{
+		// 		"A/file.go",
+		// 		"A/AA/file.go",
+		// 		"A/AB/file.go",
+		// 		"A/AB/file.txt",
+		// 		"B/file.txt",
+		// 		"B/AA/file.txt",
+		// 	},
+		// },
 	}
 
 	for _, tc := range cases {

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -2,10 +2,15 @@ package endtoend_test
 
 import (
 	"os"
+	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/tests/testenv"
@@ -112,4 +117,293 @@ func TestSnapshottingCacheDirectory(t *testing.T) {
 	if got, want := len(e.RunAndExpectSuccess(t, "ls", rootID)), 0; got != want {
 		t.Errorf("invalid number of files in snapshot of cache dir %v, want %v", got, want)
 	}
+}
+
+func TestSnapshotCreateWithIgnore(t *testing.T) {
+	cases := []struct {
+		desc     string
+		files    []testFileEntry
+		expected []string
+	}{
+		{
+			desc: "ignore_all_recursive",
+			files: []testFileEntry{
+				{
+					Name: "/.kopiaignore",
+					Content: []string{
+						"**",
+					},
+				},
+				{Name: "foo/bar/file1.txt"},
+				{Name: "foo/bar/file2.txt"},
+				{Name: "foo/file1.txt"},
+				{Name: "foo/file2.txt"},
+				{Name: "file1.txt"},
+				{Name: "file2.txt"},
+			},
+			expected: []string{},
+		},
+		{
+			desc: "ignore_all_but_text_files",
+			files: []testFileEntry{
+				{
+					Name: "/.kopiaignore",
+					Content: []string{
+						"*",
+						"!*.txt",
+						"!*/",
+					},
+				},
+				{Name: "foo/bar/file.txt"},
+				{Name: "foo/bar/file.png"},
+				{Name: "foo/file.txt"},
+				{Name: "foo/file.jpg"},
+				{Name: "car/car.jpg"},
+				{Name: "file.txt"},
+				{Name: "file.bmp"},
+			},
+			expected: []string{
+				"foo/",
+				"foo/bar/",
+				"car/", // all files in this are ignored, but the directory is still included.
+				"foo/bar/file.txt",
+				"foo/file.txt",
+				"file.txt",
+			},
+		},
+		{
+			desc: "ignore_rooted_vs_unrooted_1",
+			files: []testFileEntry{
+				{
+					Name: "/.kopiaignore",
+					Content: []string{
+						"/A/",
+					},
+				},
+				{Name: "file.txt"},
+				{Name: "/A/file.txt"},
+				{Name: "/A/AA/file.txt"},
+				{Name: "/A/B/A/file.txt"},
+				{Name: "/B/A/file.txt"},
+			},
+			expected: []string{
+				".kopiaignore",
+				"file.txt",
+				"B/A/file.txt",
+			},
+		},
+		{
+			desc: "ignore_rooted_vs_unrooted_2",
+			files: []testFileEntry{
+				{
+					Name: "/.kopiaignore",
+					Content: []string{
+						"A/",
+					},
+				},
+				{Name: "file.txt"},
+				{Name: "/A/file.txt"},
+				{Name: "/A/AA/file.txt"},
+				{Name: "/A/B/A/file.txt"},
+				{Name: "/B/A/file.txt"},
+			},
+			expected: []string{
+				".kopiaignore",
+				"file.txt",
+				"B/", // directory is empty because all contents are ignored, but the empty directory is still included.
+			},
+		},
+		{
+			desc: "ignore_rooted_vs_unrooted_3",
+			files: []testFileEntry{
+				{
+					Name: "/.kopiaignore",
+					Content: []string{
+						"B/A/",
+					},
+				},
+				{Name: "file.txt"},
+				{Name: "/A/file.txt"},
+				{Name: "/A/AA/file.txt"},
+				{Name: "/A/B/A/file.txt"},
+				{Name: "/B/A/file.txt"},
+			},
+			expected: []string{
+				".kopiaignore",
+				"file.txt",
+				"A/file.txt",
+				"A/AA/file.txt",
+				"A/B/A/file.txt",
+				"B/", // directory is empty because all contents are ignored, but the empty directory is still included.
+			},
+		},
+		{
+			desc: "ignore_rooted_vs_unrooted_4",
+			files: []testFileEntry{
+				{
+					Name: "/.kopiaignore",
+					Content: []string{
+						"/B/A/",
+					},
+				},
+				{Name: "file.txt"},
+				{Name: "/A/file.txt"},
+				{Name: "/A/AA/file.txt"},
+				{Name: "/A/B/A/file.txt"},
+				{Name: "/B/A/file.txt"},
+			},
+			expected: []string{
+				".kopiaignore",
+				"file.txt",
+				"A/file.txt",
+				"A/AA/file.txt",
+				"A/B/A/file.txt",
+				"B/", // directory is empty because all contents are ignored, but the empty directory is still included.
+			},
+		},
+		{
+			desc: "ignore_rooted_vs_unrooted_5",
+			files: []testFileEntry{
+				{
+					Name: "/.kopiaignore",
+					Content: []string{
+						"**/B/A/",
+					},
+				},
+				{Name: "file.txt"},
+				{Name: "/A/file.txt"},
+				{Name: "/A/AA/file.txt"},
+				{Name: "/A/B/A/file.txt"},
+				{Name: "/B/A/file.txt"},
+			},
+			expected: []string{
+				".kopiaignore",
+				"file.txt",
+				"A/file.txt",
+				"A/AA/file.txt",
+				"A/B/", // directory is empty because all contents are ignored, but the empty directory is still included.
+				"B/",   // directory is empty because all contents are ignored, but the empty directory is still included.
+			},
+		},
+		{
+			desc: "ignore_rooted_vs_unrooted_6",
+			files: []testFileEntry{
+				{
+					Name: "/.kopiaignore",
+					Content: []string{
+						"# This is a comment  ",
+						"test1",
+					},
+				},
+				{Name: "A/test1"},
+				{Name: "test1"},
+			},
+			expected: []string{
+				".kopiaignore",
+				"A/test1",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			e := testenv.NewCLITest(t)
+
+			baseDir := t.TempDir()
+
+			if err := createFileStructure(baseDir, tc.files); err != nil {
+				t.Fatal("Failed to create file structure", err)
+			}
+
+			defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+			e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+			e.RunAndExpectSuccess(t, "snapshot", "create", baseDir)
+			sources := e.ListSnapshotsAndExpectSuccess(t)
+			oid := sources[0].Snapshots[0].ObjectID
+			entries := e.ListDirectoryRecursive(t, oid)
+
+			var output []string
+			for _, s := range entries {
+				output = append(output, s.Name)
+			}
+
+			// Automatically add all directories of files specified so we don't have to specify all
+			// directories and subdirectories in the expected list.
+			var expected []string
+			for _, ex := range tc.expected {
+				expected = appendIfMissing(expected, ex)
+				if !strings.HasSuffix(ex, "/") {
+					for d, _ := path.Split(ex); d != ""; d, _ = path.Split(d) {
+						expected = appendIfMissing(expected, d)
+						if strings.HasSuffix(d, "/") {
+							d = d[:len(d)-1]
+						}
+					}
+				}
+			}
+
+			sort.Strings(output)
+			sort.Strings(expected)
+			if diff := pretty.Compare(output, expected); diff != "" {
+				t.Errorf("unexpected directory tree, diff(-got,+want): %v\n", diff)
+			}
+		})
+	}
+}
+
+func appendIfMissing(slice []string, i string) []string {
+	for _, ele := range slice {
+		if ele == i {
+			return slice
+		}
+	}
+
+	return append(slice, i)
+}
+
+type testFileEntry struct {
+	Name    string
+	Content []string
+}
+
+func createFileStructure(baseDir string, files []testFileEntry) error {
+	for _, ent := range files {
+		fullPath := path.Join(baseDir, ent.Name)
+
+		if strings.HasSuffix(ent.Name, "/") {
+			err := os.MkdirAll(fullPath, 0777)
+			if err != nil {
+				return errors.Errorf("failed to create directory %v: %v", fullPath, err)
+			}
+		} else {
+			dir, _ := path.Split(fullPath)
+			if dir != "" {
+				if _, err := os.Stat(dir); os.IsNotExist(err) {
+					err := os.MkdirAll(dir, 0777)
+					if err != nil {
+						return errors.Errorf("failed to create directory %v: %v", dir, err)
+					}
+				}
+			}
+
+			f, err := os.Create(fullPath)
+			if err != nil {
+				return errors.Errorf("failed to create file %v: %v", fullPath, err)
+			}
+
+			defer f.Close()
+
+			if ent.Content != nil {
+				for _, line := range ent.Content {
+					f.WriteString(line)
+					f.WriteString("\n")
+				}
+			} else {
+				f.WriteString("Test data\n")
+			}
+		}
+	}
+
+	return nil
 }

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -291,6 +291,12 @@ func (e *CLITest) ListDirectory(t *testing.T, targets ...string) []DirEntry {
 	return mustParseDirectoryEntries(lines)
 }
 
+// ListDirectoryRecursive lists a given directory recursively and returns directory entries.
+func (e *CLITest) ListDirectoryRecursive(t *testing.T, targets ...string) []DirEntry {
+	lines := e.RunAndExpectSuccess(t, append([]string{"ls", "-lr"}, targets...)...)
+	return mustParseDirectoryEntries(lines)
+}
+
 func mustParseDirectoryEntries(lines []string) []DirEntry {
 	var result []DirEntry
 


### PR DESCRIPTION
This is related to #571 and #773, but provided as a separate PR to include tests that did not work before PR #773.