### PR TITLE
content: refactoring of content.Manager

### DIFF
--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -45,11 +45,11 @@ func runStatusCommand(ctx context.Context, rep repo.Reader) error {
 
 	fmt.Println()
 	fmt.Printf("Unique ID:           %x\n", dr.UniqueID)
-	fmt.Printf("Hash:                %v\n", dr.Content.Format.Hash)
-	fmt.Printf("Encryption:          %v\n", dr.Content.Format.Encryption)
+	fmt.Printf("Hash:                %v\n", dr.Content.Format().Hash)
+	fmt.Printf("Encryption:          %v\n", dr.Content.Format().Encryption)
 	fmt.Printf("Splitter:            %v\n", dr.Objects.Format.Splitter)
-	fmt.Printf("Format version:      %v\n", dr.Content.Format.Version)
-	fmt.Printf("Max pack length:     %v\n", units.BytesStringBase2(int64(dr.Content.Format.MaxPackSize)))
+	fmt.Printf("Format version:      %v\n", dr.Content.Format().Version)
+	fmt.Printf("Max pack length:     %v\n", units.BytesStringBase2(int64(dr.Content.Format().MaxPackSize)))
 
 	if !*statusReconnectToken {
 		return nil

--- a/internal/server/api_repo.go
+++ b/internal/server/api_repo.go
@@ -29,8 +29,8 @@ func (s *Server) handleRepoParameters(ctx context.Context, r *http.Request, body
 	}
 
 	rp := &remoterepoapi.Parameters{
-		HashFunction: dr.Content.Format.Hash,
-		HMACSecret:   dr.Content.Format.HMACSecret,
+		HashFunction: dr.Content.Format().Hash,
+		HMACSecret:   dr.Content.Format().HMACSecret,
 		Format:       dr.Objects.Format,
 	}
 
@@ -50,9 +50,9 @@ func (s *Server) handleRepoStatus(ctx context.Context, r *http.Request, body []b
 			Connected:     true,
 			ConfigFile:    dr.ConfigFile,
 			CacheDir:      dr.Cache.CacheDirectory,
-			Hash:          dr.Content.Format.Hash,
-			Encryption:    dr.Content.Format.Encryption,
-			MaxPackSize:   dr.Content.Format.MaxPackSize,
+			Hash:          dr.Content.Format().Hash,
+			Encryption:    dr.Content.Format().Encryption,
+			MaxPackSize:   dr.Content.Format().MaxPackSize,
 			Splitter:      dr.Objects.Format.Splitter,
 			Storage:       dr.Blobs.ConnectionInfo().Type,
 			ClientOptions: dr.ClientOptions(),

--- a/repo/content/content_manager_iterate.go
+++ b/repo/content/content_manager_iterate.go
@@ -81,7 +81,7 @@ func maybeParallelExecutor(parallel int, originalCallback IterateCallback) (Iter
 	return callback, cleanup
 }
 
-func (bm *Manager) snapshotUncommittedItems() packIndexBuilder {
+func (bm *WriteManager) snapshotUncommittedItems() packIndexBuilder {
 	bm.lock()
 	defer bm.unlock()
 
@@ -104,7 +104,7 @@ func (bm *Manager) snapshotUncommittedItems() packIndexBuilder {
 
 // IterateContents invokes the provided callback for each content starting with a specified prefix
 // and possibly including deleted items.
-func (bm *Manager) IterateContents(ctx context.Context, opts IterateOptions, callback IterateCallback) error {
+func (bm *WriteManager) IterateContents(ctx context.Context, opts IterateOptions, callback IterateCallback) error {
 	if opts.Range == (IDRange{}) {
 		// range not specified - default to AllIDs
 		opts.Range = AllIDs
@@ -182,7 +182,7 @@ type PackInfo struct {
 type IteratePacksCallback func(PackInfo) error
 
 // IteratePacks invokes the provided callback for all pack blobs.
-func (bm *Manager) IteratePacks(ctx context.Context, options IteratePackOptions, callback IteratePacksCallback) error {
+func (bm *WriteManager) IteratePacks(ctx context.Context, options IteratePackOptions, callback IteratePacksCallback) error {
 	packUsage := map[blob.ID]*PackInfo{}
 
 	if err := bm.IterateContents(
@@ -221,7 +221,7 @@ func (bm *Manager) IteratePacks(ctx context.Context, options IteratePackOptions,
 }
 
 // IterateUnreferencedBlobs returns the list of unreferenced storage blobs.
-func (bm *Manager) IterateUnreferencedBlobs(ctx context.Context, blobPrefixes []blob.ID, parallellism int, callback func(blob.Metadata) error) error {
+func (bm *WriteManager) IterateUnreferencedBlobs(ctx context.Context, blobPrefixes []blob.ID, parallellism int, callback func(blob.Metadata) error) error {
 	usedPacks := map[blob.ID]bool{}
 
 	log(ctx).Debugf("determining blobs in use")

--- a/repo/maintenance/content_rewrite.go
+++ b/repo/maintenance/content_rewrite.go
@@ -135,7 +135,7 @@ func getContentToRewrite(ctx context.Context, rep MaintainableRepository, opt *R
 
 		// add all content IDs from short packs
 		if opt.ShortPacks {
-			threshold := int64(rep.ContentManager().Format.MaxPackSize * shortPackThresholdPercent / 100) //nolint:gomnd
+			threshold := int64(rep.ContentManager().Format().MaxPackSize * shortPackThresholdPercent / 100) //nolint:gomnd
 			findContentInShortPacks(ctx, rep, ch, threshold, opt)
 		}
 

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -37,7 +37,7 @@ type MaintainableRepository interface {
 	ConfigFilename() string
 
 	BlobStorage() blob.Storage
-	ContentManager() *content.Manager
+	ContentManager() *content.WriteManager
 
 	repo.Writer
 

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -50,11 +50,13 @@ type Repository interface {
 // DirectRepository is an implementation of repository that directly manipulates underlying storage.
 type DirectRepository struct {
 	Blobs     blob.Storage
-	Content   *content.Manager
+	Content   *content.WriteManager
 	Objects   *object.Manager
 	Manifests *manifest.Manager
 	Cache     content.CachingOptions
 	UniqueID  []byte
+
+	sharedContentManager *content.SharedManager
 
 	ConfigFile string
 
@@ -89,7 +91,7 @@ func (r *DirectRepository) BlobStorage() blob.Storage {
 }
 
 // ContentManager returns the content manager.
-func (r *DirectRepository) ContentManager() *content.Manager {
+func (r *DirectRepository) ContentManager() *content.WriteManager {
 	return r.Content
 }
 

--- a/tests/stress_test/stress_test.go
+++ b/tests/stress_test/stress_test.go
@@ -38,7 +38,7 @@ func TestStressBlockManager(t *testing.T) {
 func stressTestWithStorage(t *testing.T, st blob.Storage, duration time.Duration) {
 	ctx := testlogging.Context(t)
 
-	openMgr := func() (*content.Manager, error) {
+	openMgr := func() (*content.WriteManager, error) {
 		return content.NewManager(ctx, st, &content.FormattingOptions{
 			Version:     1,
 			Hash:        "HMAC-SHA256-128",
@@ -65,7 +65,7 @@ func stressTestWithStorage(t *testing.T, st blob.Storage, duration time.Duration
 	})
 }
 
-func stressWorker(ctx context.Context, t *testing.T, deadline time.Time, openMgr func() (*content.Manager, error), seed int64) {
+func stressWorker(ctx context.Context, t *testing.T, deadline time.Time, openMgr func() (*content.WriteManager, error), seed int64) {
 	src := rand.NewSource(seed)
 	rnd := rand.New(src)
 


### PR DESCRIPTION
- renamed content.Manager to content.WriteManager
- merged lockFreeManager and CommittedReadManager into SharedManager
- also reassigned some methods to SharedManager (no code move)