### PR TITLE
server: reworked authn/authz

### DIFF
--- a/cli/auto_upgrade.go
+++ b/cli/auto_upgrade.go
@@ -10,7 +10,9 @@ import (
 )
 
 func maybeAutoUpgradeRepository(ctx context.Context, r repo.Repository) error {
-	if r == nil {
+	// only upgrade repository when it's directly connected, not via API.
+	dr, _ := r.(repo.DirectRepository)
+	if dr == nil {
 		return nil
 	}
 
@@ -25,9 +27,9 @@ func maybeAutoUpgradeRepository(ctx context.Context, r repo.Repository) error {
 
 	log(ctx).Noticef("Setting default maintenance parameters...")
 
-	return repo.WriteSession(ctx, r, repo.WriteSessionOptions{
+	return repo.DirectWriteSession(ctx, dr, repo.WriteSessionOptions{
 		Purpose: "setDefaultMaintenanceParameters",
-	}, func(w repo.RepositoryWriter) error {
+	}, func(w repo.DirectRepositoryWriter) error {
 		return setDefaultMaintenanceParameters(ctx, w)
 	})
 }

--- a/internal/auth/authn.go
+++ b/internal/auth/authn.go
@@ -1,0 +1,23 @@
+// Package auth provides authentication and authorization constructs.
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+
+	"github.com/kopia/kopia/repo"
+)
+
+// Authenticator verifies that the provided username/password is valid.
+type Authenticator func(ctx context.Context, rep repo.Repository, username, password string) bool
+
+// AuthenticateSingleUser returns an Authenticator that only allows one username/password combination.
+func AuthenticateSingleUser(expectedUsername, expectedPassword string) Authenticator {
+	expectedUsernameBytes := []byte(expectedUsername)
+	expectedPasswordBytes := []byte(expectedPassword)
+
+	return func(ctx context.Context, rep repo.Repository, username, password string) bool {
+		return subtle.ConstantTimeCompare([]byte(username), expectedUsernameBytes)*
+			subtle.ConstantTimeCompare([]byte(password), expectedPasswordBytes) == 1
+	}
+}

--- a/internal/auth/authn_test.go
+++ b/internal/auth/authn_test.go
@@ -1,0 +1,25 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kopia/kopia/internal/auth"
+)
+
+func TestAuthentication(t *testing.T) {
+	a := auth.AuthenticateSingleUser("user1", "password1")
+	verifyAuthenticator(t, a, "user1", "password1", true)
+	verifyAuthenticator(t, a, "user1", "password2", false)
+	verifyAuthenticator(t, a, "user1", "password11", false)
+	verifyAuthenticator(t, a, "user1a", "password1", false)
+	verifyAuthenticator(t, a, "user1a", "password1a", false)
+}
+
+func verifyAuthenticator(t *testing.T, a auth.Authenticator, username, password string, want bool) {
+	t.Helper()
+
+	if got := a(context.Background(), nil, username, password); got != want {
+		t.Errorf("invalid authenticator result for %v/%v: %v, want %v", username, password, got, want)
+	}
+}

--- a/internal/auth/authz.go
+++ b/internal/auth/authz.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"strings"
+
+	"github.com/kopia/kopia/repo"
+)
+
+// AuthorizerFunc gets the authorizations for given user.
+type AuthorizerFunc func(ctx context.Context, rep repo.Repository, username string) AuthorizationInfo
+
+// AccessLevel specifies access level when accessing repository objects.
+type AccessLevel int
+
+// Access levels.
+const (
+	AccessLevelNone   AccessLevel = iota
+	AccessLevelRead               // RO access
+	AccessLevelAppend             // RO + create new
+	AccessLevelFull               // read/write/delete
+)
+
+// AuthorizationInfo determines logged in user's access level.
+type AuthorizationInfo interface {
+	// ContentAccessLevel determines whether the user can read/write contents.
+	ContentAccessLevel() AccessLevel
+
+	// ManifestAccessLevel determines whether the user has access to a manifest with given labels.
+	ManifestAccessLevel(labels map[string]string) AccessLevel
+}
+
+type noAccessAuthorizer struct{}
+
+func (noAccessAuthorizer) ContentAccessLevel() AccessLevel { return AccessLevelNone }
+func (noAccessAuthorizer) ManifestAccessLevel(labels map[string]string) AccessLevel {
+	return AccessLevelNone
+}
+
+// NoAccess implements AuthorizationInfo which grants no permissions.
+var NoAccess AuthorizationInfo = noAccessAuthorizer{}
+
+type legacyAuthorizer struct {
+	usernameAtHostname string
+}
+
+func (la legacyAuthorizer) ContentAccessLevel() AccessLevel { return AccessLevelFull }
+func (la legacyAuthorizer) ManifestAccessLevel(labels map[string]string) AccessLevel {
+	if labels["type"] == "policy" {
+		// everybody can read global policy.
+		switch labels["policyType"] {
+		case "global":
+			return AccessLevelRead
+
+		case "host":
+			if strings.HasSuffix(la.usernameAtHostname, "@"+labels["hostname"]) {
+				return AccessLevelRead
+			}
+		}
+	}
+
+	// full access to policies/snapshots for the username@hostname
+	if labels["username"]+"@"+labels["hostname"] == la.usernameAtHostname {
+		return AccessLevelFull
+	}
+
+	// no access otherwise
+	return AccessLevelNone
+}
+
+// LegacyAuthorizerForUser is an AuthorizerFunc that returns authorizer with legacy (pre-ACL)
+// authorization rules (authenticated users can see their own snapshots/policies only).
+func LegacyAuthorizerForUser(ctx context.Context, rep repo.Repository, usernameAtHostname string) AuthorizationInfo {
+	return legacyAuthorizer{usernameAtHostname}
+}
+
+var _ AuthorizerFunc = LegacyAuthorizerForUser

--- a/internal/auth/authz.go
+++ b/internal/auth/authz.go
@@ -37,8 +37,10 @@ func (noAccessAuthorizer) ManifestAccessLevel(labels map[string]string) AccessLe
 	return AccessLevelNone
 }
 
-// NoAccess implements AuthorizationInfo which grants no permissions.
-var NoAccess AuthorizationInfo = noAccessAuthorizer{}
+// NoAccess returns AuthorizationInfo which grants no permissions.
+func NoAccess() AuthorizationInfo {
+	return noAccessAuthorizer{}
+}
 
 type legacyAuthorizer struct {
 	usernameAtHostname string

--- a/internal/auth/authz_test.go
+++ b/internal/auth/authz_test.go
@@ -1,0 +1,170 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kopia/kopia/internal/auth"
+)
+
+var globalPolicyLabels = map[string]string{
+	"type":       "policy",
+	"policyType": "global",
+}
+
+var fooAtBarPathPolicy = map[string]string{
+	"type":       "policy",
+	"username":   "foo",
+	"hostname":   "bar",
+	"path":       "/path",
+	"policyType": "path",
+}
+
+var fooAtBazPathPolicy = map[string]string{
+	"type":       "policy",
+	"username":   "foo",
+	"hostname":   "baz",
+	"path":       "/path",
+	"policyType": "path",
+}
+
+var fooAtBarSnapshot = map[string]string{
+	"type":     "snapshot",
+	"username": "foo",
+	"hostname": "bar",
+	"path":     "/path",
+}
+
+var fooAtBazSnapshot = map[string]string{
+	"type":     "snapshot",
+	"username": "foo",
+	"hostname": "baz",
+	"path":     "/path",
+}
+
+var fooAtBarPolicy = map[string]string{
+	"type":       "policy",
+	"username":   "foo",
+	"hostname":   "bar",
+	"policyType": "user",
+}
+
+var fooAtBazPolicy = map[string]string{
+	"type":       "policy",
+	"username":   "foo",
+	"hostname":   "baz",
+	"policyType": "user",
+}
+
+var barPolicy = map[string]string{
+	"type":       "policy",
+	"hostname":   "bar",
+	"policyType": "host",
+}
+
+var bazPolicy = map[string]string{
+	"type":       "policy",
+	"hostname":   "baz",
+	"policyType": "host",
+}
+
+func TestNoAccess(t *testing.T) {
+	na := auth.NoAccess
+
+	if got, want := na.ContentAccessLevel(), auth.AccessLevelNone; got != want {
+		t.Errorf("invalid content access level: %v, want %v", got, want)
+	}
+
+	verifyManifestAccessLevel(t, na, globalPolicyLabels, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, na, fooAtBarPathPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, na, fooAtBazPathPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, na, fooAtBarPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, na, fooAtBazPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, na, barPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, na, bazPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, na, fooAtBarSnapshot, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, na, fooAtBazSnapshot, auth.AccessLevelNone)
+}
+
+func TestLegacyAuthorizer(t *testing.T) {
+	cases := []struct {
+		usernameAtHost           string
+		globalPolicyAccess       auth.AccessLevel
+		fooAtBarPathPolicyAccess auth.AccessLevel
+		fooAtBazPathPolicyAccess auth.AccessLevel
+		fooAtBarPolicyAccess     auth.AccessLevel
+		fooAtBazPolicyAccess     auth.AccessLevel
+		barPolicyAccess          auth.AccessLevel
+		bazPolicyAccess          auth.AccessLevel
+		fooAtBarSnapshotAccess   auth.AccessLevel
+		fooAtBazSnapshotAccess   auth.AccessLevel
+	}{
+		{
+			usernameAtHost:           "foo@bar",
+			globalPolicyAccess:       auth.AccessLevelRead,
+			fooAtBarPathPolicyAccess: auth.AccessLevelFull, // full access to own path policies
+			fooAtBazPathPolicyAccess: auth.AccessLevelNone,
+			fooAtBarPolicyAccess:     auth.AccessLevelFull, // full access to own user policy
+			fooAtBazPolicyAccess:     auth.AccessLevelNone,
+			barPolicyAccess:          auth.AccessLevelRead, // read access to own host policy
+			bazPolicyAccess:          auth.AccessLevelNone,
+			fooAtBarSnapshotAccess:   auth.AccessLevelFull, // full access to own snapshot
+			fooAtBazSnapshotAccess:   auth.AccessLevelNone,
+		},
+		{
+			usernameAtHost:           "evil@bar",
+			globalPolicyAccess:       auth.AccessLevelRead,
+			fooAtBarPathPolicyAccess: auth.AccessLevelNone,
+			fooAtBazPathPolicyAccess: auth.AccessLevelNone,
+			fooAtBarPolicyAccess:     auth.AccessLevelNone,
+			fooAtBazPolicyAccess:     auth.AccessLevelNone,
+			barPolicyAccess:          auth.AccessLevelRead,
+			bazPolicyAccess:          auth.AccessLevelNone,
+			fooAtBarSnapshotAccess:   auth.AccessLevelNone,
+			fooAtBazSnapshotAccess:   auth.AccessLevelNone,
+		},
+		{
+			usernameAtHost:           "evil@elsewhere",
+			globalPolicyAccess:       auth.AccessLevelRead,
+			fooAtBarPathPolicyAccess: auth.AccessLevelNone,
+			fooAtBazPathPolicyAccess: auth.AccessLevelNone,
+			fooAtBarPolicyAccess:     auth.AccessLevelNone,
+			fooAtBazPolicyAccess:     auth.AccessLevelNone,
+			barPolicyAccess:          auth.AccessLevelNone,
+			bazPolicyAccess:          auth.AccessLevelNone,
+			fooAtBarSnapshotAccess:   auth.AccessLevelNone,
+			fooAtBazSnapshotAccess:   auth.AccessLevelNone,
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.usernameAtHost, func(t *testing.T) {
+			a := auth.LegacyAuthorizerForUser(ctx, nil, tc.usernameAtHost)
+
+			if got, want := a.ContentAccessLevel(), auth.AccessLevelFull; got != want {
+				t.Errorf("invalid content access level: %v, want %v", got, want)
+			}
+
+			verifyManifestAccessLevel(t, a, globalPolicyLabels, tc.globalPolicyAccess)
+			verifyManifestAccessLevel(t, a, fooAtBarPathPolicy, tc.fooAtBarPathPolicyAccess)
+			verifyManifestAccessLevel(t, a, fooAtBazPathPolicy, tc.fooAtBazPathPolicyAccess)
+			verifyManifestAccessLevel(t, a, fooAtBarPolicy, tc.fooAtBarPolicyAccess)
+			verifyManifestAccessLevel(t, a, fooAtBazPolicy, tc.fooAtBazPolicyAccess)
+			verifyManifestAccessLevel(t, a, barPolicy, tc.barPolicyAccess)
+			verifyManifestAccessLevel(t, a, bazPolicy, tc.bazPolicyAccess)
+			verifyManifestAccessLevel(t, a, fooAtBarSnapshot, tc.fooAtBarSnapshotAccess)
+			verifyManifestAccessLevel(t, a, fooAtBazSnapshot, tc.fooAtBazSnapshotAccess)
+		})
+	}
+}
+
+func verifyManifestAccessLevel(t *testing.T, a auth.AuthorizationInfo, labels map[string]string, wantLevel auth.AccessLevel) {
+	t.Helper()
+
+	if got, want := a.ManifestAccessLevel(labels), wantLevel; got != want {
+		t.Errorf("invalid access level to %v: %v, want %v", labels, got, want)
+	}
+}

--- a/internal/auth/authz_test.go
+++ b/internal/auth/authz_test.go
@@ -69,7 +69,7 @@ var bazPolicy = map[string]string{
 }
 
 func TestNoAccess(t *testing.T) {
-	na := auth.NoAccess
+	na := auth.NoAccess()
 
 	if got, want := na.ContentAccessLevel(), auth.AccessLevelNone; got != want {
 		t.Errorf("invalid content access level: %v, want %v", got, want)

--- a/internal/server/api_error.go
+++ b/internal/server/api_error.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/pkg/errors"
 
@@ -15,11 +16,15 @@ type apiError struct {
 }
 
 func requestError(apiErrorCode serverapi.APIErrorCode, message string) *apiError {
-	return &apiError{400, apiErrorCode, message}
+	return &apiError{http.StatusBadRequest, apiErrorCode, message}
 }
 
 func notFoundError(message string) *apiError {
-	return &apiError{404, serverapi.ErrorNotFound, message}
+	return &apiError{http.StatusNotFound, serverapi.ErrorNotFound, message}
+}
+
+func accessDeniedError() *apiError {
+	return &apiError{http.StatusForbidden, serverapi.ErrorAccessDenied, "access is denied"}
 }
 
 func repositoryNotWritableError() *apiError {
@@ -27,5 +32,5 @@ func repositoryNotWritableError() *apiError {
 }
 
 func internalServerError(err error) *apiError {
-	return &apiError{500, serverapi.ErrorInternal, fmt.Sprintf("internal server error: %v", err)}
+	return &apiError{http.StatusInternalServerError, serverapi.ErrorInternal, fmt.Sprintf("internal server error: %v", err)}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,7 +140,7 @@ func (s *Server) httpAuthorizationInfo(r *http.Request) auth.AuthorizationInfo {
 
 	authz := s.authorizer(r.Context(), s.rep, userAtHost)
 	if authz == nil {
-		authz = auth.NoAccess
+		authz = auth.NoAccess()
 	}
 
 	return authz

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -81,6 +81,7 @@ const (
 	ErrorNotInitialized     APIErrorCode = "NOT_INITIALIZED"
 	ErrorPathNotFound       APIErrorCode = "PATH_NOT_FOUND"
 	ErrorStorageConnection  APIErrorCode = "STORAGE_CONNECTION"
+	ErrorAccessDenied       APIErrorCode = "ACCESS_DENIED"
 )
 
 // ErrorResponse represents error response.


### PR DESCRIPTION
Previously authentication was done as an wrapper handler and
authorization was inlined. This change moves authn/authz handlers
inside the server and implements separate authorization module that's
individually tested.

Also fixed an issue where server users were not able to see global
or host-level policies.