### PR TITLE
All robustness test engine interface definitions moved into the test root directory

### DIFF
--- a/tests/robustness/checker/checker.go
+++ b/tests/robustness/checker/checker.go
@@ -16,8 +16,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/clock"
-	"github.com/kopia/kopia/tests/robustness/snap"
-	"github.com/kopia/kopia/tests/robustness/snapmeta"
+	"github.com/kopia/kopia/tests/robustness"
 )
 
 const (
@@ -29,16 +28,16 @@ const (
 // a validation for data consistency.
 type Checker struct {
 	RestoreDir            string
-	snapshotIssuer        snap.Snapshotter
-	snapshotMetadataStore snapmeta.Store
-	validator             Comparer
+	snapshotIssuer        robustness.Snapshotter
+	snapshotMetadataStore robustness.Store
+	validator             robustness.Comparer
 	RecoveryMode          bool
 	DeleteLimit           int
 }
 
 // NewChecker instantiates a new Checker, returning its pointer. A temporary
 // directory is created to mount restored data.
-func NewChecker(snapIssuer snap.Snapshotter, snapmetaStore snapmeta.Store, validator Comparer, restoreDir string) (*Checker, error) {
+func NewChecker(snapIssuer robustness.Snapshotter, snapmetaStore robustness.Store, validator robustness.Comparer, restoreDir string) (*Checker, error) {
 	restoreDir, err := ioutil.TempDir(restoreDir, "restore-data-")
 	if err != nil {
 		return nil, err

--- a/tests/robustness/comparer.go
+++ b/tests/robustness/comparer.go
@@ -1,6 +1,4 @@
-// Package checker defines the framework for creating and restoring snapshots
-// with a data integrity check
-package checker
+package robustness
 
 import (
 	"context"

--- a/tests/robustness/engine/engine.go
+++ b/tests/robustness/engine/engine.go
@@ -17,8 +17,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kopia/kopia/tests/robustness"
 	"github.com/kopia/kopia/tests/robustness/checker"
-	"github.com/kopia/kopia/tests/robustness/snap"
 	"github.com/kopia/kopia/tests/robustness/snapmeta"
 	"github.com/kopia/kopia/tests/tools/fio"
 	"github.com/kopia/kopia/tests/tools/fswalker"
@@ -52,8 +52,8 @@ var (
 // Engine is the outer level testing framework for robustness testing.
 type Engine struct {
 	FileWriter      *fio.Runner
-	TestRepo        snap.Snapshotter
-	MetaStore       snapmeta.Persister
+	TestRepo        robustness.Snapshotter
+	MetaStore       robustness.Persister
 	Checker         *checker.Checker
 	cleanupRoutines []func()
 	baseDirPath     string

--- a/tests/robustness/persister.go
+++ b/tests/robustness/persister.go
@@ -1,8 +1,4 @@
-// Package snapmeta describes entities that can accept
-// arbitrary metadata and flush it to a persistent repository.
-package snapmeta
-
-import "github.com/kopia/kopia/tests/robustness/snap"
+package robustness
 
 // Store describes the ability to store and retrieve
 // a buffer of metadata, indexed by a string key.
@@ -24,7 +20,7 @@ type Indexer interface {
 // to, and load it again, from a repository.
 type Persister interface {
 	Store
-	snap.RepoManager
+	RepoManager // TBD: may not be needed once initialization refactored
 	LoadMetadata() error
 	FlushMetadata() error
 	GetPersistDir() string

--- a/tests/robustness/snapmeta/kopia_meta.go
+++ b/tests/robustness/snapmeta/kopia_meta.go
@@ -1,3 +1,5 @@
+// Package snapmeta describes entities that can accept
+// arbitrary metadata and flush it to a persistent repository.
 package snapmeta
 
 import (
@@ -7,10 +9,11 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/kopia/kopia/tests/robustness"
 	"github.com/kopia/kopia/tests/tools/kopiarunner"
 )
 
-var _ Persister = &kopiaMetadata{}
+var _ robustness.Persister = &kopiaMetadata{}
 
 // kopiaMetadata handles metadata persistency of a snapshot store, using a Kopia
 // repository as the persistency mechanism.
@@ -22,7 +25,7 @@ type kopiaMetadata struct {
 }
 
 // New instantiates a new Persister and returns it.
-func New(baseDir string) (Persister, error) {
+func New(baseDir string) (robustness.Persister, error) {
 	localDir, err := ioutil.TempDir(baseDir, "kopia-local-metadata-")
 	if err != nil {
 		return nil, err

--- a/tests/robustness/snapmeta/simple.go
+++ b/tests/robustness/snapmeta/simple.go
@@ -3,12 +3,14 @@ package snapmeta
 import (
 	"errors"
 	"sync"
+
+	"github.com/kopia/kopia/tests/robustness"
 )
 
 // ErrKeyNotFound is returned when the store can't find the key provided.
 var ErrKeyNotFound = errors.New("key not found")
 
-var _ Store = &Simple{}
+var _ robustness.Store = &Simple{}
 
 // Simple is a snapstore implementation that stores
 // snapshot metadata as a byte slice in a map in memory.

--- a/tests/robustness/snapshotter.go
+++ b/tests/robustness/snapshotter.go
@@ -1,6 +1,7 @@
-// Package snap describes entities that are capable of performing
-// common snapshot operations
-package snap
+// Package robustness contains tests that that validate data stability over time.
+// The package, while designed for Kopia, is written with abstractions that
+// can be used to test other environments.
+package robustness
 
 import "os/exec"
 
@@ -8,17 +9,18 @@ import "os/exec"
 // for taking, restoring, deleting snapshots, and
 // tracking them by a string snapshot ID.
 type Snapshotter interface {
-	RepoManager
+	RepoManager // TBD: may not be needed once initialization refactored
 	CreateSnapshot(sourceDir string) (snapID string, err error)
 	RestoreSnapshot(snapID string, restoreDir string) error
 	DeleteSnapshot(snapID string) error
 	RunGC() error
 	ListSnapshots() ([]string, error)
-	Run(args ...string) (stdout, stderr string, err error)
+	Run(args ...string) (stdout, stderr string, err error) // TBD: remove once initialization refactored
 }
 
 // RepoManager is an interface that describes connecting to
 // a repository.
+// TBD: may not be needed once initialization refactored
 type RepoManager interface {
 	ConnectOrCreateS3(bucketName, pathPrefix string) error
 	ConnectOrCreateFilesystem(path string) error

--- a/tests/robustness/snapshotter.go
+++ b/tests/robustness/snapshotter.go
@@ -20,7 +20,7 @@ type Snapshotter interface {
 
 // RepoManager is an interface that describes connecting to
 // a repository.
-// TBD: may not be needed once initialization refactored
+// TBD: may not be needed once initialization refactored.
 type RepoManager interface {
 	ConnectOrCreateS3(bucketName, pathPrefix string) error
 	ConnectOrCreateFilesystem(path string) error

--- a/tests/tools/fswalker/fswalker.go
+++ b/tests/tools/fswalker/fswalker.go
@@ -18,12 +18,12 @@ import (
 	fspb "github.com/google/fswalker/proto/fswalker"
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/tests/robustness/checker"
+	"github.com/kopia/kopia/tests/robustness"
 	"github.com/kopia/kopia/tests/tools/fswalker/reporter"
 	"github.com/kopia/kopia/tests/tools/fswalker/walker"
 )
 
-var _ checker.Comparer = &WalkCompare{}
+var _ robustness.Comparer = &WalkCompare{}
 
 // WalkCompare is a checker.Comparer that utilizes the fswalker
 // libraries to perform the data consistency check.

--- a/tests/tools/kopiarunner/kopia_snapshotter.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter.go
@@ -19,10 +19,10 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/retry"
-	"github.com/kopia/kopia/tests/robustness/snap"
+	"github.com/kopia/kopia/tests/robustness"
 )
 
-var _ snap.Snapshotter = &KopiaSnapshotter{}
+var _ robustness.Snapshotter = &KopiaSnapshotter{}
 
 const (
 	contentCacheSizeMBFlag  = "--content-cache-size-mb"


### PR DESCRIPTION
Tested with
```
# TEST_FLAGS=-run=TestOneLargeFile make robustness-tests
```
