### PR TITLE
restore: added support for incremental restore and ignoring copy errors

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -104,7 +104,7 @@ func addRestoreFlags(cmd *kingpin.CmdClause) {
 	cmd.Flag("skip-times", "Skip times during restore").BoolVar(&restoreSkipTimes)
 	cmd.Flag("ignore-permission-errors", "Ignore permission errors").BoolVar(&restoreIgnorePermissionErrors)
 	cmd.Flag("ignore-errors", "Ignore all errors").BoolVar(&restoreIgnoreErrors)
-	cmd.Flag("incremental", "Incremental restore, do not download files that already exist in the destination").BoolVar(&restoreIncremental)
+	cmd.Flag("skip-existing", "Skip files and symlinks that exist in the output").BoolVar(&restoreIncremental)
 }
 
 func restoreOutput(ctx context.Context) (restore.Output, error) {

--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -77,6 +77,8 @@ var (
 	restoreSkipTimes              = false
 	restoreSkipOwners             = false
 	restoreSkipPermissions        = false
+	restoreIncremental            = false
+	restoreIgnoreErrors           = false
 )
 
 const (
@@ -101,6 +103,8 @@ func addRestoreFlags(cmd *kingpin.CmdClause) {
 	cmd.Flag("skip-permissions", "Skip permissions during restore").BoolVar(&restoreSkipPermissions)
 	cmd.Flag("skip-times", "Skip times during restore").BoolVar(&restoreSkipTimes)
 	cmd.Flag("ignore-permission-errors", "Ignore permission errors").BoolVar(&restoreIgnorePermissionErrors)
+	cmd.Flag("ignore-errors", "Ignore all errors").BoolVar(&restoreIgnoreErrors)
+	cmd.Flag("incremental", "Incremental restore, do not download files that already exist in the destination").BoolVar(&restoreIncremental)
 }
 
 func restoreOutput(ctx context.Context) (restore.Output, error) {
@@ -182,7 +186,22 @@ func detectRestoreMode(ctx context.Context, m string) string {
 }
 
 func printRestoreStats(ctx context.Context, st restore.Stats) {
-	log(ctx).Infof("Restored %v files, %v directories and %v symbolic links (%v)\n", st.RestoredFileCount, st.RestoredDirCount, st.RestoredSymlinkCount, units.BytesStringBase10(st.RestoredTotalFileSize))
+	var maybeSkipped, maybeErrors string
+
+	if st.SkippedCount > 0 {
+		maybeSkipped = fmt.Sprintf(", skipped %v (%v)", st.SkippedCount, units.BytesStringBase10(st.SkippedTotalFileSize))
+	}
+
+	if st.IgnoredErrorCount > 0 {
+		maybeErrors = fmt.Sprintf(", ignored %v errors", st.IgnoredErrorCount)
+	}
+
+	log(ctx).Infof("Restored %v files, %v directories and %v symbolic links (%v)%v%v.\n",
+		st.RestoredFileCount,
+		st.RestoredDirCount,
+		st.RestoredSymlinkCount,
+		units.BytesStringBase10(st.RestoredTotalFileSize),
+		maybeSkipped, maybeErrors)
 }
 
 func runRestoreCommand(ctx context.Context, rep repo.Repository) error {
@@ -199,16 +218,18 @@ func runRestoreCommand(ctx context.Context, rep repo.Repository) error {
 	t0 := clock.Now()
 
 	st, err := restore.Entry(ctx, rep, output, rootEntry, restore.Options{
-		Parallel: restoreParallel,
+		Parallel:     restoreParallel,
+		Incremental:  restoreIncremental,
+		IgnoreErrors: restoreIgnoreErrors,
 		ProgressCallback: func(ctx context.Context, stats restore.Stats) {
-			restoredCount := stats.RestoredFileCount + stats.RestoredDirCount + stats.RestoredSymlinkCount
+			restoredCount := stats.RestoredFileCount + stats.RestoredDirCount + stats.RestoredSymlinkCount + stats.SkippedCount
 			enqueuedCount := stats.EnqueuedFileCount + stats.EnqueuedDirCount + stats.EnqueuedSymlinkCount
 
 			if restoredCount == 0 {
 				return
 			}
 
-			var maybeRemaining string
+			var maybeRemaining, maybeSkipped, maybeErrors string
 
 			if stats.EnqueuedTotalFileSize > 0 {
 				progress := float64(stats.RestoredTotalFileSize) / float64(stats.EnqueuedTotalFileSize)
@@ -223,9 +244,19 @@ func runRestoreCommand(ctx context.Context, rep repo.Repository) error {
 				}
 			}
 
-			log(ctx).Infof("Processed %v (%v) of %v (%v)%v.",
+			if stats.SkippedCount > 0 {
+				maybeSkipped = fmt.Sprintf(", skipped %v (%v)", stats.SkippedCount, units.BytesStringBase10(stats.SkippedTotalFileSize))
+			}
+
+			if stats.IgnoredErrorCount > 0 {
+				maybeErrors = fmt.Sprintf(", ignored %v errors", stats.IgnoredErrorCount)
+			}
+
+			log(ctx).Infof("Processed %v (%v) of %v (%v)%v%v.",
 				restoredCount, units.BytesStringBase10(stats.RestoredTotalFileSize),
 				enqueuedCount, units.BytesStringBase10(stats.EnqueuedTotalFileSize),
+				maybeSkipped,
+				maybeErrors,
 				maybeRemaining)
 		},
 	})

--- a/snapshot/restore/local_fs_output.go
+++ b/snapshot/restore/local_fs_output.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/natefinch/atomic"
 	"github.com/pkg/errors"
@@ -16,6 +17,8 @@ import (
 )
 
 const modBits = os.ModePerm | os.ModeSetgid | os.ModeSetuid | os.ModeSticky
+
+const maxTimeDeltaToConsiderFileTheSame = 2 * time.Second
 
 // FilesystemOutput contains the options for outputting a file system tree.
 type FilesystemOutput struct {
@@ -95,6 +98,31 @@ func (o *FilesystemOutput) WriteFile(ctx context.Context, relativePath string, f
 	return nil
 }
 
+// FileExists implements restore.Output interface.
+func (o *FilesystemOutput) FileExists(ctx context.Context, relativePath string, e fs.File) bool {
+	st, err := os.Lstat(filepath.Join(o.TargetPath, relativePath))
+	if err != nil {
+		return false
+	}
+
+	if (st.Mode() & os.ModeType) != 0 {
+		// not a file
+		return false
+	}
+
+	if st.Size() != e.Size() {
+		// wrong size
+		return false
+	}
+
+	timeDelta := st.ModTime().Sub(e.ModTime())
+	if timeDelta < 0 {
+		timeDelta = -timeDelta
+	}
+
+	return timeDelta < maxTimeDeltaToConsiderFileTheSame
+}
+
 // CreateSymlink implements restore.Output interface.
 func (o *FilesystemOutput) CreateSymlink(ctx context.Context, relativePath string, e fs.Symlink) error {
 	targetPath, err := e.Readlink(ctx)
@@ -137,6 +165,16 @@ func (o *FilesystemOutput) CreateSymlink(ctx context.Context, relativePath strin
 
 func fileIsSymlink(stat os.FileInfo) bool {
 	return stat.Mode()&os.ModeSymlink != 0
+}
+
+// SymlinkExists implements restore.Output interface.
+func (o *FilesystemOutput) SymlinkExists(ctx context.Context, relativePath string, e fs.Symlink) bool {
+	st, err := os.Lstat(filepath.Join(o.TargetPath, relativePath))
+	if err != nil {
+		return false
+	}
+
+	return (st.Mode() & os.ModeType) == os.ModeSymlink
 }
 
 // set permission, modification time and user/group ids on targetPath.

--- a/snapshot/restore/restore.go
+++ b/snapshot/restore/restore.go
@@ -120,7 +120,7 @@ func (c *copier) copyEntry(ctx context.Context, e fs.Entry, targetPath string, o
 		switch e := e.(type) {
 		case fs.File:
 			if c.output.FileExists(ctx, targetPath, e) {
-				log(ctx).Debugf("skipping file %v because it already exists and is correct", targetPath)
+				log(ctx).Debugf("skipping file %v because it already exists and metadata matches", targetPath)
 				atomic.AddInt32(&c.stats.SkippedCount, 1)
 				atomic.AddInt64(&c.stats.SkippedTotalFileSize, e.Size())
 

--- a/snapshot/restore/restore.go
+++ b/snapshot/restore/restore.go
@@ -130,7 +130,7 @@ func (c *copier) copyEntry(ctx context.Context, e fs.Entry, targetPath string, o
 		case fs.Symlink:
 			if c.output.SymlinkExists(ctx, targetPath, e) {
 				atomic.AddInt32(&c.stats.SkippedCount, 1)
-				log(ctx).Debugf("skipping symlink %v because it already exists and is correct", targetPath)
+				log(ctx).Debugf("skipping symlink %v because it already exists", targetPath)
 
 				return onCompletion()
 			}

--- a/snapshot/restore/tar_output.go
+++ b/snapshot/restore/tar_output.go
@@ -86,6 +86,11 @@ func (o *TarOutput) WriteFile(ctx context.Context, relativePath string, f fs.Fil
 	return nil
 }
 
+// FileExists implements restore.Output interface.
+func (o *TarOutput) FileExists(ctx context.Context, relativePath string, f fs.File) bool {
+	return false
+}
+
 // CreateSymlink implements restore.Output interface.
 func (o *TarOutput) CreateSymlink(ctx context.Context, relativePath string, l fs.Symlink) error {
 	target, err := l.Readlink(ctx)
@@ -108,6 +113,11 @@ func (o *TarOutput) CreateSymlink(ctx context.Context, relativePath string, l fs
 	}
 
 	return nil
+}
+
+// SymlinkExists implements restore.Output interface.
+func (o *TarOutput) SymlinkExists(ctx context.Context, relativePath string, l fs.Symlink) bool {
+	return false
 }
 
 // NewTarOutput creates new tar writer output.

--- a/snapshot/restore/zip_output.go
+++ b/snapshot/restore/zip_output.go
@@ -69,10 +69,20 @@ func (o *ZipOutput) WriteFile(ctx context.Context, relativePath string, f fs.Fil
 	return nil
 }
 
+// FileExists implements restore.Output interface.
+func (o *ZipOutput) FileExists(ctx context.Context, relativePath string, l fs.File) bool {
+	return false
+}
+
 // CreateSymlink implements restore.Output interface.
 func (o *ZipOutput) CreateSymlink(ctx context.Context, relativePath string, e fs.Symlink) error {
 	log(ctx).Debugf("create symlink not implemented yet")
 	return nil
+}
+
+// SymlinkExists implements restore.Output interface.
+func (o *ZipOutput) SymlinkExists(ctx context.Context, relativePath string, l fs.Symlink) bool {
+	return false
 }
 
 // NewZipOutput creates new zip writer output.

--- a/tests/end_to_end_test/restore_fail_test.go
+++ b/tests/end_to_end_test/restore_fail_test.go
@@ -64,6 +64,9 @@ func TestRestoreFail(t *testing.T) {
 
 	// Expect a subsequent restore to fail
 	e.RunAndExpectFailure(t, "snapshot", "restore", snapID, targetDir)
+
+	// --ignore-errors allows the snapshot to succeed despite missing blob.
+	e.RunAndExpectSuccess(t, "snapshot", "restore", "--ignore-errors", snapID, targetDir)
 }
 
 func findPackBlob(blobIDs []string) string {

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -95,7 +95,7 @@ func TestRestoreCommand(t *testing.T) {
 	re := regexp.MustCompile(`Restored (\d+) files.*skipped (\d+) `)
 	foundStatus := false
 	lastFileCount := 0
-	_, stderr := e.RunAndExpectSuccessWithErrOut(t, "restore", rootID, restoreDir, "--incremental")
+	_, stderr := e.RunAndExpectSuccessWithErrOut(t, "restore", rootID, restoreDir, "--skip-existing")
 
 	for _, l := range stderr {
 		if m := re.FindStringSubmatch(l); m != nil {


### PR DESCRIPTION
Created this as a hotfix for one of the users on Slack. We were trying to restore ~TB of data where a blob went missing in B2 storage (suspect pre-0.7.3 repository which did not have correct retry logic). 

This adds:

* `--incremental` - which will not attempt to download files already present in the output as long as the size and mod time are correct
* `--ignore-errors` in case a file can't be restored for any reason, print the error to output but continue copying