### PR TITLE
blob: rewrote blob storage providers retry logic

### DIFF
--- a/repo/blob/azure/azure_storage_test.go
+++ b/repo/blob/azure/azure_storage_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/azure"
 )
@@ -80,7 +81,7 @@ func TestAzureStorage(t *testing.T) {
 	data := make([]byte, 8)
 	rand.Read(data)
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	st, err := azure.New(ctx, &azure.Options{
 		Container:      container,

--- a/repo/blob/b2/b2_storage_test.go
+++ b/repo/blob/b2/b2_storage_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/b2"
@@ -40,7 +41,7 @@ func TestB2Storage(t *testing.T) {
 		data := make([]byte, 8)
 		rand.Read(data)
 
-		ctx := context.Background()
+		ctx := testlogging.Context(t)
 		st, err := b2.New(ctx, &b2.Options{
 			BucketName: bucket,
 			KeyID:      keyID,

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -123,7 +123,7 @@ func (fs *fsImpl) GetBlobFromPath(ctx context.Context, dirPath, path string, off
 		return nil, err
 	}
 
-	return val.([]byte), nil
+	return blob.EnsureLengthExactly(val.([]byte), length)
 }
 
 func (fs *fsImpl) GetMetadataFromPath(ctx context.Context, dirPath, path string) (blob.Metadata, error) {

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -62,18 +62,9 @@ func (s retryingStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
 	return err // nolint:wrapcheck
 }
 
-// NewWrapper returns a readonly Storage wrapper that prevents any mutations to the underlying storage.
+// NewWrapper returns a Storage wrapper that adds retry loop around all operations of the underlying storage.
 func NewWrapper(wrapped blob.Storage) blob.Storage {
 	return &retryingStorage{Storage: wrapped}
-}
-
-// NonRetriable wraps an error tha is not retriable.
-type NonRetriable struct {
-	Err error
-}
-
-func (e NonRetriable) Error() string {
-	return e.Err.Error()
 }
 
 func isRetriable(err error) bool {

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -1,0 +1,93 @@
+// Package retrying implements wrapper around blob.Storage that adds retry loop around all operations in case they return unexpected errors.
+package retrying
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kopia/kopia/internal/retry"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+// retryingStorage adds retry loop around all operations of the underlying storage.
+type retryingStorage struct {
+	blob.Storage
+}
+
+func (s retryingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64) ([]byte, error) {
+	v, err := retry.WithExponentialBackoff(ctx, fmt.Sprintf("GetBlob(%v,%v,%v)", id, offset, length), func() (interface{}, error) {
+		return s.Storage.GetBlob(ctx, id, offset, length)
+	}, isRetriable)
+	if err != nil {
+		return nil, err // nolint:wrapcheck
+	}
+
+	return v.([]byte), nil
+}
+
+func (s retryingStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata, error) {
+	v, err := retry.WithExponentialBackoff(ctx, "GetMetadata("+string(id)+")", func() (interface{}, error) {
+		return s.Storage.GetMetadata(ctx, id)
+	}, isRetriable)
+	if err != nil {
+		return blob.Metadata{}, err // nolint:wrapcheck
+	}
+
+	return v.(blob.Metadata), nil
+}
+
+func (s retryingStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) error {
+	_, err := retry.WithExponentialBackoff(ctx, "GetMetadata("+string(id)+")", func() (interface{}, error) {
+		return true, s.Storage.SetTime(ctx, id, t)
+	}, isRetriable)
+
+	return err // nolint:wrapcheck
+}
+
+func (s retryingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
+	_, err := retry.WithExponentialBackoff(ctx, "PutBlob("+string(id)+")", func() (interface{}, error) {
+		return true, s.Storage.PutBlob(ctx, id, data)
+	}, isRetriable)
+
+	return err // nolint:wrapcheck
+}
+
+func (s retryingStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
+	_, err := retry.WithExponentialBackoff(ctx, "DeleteBlob("+string(id)+")", func() (interface{}, error) {
+		return true, s.Storage.DeleteBlob(ctx, id)
+	}, isRetriable)
+
+	return err // nolint:wrapcheck
+}
+
+// NewWrapper returns a readonly Storage wrapper that prevents any mutations to the underlying storage.
+func NewWrapper(wrapped blob.Storage) blob.Storage {
+	return &retryingStorage{Storage: wrapped}
+}
+
+// NonRetriable wraps an error tha is not retriable.
+type NonRetriable struct {
+	Err error
+}
+
+func (e NonRetriable) Error() string {
+	return e.Err.Error()
+}
+
+func isRetriable(err error) bool {
+	switch {
+	case errors.Is(err, blob.ErrBlobNotFound):
+		return false
+
+	case errors.Is(err, blob.ErrInvalidRange):
+		return false
+
+	case errors.Is(err, blob.ErrSetTimeUnsupported):
+		return false
+
+	default:
+		return true
+	}
+}

--- a/repo/blob/retrying/retrying_storage_test.go
+++ b/repo/blob/retrying/retrying_storage_test.go
@@ -1,0 +1,73 @@
+package retrying_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/retrying"
+)
+
+func TestRetrying(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	someError := errors.New("some error")
+	ms := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+	fs := &blobtesting.FaultyStorage{
+		Base: ms,
+		Faults: map[string][]*blobtesting.Fault{
+			"PutBlob": {
+				{Err: someError},
+			},
+			"GetBlob": {
+				{Err: someError},
+			},
+			"GetMetadata": {
+				{Err: someError},
+			},
+			"DeleteBlob": {
+				{Err: someError},
+			},
+			"SetTime": {
+				{Err: someError},
+			},
+		},
+	}
+
+	rs := retrying.NewWrapper(fs)
+	blobID := blob.ID("deadcafe")
+	blobID2 := blob.ID("deadcafe2")
+
+	must(t, rs.PutBlob(ctx, blobID, gather.FromSlice([]byte{1, 2, 3})))
+
+	must(t, rs.PutBlob(ctx, blobID2, gather.FromSlice([]byte{1, 2, 3, 4})))
+
+	must(t, rs.SetTime(ctx, blobID, time.Now()))
+
+	_, err := rs.GetBlob(ctx, blobID, 0, -1)
+	must(t, err)
+
+	_, err = rs.GetMetadata(ctx, blobID)
+	must(t, err)
+
+	must(t, rs.DeleteBlob(ctx, blobID))
+
+	if _, err = rs.GetBlob(ctx, blobID, 0, -1); !errors.Is(err, blob.ErrBlobNotFound) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fs.VerifyAllFaultsExercised(t)
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -221,7 +221,7 @@ func TestS3StorageMinioSTS(t *testing.T) {
 }
 
 func testStorage(t *testutil.RetriableT, options *Options) {
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	data := make([]byte, 8)
 	rand.Read(data)

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -71,16 +71,11 @@ func (s *sftpImpl) GetBlobFromPath(ctx context.Context, dirPath, fullPath string
 
 	b := make([]byte, length)
 
-	n, err := r.Read(b)
-	if err != nil {
+	if _, err := r.Read(b); err != nil {
 		return nil, errors.Wrap(err, "read error")
 	}
 
-	if n != len(b) {
-		return nil, errors.Errorf("truncated read")
-	}
-
-	return b, nil
+	return blob.EnsureLengthExactly(b, length)
 }
 
 func (s *sftpImpl) GetMetadataFromPath(ctx context.Context, dirPath, fullPath string) (blob.Metadata, error) {

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -160,7 +160,7 @@ func EnsureLengthExactly(b []byte, length int64) ([]byte, error) {
 		return nil, errors.Wrapf(ErrInvalidRange, "invalid length %v, expected %v", len(b), length)
 	}
 
-	return b[0:length], nil
+	return b, nil
 }
 
 // EnsureLengthAndTruncate validates that length of the given slice is at least the provided value

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -13,6 +13,9 @@ import (
 // ErrSetTimeUnsupported is returned by implementations of Storage that don't support SetTime.
 var ErrSetTimeUnsupported = errors.Errorf("SetTime is not supported")
 
+// ErrInvalidRange is returned when the requested blob offset or length is invalid.
+var ErrInvalidRange = errors.Errorf("invalid blob offset or length")
+
 // Bytes encapsulates a sequence of bytes, possibly stored in a non-contiguous buffers,
 // which can be written sequentially or treated as a io.Reader.
 type Bytes interface {
@@ -27,6 +30,7 @@ type Reader interface {
 	// GetBlob returns full or partial contents of a blob with given ID.
 	// If length>0, the the function retrieves a range of bytes [offset,offset+length)
 	// If length<0, the entire blob must be fetched.
+	// Returns ErrInvalidRange if the fetched blob length is invalid.
 	GetBlob(ctx context.Context, blobID ID, offset, length int64) ([]byte, error)
 
 	// GetMetadata returns Metadata about single blob.
@@ -142,4 +146,34 @@ func IterateAllPrefixesInParallel(ctx context.Context, parallelism int, st Stora
 
 	// return first error or nil
 	return <-errch
+}
+
+// EnsureLengthExactly validates that length of the given slice is exactly the provided value.
+// and returns ErrInvalidRange if the length is of the slice if not.
+// As a special case length < 0 disables validation.
+func EnsureLengthExactly(b []byte, length int64) ([]byte, error) {
+	if length < 0 {
+		return b, nil
+	}
+
+	if len(b) != int(length) {
+		return nil, errors.Wrapf(ErrInvalidRange, "invalid length %v, expected %v", len(b), length)
+	}
+
+	return b[0:length], nil
+}
+
+// EnsureLengthAndTruncate validates that length of the given slice is at least the provided value
+// and returns ErrInvalidRange if the length is of the slice if not.
+// As a special case length < 0 disables validation.
+func EnsureLengthAndTruncate(b []byte, length int64) ([]byte, error) {
+	if length < 0 {
+		return b, nil
+	}
+
+	if len(b) < int(length) {
+		return nil, errors.Wrapf(ErrInvalidRange, "invalid length %v, expected at least %v", len(b), length)
+	}
+
+	return b[0:length], nil
 }

--- a/snapshot/policy/retention_policy.go
+++ b/snapshot/policy/retention_policy.go
@@ -174,13 +174,22 @@ func hoursAgo(base time.Time, n int) time.Time {
 	return base.Add(time.Duration(-n) * time.Hour)
 }
 
+const (
+	defaultKeepLatest  = 10
+	defaultKeepHourly  = 48
+	defaultKeepDaily   = 7
+	defaultKeepWeekly  = 4
+	defaultKeepMonthly = 24
+	defaultKeepAnnual  = 3
+)
+
 var defaultRetentionPolicy = RetentionPolicy{
-	KeepLatest:  intPtr(10), // nolint:gomnd
-	KeepHourly:  intPtr(48), // nolint:gomnd
-	KeepDaily:   intPtr(7),  // nolint:gomnd
-	KeepWeekly:  intPtr(4),  // nolint:gomnd
-	KeepMonthly: intPtr(24), // nolint:gomnd
-	KeepAnnual:  intPtr(3),  // nolint:gomnd
+	KeepLatest:  intPtr(defaultKeepLatest),
+	KeepHourly:  intPtr(defaultKeepHourly),
+	KeepDaily:   intPtr(defaultKeepDaily),
+	KeepWeekly:  intPtr(defaultKeepWeekly),
+	KeepMonthly: intPtr(defaultKeepMonthly),
+	KeepAnnual:  intPtr(defaultKeepAnnual),
 }
 
 // Merge applies default values from the provided policy.


### PR DESCRIPTION
Previously we were trying to guess which errors are retriable
(often poorly, since things like DNS or HTTP errors were not retried)

This change makes it so the provider does not need built-in retry logic
and instead retrying wrapper is added which retries on all errors other
than

`blob.ErrNotFound`, `blob.ErrInvalidRange` and `blob.ErrSetTimeUnsupported`.

This required thorough testing of negative conditions that would trigger
blob.ErrInvalidLength (we already had those). Verified that tests pass
against Azure, B2, S3, GCS, Rclone, WebDAV, SFTP.