### PR TITLE
cli: added '--insecure' flag to 'kopia server start'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,15 +210,15 @@ dev-deps:
 	GO111MODULE=off go get -u github.com/sqs/goreturns
 
 test-with-coverage: export RCLONE_EXE=$(rclone)
-test-with-coverage:
+test-with-coverage: $(gotestsum) $(rclone)
 	$(GO_TEST) -count=$(REPEAT_TEST) -coverprofile=tmp.cov --coverpkg $(COVERAGE_PACKAGES) -timeout 300s $(shell go list ./...)
 
 test-with-coverage-pkgonly: export RCLONE_EXE=$(rclone)
-test-with-coverage-pkgonly:
+test-with-coverage-pkgonly: $(gotestsum) $(rclone)
 	$(GO_TEST) -count=$(REPEAT_TEST) -coverprofile=tmp.cov -timeout 300s github.com/kopia/kopia/...
 
 test: export RCLONE_EXE=$(rclone)
-test: $(gotestsum)
+test: $(gotestsum) $(rclone)
 	$(GO_TEST) -count=$(REPEAT_TEST) -timeout $(UNIT_TESTS_TIMEOUT) ./...
 
 vtest: $(gotestsum)

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -35,6 +35,7 @@ var (
 	serverStartGRPC                = serverStartCommand.Flag("grpc", "Start the GRPC server").Default("true").Bool()
 
 	serverStartRefreshInterval = serverStartCommand.Flag("refresh-interval", "Frequency for refreshing repository status").Default("300s").Duration()
+	serverStartInsecure        = serverStartCommand.Flag("insecure", "Allow insecure configurations (do not use in production)").Hidden().Bool()
 	serverStartMaxConcurrency  = serverStartCommand.Flag("max-concurrency", "Maximum number of server goroutines").Default("0").Int()
 
 	serverStartRandomPassword = serverStartCommand.Flag("random-password", "Generate random password and print to stderr").Hidden().Bool()
@@ -255,6 +256,10 @@ func getAuthenticatorFunc() (auth.Authenticator, error) {
 		return auth.AuthenticateSingleUser(*serverUsername, randomPassword), nil
 
 	default:
+		if !*serverStartInsecure {
+			return nil, errors.Errorf("no password option specified, refusing to start server. To start non-authenticated server pass --insecure.")
+		}
+
 		return nil, nil
 	}
 }

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -54,7 +54,7 @@ func init() {
 func runServer(ctx context.Context, rep repo.Repository) error {
 	authn, err := getAuthenticatorFunc()
 	if err != nil {
-		return errors.Wrap(err, "unable to initialize authn")
+		return errors.Wrap(err, "unable to initialize authentication")
 	}
 
 	srv, err := server.New(ctx, server.Options{

--- a/cli/command_server_tls.go
+++ b/cli/command_server_tls.go
@@ -139,6 +139,10 @@ func startServerWithOptionalTLSAndListener(ctx context.Context, httpServer *http
 		return httpServer.ServeTLS(listener, "", "")
 
 	default:
+		if !*serverStartInsecure {
+			return errors.Errorf("TLS not configured. To start server without encryption pass --insecure.")
+		}
+
 		fmt.Fprintf(os.Stderr, "SERVER ADDRESS: http://%v\n", httpServer.Addr)
 		showServerUIPrompt(ctx)
 

--- a/repo/blob/sftp/sftp_storage_test.go
+++ b/repo/blob/sftp/sftp_storage_test.go
@@ -100,6 +100,8 @@ func startDockerSFTPServerOrSkip(t *testing.T, idRSA string) (host string, port 
 		knownHostsFile = filepath.Join(t.TempDir(), "known_hosts")
 		knownHostsData := mustRunOrSkip(t, "ssh-keyscan", "-t", "rsa", "-p", strconv.Itoa(port), host)
 
+		t.Logf("knownHostsData: %s", knownHostsData)
+
 		ioutil.WriteFile(knownHostsFile, knownHostsData, 0600)
 
 		t.Logf("SFTP server OK on host:%q port:%v. Known hosts file: %v", host, port, knownHostsFile)

--- a/repo/blob/sftp/sftp_storage_test.go
+++ b/repo/blob/sftp/sftp_storage_test.go
@@ -98,6 +98,9 @@ func startDockerSFTPServerOrSkip(t *testing.T, idRSA string) (host string, port 
 		host = parts[0]
 		port, _ = strconv.Atoi(parts[1])
 		knownHostsFile = filepath.Join(t.TempDir(), "known_hosts")
+
+		time.Sleep(3 * time.Second)
+
 		knownHostsData := mustRunOrSkip(t, "ssh-keyscan", "-t", "rsa", "-p", strconv.Itoa(port), host)
 
 		t.Logf("knownHostsData: %s", knownHostsData)


### PR DESCRIPTION
This is a breaking change for development scenarios to prevent people
from unknowingly launching insecure servers.

Attempt to start a server without either TLS or password protection
results in an error now (unless --insecure is also passed).

KopiaUI already launches server with TLS and random password, so it
does not require it.