### PR TITLE
Support for ignoring sources when using `snapshot create --all`

### DIFF
--- a/cli/command_policy_edit.go
+++ b/cli/command_policy_edit.go
@@ -104,10 +104,6 @@ func editPolicy(ctx context.Context, rep repo.RepositoryWriter) error {
 		fmt.Scanf("%v", &shouldSave)
 
 		if strings.HasPrefix(strings.ToLower(shouldSave), "y") {
-			if err := policy.ValidatePolicy(updated); err != nil {
-				return errors.Wrap(err, "failed to validate policy")
-			}
-
 			if err := policy.SetPolicy(ctx, rep, target, updated); err != nil {
 				return errors.Wrapf(err, "can't save policy for %v", target)
 			}

--- a/cli/command_policy_edit.go
+++ b/cli/command_policy_edit.go
@@ -46,7 +46,8 @@ const policyEditFilesHelpText = `
 const policyEditSchedulingHelpText = `
   # Snapshot scheduling options. Options include:
   #   "intervalSeconds": number /* 86400-day, 3600-hour, 60-minute */
-  #   "timesOfDay": [{"hour":H,"min":M},{"hour":H,"min":M}]
+  #   "timeOfDay": [{"hour":H,"min":M},{"hour":H,"min":M}]
+  #   "manual": false /* Only create snapshots manually if set to true. NOTE: cannot be used with the above two fields */
 `
 
 var (
@@ -103,6 +104,10 @@ func editPolicy(ctx context.Context, rep repo.RepositoryWriter) error {
 		fmt.Scanf("%v", &shouldSave)
 
 		if strings.HasPrefix(strings.ToLower(shouldSave), "y") {
+			if err := policy.ValidatePolicy(updated); err != nil {
+				return errors.Wrap(err, "failed to validate policy")
+			}
+
 			if err := policy.SetPolicy(ctx, rep, target, updated); err != nil {
 				return errors.Wrapf(err, "can't save policy for %v", target)
 			}

--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/snapshot/policy"
@@ -178,6 +179,207 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 
 		if !reflect.DeepEqual(tc.startingPolicy, tc.expResult) {
 			t.Errorf("Did not get expected output: (actual) %v != %v (expected)", tc.startingPolicy, tc.expResult)
+		}
+	}
+}
+
+func TestSetSchedulingPolicyFromFlags(t *testing.T) {
+	initialIntervalFlagVal := *policySetInterval
+	initialTimesOfDayFlagVal := *policySetTimesOfDay
+	initialManualFlagVal := *policySetManual
+
+	ctx := testlogging.Context(t)
+
+	defer func() {
+		*policySetInterval = initialIntervalFlagVal
+		*policySetTimesOfDay = initialTimesOfDayFlagVal
+		*policySetManual = initialManualFlagVal
+	}()
+
+	for _, tc := range []struct {
+		name           string
+		startingPolicy *policy.SchedulingPolicy
+		intervalArg    []time.Duration
+		timesOfDayArg  []string
+		manualArg      bool
+		expResult      *policy.SchedulingPolicy
+		expErr         bool
+		expChangeCount int
+	}{
+		{
+			name:           "No flags provided, no starting policy",
+			startingPolicy: &policy.SchedulingPolicy{},
+			expResult:      &policy.SchedulingPolicy{},
+			expErr:         false,
+			expChangeCount: 0,
+		},
+		{
+			name:           "Manual flag set to true, no starting policy",
+			startingPolicy: &policy.SchedulingPolicy{},
+			manualArg:      true,
+			expResult: &policy.SchedulingPolicy{
+				Manual: true,
+			},
+			expErr:         false,
+			expChangeCount: 1,
+		},
+		{
+			name:           "Interval set, no starting policy",
+			startingPolicy: &policy.SchedulingPolicy{},
+			intervalArg: []time.Duration{
+				time.Hour * 1,
+			},
+			expResult: &policy.SchedulingPolicy{
+				IntervalSeconds: 3600,
+			},
+			expErr:         false,
+			expChangeCount: 1,
+		},
+		{
+			name:           "Times of day set, no starting policy",
+			startingPolicy: &policy.SchedulingPolicy{},
+			timesOfDayArg: []string{
+				"12:00",
+			},
+			expResult: &policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{
+					{
+						Hour:   12,
+						Minute: 0,
+					},
+				},
+			},
+			expErr:         false,
+			expChangeCount: 1,
+		},
+		{
+			name:           "Manual and interval set, no starting policy",
+			startingPolicy: &policy.SchedulingPolicy{},
+			intervalArg: []time.Duration{
+				time.Hour * 1,
+			},
+			manualArg:      true,
+			expResult:      &policy.SchedulingPolicy{},
+			expErr:         true,
+			expChangeCount: 0,
+		},
+		{
+			name:           "Manual and times of day set, no starting policy",
+			startingPolicy: &policy.SchedulingPolicy{},
+			timesOfDayArg: []string{
+				"12:00",
+			},
+			manualArg:      true,
+			expResult:      &policy.SchedulingPolicy{},
+			expErr:         true,
+			expChangeCount: 0,
+		},
+		{
+			name: "Manual set to true, starting policy with interval",
+			startingPolicy: &policy.SchedulingPolicy{
+				IntervalSeconds: 3600,
+			},
+			manualArg: true,
+			expResult: &policy.SchedulingPolicy{
+				Manual: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "Manual set to true, starting policy with times of day",
+			startingPolicy: &policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{
+					{
+						Hour:   12,
+						Minute: 0,
+					},
+				},
+			},
+			manualArg: true,
+			expResult: &policy.SchedulingPolicy{
+				Manual: true,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "Manual set to true, starting policy with schedule",
+			startingPolicy: &policy.SchedulingPolicy{
+				IntervalSeconds: 3600,
+				TimesOfDay: []policy.TimeOfDay{
+					{
+						Hour:   12,
+						Minute: 0,
+					},
+				},
+			},
+			manualArg: true,
+			expResult: &policy.SchedulingPolicy{
+				Manual: true,
+			},
+			expErr:         false,
+			expChangeCount: 3,
+		},
+		{
+			name: "Interval set, starting policy with manual",
+			startingPolicy: &policy.SchedulingPolicy{
+				Manual: true,
+			},
+			intervalArg: []time.Duration{
+				time.Hour * 1,
+			},
+			expResult: &policy.SchedulingPolicy{
+				IntervalSeconds: 3600,
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+		{
+			name: "Times of day set, starting policy with manual",
+			startingPolicy: &policy.SchedulingPolicy{
+				Manual: true,
+			},
+			timesOfDayArg: []string{
+				"12:00",
+			},
+			expResult: &policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{
+					{
+						Hour:   12,
+						Minute: 0,
+					},
+				},
+			},
+			expErr:         false,
+			expChangeCount: 2,
+		},
+	} {
+		t.Log(tc.name)
+
+		changeCount := 0
+
+		*policySetInterval = tc.intervalArg
+		*policySetTimesOfDay = tc.timesOfDayArg
+		*policySetManual = tc.manualArg
+
+		err := setSchedulingPolicyFromFlags(ctx, tc.startingPolicy, &changeCount)
+		if tc.expErr {
+			if err == nil {
+				t.Errorf("Expected error but got none")
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Expected none but got err: %v", err)
+			}
+		}
+
+		if !reflect.DeepEqual(tc.startingPolicy, tc.expResult) {
+			t.Errorf("Did not get expected output: (actual) %v != %v (expected)", tc.startingPolicy, tc.expResult)
+		}
+
+		if !reflect.DeepEqual(tc.expChangeCount, changeCount) {
+			t.Errorf("Did not get expected output: (actual) %v != %v (expected)", tc.expChangeCount, changeCount)
 		}
 	}
 }

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -189,12 +189,14 @@ func printErrorHandlingPolicy(p *policy.Policy, parents []*policy.Policy) {
 }
 
 func printSchedulingPolicy(p *policy.Policy, parents []*policy.Policy) {
-	printStdout("Scheduled snapshots:\n")
+	printStdout("Scheduling policy:\n")
 
 	any := false
 
+	printStdout("  Scheduled snapshots:\n")
+
 	if p.SchedulingPolicy.Interval() != 0 {
-		printStdout("  Snapshot interval:   %10v  %v\n", p.SchedulingPolicy.Interval(), getDefinitionPoint(p.Target(), parents, func(pol *policy.Policy) bool {
+		printStdout("    Snapshot interval:   %10v  %v\n", p.SchedulingPolicy.Interval(), getDefinitionPoint(p.Target(), parents, func(pol *policy.Policy) bool {
 			return pol.SchedulingPolicy.Interval() != 0
 		}))
 
@@ -202,11 +204,11 @@ func printSchedulingPolicy(p *policy.Policy, parents []*policy.Policy) {
 	}
 
 	if len(p.SchedulingPolicy.TimesOfDay) > 0 {
-		printStdout("  Snapshot times:\n")
+		printStdout("    Snapshot times:\n")
 
 		for _, tod := range p.SchedulingPolicy.TimesOfDay {
 			tod := tod
-			printStdout("    %9v                      %v\n", tod, getDefinitionPoint(p.Target(), parents, func(pol *policy.Policy) bool {
+			printStdout("      %9v                      %v\n", tod, getDefinitionPoint(p.Target(), parents, func(pol *policy.Policy) bool {
 				for _, t := range pol.SchedulingPolicy.TimesOfDay {
 					if t == tod {
 						return true
@@ -221,8 +223,14 @@ func printSchedulingPolicy(p *policy.Policy, parents []*policy.Policy) {
 	}
 
 	if !any {
-		printStdout("  None\n")
+		printStdout("    None\n")
 	}
+
+	printStdout("  Manual snapshot:           %5v   %v\n",
+		p.SchedulingPolicy.Manual,
+		getDefinitionPoint(p.Target(), parents, func(pol *policy.Policy) bool {
+			return pol.SchedulingPolicy.Manual
+		}))
 }
 
 func printCompressionPolicy(p *policy.Policy, parents []*policy.Policy) {

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -292,19 +292,28 @@ func getLocalBackupPaths(ctx context.Context, rep repo.Repository) ([]string, er
 	for _, src := range sources {
 		// add all sources belonging to the repository user@host
 		// ignore sources that have Manual field set to true in the SchedulingPolicy
-		policyTree, err := policy.TreeForSource(ctx, rep, src)
+		includeSource, err := shouldSnapshotSource(ctx, src, rep)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to get policy tree for source %v", src)
+			return nil, err
 		}
 
-		if src.Host == rep.ClientOptions().Hostname &&
-			src.UserName == rep.ClientOptions().Username &&
-			!policy.IsManualSnapshot(policyTree) {
+		if includeSource {
 			result = append(result, src.Path)
 		}
 	}
 
 	return result, nil
+}
+
+func shouldSnapshotSource(ctx context.Context, src snapshot.SourceInfo, rep repo.Repository) (bool, error) {
+	policyTree, err := policy.TreeForSource(ctx, rep, src)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to get policy tree for source %v", src)
+	}
+
+	return src.Host == rep.ClientOptions().Hostname &&
+		src.UserName == rep.ClientOptions().Username &&
+		!policy.IsManualSnapshot(policyTree), nil
 }
 
 func init() {

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -290,7 +290,16 @@ func getLocalBackupPaths(ctx context.Context, rep repo.Repository) ([]string, er
 	var result []string
 
 	for _, src := range sources {
-		if src.Host == rep.ClientOptions().Hostname && src.UserName == rep.ClientOptions().Username {
+		// add all sources belonging to the repository user@host
+		// ignore sources that have Manual field set to true in the SchedulingPolicy
+		policyTree, err := policy.TreeForSource(ctx, rep, src)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to get policy tree for source %v", src)
+		}
+
+		if src.Host == rep.ClientOptions().Hostname &&
+			src.UserName == rep.ClientOptions().Username &&
+			!policy.IsManualSnapshot(policyTree) {
 			result = append(result, src.Path)
 		}
 	}

--- a/htmlui/src/PolicyEditor.js
+++ b/htmlui/src/PolicyEditor.js
@@ -80,20 +80,20 @@ export class PolicyEditor extends Component {
             if (!l) {
                 return l;
             }
-    
+
             let result = [];
             for (let i = 0; i < l.length; i++) {
                 const s = l[i];
                 if (s === "") {
                     continue;
                 }
-    
+
                 result.push(s);
             }
-    
+
             return result;
         }
-        
+
         // clean up policy before saving
         let policy = JSON.parse(JSON.stringify(this.state.policy));
         if (policy.files) {
@@ -117,7 +117,7 @@ export class PolicyEditor extends Component {
         axios.put(this.snapshotURL(this.props), policy).then(result => {
             this.props.close();
         }).catch(error => {
-            alert('Error saving snapshot: ' + error);
+            alert('Error saving policy: ' + error);
         });
     }
 
@@ -224,6 +224,9 @@ export class PolicyEditor extends Component {
                         <p className="policy-help">Controls when snapshots are automatically created.</p>
                         <Form.Row>
                             {OptionalNumberField(this, "Snapshot Interval", "policy.scheduling.intervalSeconds", { placeholder: "seconds" })}
+                        </Form.Row>
+                        <Form.Row>
+                            {OptionalBoolean(this, "Only create snapshots manually (disables scheduled snapshots)", "policy.scheduling.manual")}
                         </Form.Row>
                     </div>
                 </Tab>

--- a/snapshot/policy/policy.go
+++ b/snapshot/policy/policy.go
@@ -82,6 +82,12 @@ func MergePolicies(policies []*Policy) *Policy {
 	return &merged
 }
 
+// ValidatePolicy returns error if the given policy is invalid.
+// Currently, only SchedulingPolicy is validated.
+func ValidatePolicy(pol *Policy) error {
+	return ValidateSchedulingPolicy(pol.SchedulingPolicy)
+}
+
 func intPtr(n int) *int {
 	return &n
 }

--- a/snapshot/policy/policy_manager.go
+++ b/snapshot/policy/policy_manager.go
@@ -113,6 +113,10 @@ func GetDefinedPolicy(ctx context.Context, rep repo.Repository, si snapshot.Sour
 
 // SetPolicy sets the policy on a given source.
 func SetPolicy(ctx context.Context, rep repo.RepositoryWriter, si snapshot.SourceInfo, pol *Policy) error {
+	if err := ValidatePolicy(pol); err != nil {
+		return errors.Wrap(err, "failed to validate policy")
+	}
+
 	md, err := rep.FindManifests(ctx, labelsForSource(si))
 	if err != nil {
 		return errors.Wrapf(err, "unable to load manifests for %v", si)

--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 	"time"
 
@@ -111,12 +112,8 @@ func SetManual(ctx context.Context, rep repo.RepositoryWriter, sourceInfo snapsh
 
 // ValidateSchedulingPolicy returns an error if manual field is set along with scheduling fields.
 func ValidateSchedulingPolicy(p SchedulingPolicy) error {
-	if p.IntervalSeconds != 0 && p.Manual {
-		return errors.New("invalid scheduling policy: cannot set manual snapshot field with intervals")
-	}
-
-	if len(p.TimesOfDay) > 0 && p.Manual {
-		return errors.New("invalid scheduling policy: cannot set manual snapshot field with times of day")
+	if p.Manual && !reflect.DeepEqual(p, SchedulingPolicy{Manual: true}) {
+		return errors.New("invalid scheduling policy: manual cannot be combined with other scheduling policies")
 	}
 
 	return nil

--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -1,11 +1,15 @@
 package policy
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
 
 	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/snapshot"
 )
 
 // TimeOfDay represents the time of day (hh:mm) using 24-hour time format.
@@ -52,6 +56,7 @@ func SortAndDedupeTimesOfDay(tod []TimeOfDay) []TimeOfDay {
 type SchedulingPolicy struct {
 	IntervalSeconds int64       `json:"intervalSeconds,omitempty"`
 	TimesOfDay      []TimeOfDay `json:"timeOfDay,omitempty"`
+	Manual          bool        `json:"manual,omitempty"`
 }
 
 // Interval returns the snapshot interval or zero if not specified.
@@ -72,6 +77,49 @@ func (p *SchedulingPolicy) Merge(src SchedulingPolicy) {
 
 	p.TimesOfDay = SortAndDedupeTimesOfDay(
 		append(append([]TimeOfDay(nil), src.TimesOfDay...), p.TimesOfDay...))
+
+	if !p.Manual {
+		p.Manual = src.Manual
+	}
+}
+
+// IsManualSnapshot returns the SchedulingPolicy manual value from the given policy tree.
+func IsManualSnapshot(policyTree *Tree) bool {
+	return policyTree.EffectivePolicy().SchedulingPolicy.Manual
+}
+
+// SetManual sets the manual setting in the SchedulingPolicy on the given source.
+func SetManual(ctx context.Context, rep repo.RepositoryWriter, sourceInfo snapshot.SourceInfo) error {
+	// Get existing defined policy for the source
+	p, err := GetDefinedPolicy(ctx, rep, sourceInfo)
+
+	switch {
+	case errors.Is(err, ErrPolicyNotFound):
+		p = &Policy{}
+	case err != nil:
+		return errors.Wrap(err, "could not get defined policy for source")
+	}
+
+	p.SchedulingPolicy.Manual = true
+
+	if err := SetPolicy(ctx, rep, sourceInfo, p); err != nil {
+		return errors.Wrapf(err, "can't save policy for %v", sourceInfo)
+	}
+
+	return nil
+}
+
+// ValidateSchedulingPolicy returns an error if manual field is set along with scheduling fields.
+func ValidateSchedulingPolicy(p SchedulingPolicy) error {
+	if p.IntervalSeconds != 0 && p.Manual {
+		return errors.New("invalid scheduling policy: cannot set manual snapshot field with intervals")
+	}
+
+	if len(p.TimesOfDay) > 0 && p.Manual {
+		return errors.New("invalid scheduling policy: cannot set manual snapshot field with times of day")
+	}
+
+	return nil
 }
 
 var defaultSchedulingPolicy = SchedulingPolicy{}

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -443,6 +443,33 @@ func TestSnapshotCreateWithIgnore(t *testing.T) {
 	}
 }
 
+func TestSnapshotCreateAllWithManualSnapshot(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir2)
+
+	sourceSnapshotCount := len(e.RunAndExpectSuccess(t, "snapshot", "list", "-a"))
+
+	// set manual field in the scheduling policy for `sharedTestDataDir1`
+	e.RunAndExpectSuccess(t, "policy", "set", "--manual", sharedTestDataDir1)
+
+	// make sure the policy is visible in the policy list, includes global policy
+	e.RunAndVerifyOutputLineCount(t, 2, "policy", "list")
+
+	// create snapshot for all sources
+	e.RunAndExpectSuccess(t, "snapshot", "create", "--all")
+
+	// snapshot count must increase by 1 since `sharedTestDataDir1` is ignored
+	expectedSnapshotCount := sourceSnapshotCount + 1
+	e.RunAndVerifyOutputLineCount(t, expectedSnapshotCount, "snapshot", "list", "--show-identical", "-a")
+}
+
 func appendIfMissing(slice []string, i string) []string {
 	for _, ele := range slice {
 		if ele == i {


### PR DESCRIPTION
### Overview

Added a new manual field in the scheduling policy.
While gathering all the existing sources during creation of snapshot using `--all` flag, we check the effective policy on each source and skip it if the `manual` value is set to true.

This mechanism can be used for virtual sources (`stdin`) where we don't have the respective directory/file on the local filesystem.
