### PR TITLE
Added support for user authentication using user profiles stored in the repository

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -46,6 +46,7 @@ var (
 	benchmarkCommands   = app.Command("benchmark", "Commands to test performance of algorithms.").Hidden()
 	maintenanceCommands = app.Command("maintenance", "Maintenance commands.").Hidden().Alias("gc")
 	sessionCommands     = app.Command("session", "Session commands.").Hidden()
+	userCommands        = app.Command("users", "Manager repository users").Alias("user")
 )
 
 func helpFullAction(ctx *kingpin.ParseContext) error {

--- a/cli/command_user_add_set.go
+++ b/cli/command_user_add_set.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/alecthomas/kingpin"
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+var (
+	userCreateCommand = userCommands.Command("add", "Add new repository user").Alias("create")
+	userUpdateCommand = userCommands.Command("set", "Set password for a repository user.").Alias("update")
+
+	userAskPassword     bool
+	userSetName         string
+	userSetPassword     string
+	userSetPasswordHash string
+)
+
+func registerAddSetUserCommandArguments(cmd *kingpin.CmdClause) {
+	cmd.Flag("ask-password", "Ask for user password").BoolVar(&userAskPassword)
+	cmd.Flag("user-password", "Password").StringVar(&userSetPassword)
+	cmd.Flag("user-password-hash", "Password hash").StringVar(&userSetPasswordHash)
+	cmd.Arg("username", "Username").Required().StringVar(&userSetName)
+}
+
+func runUserCreate(ctx context.Context, rep repo.RepositoryWriter) error {
+	return runServerUserAddSet(ctx, rep, true)
+}
+
+func runUserUpdate(ctx context.Context, rep repo.RepositoryWriter) error {
+	return runServerUserAddSet(ctx, rep, false)
+}
+
+func runServerUserAddSet(ctx context.Context, rep repo.RepositoryWriter, isNew bool) error {
+	username := userSetName
+
+	up, err := user.GetUserProfile(ctx, rep, username)
+
+	if isNew {
+		switch {
+		case err == nil:
+			return errors.Errorf("user %q already exists", username)
+
+		case errors.Is(err, user.ErrUserNotFound):
+			up = &user.Profile{
+				Username: username,
+			}
+			err = nil
+		}
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "error getting user profile")
+	}
+
+	if p := userSetPassword; p != "" {
+		if err := up.SetPassword(p); err != nil {
+			return errors.Wrap(err, "error setting password")
+		}
+	}
+
+	if p := userSetPasswordHash; p != "" {
+		up.PasswordHash = p
+	}
+
+	if up.PasswordHash == "" || userAskPassword {
+		pwd, err := askPass("Enter new password for user " + username + ": ")
+		if err != nil {
+			return errors.Wrap(err, "error asking for password")
+		}
+
+		pwd2, err := askPass("Re-enter new password for verification: ")
+		if err != nil {
+			return errors.Wrap(err, "error asking for password")
+		}
+
+		if pwd != pwd2 {
+			return errors.Wrap(err, "passwords don't match")
+		}
+
+		if err := up.SetPassword(pwd); err != nil {
+			return errors.Wrap(err, "error setting password")
+		}
+	}
+
+	if err := user.SetUserProfile(ctx, rep, up); err != nil {
+		return errors.Wrap(err, "error setting user profile")
+	}
+
+	log(ctx).Noticef(`
+Updated user credentials will take effect in 5-10 minutes or when the server is restarted.
+To refresh credentials in a running server use 'kopia server refresh' command.
+`)
+
+	return nil
+}
+
+func init() {
+	registerAddSetUserCommandArguments(userCreateCommand)
+	registerAddSetUserCommandArguments(userUpdateCommand)
+	userCreateCommand.Action(repositoryWriterAction(runUserCreate))
+	userUpdateCommand.Action(repositoryWriterAction(runUserUpdate))
+}

--- a/cli/command_user_add_set.go
+++ b/cli/command_user_add_set.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/base64"
 
 	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
@@ -14,16 +15,18 @@ var (
 	userCreateCommand = userCommands.Command("add", "Add new repository user").Alias("create")
 	userUpdateCommand = userCommands.Command("set", "Set password for a repository user.").Alias("update")
 
-	userAskPassword     bool
-	userSetName         string
-	userSetPassword     string
-	userSetPasswordHash string
+	userAskPassword            bool
+	userSetName                string
+	userSetPassword            string
+	userSetPasswordHashVersion int = 1
+	userSetPasswordHash        string
 )
 
 func registerAddSetUserCommandArguments(cmd *kingpin.CmdClause) {
 	cmd.Flag("ask-password", "Ask for user password").BoolVar(&userAskPassword)
 	cmd.Flag("user-password", "Password").StringVar(&userSetPassword)
 	cmd.Flag("user-password-hash", "Password hash").StringVar(&userSetPasswordHash)
+	cmd.Flag("user-password-hash-version", "Password hash version").Default("1").IntVar(&userSetPasswordHashVersion)
 	cmd.Arg("username", "Username").Required().StringVar(&userSetName)
 }
 
@@ -35,24 +38,28 @@ func runUserUpdate(ctx context.Context, rep repo.RepositoryWriter) error {
 	return runServerUserAddSet(ctx, rep, false)
 }
 
-func runServerUserAddSet(ctx context.Context, rep repo.RepositoryWriter, isNew bool) error {
-	username := userSetName
-
+func getExistingOrNewUserProfile(ctx context.Context, rep repo.Repository, username string, isNew bool) (*user.Profile, error) {
 	up, err := user.GetUserProfile(ctx, rep, username)
 
 	if isNew {
 		switch {
 		case err == nil:
-			return errors.Errorf("user %q already exists", username)
+			return nil, errors.Errorf("user %q already exists", username)
 
 		case errors.Is(err, user.ErrUserNotFound):
-			up = &user.Profile{
+			return &user.Profile{
 				Username: username,
-			}
-			err = nil
+			}, nil
 		}
 	}
 
+	return up, err
+}
+
+func runServerUserAddSet(ctx context.Context, rep repo.RepositoryWriter, isNew bool) error {
+	username := userSetName
+
+	up, err := getExistingOrNewUserProfile(ctx, rep, username, isNew)
 	if err != nil {
 		return errors.Wrap(err, "error getting user profile")
 	}
@@ -64,10 +71,16 @@ func runServerUserAddSet(ctx context.Context, rep repo.RepositoryWriter, isNew b
 	}
 
 	if p := userSetPasswordHash; p != "" {
-		up.PasswordHash = p
+		ph, err := base64.StdEncoding.DecodeString(p)
+		if err != nil {
+			return errors.Wrap(err, "invalid password hash, must be valid base64 string")
+		}
+
+		up.PasswordHashVersion = userSetPasswordHashVersion
+		up.PasswordHash = ph
 	}
 
-	if up.PasswordHash == "" || userAskPassword {
+	if up.PasswordHash == nil || userAskPassword {
 		pwd, err := askPass("Enter new password for user " + username + ": ")
 		if err != nil {
 			return errors.Wrap(err, "error asking for password")

--- a/cli/command_user_add_set.go
+++ b/cli/command_user_add_set.go
@@ -53,7 +53,7 @@ func getExistingOrNewUserProfile(ctx context.Context, rep repo.Repository, usern
 		}
 	}
 
-	return up, err
+	return up, errors.Wrap(err, "error getting user profile")
 }
 
 func runServerUserAddSet(ctx context.Context, rep repo.RepositoryWriter, isNew bool) error {
@@ -61,7 +61,7 @@ func runServerUserAddSet(ctx context.Context, rep repo.RepositoryWriter, isNew b
 
 	up, err := getExistingOrNewUserProfile(ctx, rep, username, isNew)
 	if err != nil {
-		return errors.Wrap(err, "error getting user profile")
+		return err
 	}
 
 	if p := userSetPassword; p != "" {

--- a/cli/command_user_delete.go
+++ b/cli/command_user_delete.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+var (
+	userDeleteCommand = userCommands.Command("delete", "Delete user")
+	userDeleteName    = userDeleteCommand.Arg("username", "The username to delete.").Required().String()
+)
+
+func runUserDelete(ctx context.Context, rep repo.RepositoryWriter) error {
+	err := user.DeleteUserProfile(ctx, rep, *userDeleteName)
+	if err != nil {
+		return errors.Wrap(err, "error deleting user profile")
+	}
+
+	log(ctx).Infof("User %q deleted.", *userDeleteName)
+
+	return nil
+}
+
+func init() {
+	userDeleteCommand.Action(repositoryWriterAction(runUserDelete))
+}

--- a/cli/command_user_info.go
+++ b/cli/command_user_info.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+var (
+	userInfoCommand = userCommands.Command("info", "Info about particular user")
+	userInfoName    = userInfoCommand.Arg("username", "The username to look up.").Required().String()
+)
+
+func runUserInfo(ctx context.Context, rep repo.DirectRepository) error {
+	up, err := user.GetUserProfile(ctx, rep, *userInfoName)
+	if err != nil {
+		return errors.Wrap(err, "error getting user profile")
+	}
+
+	j, err := json.MarshalIndent(up, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "error marshaling JSON")
+	}
+
+	printStdout("%v", string(j))
+
+	return nil
+}
+
+func init() {
+	userInfoCommand.Action(directRepositoryReadAction(runUserInfo))
+}

--- a/cli/command_user_info.go
+++ b/cli/command_user_info.go
@@ -26,7 +26,7 @@ func runUserInfo(ctx context.Context, rep repo.DirectRepository) error {
 		return errors.Wrap(err, "error marshaling JSON")
 	}
 
-	printStdout("%v", string(j))
+	printStdout("%s", j)
 
 	return nil
 }

--- a/cli/command_user_list.go
+++ b/cli/command_user_list.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+var userListCommand = userCommands.Command("list", "List users").Alias("ls")
+
+func runUserList(ctx context.Context, rep repo.Repository) error {
+	profiles, err := user.ListUserProfiles(ctx, rep)
+	if err != nil {
+		return errors.Wrap(err, "error listing user profiles")
+	}
+
+	for _, p := range profiles {
+		printStdout("%v\n", p.Username)
+	}
+
+	return nil
+}
+
+func init() {
+	userListCommand.Action(repositoryReaderAction(runUserList))
+}

--- a/internal/auth/authn.go
+++ b/internal/auth/authn.go
@@ -6,7 +6,10 @@ import (
 	"crypto/subtle"
 
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/logging"
 )
+
+var log = logging.GetContextLoggerFunc("auth")
 
 // Authenticator verifies that the provided username/password is valid.
 type Authenticator func(ctx context.Context, rep repo.Repository, username, password string) bool

--- a/internal/auth/authn_repo.go
+++ b/internal/auth/authn_repo.go
@@ -30,6 +30,9 @@ func (ac *repositoryUserAuthenticator) authenticate(ctx context.Context, rep rep
 	if rep != ac.lastRep {
 		ac.userProfiles = nil
 		ac.lastRep = rep
+
+		// ensure profiles are reloaded below
+		ac.nextRefreshTime = time.Time{}
 	}
 
 	// see if we're due for a refresh and refresh userProfiles map
@@ -44,12 +47,9 @@ func (ac *repositoryUserAuthenticator) authenticate(ctx context.Context, rep rep
 		}
 	}
 
-	u := ac.userProfiles[username]
-	if u == nil {
-		return false
-	}
-
-	return u.IsValidPassword(password)
+	// IsValidPassword can be safely called on nil and the call will take as much time as for a valid user
+	// thus not revealing anything about whether the user exists.
+	return ac.userProfiles[username].IsValidPassword(password)
 }
 
 // AuthenticateRepositoryUsers returns authenticator that accepts username/password combinations

--- a/internal/auth/authn_repo.go
+++ b/internal/auth/authn_repo.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+const defaultProfileRefreshFrequency = 10 * time.Second
+
+type repositoryUserAuthenticator struct {
+	lastRep repo.Repository
+
+	mu                          sync.Mutex
+	nextRefreshTime             time.Time
+	userProfiles                map[string]*user.Profile
+	userProfileRefreshFrequency time.Duration
+}
+
+// AuthenticateSingleUser returns an Authenticator that only allows one username/password combination.
+func (ac *repositoryUserAuthenticator) authenticate(ctx context.Context, rep repo.Repository, username, password string) bool {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	// if the server switched to serving another repository, discard cache.
+	if rep != ac.lastRep {
+		ac.userProfiles = nil
+		ac.lastRep = rep
+	}
+
+	// see if we're due for a refresh and refresh userProfiles map
+	if clock.Now().After(ac.nextRefreshTime) {
+		ac.nextRefreshTime = clock.Now().Add(ac.userProfileRefreshFrequency)
+
+		newUsers, err := user.LoadProfileMap(ctx, rep, ac.userProfiles)
+		if err != nil {
+			log(ctx).Warningf("unable to load userProfiles map: %v", err)
+		} else {
+			ac.userProfiles = newUsers
+		}
+	}
+
+	u := ac.userProfiles[username]
+	if u == nil {
+		return false
+	}
+
+	return u.IsValidPassword(password)
+}
+
+// AuthenticateRepositoryUsers returns authenticator that accepts username/password combinations
+// stored in 'user' manifests in the repository.
+func AuthenticateRepositoryUsers() Authenticator {
+	a := &repositoryUserAuthenticator{
+		userProfileRefreshFrequency: defaultProfileRefreshFrequency,
+	}
+
+	return a.authenticate
+}

--- a/internal/auth/authn_repo_test.go
+++ b/internal/auth/authn_repo_test.go
@@ -1,0 +1,45 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kopia/kopia/internal/auth"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+func TestRepositoryAuthenticator(t *testing.T) {
+	a := auth.AuthenticateRepositoryUsers()
+	ctx := testlogging.Context(t)
+
+	var env repotesting.Environment
+	defer env.Setup(t).Close(ctx, t)
+
+	repo.WriteSession(ctx, env.Repository, repo.WriteSessionOptions{},
+		func(w repo.RepositoryWriter) error {
+			p := &user.Profile{
+				Username: "user1",
+			}
+
+			p.SetPassword("password1")
+
+			return user.SetUserProfile(ctx, w, p)
+		})
+
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user1", "password1", true)
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user1", "password2", false)
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user1", "password11", false)
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user1a", "password1", false)
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user1a", "password1a", false)
+}
+
+func verifyRepoAuthenticator(ctx context.Context, t *testing.T, a auth.Authenticator, r repo.Repository, username, password string, want bool) {
+	t.Helper()
+
+	if got := a(ctx, r, username, password); got != want {
+		t.Errorf("invalid authenticator result for %v/%v: %v, want %v", username, password, got, want)
+	}
+}

--- a/internal/user/user_manager.go
+++ b/internal/user/user_manager.go
@@ -1,0 +1,154 @@
+// Package user provides management of user accounts.
+package user
+
+import (
+	"context"
+	"sort"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/manifest"
+)
+
+const (
+	usernameLabel = "username"
+
+	userManifestType = "user"
+)
+
+// ErrUserNotFound is returned to indicate that a user was not found in the system.
+var ErrUserNotFound = errors.New("user not found")
+
+// LoadProfileMap returns the map of all users profiles in the repository by username, using old map as a cache.
+func LoadProfileMap(ctx context.Context, rep repo.Repository, old map[string]*Profile) (map[string]*Profile, error) {
+	if rep == nil {
+		return nil, nil
+	}
+
+	entries, err := rep.FindManifests(ctx, map[string]string{manifest.TypeLabelKey: userManifestType})
+	if err != nil {
+		return nil, errors.Wrap(err, "error listing user manifests")
+	}
+
+	result := map[string]*Profile{}
+
+	for _, m := range manifest.DedupeEntryMetadataByLabel(entries, usernameLabel) {
+		user := m.Labels[usernameLabel]
+
+		// same user info as before
+		if o := old[user]; o != nil && o.ManifestID == m.ID {
+			result[user] = o
+			continue
+		}
+
+		p := &Profile{}
+		if _, err := rep.GetManifest(ctx, m.ID, p); err != nil {
+			return nil, errors.Wrapf(err, "error loading user manifest %v", user)
+		}
+
+		p.ManifestID = m.ID
+
+		result[user] = p
+	}
+
+	return result, nil
+}
+
+// ListUserProfiles gets the list of all user profiles in the system.
+func ListUserProfiles(ctx context.Context, rep repo.Repository) ([]*Profile, error) {
+	var result []*Profile
+
+	users, err := LoadProfileMap(ctx, rep, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range users {
+		result = append(result, v)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Username < result[j].Username
+	})
+
+	return result, nil
+}
+
+// GetUserProfile returns the user profile with a given username.
+func GetUserProfile(ctx context.Context, r repo.Repository, username string) (*Profile, error) {
+	manifests, err := r.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey: userManifestType,
+		usernameLabel:         username,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error looking for user profile")
+	}
+
+	if len(manifests) == 0 {
+		return nil, errors.Wrap(ErrUserNotFound, username)
+	}
+
+	p := &Profile{}
+	if _, err := r.GetManifest(ctx, manifest.PickLatestID(manifests), p); err != nil {
+		return nil, errors.Wrap(err, "error loading user profile")
+	}
+
+	return p, nil
+}
+
+// SetUserProfile creates or updates user profile.
+func SetUserProfile(ctx context.Context, w repo.RepositoryWriter, p *Profile) error {
+	if p.Username == "" {
+		return errors.Errorf("username is required")
+	}
+
+	manifests, err := w.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey: userManifestType,
+		usernameLabel:         p.Username,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error looking for user profile")
+	}
+
+	id, err := w.PutManifest(ctx, map[string]string{
+		manifest.TypeLabelKey: userManifestType,
+		usernameLabel:         p.Username,
+	}, p)
+	if err != nil {
+		return errors.Wrap(err, "error writing user profile")
+	}
+
+	for _, m := range manifests {
+		if err := w.DeleteManifest(ctx, m.ID); err != nil {
+			return errors.Wrapf(err, "error deleting user profile %v", p.Username)
+		}
+	}
+
+	p.ManifestID = id
+
+	return nil
+}
+
+// DeleteUserProfile removes user profile with a given username.
+func DeleteUserProfile(ctx context.Context, w repo.RepositoryWriter, username string) error {
+	if username == "" {
+		return errors.Errorf("username is required")
+	}
+
+	manifests, err := w.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey: userManifestType,
+		usernameLabel:         username,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error looking for user profile")
+	}
+
+	for _, m := range manifests {
+		if err := w.DeleteManifest(ctx, m.ID); err != nil {
+			return errors.Wrapf(err, "error deleting user profile %v", username)
+		}
+	}
+
+	return nil
+}

--- a/internal/user/user_manager_test.go
+++ b/internal/user/user_manager_test.go
@@ -1,0 +1,70 @@
+package user_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/user"
+)
+
+func TestUserManager(t *testing.T) {
+	var env repotesting.Environment
+
+	ctx := testlogging.Context(t)
+	defer env.Setup(t).Close(ctx, t)
+
+	if _, err := user.GetUserProfile(ctx, env.RepositoryWriter, "alice"); !errors.Is(err, user.ErrUserNotFound) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	must(t, user.SetUserProfile(ctx, env.RepositoryWriter, &user.Profile{
+		Username:     "alice",
+		PasswordHash: "hahaha",
+	}))
+
+	if _, err := user.GetUserProfile(ctx, env.RepositoryWriter, "bob"); !errors.Is(err, user.ErrUserNotFound) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	a, err := user.GetUserProfile(ctx, env.RepositoryWriter, "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := a.PasswordHash, "hahaha"; got != want {
+		t.Errorf("unexpected password hash: %v, want %v", got, want)
+	}
+
+	must(t, user.SetUserProfile(ctx, env.RepositoryWriter, &user.Profile{
+		Username:     "alice",
+		PasswordHash: "hehehehe",
+	}))
+
+	a, err = user.GetUserProfile(ctx, env.RepositoryWriter, "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := a.PasswordHash, "hehehehe"; got != want {
+		t.Errorf("unexpected password hash: %v, want %v", got, want)
+	}
+
+	err = user.DeleteUserProfile(ctx, env.RepositoryWriter, "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err = user.GetUserProfile(ctx, env.RepositoryWriter, "alice"); !errors.Is(err, user.ErrUserNotFound) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/user/user_manager_test.go
+++ b/internal/user/user_manager_test.go
@@ -21,7 +21,7 @@ func TestUserManager(t *testing.T) {
 
 	must(t, user.SetUserProfile(ctx, env.RepositoryWriter, &user.Profile{
 		Username:     "alice",
-		PasswordHash: "hahaha",
+		PasswordHash: []byte("hahaha"),
 	}))
 
 	if _, err := user.GetUserProfile(ctx, env.RepositoryWriter, "bob"); !errors.Is(err, user.ErrUserNotFound) {
@@ -33,13 +33,13 @@ func TestUserManager(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got, want := a.PasswordHash, "hahaha"; got != want {
+	if got, want := string(a.PasswordHash), "hahaha"; got != want {
 		t.Errorf("unexpected password hash: %v, want %v", got, want)
 	}
 
 	must(t, user.SetUserProfile(ctx, env.RepositoryWriter, &user.Profile{
 		Username:     "alice",
-		PasswordHash: "hehehehe",
+		PasswordHash: []byte("hehehehe"),
 	}))
 
 	a, err = user.GetUserProfile(ctx, env.RepositoryWriter, "alice")
@@ -47,7 +47,7 @@ func TestUserManager(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got, want := a.PasswordHash, "hehehehe"; got != want {
+	if got, want := string(a.PasswordHash), "hehehehe"; got != want {
 		t.Errorf("unexpected password hash: %v, want %v", got, want)
 	}
 

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -23,7 +23,9 @@ func (p *Profile) IsValidPassword(password string) bool {
 	if p == nil {
 		// if the user is invalid, return false but use the same amount of time as when we
 		// compare against valid user to avoid revealing whether the user account exists.
-		return isValidPasswordV1(password, dummyV1HashThatNeverMatchesAnyPassword)
+		isValidPasswordV1(password, dummyV1HashThatNeverMatchesAnyPassword)
+
+		return false
 	}
 
 	switch p.PasswordHashVersion {

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -1,8 +1,6 @@
 package user
 
 import (
-	"strings"
-
 	"github.com/kopia/kopia/repo/manifest"
 )
 
@@ -10,8 +8,9 @@ import (
 type Profile struct {
 	ManifestID manifest.ID `json:"-"`
 
-	Username     string `json:"username"`
-	PasswordHash string `json:"passwordHash"`
+	Username            string `json:"username"`
+	PasswordHashVersion int    `json:"passwordHashVersion"` // indicates how password is hashed
+	PasswordHash        []byte `json:"passwordHash"`
 }
 
 // SetPassword changes the password for a user profile.
@@ -21,8 +20,14 @@ func (p *Profile) SetPassword(password string) error {
 
 // IsValidPassword determines whether the password is valid for a given user.
 func (p *Profile) IsValidPassword(password string) bool {
-	switch {
-	case strings.HasPrefix(p.PasswordHash, v1Prefix):
+	if p == nil {
+		// if the user is invalid, return false but use the same amount of time as when we
+		// compare against valid user to avoid revealing whether the user account exists.
+		return isValidPasswordV1(password, dummyV1HashThatNeverMatchesAnyPassword)
+	}
+
+	switch p.PasswordHashVersion {
+	case hashVersion1:
 		return isValidPasswordV1(password, p.PasswordHash)
 
 	default:

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -1,0 +1,31 @@
+package user
+
+import (
+	"strings"
+
+	"github.com/kopia/kopia/repo/manifest"
+)
+
+// Profile describes information about a single user.
+type Profile struct {
+	ManifestID manifest.ID `json:"-"`
+
+	Username     string `json:"username"`
+	PasswordHash string `json:"passwordHash"`
+}
+
+// SetPassword changes the password for a user profile.
+func (p *Profile) SetPassword(password string) error {
+	return p.setPasswordV1(password)
+}
+
+// IsValidPassword determines whether the password is valid for a given user.
+func (p *Profile) IsValidPassword(password string) bool {
+	switch {
+	case strings.HasPrefix(p.PasswordHash, v1Prefix):
+		return isValidPasswordV1(password, p.PasswordHash)
+
+	default:
+		return false
+	}
+}

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -1,0 +1,65 @@
+package user
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"io"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/scrypt"
+)
+
+//  parameters for v1 hashing.
+const (
+	v1Prefix = "v1:"
+
+	v1ScryptN    = 65536
+	v1ScryptR    = 8
+	v1ScryptP    = 1
+	v1SaltLength = 32
+	v1KeyLength  = 32
+)
+
+func (p *Profile) setPasswordV1(password string) error {
+	salt := make([]byte, v1SaltLength)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return errors.Wrap(err, "error generating salt")
+	}
+
+	p.PasswordHash = computePasswordHashV1(password, salt)
+
+	return nil
+}
+
+func computePasswordHashV1(password string, salt []byte) string {
+	key, err := scrypt.Key([]byte(password), salt, v1ScryptN, v1ScryptR, v1ScryptP, v1KeyLength)
+	if err != nil {
+		panic("unexpected scrypt error")
+	}
+
+	payload := append(append([]byte(nil), salt...), key...)
+
+	return v1Prefix + base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func isValidPasswordV1(password, hashedPassword string) bool {
+	if len(hashedPassword) < len(v1Prefix) {
+		return false
+	}
+
+	data, err := base64.RawURLEncoding.DecodeString(hashedPassword[len(v1Prefix):])
+	if err != nil {
+		return false
+	}
+
+	if len(data) != v1SaltLength+v1KeyLength {
+		return false
+	}
+
+	salt := data[0:v1SaltLength]
+
+	h := computePasswordHashV1(password, salt)
+
+	return subtle.ConstantTimeCompare([]byte(h), []byte(hashedPassword)) != 0
+}

--- a/internal/user/user_profile_test.go
+++ b/internal/user/user_profile_test.go
@@ -1,0 +1,41 @@
+package user_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/user"
+)
+
+func TestUserProfile(t *testing.T) {
+	p := &user.Profile{}
+
+	if p.IsValidPassword("bar") {
+		t.Fatalf("password unexpectedly valid!")
+	}
+
+	p.SetPassword("foo")
+
+	if !p.IsValidPassword("foo") {
+		t.Fatalf("password not valid!")
+	}
+
+	if p.IsValidPassword("bar") {
+		t.Fatalf("password unexpectedly valid!")
+	}
+}
+
+func TestInvalidPasswordHash(t *testing.T) {
+	cases := []string{
+		"",
+		"v1",
+		"v1:**invalid*base64*",
+		"???",
+	}
+
+	for _, tc := range cases {
+		p := &user.Profile{PasswordHash: tc}
+		if p.IsValidPassword("some-password") {
+			t.Fatalf("password unexpectedly valid for %v", tc)
+		}
+	}
+}

--- a/internal/user/user_profile_test.go
+++ b/internal/user/user_profile_test.go
@@ -24,12 +24,18 @@ func TestUserProfile(t *testing.T) {
 	}
 }
 
+func TestNilUserProfile(t *testing.T) {
+	var p *user.Profile
+
+	if p.IsValidPassword("bar") {
+		t.Fatalf("password unexpectedly valid!")
+	}
+}
+
 func TestInvalidPasswordHash(t *testing.T) {
-	cases := []string{
-		"",
-		"v1",
-		"v1:**invalid*base64*",
-		"???",
+	cases := [][]byte{
+		[]byte("**invalid*base64*"),
+		[]byte(""),
 	}
 
 	for _, tc := range cases {

--- a/repo/maintenance/maintenance_params.go
+++ b/repo/maintenance/maintenance_params.go
@@ -82,7 +82,7 @@ func GetParams(ctx context.Context, rep repo.Repository) (*Params, error) {
 	// this is possible when two repository clients independently create manifests at approximately the same time
 	// so it should not really matter which one we pick.
 	// see https://github.com/kopia/kopia/issues/391
-	manifestID := md[0].ID
+	manifestID := manifest.PickLatestID(md)
 
 	p := &Params{}
 	if _, err := rep.GetManifest(ctx, manifestID, p); err != nil {

--- a/repo/manifest/manifest_entry.go
+++ b/repo/manifest/manifest_entry.go
@@ -1,6 +1,9 @@
 package manifest
 
-import "time"
+import (
+	"sort"
+	"time"
+)
 
 // EntryMetadata contains metadata about manifest item. Each manifest item has one or more labels
 // Including required "type" label.
@@ -9,4 +12,72 @@ type EntryMetadata struct {
 	Length  int               `json:"length"`
 	Labels  map[string]string `json:"labels"`
 	ModTime time.Time         `json:"mtime"`
+}
+
+// DedupeEntryMetadataByLabel deduplicates EntryMetadata in a provided slice by picking
+// the latest one for a given set of label.
+func DedupeEntryMetadataByLabel(entries []*EntryMetadata, label string) []*EntryMetadata {
+	var result []*EntryMetadata
+
+	m := map[string]*EntryMetadata{}
+
+	for _, e := range entries {
+		u := e.Labels[label]
+		if isLaterThan(e, m[u]) {
+			m[u] = e
+		}
+	}
+
+	for _, v := range m {
+		result = append(result, v)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if l, r := result[i].ModTime, result[j].ModTime; !l.Equal(r) {
+			return l.Before(r)
+		}
+
+		if l, r := result[i].ID, result[j].ID; l != r {
+			return l < r
+		}
+
+		return false
+	})
+
+	return result
+}
+
+// PickLatestID picks the ID of latest EntryMetadata in a given slice.
+func PickLatestID(entries []*EntryMetadata) ID {
+	var latest *EntryMetadata
+
+	for _, e := range entries {
+		if isLaterThan(e, latest) {
+			latest = e
+		}
+	}
+
+	if latest == nil {
+		return ""
+	}
+
+	return latest.ID
+}
+
+// isLaterThan returns true if a is later than b by examining modification time.
+// in case modification times are the same, arbitrary ordering based on IDs is used.
+func isLaterThan(a, b *EntryMetadata) bool {
+	if b == nil {
+		return true
+	}
+
+	if a == nil {
+		return false
+	}
+
+	if a.ModTime.After(b.ModTime) {
+		return true
+	}
+
+	return a.ID > b.ID
 }

--- a/repo/manifest/manifest_entry_test.go
+++ b/repo/manifest/manifest_entry_test.go
@@ -1,0 +1,95 @@
+package manifest_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/kopia/kopia/repo/manifest"
+)
+
+func TestPickLatestID(t *testing.T) {
+	t0 := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2000, 1, 2, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2000, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		input []*manifest.EntryMetadata
+		want  manifest.ID
+	}{
+		{
+			input: []*manifest.EntryMetadata{},
+			want:  "",
+		},
+		{
+			// pick only item
+			input: []*manifest.EntryMetadata{
+				{ID: "id1", ModTime: t0},
+			},
+			want: "id1",
+		},
+		{
+			// pick highest time
+			input: []*manifest.EntryMetadata{
+				{ID: "id1", ModTime: t0},
+				{ID: "id2", ModTime: t1},
+				{ID: "id3", ModTime: t2},
+			},
+			want: "id3",
+		},
+		{
+			// pick lexicographically latests ID if all times are the same.
+			input: []*manifest.EntryMetadata{
+				{ID: "idx", ModTime: t0},
+				{ID: "ida", ModTime: t0},
+				{ID: "idz", ModTime: t0},
+				{ID: "idb", ModTime: t0},
+			},
+			want: "idz",
+		},
+	}
+
+	for _, tc := range cases {
+		if got := manifest.PickLatestID(tc.input); got != tc.want {
+			t.Errorf("invalid result of PickLatestID: %v, want %v", got, tc.want)
+		}
+	}
+}
+
+func TestDedupeEntryMetadataByLabel(t *testing.T) {
+	t0 := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2000, 1, 2, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2000, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	theLabel := "the-label"
+
+	manA0 := &manifest.EntryMetadata{ID: "id1", Labels: map[string]string{theLabel: "a"}, ModTime: t0}
+	manA1 := &manifest.EntryMetadata{ID: "id2", Labels: map[string]string{theLabel: "a"}, ModTime: t1}
+	manA2 := &manifest.EntryMetadata{ID: "id3", Labels: map[string]string{theLabel: "a"}, ModTime: t2}
+	manB0 := &manifest.EntryMetadata{ID: "id4", Labels: map[string]string{theLabel: "b"}, ModTime: t0}
+	manB1 := &manifest.EntryMetadata{ID: "id5", Labels: map[string]string{theLabel: "b"}, ModTime: t1}
+	manC2 := &manifest.EntryMetadata{ID: "id6", Labels: map[string]string{theLabel: "c"}, ModTime: t2}
+
+	cases := []struct {
+		input []*manifest.EntryMetadata
+		want  []*manifest.EntryMetadata
+	}{
+		{
+			input: []*manifest.EntryMetadata{},
+			want:  nil,
+		},
+		{
+			input: []*manifest.EntryMetadata{manA0, manA1, manA2, manB1, manB0, manC2},
+			// results will be sorted by time then ID
+			want: []*manifest.EntryMetadata{manB1, manA2, manC2},
+		},
+	}
+
+	for _, tc := range cases {
+		got := manifest.DedupeEntryMetadataByLabel(tc.input, theLabel)
+		if diff := cmp.Diff(got, tc.want); diff != "" {
+			t.Errorf("invalid result of DedupeEntryMetadataByLabel (-got, +want): %v", diff)
+		}
+	}
+}

--- a/snapshot/policy/policy_manager.go
+++ b/snapshot/policy/policy_manager.go
@@ -99,7 +99,7 @@ func GetDefinedPolicy(ctx context.Context, rep repo.Repository, si snapshot.Sour
 	// this is possible when two repository clients independently create manifests at approximately the same time
 	// so it should not really matter which one we pick.
 	// see https://github.com/kopia/kopia/issues/391
-	manifestID := md[0].ID
+	manifestID := manifest.PickLatestID(md)
 
 	p := &Policy{}
 


### PR DESCRIPTION
This is an alternative to htpasswd-based authentication. Users can be added and manipulated using CLI and are stored in a repository as manifests of type `user`.