### PR TITLE
[DRAFT] Repository user authorization using ACLs

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -46,6 +46,7 @@ var (
 	benchmarkCommands   = app.Command("benchmark", "Commands to test performance of algorithms.").Hidden()
 	maintenanceCommands = app.Command("maintenance", "Maintenance commands.").Hidden().Alias("gc")
 	sessionCommands     = app.Command("session", "Session commands.").Hidden()
+	userCommands        = app.Command("users", "Manager repository users").Alias("user")
 )
 
 func helpFullAction(ctx *kingpin.ParseContext) error {

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -64,7 +64,7 @@ func runServer(ctx context.Context, rep repo.Repository) error {
 		RefreshInterval: *serverStartRefreshInterval,
 		MaxConcurrency:  *serverStartMaxConcurrency,
 		Authenticator:   authn,
-		Authorizer:      auth.LegacyAuthorizerForUser,
+		Authorizer:      auth.ACLAuthorizer(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "unable to initialize server")

--- a/cli/command_user_add_set.go
+++ b/cli/command_user_add_set.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/alecthomas/kingpin"
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+var (
+	userCreateCommand = userCommands.Command("add", "Add new repository user").Alias("create")
+	userUpdateCommand = userCommands.Command("set", "Set password for a repository user.").Alias("update")
+
+	userAskPassword     bool
+	userSetName         string
+	userSetPassword     string
+	userSetPasswordHash string
+)
+
+func registerAddSetUserCommandArguments(cmd *kingpin.CmdClause) {
+	cmd.Flag("ask-password", "Ask for user password").BoolVar(&userAskPassword)
+	cmd.Flag("user-password", "Password").StringVar(&userSetPassword)
+	cmd.Flag("user-password-hash", "Password hash").StringVar(&userSetPasswordHash)
+	cmd.Arg("username", "Username").Required().StringVar(&userSetName)
+}
+
+func runUserCreate(ctx context.Context, rep repo.RepositoryWriter) error {
+	return runServerUserAddSet(ctx, rep, true)
+}
+
+func runUserUpdate(ctx context.Context, rep repo.RepositoryWriter) error {
+	return runServerUserAddSet(ctx, rep, false)
+}
+
+func runServerUserAddSet(ctx context.Context, rep repo.RepositoryWriter, isNew bool) error {
+	username := userSetName
+
+	up, err := user.GetUserProfile(ctx, rep, username)
+
+	if isNew {
+		switch {
+		case err == nil:
+			return errors.Errorf("user %q already exists", username)
+
+		case errors.Is(err, user.ErrUserNotFound):
+			up = &user.Profile{
+				Username: username,
+			}
+			err = nil
+		}
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "error getting user profile")
+	}
+
+	if p := userSetPassword; p != "" {
+		if err := up.SetPassword(p); err != nil {
+			return errors.Wrap(err, "error setting password")
+		}
+	}
+
+	if p := userSetPasswordHash; p != "" {
+		up.PasswordHash = p
+	}
+
+	if up.PasswordHash == "" || userAskPassword {
+		pwd, err := askPass("Enter new password for user " + username + ": ")
+		if err != nil {
+			return errors.Wrap(err, "error asking for password")
+		}
+
+		pwd2, err := askPass("Re-enter new password for verification: ")
+		if err != nil {
+			return errors.Wrap(err, "error asking for password")
+		}
+
+		if pwd != pwd2 {
+			return errors.Wrap(err, "passwords don't match")
+		}
+
+		if err := up.SetPassword(pwd); err != nil {
+			return errors.Wrap(err, "error setting password")
+		}
+	}
+
+	if err := user.SetUserProfile(ctx, rep, up); err != nil {
+		return errors.Wrap(err, "error setting user profile")
+	}
+
+	log(ctx).Noticef(`
+Updated user credentials will take effect in 5-10 minutes or when the server is restarted.
+To refresh credentials in a running server use 'kopia server refresh' command.
+`)
+
+	return nil
+}
+
+func init() {
+	registerAddSetUserCommandArguments(userCreateCommand)
+	registerAddSetUserCommandArguments(userUpdateCommand)
+	userCreateCommand.Action(repositoryWriterAction(runUserCreate))
+	userUpdateCommand.Action(repositoryWriterAction(runUserUpdate))
+}

--- a/cli/command_user_delete.go
+++ b/cli/command_user_delete.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+var (
+	userDeleteCommand = userCommands.Command("delete", "Delete user")
+	userDeleteName    = userDeleteCommand.Arg("username", "The username to delete.").Required().String()
+)
+
+func runUserDelete(ctx context.Context, rep repo.RepositoryWriter) error {
+	err := user.DeleteUserProfile(ctx, rep, *userDeleteName)
+	if err != nil {
+		return errors.Wrap(err, "error deleting user profile")
+	}
+
+	log(ctx).Infof("User %q deleted.", *userDeleteName)
+
+	return nil
+}
+
+func init() {
+	userDeleteCommand.Action(repositoryWriterAction(runUserDelete))
+}

--- a/cli/command_user_info.go
+++ b/cli/command_user_info.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+var (
+	userInfoCommand = userCommands.Command("info", "Info about particular user")
+	userInfoName    = userInfoCommand.Arg("username", "The username to look up.").Required().String()
+)
+
+func runUserInfo(ctx context.Context, rep repo.DirectRepository) error {
+	up, err := user.GetUserProfile(ctx, rep, *userInfoName)
+	if err != nil {
+		return errors.Wrap(err, "error getting user profile")
+	}
+
+	j, err := json.MarshalIndent(up, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "error marshaling JSON")
+	}
+
+	printStdout("%v", string(j))
+
+	return nil
+}
+
+func init() {
+	userInfoCommand.Action(directRepositoryReadAction(runUserInfo))
+}

--- a/cli/command_user_list.go
+++ b/cli/command_user_list.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+var userListCommand = userCommands.Command("list", "List users").Alias("ls")
+
+func runUserList(ctx context.Context, rep repo.Repository) error {
+	profiles, err := user.ListUserProfiles(ctx, rep)
+	if err != nil {
+		return errors.Wrap(err, "error listing user profiles")
+	}
+
+	for _, p := range profiles {
+		printStdout("%v\n", p.Username)
+	}
+
+	return nil
+}
+
+func init() {
+	userListCommand.Action(repositoryReaderAction(runUserList))
+}

--- a/internal/acl/acl.go
+++ b/internal/acl/acl.go
@@ -1,0 +1,135 @@
+package acl
+
+import "github.com/kopia/kopia/repo/manifest"
+
+// placeholders that can be used in ACL definitions to refer to the current user.
+const (
+	CurrentUsernamePlaceholder = "CURRENT_USER"
+	CurrentHostnamePlaceholder = "CURRENT_HOST"
+)
+
+// AccessControlList defines access control list.
+type AccessControlList struct {
+	ManifestID manifest.ID `json:"-"`
+
+	ContentAccess  AccessLevel                     `json:"content,omitempty"`
+	ManifestAccess map[string][]ManifestAccessRule `json:"manifest"`
+}
+
+// ContentAccessLevel implements authz.AuthorizationInfo.
+func (m AccessControlList) ContentAccessLevel() AccessLevel {
+	if m.ContentAccess == AccessLevelUnspecified {
+		return AccessLevelNone
+	}
+
+	return m.ContentAccess
+}
+
+// ManifestAccessLevel implements authz.AuthorizationInfo.
+func (m AccessControlList) ManifestAccessLevel(labels map[string]string) AccessLevel {
+	result := AccessLevelUnspecified
+
+	for _, r := range m.ManifestAccess[labels[manifest.TypeLabelKey]] {
+		if r.Access != AccessLevelUnspecified && isMatch(labels, r.Match) {
+			result = r.Access
+		}
+	}
+
+	if result == AccessLevelUnspecified {
+		result = AccessLevelNone
+	}
+
+	return result
+}
+
+// Personalize returns modified access control list by replacing username and hostname
+// placeholders with the provided username and hostname.
+func (m AccessControlList) Personalize(username, hostname string) AccessControlList {
+	result := AccessControlList{
+		ContentAccess:  m.ContentAccess,
+		ManifestAccess: map[string][]ManifestAccessRule{},
+	}
+
+	// combine manifest access rules left-to-right
+	for k, v := range m.ManifestAccess {
+		for _, r := range v {
+			result.ManifestAccess[k] = append(result.ManifestAccess[k], r.Personalize(username, hostname))
+		}
+	}
+
+	return result
+}
+
+func isMatch(actual, expected map[string]string) bool {
+	for k, v := range expected {
+		if actual[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+// AccessLevel specifies access level.
+type AccessLevel int
+
+// Supported access levels.
+const (
+	AccessLevelUnspecified AccessLevel = 0 // permissions unspecified
+	AccessLevelNone        AccessLevel = 1 // no access
+	AccessLevelView        AccessLevel = 2 // permissions to view, but not change
+	AccessLevelAppend      AccessLevel = 3 // permissions to view/add but not update/delete.
+	AccessLevelFull        AccessLevel = 4 // permission to view/add/update/delete.
+)
+
+// ManifestAccessRule specifies rules for accessing policies and snapshot manifests.
+type ManifestAccessRule struct {
+	Access AccessLevel       `json:"level"`
+	Match  map[string]string `json:"match"`
+}
+
+// Personalize returns personalized version of the rule by replacing current username/hostname
+// placeholders with the provided values.
+func (m ManifestAccessRule) Personalize(username, hostname string) ManifestAccessRule {
+	result := ManifestAccessRule{
+		Access: m.Access,
+		Match:  map[string]string{},
+	}
+
+	for k, v := range m.Match {
+		switch v {
+		case CurrentUsernamePlaceholder:
+			result.Match[k] = username
+
+		case CurrentHostnamePlaceholder:
+			result.Match[k] = hostname
+		default:
+			result.Match[k] = v
+		}
+	}
+
+	return result
+}
+
+// Merge returns a merged AccessControlList from a provided list,
+// which must be ordered from most general (global) to most specific (individual user) ACLs.
+func Merge(acls ...AccessControlList) AccessControlList {
+	result := AccessControlList{
+		ManifestAccess: map[string][]ManifestAccessRule{},
+	}
+
+	for _, a := range acls {
+		// when merging, pick the most specific content access.
+		// this allows both allow and deny rules.
+		if a.ContentAccess != AccessLevelUnspecified {
+			result.ContentAccess = a.ContentAccess
+		}
+
+		// combine manifest access rules left-to-right
+		for k, v := range a.ManifestAccess {
+			result.ManifestAccess[k] = append(result.ManifestAccess[k], v...)
+		}
+	}
+
+	return result
+}

--- a/internal/acl/acl_manager.go
+++ b/internal/acl/acl_manager.go
@@ -1,0 +1,136 @@
+// Package acl provides management of ACLs that define permissions granted to repository users.
+package acl
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/manifest"
+)
+
+const (
+	aclManifestType = "acl"
+	usernameLabel   = "username"
+	hostnameLabel   = "hostname"
+)
+
+// Scope defines scope to which the ACL is applicable.
+type Scope struct {
+	Username string // empty == all users
+	Hostname string // empty == all hosts
+}
+
+// LoadACLMap returns the map of all ACLs in the repository by their Scope, using old map as a cache.
+func LoadACLMap(ctx context.Context, rep repo.Repository, old map[Scope]AccessControlList) (map[Scope]AccessControlList, error) {
+	if rep == nil {
+		return nil, nil
+	}
+
+	entries, err := rep.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey: aclManifestType,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error listing ACL manifests")
+	}
+
+	result := map[Scope]AccessControlList{}
+
+	for _, m := range manifest.DedupeEntryMetadataByLabels(entries, usernameLabel, hostnameLabel) {
+		scope := Scope{m.Labels[usernameLabel], m.Labels[hostnameLabel]}
+
+		// same scope info as before
+		if o, ok := old[scope]; ok && o.ManifestID == m.ID {
+			result[scope] = o
+			continue
+		}
+
+		var p AccessControlList
+
+		_, err := rep.GetManifest(ctx, m.ID, &p)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error loading ACL manifest %v", scope)
+		}
+
+		p.ManifestID = m.ID
+
+		result[scope] = p
+	}
+
+	return result, nil
+}
+
+// GetACL returns the ACL for a given scope.
+func GetACL(ctx context.Context, r repo.Repository, scope Scope) (AccessControlList, error) {
+	manifests, err := r.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey: aclManifestType,
+		usernameLabel:         scope.Username,
+		hostnameLabel:         scope.Hostname,
+	})
+	if err != nil {
+		return AccessControlList{}, errors.Wrap(err, "error looking for ACL")
+	}
+
+	if len(manifests) == 0 {
+		return AccessControlList{}, nil
+	}
+
+	p := AccessControlList{}
+	if _, err := r.GetManifest(ctx, manifest.PickLatestID(manifests), &p); err != nil {
+		return AccessControlList{}, errors.Wrap(err, "error loading ACL")
+	}
+
+	return p, nil
+}
+
+// SetACL creates or updates ACL for a given scope.
+func SetACL(ctx context.Context, w repo.RepositoryWriter, scope Scope, p AccessControlList) error {
+	manifests, err := w.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey: aclManifestType,
+		usernameLabel:         scope.Username,
+		hostnameLabel:         scope.Hostname,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error looking for ACL")
+	}
+
+	id, err := w.PutManifest(ctx, map[string]string{
+		manifest.TypeLabelKey: aclManifestType,
+		usernameLabel:         scope.Username,
+		hostnameLabel:         scope.Hostname,
+	}, p)
+	if err != nil {
+		return errors.Wrap(err, "error writing ACL")
+	}
+
+	for _, m := range manifests {
+		if err := w.DeleteManifest(ctx, m.ID); err != nil {
+			return errors.Wrapf(err, "error deleting ACL %v", scope)
+		}
+	}
+
+	p.ManifestID = id
+
+	return nil
+}
+
+// DeleteACL removes ACL with a given scope.
+func DeleteACL(ctx context.Context, w repo.RepositoryWriter, scope Scope) error {
+	manifests, err := w.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey: aclManifestType,
+		usernameLabel:         scope.Username,
+		hostnameLabel:         scope.Hostname,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error looking for ACL")
+	}
+
+	for _, m := range manifests {
+		if err := w.DeleteManifest(ctx, m.ID); err != nil {
+			return errors.Wrapf(err, "error deleting ACL %v", scope)
+		}
+	}
+
+	return nil
+}

--- a/internal/acl/acl_manager_test.go
+++ b/internal/acl/acl_manager_test.go
@@ -1,0 +1,65 @@
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/acl"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testlogging"
+)
+
+func TestACLManager(t *testing.T) {
+	var env repotesting.Environment
+
+	ctx := testlogging.Context(t)
+	defer env.Setup(t).Close(ctx, t)
+
+	scope1 := acl.Scope{Username: "user1", Hostname: "host1"}
+
+	a, err := acl.GetACL(ctx, env.RepositoryWriter, scope1)
+	must(t, err)
+
+	if got, want := a.ContentAccess, acl.AccessLevelUnspecified; got != want {
+		t.Errorf("unexpected content access: %v, want %v", got, want)
+	}
+
+	must(t, acl.SetACL(ctx, env.RepositoryWriter, scope1, acl.AccessControlList{
+		ContentAccess: acl.AccessLevelView,
+	}))
+
+	a, err = acl.GetACL(ctx, env.RepositoryWriter, scope1)
+	must(t, err)
+
+	if got, want := a.ContentAccess, acl.AccessLevelView; got != want {
+		t.Errorf("unexpected content access: %v, want %v", got, want)
+	}
+
+	must(t, acl.SetACL(ctx, env.RepositoryWriter, scope1, acl.AccessControlList{
+		ContentAccess: acl.AccessLevelAppend,
+	}))
+
+	a, err = acl.GetACL(ctx, env.RepositoryWriter, scope1)
+	must(t, err)
+
+	if got, want := a.ContentAccess, acl.AccessLevelAppend; got != want {
+		t.Errorf("unexpected content access: %v, want %v", got, want)
+	}
+
+	err = acl.DeleteACL(ctx, env.RepositoryWriter, scope1)
+	must(t, err)
+
+	a, err = acl.GetACL(ctx, env.RepositoryWriter, scope1)
+	must(t, err)
+
+	if got, want := a.ContentAccess, acl.AccessLevelUnspecified; got != want {
+		t.Errorf("unexpected content access: %v, want %v", got, want)
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/auth/authn.go
+++ b/internal/auth/authn.go
@@ -6,7 +6,10 @@ import (
 	"crypto/subtle"
 
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/logging"
 )
+
+var log = logging.GetContextLoggerFunc("auth")
 
 // Authenticator verifies that the provided username/password is valid.
 type Authenticator func(ctx context.Context, rep repo.Repository, username, password string) bool

--- a/internal/auth/authn_repo.go
+++ b/internal/auth/authn_repo.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+const defaultProfileRefreshFrequency = 10 * time.Second
+
+type repositoryUserAuthenticator struct {
+	lastRep repo.Repository
+
+	mu                          sync.Mutex
+	nextRefreshTime             time.Time
+	userProfiles                map[string]*user.Profile
+	userProfileRefreshFrequency time.Duration
+}
+
+// AuthenticateSingleUser returns an Authenticator that only allows one username/password combination.
+func (ac *repositoryUserAuthenticator) authenticate(ctx context.Context, rep repo.Repository, username, password string) bool {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	// if the server switched to serving another repository, discard cache.
+	if rep != ac.lastRep {
+		ac.userProfiles = nil
+		ac.lastRep = rep
+	}
+
+	// see if we're due for a refresh and refresh userProfiles map
+	if clock.Now().After(ac.nextRefreshTime) {
+		ac.nextRefreshTime = clock.Now().Add(ac.userProfileRefreshFrequency)
+
+		newUsers, err := user.LoadProfileMap(ctx, rep, ac.userProfiles)
+		if err != nil {
+			log(ctx).Warningf("unable to load userProfiles map: %v", err)
+		} else {
+			ac.userProfiles = newUsers
+		}
+	}
+
+	u := ac.userProfiles[username]
+	if u == nil {
+		return false
+	}
+
+	return u.IsValidPassword(password)
+}
+
+// AuthenticateRepositoryUsers returns authenticator that accepts username/password combinations
+// stored in 'user' manifests in the repository.
+func AuthenticateRepositoryUsers() Authenticator {
+	a := &repositoryUserAuthenticator{
+		userProfileRefreshFrequency: defaultProfileRefreshFrequency,
+	}
+
+	return a.authenticate
+}

--- a/internal/auth/authn_repo_test.go
+++ b/internal/auth/authn_repo_test.go
@@ -1,0 +1,45 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kopia/kopia/internal/auth"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+)
+
+func TestRepositoryAuthenticator(t *testing.T) {
+	a := auth.AuthenticateRepositoryUsers()
+	ctx := testlogging.Context(t)
+
+	var env repotesting.Environment
+	defer env.Setup(t).Close(ctx, t)
+
+	repo.WriteSession(ctx, env.Repository, repo.WriteSessionOptions{},
+		func(w repo.RepositoryWriter) error {
+			p := &user.Profile{
+				Username: "user1",
+			}
+
+			p.SetPassword("password1")
+
+			return user.SetUserProfile(ctx, w, p)
+		})
+
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user1", "password1", true)
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user1", "password2", false)
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user1", "password11", false)
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user1a", "password1", false)
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user1a", "password1a", false)
+}
+
+func verifyRepoAuthenticator(ctx context.Context, t *testing.T, a auth.Authenticator, r repo.Repository, username, password string, want bool) {
+	t.Helper()
+
+	if got := a(ctx, r, username, password); got != want {
+		t.Errorf("invalid authenticator result for %v/%v: %v, want %v", username, password, got, want)
+	}
+}

--- a/internal/auth/authz_acl.go
+++ b/internal/auth/authz_acl.go
@@ -1,0 +1,128 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kopia/kopia/internal/acl"
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/policy"
+)
+
+const defaultACLRefreshFrequency = 10 * time.Second
+
+// currentUserAtHostMatch is a set of labels that when personalized matches manifests which have
+// username equal to current user and hostname matching current host.
+var currentUserAtHostMatch = map[string]string{
+	"username": acl.CurrentUsernamePlaceholder,
+	"hostname": acl.CurrentHostnamePlaceholder,
+}
+
+// nonPersonalizedDefaultACL is the default access control list applied when no other ACL is defined.
+// The ACL must be personalized to a user account.
+var nonPersonalizedDefaultACL = acl.AccessControlList{
+	ContentAccess: AccessLevelFull,
+	ManifestAccess: map[string][]acl.ManifestAccessRule{
+		policy.ManifestType: {
+			// everybody can read global policy.
+			{
+				Match:  map[string]string{"policyType": "global"},
+				Access: acl.AccessLevelView,
+			},
+
+			// users *@host can see that host's policy.
+			{
+				Match: map[string]string{
+					"policyType": "host",
+					"hostname":   acl.CurrentHostnamePlaceholder,
+				},
+				Access: acl.AccessLevelView,
+			},
+
+			// username@hostname has full access to their own policies
+			{
+				Match:  currentUserAtHostMatch,
+				Access: acl.AccessLevelFull,
+			},
+		},
+		snapshot.ManifestType: {
+			// username@hostname has full access to their own snapshots
+			{
+				Match:  currentUserAtHostMatch,
+				Access: acl.AccessLevelFull,
+			},
+		},
+		user.ManifestType: {
+			// username@hostname has full access to their own user account to be able to change password.
+			{
+				Match:  currentUserAtHostMatch,
+				Access: acl.AccessLevelFull,
+			},
+		},
+	},
+}
+
+type aclCache struct {
+	aclRefreshFrequency time.Duration
+
+	mu              sync.Mutex
+	lastRep         repo.Repository
+	nextRefreshTime time.Time
+	aclMap          map[acl.Scope]acl.AccessControlList
+}
+
+// authorize is an AuthorizerFunc that returns authorizer that uses ACLs stored in the repository.
+func (ac *aclCache) authorize(ctx context.Context, rep repo.Repository, usernameAtHostname string) AuthorizationInfo {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	parts := strings.Split(usernameAtHostname, "@")
+	if len(parts) != 2 { //nolint:gomnd
+		return NoAccess()
+	}
+
+	u := parts[0]
+	h := parts[1]
+
+	if rep == ac.lastRep {
+		// the server switched to another repository, discard cache.
+		ac.aclMap = nil
+		ac.lastRep = rep
+	}
+
+	// see if we're due for a refresh and refresh aclMap
+	if clock.Now().After(ac.nextRefreshTime) {
+		ac.nextRefreshTime = clock.Now().Add(ac.aclRefreshFrequency)
+
+		newMap, err := acl.LoadACLMap(ctx, rep, ac.aclMap)
+		if err != nil {
+			log(ctx).Warningf("unable to load aclMap: %v", err)
+		} else {
+			ac.aclMap = newMap
+		}
+	}
+
+	// Get ACLs at different scopes, personalize and merge them from most general to most specific.
+	// acl.AccessList implements AuthorizationInfo
+	return acl.Merge(
+		nonPersonalizedDefaultACL.Personalize(u, h),
+		ac.aclMap[acl.Scope{}].Personalize(u, h),
+		ac.aclMap[acl.Scope{Hostname: h}].Personalize(u, h),
+		ac.aclMap[acl.Scope{Username: u}].Personalize(u, h),
+		ac.aclMap[acl.Scope{Username: u, Hostname: h}].Personalize(u, h))
+}
+
+// ACLAuthorizer returns AuthorizerFunc that will fetch ACLs from the repository
+// and evaluate them in the context of current user to determine their permision levels.
+func ACLAuthorizer() AuthorizerFunc {
+	c := &aclCache{
+		aclRefreshFrequency: defaultACLRefreshFrequency,
+	}
+
+	return c.authorize
+}

--- a/internal/auth/authz_acl_test.go
+++ b/internal/auth/authz_acl_test.go
@@ -1,0 +1,36 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/auth"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testlogging"
+)
+
+func TestACL(t *testing.T) {
+	aa := auth.ACLAuthorizer()
+	ctx := testlogging.Context(t)
+
+	var env repotesting.Environment
+
+	defer env.Setup(t).Close(ctx, t)
+
+	rep := env.Repository
+
+	ai := aa(ctx, rep, "someuser@hostname")
+
+	if got, want := ai.ContentAccessLevel(), auth.AccessLevelNone; got != want {
+		t.Errorf("invalid content access level: %v, want %v", got, want)
+	}
+
+	verifyManifestAccessLevel(t, ai, globalPolicyLabels, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, ai, fooAtBarPathPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, ai, fooAtBazPathPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, ai, fooAtBarPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, ai, fooAtBazPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, ai, barPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, ai, bazPolicy, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, ai, fooAtBarSnapshot, auth.AccessLevelNone)
+	verifyManifestAccessLevel(t, ai, fooAtBazSnapshot, auth.AccessLevelNone)
+}

--- a/internal/user/user_manager.go
+++ b/internal/user/user_manager.go
@@ -1,0 +1,154 @@
+// Package user provides management of user accounts.
+package user
+
+import (
+	"context"
+	"sort"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/manifest"
+)
+
+const (
+	usernameLabel = "username"
+
+	userManifestType = "user"
+)
+
+// ErrUserNotFound is returned to indicate that a user was not found in the system.
+var ErrUserNotFound = errors.New("user not found")
+
+// LoadProfileMap returns the map of all users profiles in the repository by username, using old map as a cache.
+func LoadProfileMap(ctx context.Context, rep repo.Repository, old map[string]*Profile) (map[string]*Profile, error) {
+	if rep == nil {
+		return nil, nil
+	}
+
+	entries, err := rep.FindManifests(ctx, map[string]string{manifest.TypeLabelKey: userManifestType})
+	if err != nil {
+		return nil, errors.Wrap(err, "error listing user manifests")
+	}
+
+	result := map[string]*Profile{}
+
+	for _, m := range manifest.DedupeEntryMetadataByLabel(entries, usernameLabel) {
+		user := m.Labels[usernameLabel]
+
+		// same user info as before
+		if o := old[user]; o != nil && o.ManifestID == m.ID {
+			result[user] = o
+			continue
+		}
+
+		p := &Profile{}
+		if _, err := rep.GetManifest(ctx, m.ID, p); err != nil {
+			return nil, errors.Wrapf(err, "error loading user manifest %v", user)
+		}
+
+		p.ManifestID = m.ID
+
+		result[user] = p
+	}
+
+	return result, nil
+}
+
+// ListUserProfiles gets the list of all user profiles in the system.
+func ListUserProfiles(ctx context.Context, rep repo.Repository) ([]*Profile, error) {
+	var result []*Profile
+
+	users, err := LoadProfileMap(ctx, rep, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range users {
+		result = append(result, v)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Username < result[j].Username
+	})
+
+	return result, nil
+}
+
+// GetUserProfile returns the user profile with a given username.
+func GetUserProfile(ctx context.Context, r repo.Repository, username string) (*Profile, error) {
+	manifests, err := r.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey: userManifestType,
+		usernameLabel:         username,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error looking for user profile")
+	}
+
+	if len(manifests) == 0 {
+		return nil, errors.Wrap(ErrUserNotFound, username)
+	}
+
+	p := &Profile{}
+	if _, err := r.GetManifest(ctx, manifest.PickLatestID(manifests), p); err != nil {
+		return nil, errors.Wrap(err, "error loading user profile")
+	}
+
+	return p, nil
+}
+
+// SetUserProfile creates or updates user profile.
+func SetUserProfile(ctx context.Context, w repo.RepositoryWriter, p *Profile) error {
+	if p.Username == "" {
+		return errors.Errorf("username is required")
+	}
+
+	manifests, err := w.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey: userManifestType,
+		usernameLabel:         p.Username,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error looking for user profile")
+	}
+
+	id, err := w.PutManifest(ctx, map[string]string{
+		manifest.TypeLabelKey: userManifestType,
+		usernameLabel:         p.Username,
+	}, p)
+	if err != nil {
+		return errors.Wrap(err, "error writing user profile")
+	}
+
+	for _, m := range manifests {
+		if err := w.DeleteManifest(ctx, m.ID); err != nil {
+			return errors.Wrapf(err, "error deleting user profile %v", p.Username)
+		}
+	}
+
+	p.ManifestID = id
+
+	return nil
+}
+
+// DeleteUserProfile removes user profile with a given username.
+func DeleteUserProfile(ctx context.Context, w repo.RepositoryWriter, username string) error {
+	if username == "" {
+		return errors.Errorf("username is required")
+	}
+
+	manifests, err := w.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey: userManifestType,
+		usernameLabel:         username,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error looking for user profile")
+	}
+
+	for _, m := range manifests {
+		if err := w.DeleteManifest(ctx, m.ID); err != nil {
+			return errors.Wrapf(err, "error deleting user profile %v", username)
+		}
+	}
+
+	return nil
+}

--- a/internal/user/user_manager.go
+++ b/internal/user/user_manager.go
@@ -11,11 +11,10 @@ import (
 	"github.com/kopia/kopia/repo/manifest"
 )
 
-const (
-	usernameLabel = "username"
+// ManifestType is the type of the manifest used to represent user accounts.
+const ManifestType = "user"
 
-	userManifestType = "user"
-)
+const usernameLabel = "username"
 
 // ErrUserNotFound is returned to indicate that a user was not found in the system.
 var ErrUserNotFound = errors.New("user not found")
@@ -26,7 +25,7 @@ func LoadProfileMap(ctx context.Context, rep repo.Repository, old map[string]*Pr
 		return nil, nil
 	}
 
-	entries, err := rep.FindManifests(ctx, map[string]string{manifest.TypeLabelKey: userManifestType})
+	entries, err := rep.FindManifests(ctx, map[string]string{manifest.TypeLabelKey: ManifestType})
 	if err != nil {
 		return nil, errors.Wrap(err, "error listing user manifests")
 	}
@@ -78,7 +77,7 @@ func ListUserProfiles(ctx context.Context, rep repo.Repository) ([]*Profile, err
 // GetUserProfile returns the user profile with a given username.
 func GetUserProfile(ctx context.Context, r repo.Repository, username string) (*Profile, error) {
 	manifests, err := r.FindManifests(ctx, map[string]string{
-		manifest.TypeLabelKey: userManifestType,
+		manifest.TypeLabelKey: ManifestType,
 		usernameLabel:         username,
 	})
 	if err != nil {
@@ -104,7 +103,7 @@ func SetUserProfile(ctx context.Context, w repo.RepositoryWriter, p *Profile) er
 	}
 
 	manifests, err := w.FindManifests(ctx, map[string]string{
-		manifest.TypeLabelKey: userManifestType,
+		manifest.TypeLabelKey: ManifestType,
 		usernameLabel:         p.Username,
 	})
 	if err != nil {
@@ -112,7 +111,7 @@ func SetUserProfile(ctx context.Context, w repo.RepositoryWriter, p *Profile) er
 	}
 
 	id, err := w.PutManifest(ctx, map[string]string{
-		manifest.TypeLabelKey: userManifestType,
+		manifest.TypeLabelKey: ManifestType,
 		usernameLabel:         p.Username,
 	}, p)
 	if err != nil {
@@ -137,7 +136,7 @@ func DeleteUserProfile(ctx context.Context, w repo.RepositoryWriter, username st
 	}
 
 	manifests, err := w.FindManifests(ctx, map[string]string{
-		manifest.TypeLabelKey: userManifestType,
+		manifest.TypeLabelKey: ManifestType,
 		usernameLabel:         username,
 	})
 	if err != nil {

--- a/internal/user/user_manager_test.go
+++ b/internal/user/user_manager_test.go
@@ -1,0 +1,70 @@
+package user_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/user"
+)
+
+func TestUserManager(t *testing.T) {
+	var env repotesting.Environment
+
+	ctx := testlogging.Context(t)
+	defer env.Setup(t).Close(ctx, t)
+
+	if _, err := user.GetUserProfile(ctx, env.RepositoryWriter, "alice"); !errors.Is(err, user.ErrUserNotFound) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	must(t, user.SetUserProfile(ctx, env.RepositoryWriter, &user.Profile{
+		Username:     "alice",
+		PasswordHash: "hahaha",
+	}))
+
+	if _, err := user.GetUserProfile(ctx, env.RepositoryWriter, "bob"); !errors.Is(err, user.ErrUserNotFound) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	a, err := user.GetUserProfile(ctx, env.RepositoryWriter, "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := a.PasswordHash, "hahaha"; got != want {
+		t.Errorf("unexpected password hash: %v, want %v", got, want)
+	}
+
+	must(t, user.SetUserProfile(ctx, env.RepositoryWriter, &user.Profile{
+		Username:     "alice",
+		PasswordHash: "hehehehe",
+	}))
+
+	a, err = user.GetUserProfile(ctx, env.RepositoryWriter, "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := a.PasswordHash, "hehehehe"; got != want {
+		t.Errorf("unexpected password hash: %v, want %v", got, want)
+	}
+
+	err = user.DeleteUserProfile(ctx, env.RepositoryWriter, "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err = user.GetUserProfile(ctx, env.RepositoryWriter, "alice"); !errors.Is(err, user.ErrUserNotFound) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -1,0 +1,31 @@
+package user
+
+import (
+	"strings"
+
+	"github.com/kopia/kopia/repo/manifest"
+)
+
+// Profile describes information about a single user.
+type Profile struct {
+	ManifestID manifest.ID `json:"-"`
+
+	Username     string `json:"username"`
+	PasswordHash string `json:"passwordHash"`
+}
+
+// SetPassword changes the password for a user profile.
+func (p *Profile) SetPassword(password string) error {
+	return p.setPasswordV1(password)
+}
+
+// IsValidPassword determines whether the password is valid for a given user.
+func (p *Profile) IsValidPassword(password string) bool {
+	switch {
+	case strings.HasPrefix(p.PasswordHash, v1Prefix):
+		return isValidPasswordV1(password, p.PasswordHash)
+
+	default:
+		return false
+	}
+}

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -1,0 +1,65 @@
+package user
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"io"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/scrypt"
+)
+
+//  parameters for v1 hashing.
+const (
+	v1Prefix = "v1:"
+
+	v1ScryptN    = 65536
+	v1ScryptR    = 8
+	v1ScryptP    = 1
+	v1SaltLength = 32
+	v1KeyLength  = 32
+)
+
+func (p *Profile) setPasswordV1(password string) error {
+	salt := make([]byte, v1SaltLength)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return errors.Wrap(err, "error generating salt")
+	}
+
+	p.PasswordHash = computePasswordHashV1(password, salt)
+
+	return nil
+}
+
+func computePasswordHashV1(password string, salt []byte) string {
+	key, err := scrypt.Key([]byte(password), salt, v1ScryptN, v1ScryptR, v1ScryptP, v1KeyLength)
+	if err != nil {
+		panic("unexpected scrypt error")
+	}
+
+	payload := append(append([]byte(nil), salt...), key...)
+
+	return v1Prefix + base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func isValidPasswordV1(password, hashedPassword string) bool {
+	if len(hashedPassword) < len(v1Prefix) {
+		return false
+	}
+
+	data, err := base64.RawURLEncoding.DecodeString(hashedPassword[len(v1Prefix):])
+	if err != nil {
+		return false
+	}
+
+	if len(data) != v1SaltLength+v1KeyLength {
+		return false
+	}
+
+	salt := data[0:v1SaltLength]
+
+	h := computePasswordHashV1(password, salt)
+
+	return subtle.ConstantTimeCompare([]byte(h), []byte(hashedPassword)) != 0
+}

--- a/internal/user/user_profile_test.go
+++ b/internal/user/user_profile_test.go
@@ -1,0 +1,41 @@
+package user_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/user"
+)
+
+func TestUserProfile(t *testing.T) {
+	p := &user.Profile{}
+
+	if p.IsValidPassword("bar") {
+		t.Fatalf("password unexpectedly valid!")
+	}
+
+	p.SetPassword("foo")
+
+	if !p.IsValidPassword("foo") {
+		t.Fatalf("password not valid!")
+	}
+
+	if p.IsValidPassword("bar") {
+		t.Fatalf("password unexpectedly valid!")
+	}
+}
+
+func TestInvalidPasswordHash(t *testing.T) {
+	cases := []string{
+		"",
+		"v1",
+		"v1:**invalid*base64*",
+		"???",
+	}
+
+	for _, tc := range cases {
+		p := &user.Profile{PasswordHash: tc}
+		if p.IsValidPassword("some-password") {
+			t.Fatalf("password unexpectedly valid for %v", tc)
+		}
+	}
+}

--- a/repo/maintenance/maintenance_params.go
+++ b/repo/maintenance/maintenance_params.go
@@ -82,7 +82,7 @@ func GetParams(ctx context.Context, rep repo.Repository) (*Params, error) {
 	// this is possible when two repository clients independently create manifests at approximately the same time
 	// so it should not really matter which one we pick.
 	// see https://github.com/kopia/kopia/issues/391
-	manifestID := md[0].ID
+	manifestID := manifest.PickLatestID(md)
 
 	p := &Params{}
 	if _, err := rep.GetManifest(ctx, manifestID, p); err != nil {

--- a/repo/manifest/manifest_entry.go
+++ b/repo/manifest/manifest_entry.go
@@ -47,6 +47,39 @@ func DedupeEntryMetadataByLabel(entries []*EntryMetadata, label string) []*Entry
 	return result
 }
 
+// DedupeEntryMetadataByLabels deduplicates EntryMetadata in a provided slice by picking
+// the latest one for a given set of two labels.
+func DedupeEntryMetadataByLabels(entries []*EntryMetadata, label1, label2 string) []*EntryMetadata {
+	var result []*EntryMetadata
+
+	m := map[string]*EntryMetadata{}
+
+	for _, e := range entries {
+		u := e.Labels[label1] + "\n" + e.Labels[label2]
+		if isLaterThan(e, m[u]) {
+			m[u] = e
+		}
+	}
+
+	for _, v := range m {
+		result = append(result, v)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if l, r := result[i].ModTime, result[j].ModTime; !l.Equal(r) {
+			return l.Before(r)
+		}
+
+		if l, r := result[i].ID, result[j].ID; l != r {
+			return l < r
+		}
+
+		return false
+	})
+
+	return result
+}
+
 // PickLatestID picks the ID of latest EntryMetadata in a given slice.
 func PickLatestID(entries []*EntryMetadata) ID {
 	var latest *EntryMetadata

--- a/repo/manifest/manifest_entry.go
+++ b/repo/manifest/manifest_entry.go
@@ -1,6 +1,9 @@
 package manifest
 
-import "time"
+import (
+	"sort"
+	"time"
+)
 
 // EntryMetadata contains metadata about manifest item. Each manifest item has one or more labels
 // Including required "type" label.
@@ -9,4 +12,72 @@ type EntryMetadata struct {
 	Length  int               `json:"length"`
 	Labels  map[string]string `json:"labels"`
 	ModTime time.Time         `json:"mtime"`
+}
+
+// DedupeEntryMetadataByLabel deduplicates EntryMetadata in a provided slice by picking
+// the latest one for a given set of label.
+func DedupeEntryMetadataByLabel(entries []*EntryMetadata, label string) []*EntryMetadata {
+	var result []*EntryMetadata
+
+	m := map[string]*EntryMetadata{}
+
+	for _, e := range entries {
+		u := e.Labels[label]
+		if isLaterThan(e, m[u]) {
+			m[u] = e
+		}
+	}
+
+	for _, v := range m {
+		result = append(result, v)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if l, r := result[i].ModTime, result[j].ModTime; !l.Equal(r) {
+			return l.Before(r)
+		}
+
+		if l, r := result[i].ID, result[j].ID; l != r {
+			return l < r
+		}
+
+		return false
+	})
+
+	return result
+}
+
+// PickLatestID picks the ID of latest EntryMetadata in a given slice.
+func PickLatestID(entries []*EntryMetadata) ID {
+	var latest *EntryMetadata
+
+	for _, e := range entries {
+		if isLaterThan(e, latest) {
+			latest = e
+		}
+	}
+
+	if latest == nil {
+		return ""
+	}
+
+	return latest.ID
+}
+
+// isLaterThan returns true if a is later than b by examining modification time.
+// in case modification times are the same, arbitrary ordering based on IDs is used.
+func isLaterThan(a, b *EntryMetadata) bool {
+	if b == nil {
+		return true
+	}
+
+	if a == nil {
+		return false
+	}
+
+	if a.ModTime.After(b.ModTime) {
+		return true
+	}
+
+	return a.ID > b.ID
 }

--- a/repo/manifest/manifest_entry_test.go
+++ b/repo/manifest/manifest_entry_test.go
@@ -1,0 +1,95 @@
+package manifest_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/kopia/kopia/repo/manifest"
+)
+
+func TestPickLatestID(t *testing.T) {
+	t0 := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2000, 1, 2, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2000, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		input []*manifest.EntryMetadata
+		want  manifest.ID
+	}{
+		{
+			input: []*manifest.EntryMetadata{},
+			want:  "",
+		},
+		{
+			// pick only item
+			input: []*manifest.EntryMetadata{
+				{ID: "id1", ModTime: t0},
+			},
+			want: "id1",
+		},
+		{
+			// pick highest time
+			input: []*manifest.EntryMetadata{
+				{ID: "id1", ModTime: t0},
+				{ID: "id2", ModTime: t1},
+				{ID: "id3", ModTime: t2},
+			},
+			want: "id3",
+		},
+		{
+			// pick lexicographically latests ID if all times are the same.
+			input: []*manifest.EntryMetadata{
+				{ID: "idx", ModTime: t0},
+				{ID: "ida", ModTime: t0},
+				{ID: "idz", ModTime: t0},
+				{ID: "idb", ModTime: t0},
+			},
+			want: "idz",
+		},
+	}
+
+	for _, tc := range cases {
+		if got := manifest.PickLatestID(tc.input); got != tc.want {
+			t.Errorf("invalid result of PickLatestID: %v, want %v", got, tc.want)
+		}
+	}
+}
+
+func TestDedupeEntryMetadataByLabel(t *testing.T) {
+	t0 := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2000, 1, 2, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2000, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	theLabel := "the-label"
+
+	manA0 := &manifest.EntryMetadata{ID: "id1", Labels: map[string]string{theLabel: "a"}, ModTime: t0}
+	manA1 := &manifest.EntryMetadata{ID: "id2", Labels: map[string]string{theLabel: "a"}, ModTime: t1}
+	manA2 := &manifest.EntryMetadata{ID: "id3", Labels: map[string]string{theLabel: "a"}, ModTime: t2}
+	manB0 := &manifest.EntryMetadata{ID: "id4", Labels: map[string]string{theLabel: "b"}, ModTime: t0}
+	manB1 := &manifest.EntryMetadata{ID: "id5", Labels: map[string]string{theLabel: "b"}, ModTime: t1}
+	manC2 := &manifest.EntryMetadata{ID: "id6", Labels: map[string]string{theLabel: "c"}, ModTime: t2}
+
+	cases := []struct {
+		input []*manifest.EntryMetadata
+		want  []*manifest.EntryMetadata
+	}{
+		{
+			input: []*manifest.EntryMetadata{},
+			want:  nil,
+		},
+		{
+			input: []*manifest.EntryMetadata{manA0, manA1, manA2, manB1, manB0, manC2},
+			// results will be sorted by time then ID
+			want: []*manifest.EntryMetadata{manB1, manA2, manC2},
+		},
+	}
+
+	for _, tc := range cases {
+		got := manifest.DedupeEntryMetadataByLabel(tc.input, theLabel)
+		if diff := cmp.Diff(got, tc.want); diff != "" {
+			t.Errorf("invalid result of DedupeEntryMetadataByLabel (-got, +want): %v", diff)
+		}
+	}
+}

--- a/snapshot/policy/policy_manager.go
+++ b/snapshot/policy/policy_manager.go
@@ -13,6 +13,9 @@ import (
 	"github.com/kopia/kopia/snapshot"
 )
 
+// ManifestType is the type of the manifest that represents policy.
+const ManifestType = "policy"
+
 const typeKey = manifest.TypeLabelKey
 
 // GlobalPolicySourceInfo is a source where global policy is attached.
@@ -159,7 +162,7 @@ func GetPolicyByID(ctx context.Context, rep repo.Repository, id manifest.ID) (*P
 // ListPolicies returns a list of all policies.
 func ListPolicies(ctx context.Context, rep repo.Repository) ([]*Policy, error) {
 	ids, err := rep.FindManifests(ctx, map[string]string{
-		typeKey: "policy",
+		typeKey: ManifestType,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list manifests")
@@ -210,7 +213,7 @@ func applicablePoliciesForSource(ctx context.Context, rep repo.Repository, si sn
 
 	// Find all policies for this host and user
 	policies, err := rep.FindManifests(ctx, map[string]string{
-		typeKey:      "policy",
+		typeKey:      ManifestType,
 		"policyType": "path",
 		"username":   si.UserName,
 		"hostname":   si.Host,
@@ -266,7 +269,7 @@ func labelsForSource(si snapshot.SourceInfo) map[string]string {
 	switch {
 	case si.Path != "":
 		return map[string]string{
-			typeKey:      "policy",
+			typeKey:      ManifestType,
 			"policyType": "path",
 			"username":   si.UserName,
 			"hostname":   si.Host,
@@ -274,20 +277,20 @@ func labelsForSource(si snapshot.SourceInfo) map[string]string {
 		}
 	case si.UserName != "":
 		return map[string]string{
-			typeKey:      "policy",
+			typeKey:      ManifestType,
 			"policyType": "user",
 			"username":   si.UserName,
 			"hostname":   si.Host,
 		}
 	case si.Host != "":
 		return map[string]string{
-			typeKey:      "policy",
+			typeKey:      ManifestType,
 			"policyType": "host",
 			"hostname":   si.Host,
 		}
 	default:
 		return map[string]string{
-			typeKey:      "policy",
+			typeKey:      ManifestType,
 			"policyType": "global",
 		}
 	}

--- a/snapshot/policy/policy_manager.go
+++ b/snapshot/policy/policy_manager.go
@@ -99,7 +99,7 @@ func GetDefinedPolicy(ctx context.Context, rep repo.Repository, si snapshot.Sour
 	// this is possible when two repository clients independently create manifests at approximately the same time
 	// so it should not really matter which one we pick.
 	// see https://github.com/kopia/kopia/issues/391
-	manifestID := md[0].ID
+	manifestID := manifest.PickLatestID(md)
 
 	p := &Policy{}
 


### PR DESCRIPTION
This replaces static LegacyUserAuthorizer with a dynamic one that evaluates ACLs stored in the repository.

This needs a lot more tests, but current test for LegacyUserAuthorizer is passing without significant change.