### PR TITLE
fix long filenames on Windows

### DIFF
--- a/cli/update_check.go
+++ b/cli/update_check.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/natefinch/atomic"
 	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 
+	"github.com/kopia/kopia/internal/atomicfile"
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo"
 )
@@ -69,7 +69,7 @@ func writeUpdateState(us *updateState) error {
 		return errors.Wrap(err, "unable to marshal JSON")
 	}
 
-	return atomic.WriteFile(updateStateFilename(), &buf)
+	return atomicfile.Write(updateStateFilename(), &buf)
 }
 
 func removeUpdateState() {

--- a/fs/localfs/local_fs_test.go
+++ b/fs/localfs/local_fs_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
 )
 
 //nolint:gocyclo
@@ -20,13 +21,7 @@ func TestFiles(t *testing.T) {
 
 	var err error
 
-	tmp, err := ioutil.TempDir("", "kopia")
-	if err != nil {
-		t.Errorf("cannot create temp directory: %v", err)
-		return
-	}
-
-	defer os.RemoveAll(tmp)
+	tmp := testutil.TempDirectory(t)
 
 	var dir fs.Directory
 

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -10,7 +10,9 @@ import (
 	"github.com/natefinch/atomic"
 )
 
-const maxPathLength = 260
+// Do not prefix files shorter than this, we are intentionally using less than MAX_PATH
+// in Windows to allow some suffixes.
+const maxPathLength = 240
 
 // MaybePrefixLongFilenameOnWindows prefixes the given filename with \\?\ on Windows
 // if the filename is longer than 260 characters, which is required to be able to
@@ -28,7 +30,7 @@ func MaybePrefixLongFilenameOnWindows(fname string) string {
 	}
 
 	if !filepath.IsAbs(fname) {
-		// only convert relative paths
+		// only convert absolute paths
 		return fname
 	}
 

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,31 @@
+// Package atomicfile provides wrappers for atomically writing files in a manner compatible with long filenames.
+package atomicfile
+
+import (
+	"io"
+	"runtime"
+
+	"github.com/natefinch/atomic"
+)
+
+const maxPathLength = 260
+
+// MaybePrefixLongFilenameOnWindows prefixes the given filename with \\?\ on Windows
+// if the filename is longer than 260 characters, which is required to be able to
+// use some low-level Windows APIs.
+func MaybePrefixLongFilenameOnWindows(fname string) string {
+	if runtime.GOOS != "windows" {
+		return fname
+	}
+
+	if len(fname) < maxPathLength {
+		return fname
+	}
+
+	return "\\\\?\\" + fname
+}
+
+// Write is a wrapper around atomic.WriteFile that handles long file names on Windows.
+func Write(filename string, r io.Reader) error {
+	return atomic.WriteFile(MaybePrefixLongFilenameOnWindows(filename), r)
+}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,43 @@
+package atomicfile
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var veryLongSegment = strings.Repeat("f", 270)
+
+func TestMaybePrefixLongFilenameOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+
+	cases := []struct {
+		input string
+		want  string
+	}{
+		// too short
+		{"C:\\Short.txt", "C:\\Short.txt"},
+
+		// long paths
+		{"C:\\" + veryLongSegment + "\\foo", "\\\\?\\C:\\" + veryLongSegment + "\\foo"},
+		{"C:\\" + veryLongSegment + "/foo/bar", "\\\\?\\C:\\" + veryLongSegment + "\\foo\\bar"},
+		{"C:\\" + veryLongSegment + "/foo/./././bar", "\\\\?\\C:\\" + veryLongSegment + "\\foo\\bar"},
+		{"C:\\" + veryLongSegment + "\\.\\foo", "\\\\?\\C:\\" + veryLongSegment + "\\foo"},
+		{"C:\\" + veryLongSegment + "/.\\foo", "\\\\?\\C:\\" + veryLongSegment + "\\foo"},
+		{"C:\\" + veryLongSegment + "\\./foo", "\\\\?\\C:\\" + veryLongSegment + "\\foo"},
+
+		// relative
+		{veryLongSegment + "\\foo", veryLongSegment + "\\foo"},
+		{"./" + veryLongSegment + "\\foo", "./" + veryLongSegment + "\\foo"},
+		{"../../" + veryLongSegment + "\\foo", "../../" + veryLongSegment + "\\foo"},
+		{"..\\..\\" + veryLongSegment + "\\foo", "..\\..\\" + veryLongSegment + "\\foo"},
+	}
+
+	for _, tc := range cases {
+		if got := MaybePrefixLongFilenameOnWindows(tc.input); got != tc.want {
+			t.Errorf("invalid result for %v: got %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/filesystem"
@@ -39,8 +40,8 @@ func (e *Environment) Setup(t *testing.T, opts ...Options) *Environment {
 	t.Helper()
 
 	ctx := testlogging.Context(t)
-	e.configDir = t.TempDir()
-	e.storageDir = t.TempDir()
+	e.configDir = testutil.TempDirectory(t)
+	e.storageDir = testutil.TempDirectory(t)
 	openOpt := &repo.Options{}
 
 	opt := &repo.NewRepositoryOptions{
@@ -179,10 +180,10 @@ func (e *Environment) MustConnectOpenAnother(t *testing.T, openOpts ...func(*rep
 		t.Fatal("err:", err)
 	}
 
-	config := filepath.Join(t.TempDir(), "kopia.config")
+	config := filepath.Join(testutil.TempDirectory(t), "kopia.config")
 	connOpts := &repo.ConnectOptions{
 		CachingOptions: content.CachingOptions{
-			CacheDirectory: t.TempDir(),
+			CacheDirectory: testutil.TempDirectory(t),
 		},
 	}
 

--- a/internal/testutil/tmpdir.go
+++ b/internal/testutil/tmpdir.go
@@ -1,0 +1,56 @@
+package testutil
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+var interestingLengths = []int{10, 50, 100, 240, 250, 260, 270}
+
+// GetInterestingTempDirectoryName returns interesting directory name used for testing.
+func GetInterestingTempDirectoryName() (string, error) {
+	td, err := ioutil.TempDir("", "kopia-test")
+	if err != nil {
+		return "", errors.Wrap(err, "unable to create temp directory")
+	}
+
+	// nolint:gosec
+	targetLen := interestingLengths[rand.Intn(len(interestingLengths))]
+
+	// make sure the base directory is quite long to trigger very long filenames on Windows.
+	if n := len(td); n < targetLen {
+		td = filepath.Join(td, strings.Repeat("f", targetLen-n))
+		if err := os.MkdirAll(td, 0700); err != nil {
+			return "", errors.Wrap(err, "unable to create temp directory")
+		}
+	}
+
+	return td, nil
+}
+
+// TempDirectory returns an interesting temporary directory and cleans it up before test
+// completes.
+func TempDirectory(t *testing.T) string {
+	t.Helper()
+
+	d, err := GetInterestingTempDirectoryName()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		if !t.Failed() {
+			os.RemoveAll(d) // nolint:errcheck
+		} else {
+			t.Logf("temporary files left in %v", d)
+		}
+	})
+
+	return d
+}

--- a/repo/blob/filesystem/filesystem_storage_test.go
+++ b/repo/blob/filesystem/filesystem_storage_test.go
@@ -1,8 +1,6 @@
 package filesystem
 
 import (
-	"io/ioutil"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -11,6 +9,7 @@ import (
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -29,8 +28,7 @@ func TestFileStorage(t *testing.T) {
 		{1, 2},
 		{2, 2, 2},
 	} {
-		path, _ := ioutil.TempDir("", "r-fs")
-		defer os.RemoveAll(path)
+		path := testutil.TempDirectory(t)
 
 		r, err := New(ctx, &Options{
 			Path:            path,
@@ -61,8 +59,7 @@ func TestFileStorageTouch(t *testing.T) {
 
 	ctx := testlogging.Context(t)
 
-	path, _ := ioutil.TempDir("", "r-fs")
-	defer os.RemoveAll(path)
+	path := testutil.TempDirectory(t)
 
 	r, err := New(ctx, &Options{
 		Path: path,
@@ -99,8 +96,7 @@ func TestFileStorageTouch(t *testing.T) {
 }
 
 func TestFileStorageConcurrency(t *testing.T) {
-	path, _ := ioutil.TempDir("", "fs-concurrency")
-	defer os.RemoveAll(path)
+	path := testutil.TempDirectory(t)
 
 	ctx := testlogging.Context(t)
 

--- a/repo/blob/rclone/rclone_storage_test.go
+++ b/repo/blob/rclone/rclone_storage_test.go
@@ -1,7 +1,6 @@
 package rclone_test
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/rclone"
 )
@@ -35,13 +35,7 @@ func TestRCloneStorage(t *testing.T) {
 
 	t.Logf("using rclone exe: %v", rcloneExe)
 
-	// directory where rclone will store files
-	dataDir, err := ioutil.TempDir("", "rclonetest")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(dataDir)
+	dataDir := testutil.TempDirectory(t)
 
 	st, err := rclone.New(ctx, &rclone.Options{
 		// pass local file as remote path.

--- a/repo/blob/sftp/sftp_storage_test.go
+++ b/repo/blob/sftp/sftp_storage_test.go
@@ -133,7 +133,7 @@ func startDockerSFTPServerOrSkip(t *testing.T, idRSA string) (host string, port 
 		parts := strings.Split(sftpEndpoint, ":")
 		host = parts[0]
 		port, _ = strconv.Atoi(parts[1])
-		knownHostsFile = filepath.Join(t.TempDir(), "known_hosts")
+		knownHostsFile = filepath.Join(testutil.TempDirectory(t), "known_hosts")
 
 		time.Sleep(3 * time.Second)
 

--- a/repo/blob/webdav/webdav_storage_test.go
+++ b/repo/blob/webdav/webdav_storage_test.go
@@ -2,7 +2,6 @@ package webdav
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -54,8 +54,7 @@ func TestWebDAVStorageExternalServer(t *testing.T) {
 }
 
 func TestWebDAVStorageBuiltInServer(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "webdav")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := testutil.TempDirectory(t)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", basicAuth(&webdav.Handler{

--- a/repo/content/content_cache_test.go
+++ b/repo/content/content_cache_test.go
@@ -2,8 +2,6 @@ package content
 
 import (
 	"bytes"
-	"io/ioutil"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -17,6 +15,7 @@ import (
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -106,12 +105,7 @@ func TestCacheExpiration(t *testing.T) {
 func TestDiskContentCache(t *testing.T) {
 	ctx := testlogging.Context(t)
 
-	tmpDir, err := ioutil.TempDir("", "kopia")
-	if err != nil {
-		t.Fatalf("error getting temp dir: %v", err)
-	}
-
-	defer os.RemoveAll(tmpDir)
+	tmpDir := testutil.TempDirectory(t)
 
 	const maxBytes = 10000
 

--- a/repo/content/list_cache.go
+++ b/repo/content/list_cache.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/natefinch/atomic"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/atomicfile"
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/hmac"
 	"github.com/kopia/kopia/repo/blob"
@@ -60,7 +60,7 @@ func (c *listCache) saveListToCache(ctx context.Context, prefix blob.ID, ci *cac
 
 	if data, err := json.Marshal(ci); err == nil {
 		b := hmac.Append(data, c.hmacSecret)
-		if err := atomic.WriteFile(c.cacheFilePrefix+string(prefix), bytes.NewReader(b)); err != nil {
+		if err := atomicfile.Write(c.cacheFilePrefix+string(prefix), bytes.NewReader(b)); err != nil {
 			log(ctx).Warningf("unable to write list cache: %v", err)
 		}
 	}

--- a/repo/open.go
+++ b/repo/open.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/natefinch/atomic"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/atomicfile"
 	"github.com/kopia/kopia/repo/blob"
 	loggingwrapper "github.com/kopia/kopia/repo/blob/logging"
 	"github.com/kopia/kopia/repo/blob/readonly"
@@ -288,7 +288,7 @@ func readAndCacheFormatBlobBytes(ctx context.Context, st blob.Storage, cacheDire
 	}
 
 	if cacheDirectory != "" {
-		if err := atomic.WriteFile(cachedFile, bytes.NewReader(b)); err != nil {
+		if err := atomicfile.Write(cachedFile, bytes.NewReader(b)); err != nil {
 			log(ctx).Warningf("warning: unable to write cache: %v", err)
 		}
 	}

--- a/snapshot/restore/local_fs_output.go
+++ b/snapshot/restore/local_fs_output.go
@@ -9,11 +9,11 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/natefinch/atomic"
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/fs/localfs"
+	"github.com/kopia/kopia/internal/atomicfile"
 )
 
 const modBits = os.ModePerm | os.ModeSetgid | os.ModeSetuid | os.ModeSticky
@@ -308,7 +308,7 @@ func (o *FilesystemOutput) copyFileContent(ctx context.Context, targetPath strin
 
 	log(ctx).Debugf("copying file contents to: %v", targetPath)
 
-	return atomic.WriteFile(targetPath, r)
+	return atomicfile.Write(targetPath, r)
 }
 
 func isEmptyDirectory(name string) (bool, error) {

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -2,7 +2,6 @@ package snapshotfs
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -17,6 +16,7 @@ import (
 	"github.com/kopia/kopia/internal/faketime"
 	"github.com/kopia/kopia/internal/mockfs"
 	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob/filesystem"
 	"github.com/kopia/kopia/repo/object"
@@ -42,11 +42,10 @@ func (th *uploadTestHarness) cleanup() {
 	os.RemoveAll(th.repoDir)
 }
 
-func newUploadTestHarness(ctx context.Context) *uploadTestHarness {
-	repoDir, err := ioutil.TempDir("", "kopia-repo")
-	if err != nil {
-		panic("cannot create temp directory: " + err.Error())
-	}
+func newUploadTestHarness(ctx context.Context, t *testing.T) *uploadTestHarness {
+	t.Helper()
+
+	repoDir := testutil.TempDirectory(t)
 
 	storage, err := filesystem.New(ctx, &filesystem.Options{
 		Path: repoDir,
@@ -113,7 +112,7 @@ func newUploadTestHarness(ctx context.Context) *uploadTestHarness {
 // nolint:gocyclo
 func TestUpload(t *testing.T) {
 	ctx := testlogging.Context(t)
-	th := newUploadTestHarness(ctx)
+	th := newUploadTestHarness(ctx, t)
 
 	defer th.cleanup()
 
@@ -205,7 +204,7 @@ func TestUpload(t *testing.T) {
 
 func TestUpload_TopLevelDirectoryReadFailure(t *testing.T) {
 	ctx := testlogging.Context(t)
-	th := newUploadTestHarness(ctx)
+	th := newUploadTestHarness(ctx, t)
 
 	defer th.cleanup()
 
@@ -227,7 +226,7 @@ func TestUpload_TopLevelDirectoryReadFailure(t *testing.T) {
 
 func TestUpload_SubDirectoryReadFailure(t *testing.T) {
 	ctx := testlogging.Context(t)
-	th := newUploadTestHarness(ctx)
+	th := newUploadTestHarness(ctx, t)
 
 	defer th.cleanup()
 
@@ -249,7 +248,7 @@ func objectIDsEqual(o1, o2 object.ID) bool {
 
 func TestUpload_SubDirectoryReadFailureIgnoreFailures(t *testing.T) {
 	ctx := testlogging.Context(t)
-	th := newUploadTestHarness(ctx)
+	th := newUploadTestHarness(ctx, t)
 
 	defer th.cleanup()
 
@@ -289,7 +288,7 @@ func TestUpload_SubDirectoryReadFailureIgnoreFailures(t *testing.T) {
 
 func TestUploadWithCheckpointing(t *testing.T) {
 	ctx := testlogging.Context(t)
-	th := newUploadTestHarness(ctx)
+	th := newUploadTestHarness(ctx, t)
 
 	defer th.cleanup()
 

--- a/tests/end_to_end_test/all_formats_test.go
+++ b/tests/end_to_end_test/all_formats_test.go
@@ -3,13 +3,14 @@ package endtoend_test
 import (
 	"testing"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/encryption"
 	"github.com/kopia/kopia/repo/hashing"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
 func TestAllFormatsSmokeTest(t *testing.T) {
-	srcDir := t.TempDir()
+	srcDir := testutil.TempDirectory(t)
 
 	// 3-level directory with <=10 files and <=10 subdirectories at each level
 	testenv.CreateDirectoryTree(srcDir, testenv.DirectoryTreeOptions{

--- a/tests/end_to_end_test/compression_test.go
+++ b/tests/end_to_end_test/compression_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -21,7 +22,7 @@ func TestCompression(t *testing.T) {
 	// set global policy
 	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--compression", "pgzip")
 
-	dataDir := t.TempDir()
+	dataDir := testutil.TempDirectory(t)
 
 	dataLines := []string{
 		"hello world",

--- a/tests/end_to_end_test/diff_test.go
+++ b/tests/end_to_end_test/diff_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -17,7 +18,7 @@ func TestDiff(t *testing.T) {
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
-	dataDir := t.TempDir()
+	dataDir := testutil.TempDirectory(t)
 
 	// initial snapshot
 	testenv.AssertNoError(t, os.MkdirAll(dataDir, 0o777))

--- a/tests/end_to_end_test/main_test.go
+++ b/tests/end_to_end_test/main_test.go
@@ -1,14 +1,15 @@
 package endtoend_test
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -22,9 +23,15 @@ var (
 func oneTimeSetup() error {
 	var err error
 
-	sharedTestDataDirBase, err = ioutil.TempDir("", "kopia-test")
+	sharedTestDataDirBase, err = testutil.GetInterestingTempDirectoryName()
 	if err != nil {
 		return errors.Wrap(err, "unable to create data directory")
+	}
+
+	// make sure the base directory is quite long to trigger very long filenames on Windows.
+	if n, targetLen := len(sharedTestDataDirBase), 270; n < targetLen {
+		sharedTestDataDirBase = filepath.Join(sharedTestDataDirBase, strings.Repeat("f", targetLen-n))
+		os.MkdirAll(sharedTestDataDirBase, 0700)
 	}
 
 	log.Printf("creating test data in %q", sharedTestDataDirBase)

--- a/tests/end_to_end_test/repository_sync_test.go
+++ b/tests/end_to_end_test/repository_sync_test.go
@@ -3,6 +3,7 @@ package endtoend_test
 import (
 	"testing"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -21,11 +22,11 @@ func TestRepositorySync(t *testing.T) {
 	sources := e.ListSnapshotsAndExpectSuccess(t)
 
 	// synchronize repository blobs to another directory
-	dir2 := t.TempDir()
+	dir2 := testutil.TempDirectory(t)
 	e.RunAndExpectSuccess(t, "repo", "sync-to", "filesystem", "--path", dir2, "--times")
 
 	// synchronizing to empty directory fails with --must-exist
-	dir3 := t.TempDir()
+	dir3 := testutil.TempDirectory(t)
 	e.RunAndExpectFailure(t, "repo", "sync-to", "filesystem", "--path", dir3, "--must-exist")
 
 	// now connect to the new repository in new location

--- a/tests/end_to_end_test/restore_fail_test.go
+++ b/tests/end_to_end_test/restore_fail_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/tests/testenv"
 )
@@ -35,7 +36,7 @@ func TestRestoreFail(t *testing.T) {
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
-	scratchDir := t.TempDir()
+	scratchDir := testutil.TempDirectory(t)
 	sourceDir := filepath.Join(scratchDir, "source")
 	targetDir := filepath.Join(scratchDir, "target")
 

--- a/tests/end_to_end_test/snapshot_actions_test.go
+++ b/tests/end_to_end_test/snapshot_actions_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -161,7 +162,7 @@ func TestSnapshotActionsBeforeAfterFolder(t *testing.T) {
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
 	// create directory structure
-	rootDir := t.TempDir()
+	rootDir := testutil.TempDirectory(t)
 	sd1 := filepath.Join(rootDir, "subdir1")
 	sd2 := filepath.Join(rootDir, "subdir2")
 	sd11 := filepath.Join(rootDir, "subdir1", "subdir1")
@@ -172,7 +173,7 @@ func TestSnapshotActionsBeforeAfterFolder(t *testing.T) {
 	verifyNoError(t, os.Mkdir(sd11, 0700))
 	verifyNoError(t, os.Mkdir(sd12, 0700))
 
-	actionRanDir := t.TempDir()
+	actionRanDir := testutil.TempDirectory(t)
 
 	actionRanFileBeforeRoot := filepath.Join(actionRanDir, "before-root")
 	actionRanFileAfterRoot := filepath.Join(actionRanDir, "before-root")

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/tests/testenv"
 )
@@ -401,7 +402,7 @@ func TestSnapshotCreateWithIgnore(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			e := testenv.NewCLITest(t)
 
-			baseDir := t.TempDir()
+			baseDir := testutil.TempDirectory(t)
 
 			if err := createFileStructure(baseDir, tc.files); err != nil {
 				t.Fatal("Failed to create file structure", err)

--- a/tests/end_to_end_test/snapshot_delete_test.go
+++ b/tests/end_to_end_test/snapshot_delete_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -109,7 +110,7 @@ func testSnapshotDelete(t *testing.T, argMaker deleteArgMaker, expectDeleteSucce
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
-	dataDir := t.TempDir()
+	dataDir := testutil.TempDirectory(t)
 	testenv.AssertNoError(t, os.MkdirAll(dataDir, 0o777))
 	testenv.AssertNoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
 hello world
@@ -176,7 +177,7 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
-	source := filepath.Join(t.TempDir(), "source")
+	source := filepath.Join(testutil.TempDirectory(t), "source")
 	testenv.MustCreateDirectoryTree(t, source, testenv.DirectoryTreeOptions{
 		Depth:                  1,
 		MaxSubdirsPerDirectory: 10,
@@ -199,7 +200,7 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 	snapID := si[0].Snapshots[0].SnapshotID
 	rootID := si[0].Snapshots[0].ObjectID
 
-	restoreDir := t.TempDir()
+	restoreDir := testutil.TempDirectory(t)
 	e.RunAndExpectSuccess(t, "restore", rootID, restoreDir)
 
 	// Note: restore does not reset the permissions for the top directory due to
@@ -212,7 +213,7 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 	// snapshot delete should succeed
 	e.RunAndExpectSuccess(t, "snapshot", "delete", snapID, "--delete")
 
-	notRestoreDir := t.TempDir()
+	notRestoreDir := testutil.TempDirectory(t)
 
 	// Make sure the restore did not happen from the deleted snapshot
 	e.RunAndExpectFailure(t, "snapshot", "restore", snapID, notRestoreDir)
@@ -226,7 +227,7 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 
 	// Run a restore on the deleted snapshot's root ID. The root should be
 	// marked as deleted but still recoverable
-	restoreDir2 := t.TempDir()
+	restoreDir2 := testutil.TempDirectory(t)
 
 	e.RunAndExpectSuccess(t, "restore", rootID, restoreDir2)
 	testenv.AssertNoError(t, os.Chmod(restoreDir2, 0o700))

--- a/tests/end_to_end_test/snapshot_fail_test.go
+++ b/tests/end_to_end_test/snapshot_fail_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -21,7 +22,7 @@ func TestSnapshotNonexistent(t *testing.T) {
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
-	scratchDir := t.TempDir()
+	scratchDir := testutil.TempDirectory(t)
 
 	// Test snapshot of nonexistent directory fails
 	e.RunAndExpectFailure(t, "snapshot", "create", filepath.Join(scratchDir, "notExist"))
@@ -194,7 +195,7 @@ func TestSnapshotFail(t *testing.T) {
 
 					e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
-					scratchDir := t.TempDir()
+					scratchDir := testutil.TempDirectory(t)
 
 					snapSource := filepath.Join(scratchDir, tc.snapSource)
 					modifyEntry := filepath.Join(scratchDir, tc.modifyEntry)

--- a/tests/end_to_end_test/snapshot_gc_test.go
+++ b/tests/end_to_end_test/snapshot_gc_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -20,7 +21,7 @@ func TestSnapshotGC(t *testing.T) {
 
 	expectedContentCount := len(e.RunAndExpectSuccess(t, "content", "list"))
 
-	dataDir := t.TempDir()
+	dataDir := testutil.TempDirectory(t)
 	testenv.AssertNoError(t, os.MkdirAll(dataDir, 0o777))
 	testenv.AssertNoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
 hello world

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/robustness"
 	"github.com/kopia/kopia/tests/robustness/fiofilewriter"
 	"github.com/kopia/kopia/tests/robustness/snapmeta"
@@ -324,10 +325,7 @@ func TestDataPersistency(t *testing.T) {
 	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
 	os.Setenv(snapmeta.S3BucketNameEnvKey, "")
 
-	tempDir, err := ioutil.TempDir("", "")
-	testenv.AssertNoError(t, err)
-
-	defer os.RemoveAll(tempDir)
+	tempDir := testutil.TempDirectory(t)
 
 	dataRepoPath := filepath.Join(tempDir, "data-repo-")
 	metadataRepoPath := filepath.Join(tempDir, "metadata-repo-")

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/iocopy"
+	"github.com/kopia/kopia/internal/testutil"
 )
 
 const (
@@ -74,7 +75,7 @@ func NewCLITest(t *testing.T) *CLITest {
 		t.Skip()
 	}
 
-	configDir := t.TempDir()
+	configDir := testutil.TempDirectory(t)
 
 	cleanName := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(
 		t.Name(),
@@ -119,7 +120,7 @@ func NewCLITest(t *testing.T) *CLITest {
 
 	return &CLITest{
 		startTime:                    clock.Now(),
-		RepoDir:                      t.TempDir(),
+		RepoDir:                      testutil.TempDirectory(t),
 		ConfigDir:                    configDir,
 		Exe:                          filepath.FromSlash(exe),
 		fixedArgs:                    fixedArgs,

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -250,7 +250,7 @@ $(rclone):
 	curl -LsS -o $(rclone_dir).zip https://github.com/rclone/rclone/releases/download/v$(RCLONE_VERSION)/rclone-v$(RCLONE_VERSION)-$(TRAVIS_OS_NAME)-$(kopia_arch_name).zip
 	unzip -j -q $(rclone_dir).zip -d $(rclone_dir)
 
-gotestsum=$(TOOLS_DIR)/bin/gotestsum
+gotestsum=$(TOOLS_DIR)/bin/gotestsum$(exe_suffix)
 
 $(gotestsum): export GO111MODULE=off
 $(gotestsum): export GOPATH=$(TOOLS_DIR)


### PR DESCRIPTION
Changed tests to trigger very long filenames on Windows and found 3 issues:

* `filepath.EvalSymlinks` failed for long filenames - worked around by not invoking it if the filename is not a symlink (should not matter, since it's only invoked at snapshot root)
* `atomic.WriteFile` did not support LFNs
* `symlinkChtimes` did not support LFNs

Fixed by strategically prefixing filenames with `\\?\`