### PR TITLE
Fix progress output string format for snapshot restore

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -252,7 +252,7 @@ func runRestoreCommand(ctx context.Context, rep repo.Repository) error {
 				maybeErrors = fmt.Sprintf(", ignored %v errors", stats.IgnoredErrorCount)
 			}
 
-			log(ctx).Infof("Processed %v (%v) of %v (%v)%v%v.",
+			log(ctx).Infof("Processed %v (%v) of %v (%v)%v%v%v.",
 				restoredCount, units.BytesStringBase10(stats.RestoredTotalFileSize),
 				enqueuedCount, units.BytesStringBase10(stats.EnqueuedTotalFileSize),
 				maybeSkipped,


### PR DESCRIPTION
For snapshot restore, the number of arguments to `log(ctx).Infof()` in the progress output is greater than the number of format placeholders, resulting in messy logs:
```
Processed 12140 (27.4 MB) of 79255 (614.3 MB).%!(EXTRA string= 219.2 Mbit/s (4.5%) remaining 21s)
```
Add a placeholder for the last argument, so log outputs as expected:
```
Processed 12877 (43.9 MB) of 79255 (614.3 MB) 351.5 Mbit/s (7.2%) remaining 12s.
```