### PR TITLE
Removed manifest manager refresh + server improvements

### DIFF
--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -44,8 +44,8 @@ func (c *KopiaAPIClient) Put(ctx context.Context, urlSuffix string, reqPayload, 
 
 // Delete is a helper that performs HTTP DELETE on a URL with the specified body from reqPayload and decodes the response
 // onto respPayload which must be a pointer to byte slice or JSON-serializable structure.
-func (c *KopiaAPIClient) Delete(ctx context.Context, urlSuffix string, reqPayload, respPayload interface{}) error {
-	return c.runRequest(ctx, http.MethodDelete, c.BaseURL+urlSuffix, nil, reqPayload, respPayload)
+func (c *KopiaAPIClient) Delete(ctx context.Context, urlSuffix string, onNotFound error, reqPayload, respPayload interface{}) error {
+	return c.runRequest(ctx, http.MethodDelete, c.BaseURL+urlSuffix, onNotFound, reqPayload, respPayload)
 }
 
 func (c *KopiaAPIClient) runRequest(ctx context.Context, method, url string, notFoundError error, reqPayload, respPayload interface{}) error {

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -76,13 +76,13 @@ func (e *Environment) Setup(t *testing.T, opts ...Options) *Environment {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err = repo.Connect(ctx, e.configFile(), st, masterPassword, nil); err != nil {
+	if err = repo.Connect(ctx, e.ConfigFile(), st, masterPassword, nil); err != nil {
 		t.Fatalf("can't connect: %v", err)
 	}
 
 	e.connected = true
 
-	rep, err := repo.Open(ctx, e.configFile(), masterPassword, openOpt)
+	rep, err := repo.Open(ctx, e.ConfigFile(), masterPassword, openOpt)
 	if err != nil {
 		t.Fatalf("can't open: %v", err)
 	}
@@ -106,7 +106,7 @@ func (e *Environment) Close(ctx context.Context, t *testing.T) {
 	}
 
 	if e.connected {
-		if err := repo.Disconnect(ctx, e.configFile()); err != nil {
+		if err := repo.Disconnect(ctx, e.ConfigFile()); err != nil {
 			t.Errorf("error disconnecting: %v", err)
 		}
 	}
@@ -117,7 +117,8 @@ func (e *Environment) Close(ctx context.Context, t *testing.T) {
 	}
 }
 
-func (e *Environment) configFile() string {
+// ConfigFile returns the name of the config file.
+func (e *Environment) ConfigFile() string {
 	return filepath.Join(e.configDir, "kopia.config")
 }
 
@@ -132,7 +133,7 @@ func (e *Environment) MustReopen(t *testing.T, openOpts ...func(*repo.Options)) 
 		t.Fatalf("close error: %v", err)
 	}
 
-	rep, err := repo.Open(ctx, e.configFile(), masterPassword, repoOptions(openOpts))
+	rep, err := repo.Open(ctx, e.ConfigFile(), masterPassword, repoOptions(openOpts))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -149,7 +150,7 @@ func (e *Environment) MustOpenAnother(t *testing.T) repo.RepositoryWriter {
 
 	ctx := testlogging.Context(t)
 
-	rep2, err := repo.Open(ctx, e.configFile(), masterPassword, &repo.Options{})
+	rep2, err := repo.Open(ctx, e.ConfigFile(), masterPassword, &repo.Options{})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -191,7 +192,7 @@ func (e *Environment) MustConnectOpenAnother(t *testing.T, openOpts ...func(*rep
 		t.Fatal("can't connect:", err)
 	}
 
-	rep, err := repo.Open(ctx, e.configFile(), masterPassword, repoOptions(openOpts))
+	rep, err := repo.Open(ctx, e.ConfigFile(), masterPassword, repoOptions(openOpts))
 	if err != nil {
 		t.Fatal("can't open:", err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,274 @@
+package server_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/kopia/kopia/internal/auth"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/server"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/repo/manifest"
+	"github.com/kopia/kopia/repo/object"
+	"github.com/kopia/kopia/snapshot"
+)
+
+const (
+	testUsername = "foo"
+	testHostname = "bar"
+	testPassword = "123"
+	testPathname = "/tmp/path"
+)
+
+// nolint:thelper
+func startServer(ctx context.Context, t *testing.T) *repo.APIServerInfo {
+	var env repotesting.Environment
+
+	env.Setup(t)
+	t.Cleanup(func() { env.Close(ctx, t) })
+
+	s, err := server.New(ctx, server.Options{
+		ConfigFile:      env.ConfigFile(),
+		Authorizer:      auth.LegacyAuthorizerForUser,
+		Authenticator:   auth.AuthenticateSingleUser(testUsername+"@"+testHostname, testPassword),
+		RefreshInterval: 1 * time.Minute,
+	})
+
+	s.SetRepository(ctx, env.Repository)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hs := httptest.NewUnstartedServer(s.GRPCRouterHandler(s.APIHandlers(true)))
+	hs.EnableHTTP2 = true
+	hs.StartTLS()
+
+	t.Cleanup(hs.Close)
+
+	serverHash := sha256.Sum256(hs.Certificate().Raw)
+
+	return &repo.APIServerInfo{
+		BaseURL:                             hs.URL,
+		TrustedServerCertificateFingerprint: hex.EncodeToString(serverHash[:]),
+	}
+}
+
+func TestServer_REST(t *testing.T) {
+	testServer(t, true)
+}
+
+func TestServer_GRPC(t *testing.T) {
+	testServer(t, false)
+}
+
+// nolint:thelper
+func testServer(t *testing.T, disableGRPC bool) {
+	ctx := testlogging.ContextWithLevel(t, testlogging.LevelDebug)
+	apiServerInfo := startServer(ctx, t)
+
+	apiServerInfo.DisableGRPC = disableGRPC
+
+	rep, err := repo.OpenAPIServer(ctx, apiServerInfo, repo.ClientOptions{
+		Username: testUsername,
+		Hostname: testHostname,
+	}, testPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer rep.Close(ctx)
+
+	remoteRepositoryTest(ctx, t, rep)
+}
+
+func TestGPRServer_AuthenticationError(t *testing.T) {
+	ctx := testlogging.ContextWithLevel(t, testlogging.LevelDebug)
+	apiServerInfo := startServer(ctx, t)
+
+	if _, err := repo.OpenGRPCAPIRepository(ctx, apiServerInfo, repo.ClientOptions{
+		Username: "bad-username",
+		Hostname: "bad-hostname",
+	}, "bad-password"); err == nil {
+		t.Fatal("unexpected success when connecting with invalid username")
+	}
+}
+
+// nolint:thelper
+func remoteRepositoryTest(ctx context.Context, t *testing.T, rep repo.Repository) {
+	mustListSnapshotCount(ctx, t, rep, 0)
+	mustGetObjectNotFound(ctx, t, rep, "abcd")
+	mustGetManifestNotFound(ctx, t, rep, "mnosuchmanifest")
+
+	var (
+		result                  object.ID
+		manifestID, manifestID2 manifest.ID
+		written                 = []byte{1, 2, 3}
+		srcInfo                 = snapshot.SourceInfo{
+			Host:     testHostname,
+			UserName: testUsername,
+			Path:     testPathname,
+		}
+	)
+
+	must(t, repo.WriteSession(ctx, rep, repo.WriteSessionOptions{
+		Purpose: "write test",
+	}, func(w repo.RepositoryWriter) error {
+		mustGetObjectNotFound(ctx, t, w, "abcd")
+		mustGetManifestNotFound(ctx, t, w, "mnosuchmanifest")
+		mustManifestNotFound(t, w.DeleteManifest(ctx, manifestID2))
+		mustListSnapshotCount(ctx, t, w, 0)
+
+		result = mustWriteObject(ctx, t, w, written)
+		result2 := mustWriteObject(ctx, t, w, written)
+
+		if result != result2 {
+			t.Fatalf("two identical object with different IDs: %v vs %v", result, result2)
+		}
+
+		// verify data is read back the same.
+		mustReadObject(ctx, t, w, result, written)
+
+		ow := w.NewObjectWriter(ctx, object.WriterOptions{
+			Prefix: content.ID(manifest.ContentPrefix),
+		})
+
+		_, err := ow.Write([]byte{2, 3, 4})
+		must(t, err)
+
+		_, err = ow.Result()
+		if err == nil {
+			t.Fatalf("unexpected success writing object with 'm' prefix")
+		}
+
+		manifestID, err = snapshot.SaveSnapshot(ctx, w, &snapshot.Manifest{
+			Source:      srcInfo,
+			Description: "written",
+		})
+		must(t, err)
+		mustListSnapshotCount(ctx, t, w, 1)
+
+		manifestID2, err = snapshot.SaveSnapshot(ctx, w, &snapshot.Manifest{
+			Source:      srcInfo,
+			Description: "written2",
+		})
+		must(t, err)
+		mustListSnapshotCount(ctx, t, w, 2)
+
+		mustReadManifest(ctx, t, w, manifestID, "written")
+		mustReadManifest(ctx, t, w, manifestID2, "written2")
+
+		must(t, w.DeleteManifest(ctx, manifestID2))
+		mustListSnapshotCount(ctx, t, w, 1)
+
+		mustGetManifestNotFound(ctx, t, w, manifestID2)
+		mustReadManifest(ctx, t, w, manifestID, "written")
+
+		return nil
+	}))
+
+	// data and manifest written in a session can be read outside of it
+	mustReadObject(ctx, t, rep, result, written)
+	mustReadManifest(ctx, t, rep, manifestID, "written")
+	mustGetManifestNotFound(ctx, t, rep, manifestID2)
+	mustListSnapshotCount(ctx, t, rep, 1)
+}
+
+func mustWriteObject(ctx context.Context, t *testing.T, w repo.RepositoryWriter, data []byte) object.ID {
+	t.Helper()
+
+	ow := w.NewObjectWriter(ctx, object.WriterOptions{})
+
+	_, err := ow.Write(data)
+	must(t, err)
+
+	result, err := ow.Result()
+	must(t, err)
+
+	return result
+}
+
+func mustReadObject(ctx context.Context, t *testing.T, r repo.Repository, oid object.ID, want []byte) {
+	t.Helper()
+
+	or, err := r.OpenObject(ctx, oid)
+	must(t, err)
+
+	data, err := ioutil.ReadAll(or)
+	must(t, err)
+
+	// verify data is read back the same.
+	if diff := cmp.Diff(data, want); diff != "" {
+		t.Fatalf("invalid object data, diff: %v", diff)
+	}
+}
+
+func mustReadManifest(ctx context.Context, t *testing.T, r repo.Repository, manID manifest.ID, want string) {
+	t.Helper()
+
+	man, err := snapshot.LoadSnapshot(ctx, r, manID)
+	must(t, err)
+
+	// verify data is read back the same.
+	if diff := cmp.Diff(man.Description, want); diff != "" {
+		t.Fatalf("invalid manifest data, diff: %v", diff)
+	}
+}
+
+func mustGetObjectNotFound(ctx context.Context, t *testing.T, r repo.Repository, oid object.ID) {
+	t.Helper()
+
+	if _, err := r.OpenObject(ctx, oid); !errors.Is(err, object.ErrObjectNotFound) {
+		t.Fatalf("unexpected non-existent object error: %v", err)
+	}
+}
+
+func mustGetManifestNotFound(ctx context.Context, t *testing.T, r repo.Repository, manID manifest.ID) {
+	t.Helper()
+
+	_, err := r.GetManifest(ctx, manID, nil)
+	mustManifestNotFound(t, err)
+}
+
+func mustListSnapshotCount(ctx context.Context, t *testing.T, rep repo.Repository, wantCount int) {
+	t.Helper()
+
+	snaps, err := snapshot.ListSnapshots(ctx, rep, snapshot.SourceInfo{
+		UserName: testUsername,
+		Host:     testHostname,
+		Path:     testPathname,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(snaps), wantCount; got != want {
+		t.Fatalf("unexpected number of snapshots: %v, want %v", got, want)
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustManifestNotFound(t *testing.T, err error) {
+	t.Helper()
+
+	if !errors.Is(err, manifest.ErrNotFound) {
+		t.Fatalf("invalid error %v, wanted manifest not found", err)
+	}
+}

--- a/repo/api_server_repository.go
+++ b/repo/api_server_repository.go
@@ -37,6 +37,7 @@ type apiServerRepository struct {
 	objectFormat object.Format
 	cliOpts      ClientOptions
 	omgr         *object.Manager
+	wso          WriteSessionOptions
 }
 
 func (r *apiServerRepository) APIServerURL() string {
@@ -143,6 +144,7 @@ func (r *apiServerRepository) NewWriter(ctx context.Context, opt WriteSessionOpt
 	}
 
 	w.omgr = omgr
+	w.wso = opt
 
 	return w, nil
 }
@@ -175,6 +177,14 @@ func (r *apiServerRepository) WriteContent(ctx context.Context, data []byte, pre
 	var hashOutput [128]byte
 
 	contentID := prefix + content.ID(hex.EncodeToString(r.h(hashOutput[:0], data)))
+
+	// avoid uploading the content body if it already exists.
+	if _, err := r.ContentInfo(ctx, contentID); err == nil {
+		// content already exists
+		return contentID, nil
+	}
+
+	r.wso.OnUpload(int64(len(data)))
 
 	if err := r.cli.Put(ctx, "contents/"+string(contentID), data, nil); err != nil {
 		return "", errors.Wrapf(err, "error writing content %v", contentID)
@@ -214,6 +224,9 @@ func openRestAPIRepository(ctx context.Context, si *APIServerInfo, cliOpts Clien
 	rr := &apiServerRepository{
 		cli:     cli,
 		cliOpts: cliOpts,
+		wso: WriteSessionOptions{
+			OnUpload: func(i int64) {},
+		},
 	}
 
 	var p remoterepoapi.Parameters

--- a/repo/api_server_repository.go
+++ b/repo/api_server_repository.go
@@ -116,7 +116,7 @@ func (r *apiServerRepository) FindManifests(ctx context.Context, labels map[stri
 }
 
 func (r *apiServerRepository) DeleteManifest(ctx context.Context, id manifest.ID) error {
-	return errors.Wrap(r.cli.Delete(ctx, "manifests/"+string(id), nil, nil), "DeleteManifest")
+	return errors.Wrap(r.cli.Delete(ctx, "manifests/"+string(id), manifest.ErrNotFound, nil, nil), "DeleteManifest")
 }
 
 func (r *apiServerRepository) Time() time.Time {

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -34,6 +34,7 @@ const (
 const TypeLabelKey = "type"
 
 type contentManager interface {
+	Revision() int64
 	GetContent(ctx context.Context, contentID content.ID) ([]byte, error)
 	WriteContent(ctx context.Context, data []byte, prefix content.ID) (content.ID, error)
 	DeleteContent(ctx context.Context, contentID content.ID) error
@@ -237,11 +238,6 @@ func (m *Manager) Delete(ctx context.Context, id ID) error {
 	}
 
 	return nil
-}
-
-// Refresh updates the committed contents from the underlying storage.
-func (m *Manager) Refresh(ctx context.Context) error {
-	return m.committed.invalidate()
 }
 
 // Compact performs compaction of manifest contents.

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -103,10 +103,6 @@ func TestManifest(t *testing.T) {
 	// still found in another
 	verifyItem(ctx, t, mgr2, id3, labels3, item3)
 
-	if err := mgr2.Refresh(ctx); err != nil {
-		t.Errorf("unable to load: %v", err)
-	}
-
 	if err := mgr.Compact(ctx); err != nil {
 		t.Errorf("can't compact: %v", err)
 	}

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -275,10 +275,6 @@ func (r *directRepository) Refresh(ctx context.Context) error {
 		return errors.Wrap(err, "error refreshing content index")
 	}
 
-	if err := r.mmgr.Refresh(ctx); err != nil {
-		return errors.Wrap(err, "error reloading manifests")
-	}
-
 	return nil
 }
 
@@ -320,7 +316,7 @@ func WriteSession(ctx context.Context, r Repository, opt WriteSessionOptions, cb
 		return errors.Wrap(err, "unable to create writer")
 	}
 
-	return handleWriteSessionResult(ctx, r, w, opt, cb(w))
+	return handleWriteSessionResult(ctx, w, opt, cb(w))
 }
 
 // DirectWriteSession executes the provided callback in a DirectRepositoryWriter created for the purpose and flushes writes.
@@ -330,10 +326,10 @@ func DirectWriteSession(ctx context.Context, r DirectRepository, opt WriteSessio
 		return errors.Wrap(err, "unable to create direct writer")
 	}
 
-	return handleWriteSessionResult(ctx, r, w, opt, cb(w))
+	return handleWriteSessionResult(ctx, w, opt, cb(w))
 }
 
-func handleWriteSessionResult(ctx context.Context, r Repository, w RepositoryWriter, opt WriteSessionOptions, resultErr error) error {
+func handleWriteSessionResult(ctx context.Context, w RepositoryWriter, opt WriteSessionOptions, resultErr error) error {
 	defer func() {
 		if err := w.Close(ctx); err != nil {
 			log(ctx).Warningf("error closing writer: %v", err)
@@ -344,10 +340,6 @@ func handleWriteSessionResult(ctx context.Context, r Repository, w RepositoryWri
 		if err := w.Flush(ctx); err != nil {
 			return errors.Wrap(err, "error flushing writer")
 		}
-	}
-
-	if err := r.Refresh(ctx); err != nil {
-		return errors.Wrap(err, "error refreshing repository")
 	}
 
 	return resultErr


### PR DESCRIPTION
This does 4 things as separate commits, but clumping them together since they depend on each other:

1. removed the need for manifest manager refresh. Instead content manager is exposing revision counter that changes on every mutation and every time new index blob is added - manifest manager will refresh itself when the underlying content manager revision has changed.

2. refactored server initialization - needed for test below.

3. added unit tests for the repository server API (both REST and GRPC). This actually uncovered the problem requiring manifest refresh fix. 

4. once the tests were in place, added optimization to avoid sending content payload to the server if the server already has the content with a given ID.