### PR TITLE
snapshot: reworked error handling and added fail-fast option

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -153,9 +153,9 @@ type repositoryAccessMode struct {
 
 func maybeRepositoryAction(act func(ctx context.Context, rep repo.Repository) error, mode repositoryAccessMode) func(ctx *kingpin.ParseContext) error {
 	return func(kpc *kingpin.ParseContext) error {
-		return withProfiling(func() error {
-			ctx := rootContext()
+		ctx := rootContext()
 
+		if err := withProfiling(func() error {
 			startMemoryTracking(ctx)
 			defer finishMemoryTracking(ctx)
 
@@ -189,7 +189,13 @@ func maybeRepositoryAction(act func(ctx context.Context, rep repo.Repository) er
 			}
 
 			return err
-		})
+		}); err != nil {
+			// print error in red
+			log(ctx).Errorf("ERROR: %v", err.Error())
+			os.Exit(1)
+		}
+
+		return nil
 	}
 }
 

--- a/cli/command_ls.go
+++ b/cli/command_ls.go
@@ -58,8 +58,8 @@ func listDirectory(ctx context.Context, d fs.Directory, prefix, indent string) e
 	}
 
 	if dws, ok := d.(fs.DirectoryWithSummary); ok && *lsCommandErrorSummary {
-		if ds, _ := dws.Summary(ctx); ds != nil && ds.NumFailed > 0 {
-			errorColor.Fprintf(os.Stderr, "\nNOTE: Encountered %v errors while snapshotting this directory:\n\n", ds.NumFailed) //nolint:errcheck
+		if ds, _ := dws.Summary(ctx); ds != nil && ds.FatalErrorCount > 0 {
+			errorColor.Fprintf(os.Stderr, "\nNOTE: Encountered %v errors while snapshotting this directory:\n\n", ds.FatalErrorCount) //nolint:errcheck
 
 			for _, e := range ds.FailedEntries {
 				errorColor.Fprintf(os.Stderr, "- Error in \"%v\": %v\n", e.EntryPath, e.Error) //nolint:errcheck
@@ -81,8 +81,8 @@ func printDirectoryEntry(ctx context.Context, e fs.Entry, prefix, indent string)
 	)
 
 	if dws, ok := e.(fs.DirectoryWithSummary); ok && *lsCommandErrorSummary {
-		if ds, _ := dws.Summary(ctx); ds != nil && ds.NumFailed > 0 {
-			errorSummary = fmt.Sprintf(" (%v errors)", ds.NumFailed)
+		if ds, _ := dws.Summary(ctx); ds != nil && ds.FatalErrorCount > 0 {
+			errorSummary = fmt.Sprintf(" (%v errors)", ds.FatalErrorCount)
 			col = errorColor
 		}
 	}

--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -257,8 +257,8 @@ func entryBits(ctx context.Context, m *snapshot.Manifest, ent fs.Entry, lastTota
 			bits = append(bits,
 				fmt.Sprintf("files:%v", s.TotalFileCount),
 				fmt.Sprintf("dirs:%v", s.TotalDirCount))
-			if s.NumFailed > 0 {
-				bits = append(bits, fmt.Sprintf("errors:%v", s.NumFailed))
+			if s.FatalErrorCount > 0 {
+				bits = append(bits, fmt.Sprintf("errors:%v", s.FatalErrorCount))
 				col = errorColor
 			}
 		}

--- a/cli/command_snapshot_migrate.go
+++ b/cli/command_snapshot_migrate.go
@@ -22,7 +22,6 @@ var (
 	migratePolicies          = migrateCommand.Flag("policies", "Migrate policies too").Default("true").Bool()
 	migrateOverwritePolicies = migrateCommand.Flag("overwrite-policies", "Overwrite policies").Bool()
 	migrateLatestOnly        = migrateCommand.Flag("latest-only", "Only migrate the latest snapshot").Bool()
-	migrateIgnoreErrors      = migrateCommand.Flag("ignore-errors", "Ignore errors when reading source snapshot").Bool()
 	migrateParallel          = migrateCommand.Flag("parallel", "Number of sources to migrate in parallel").Default("1").Int()
 )
 
@@ -83,7 +82,6 @@ func runMigrateCommand(ctx context.Context, destRepo repo.RepositoryWriter) erro
 
 		uploader := snapshotfs.NewUploader(destRepo)
 		uploader.Progress = progress
-		uploader.IgnoreReadErrors = *migrateIgnoreErrors
 		activeUploaders[s] = uploader
 		mu.Unlock()
 

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -98,7 +98,8 @@ type DirectorySummary struct {
 	IncompleteReason  string    `json:"incomplete,omitempty"`
 
 	// number of failed files
-	NumFailed int `json:"numFailed"`
+	FatalErrorCount   int `json:"numFailed"`
+	IgnoredErrorCount int `json:"numIgnoredErrors,omitempty"`
 
 	// first 10 failed entries
 	FailedEntries []*EntryWithError `json:"errors,omitempty"`

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -435,9 +435,9 @@ func (t *uitaskProgress) HashedBytes(numBytes int64) {
 	t.maybeReport()
 }
 
-// IgnoredError is emitted when an error is encountered and ignored.
-func (t *uitaskProgress) IgnoredError(path string, err error) {
-	t.p.IgnoredError(path, err)
+// Error is emitted when an error is encountered.
+func (t *uitaskProgress) Error(path string, err error, isIgnored bool) {
+	t.p.Error(path, err, isIgnored)
 	t.maybeReport()
 }
 

--- a/snapshot/stats.go
+++ b/snapshot/stats.go
@@ -21,6 +21,9 @@ type Stats struct {
 
 	ExcludedFileCount int32 `json:"excludedFileCount"`
 	ExcludedDirCount  int32 `json:"excludedDirCount"`
+
+	IgnoredErrorCount int32 `json:"ignoredErrorCount"`
+	ErrorCount        int32 `json:"errorCount"`
 }
 
 // AddExcluded adds the information about excluded file to the statistics.

--- a/tests/end_to_end_test/restore_fail_test.go
+++ b/tests/end_to_end_test/restore_fail_test.go
@@ -49,7 +49,7 @@ func TestRestoreFail(t *testing.T) {
 	beforeBlobList := e.RunAndExpectSuccess(t, "blob", "list")
 
 	_, errOut := e.RunAndExpectSuccessWithErrOut(t, "snapshot", "create", sourceDir)
-	snapID := parseSnapID(t, errOut)
+	parsed := parseSnapshotResult(t, errOut)
 
 	afterBlobList := e.RunAndExpectSuccess(t, "blob", "list")
 
@@ -64,10 +64,10 @@ func TestRestoreFail(t *testing.T) {
 	e.RunAndExpectSuccess(t, "blob", "delete", blobIDToDelete)
 
 	// Expect a subsequent restore to fail
-	e.RunAndExpectFailure(t, "snapshot", "restore", snapID, targetDir)
+	e.RunAndExpectFailure(t, "snapshot", "restore", parsed.manifestID, targetDir)
 
 	// --ignore-errors allows the snapshot to succeed despite missing blob.
-	e.RunAndExpectSuccess(t, "snapshot", "restore", "--ignore-errors", snapID, targetDir)
+	e.RunAndExpectSuccess(t, "snapshot", "restore", "--ignore-errors", parsed.manifestID, targetDir)
 }
 
 func findPackBlob(blobIDs []string) string {

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -85,7 +85,7 @@ func NewCLITest(t *testing.T) *CLITest {
 	logsDir := filepath.Join(os.TempDir(), "kopia-logs", cleanName+"."+clock.Now().Local().Format("20060102150405"))
 
 	t.Cleanup(func() {
-		if t.Failed() {
+		if t.Failed() && os.Getenv("KOPIA_DISABLE_LOG_DUMP_ON_FAILURE") == "" {
 			dumpLogs(t, logsDir)
 		}
 


### PR DESCRIPTION
Fixes #690

This is a breaking change for folks who are expecting snapshots to fail
quickly without writing a snapshot manifest in case of an error.

Before this change, any source read failure would cause the entire
snapshot to fail (and not write a snapshot manifest as a result),
unless `ignoreFileErrors` or `ignoreDirectoryErrors` was set.

The new behavior is to continue snapshotting remaining files and
directories (this can be disabled by passing `--fail-fast` flag or
setting `KOPIA_SNAPSHOT_FAIL_FAST=1` environment variable) and defer
returning an error until the very end.

After snapshotting we will always attempt to write the snapshot manifest
(except when the root of the snapshot itself cannot be opened). In case
of a fail-fast error, the manifest will be marked as 'partial' and
the directory tree will contain only partial set of files.

In case of any errors, the manifest (and each directory object) will
list the number if failures and no more than 10 examples of failed
files/directories along with their respective errors.

Once the snapshot is complete we will return non-zero exit code to the
operating system if there were any fatal errors during snapshotting.

With this change we are repurposing `ignoreFileErrors` and
`ignoreDirectoryErrors` to designate some errors as non-fatal.
Non-fatal errors are reported as warnings in the logs and will not
cause a non-zero exit code to be returned.