### PR TITLE
Virtual File System to support stdin source

### DIFF
--- a/fs/virtualfs/directory.go
+++ b/fs/virtualfs/directory.go
@@ -1,0 +1,177 @@
+package virtualfs
+
+import (
+	"context"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/fs"
+)
+
+// Directory is a mock in-memory implementation of fs.Directory.
+type Directory struct {
+	entry
+
+	children fs.Entries
+}
+
+var _ fs.Directory = (*Directory)(nil)
+
+// AddDir adds a directory with a given name and permissions.
+func (imd *Directory) AddDir(name string, permissions os.FileMode) (*Directory, error) {
+	subdir := &Directory{
+		entry: entry{
+			name: name,
+			mode: permissions | os.ModeDir,
+		},
+	}
+
+	if err := imd.addChild(subdir); err != nil {
+		return nil, err
+	}
+
+	return subdir, nil
+}
+
+// AddAllDirs creates under imd, all the necessary directories in the pathname, similar to os.MkdirAll.
+func (imd *Directory) AddAllDirs(pathname string, permissions os.FileMode) (subdir *Directory, err error) {
+	p, missing, err := imd.resolveDirs(pathname)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, n := range missing {
+		if p, err = p.AddDir(n, permissions); err != nil {
+			return nil, errors.Wrapf(err, "unable to add sub directory '%s'", n)
+		}
+	}
+
+	return p, nil
+}
+
+// Child gets the named child of a directory.
+func (imd *Directory) Child(ctx context.Context, name string) (fs.Entry, error) {
+	return fs.ReadDirAndFindChild(ctx, imd, name)
+}
+
+// Readdir gets the contents of a directory.
+func (imd *Directory) Readdir(ctx context.Context) (fs.Entries, error) {
+	return append(fs.Entries(nil), imd.children...), nil
+}
+
+// Remove removes directory entry with the given name.
+func (imd *Directory) Remove(name string) {
+	newChildren := imd.children[:0]
+
+	for _, e := range imd.children {
+		if e.Name() != name {
+			newChildren = append(newChildren, e)
+		}
+	}
+
+	imd.children = newChildren
+}
+
+// Subdir finds a subdirectory with the given name.
+func (imd *Directory) Subdir(name string) (*Directory, error) {
+	curr := imd
+
+	subdir := curr.children.FindByName(name)
+	if subdir == nil {
+		return nil, errors.Errorf("'%s' not found in '%s'", name, curr.Name())
+	}
+
+	if !subdir.IsDir() {
+		return nil, errors.Errorf("'%s' is not a directory in '%s'", name, curr.Name())
+	}
+
+	return subdir.(*Directory), nil
+}
+
+// Summary returns summary of a directory.
+func (imd *Directory) Summary() *fs.DirectorySummary {
+	return nil
+}
+
+// addChild adds the given entry under imd, errors out if the entry is already present.
+func (imd *Directory) addChild(e fs.Entry) error {
+	if strings.Contains(e.Name(), "/") {
+		return errors.New("unable to add child entry: name cannot contain '/'")
+	}
+
+	child := imd.children.FindByName(e.Name())
+	if child != nil {
+		return errors.New("unable to add child entry: already exists")
+	}
+
+	imd.children = append(imd.children, e)
+	imd.children.Sort()
+
+	return nil
+}
+
+// resolveDirs finds the directories in the pathname under imd and returns a list of missing sub directories.
+func (imd *Directory) resolveDirs(pathname string) (parent *Directory, missing []string, err error) {
+	if pathname == "" {
+		return imd, nil, nil
+	}
+
+	p := imd
+
+	parts := strings.Split(path.Clean(pathname), "/")
+	for i, n := range parts {
+		i2 := p.children.FindByName(n)
+		if i2 == nil {
+			return p, parts[i:], nil
+		}
+
+		if !i2.IsDir() {
+			return nil, nil, errors.Errorf("'%s' is not a directory in '%s'", n, p.Name())
+		}
+
+		p = i2.(*Directory)
+	}
+
+	return p, nil, nil
+}
+
+// AddFileWithContent adds a virtual file with specified name, permissions and content.
+func AddFileWithContent(imd *Directory, filePath string, content []byte, dirPermissions, filePermissions os.FileMode) (*File, error) {
+	dir, name := path.Split(filePath)
+
+	p, err := imd.AddAllDirs(dir, dirPermissions)
+	if err != nil {
+		return nil, err
+	}
+
+	f := FileWithContent(name, filePermissions, content)
+	if err := p.addChild(f); err != nil {
+		return nil, errors.Wrap(err, "unable to add file")
+	}
+
+	return f, nil
+}
+
+// AddFileWithStdinSource adds a virtual file with the specified name, permissions and stdin source.
+func AddFileWithStdinSource(imd *Directory, filePath string, dirPermissions, filePermissions os.FileMode) (*File, error) {
+	dir, name := path.Split(filePath)
+
+	p, err := imd.AddAllDirs(dir, dirPermissions)
+	if err != nil {
+		return nil, err
+	}
+
+	source := func() (ReaderSeekerCloser, error) {
+		return readCloserWrapper{os.Stdin}, nil
+	}
+
+	f := FileWithSource(name, filePermissions, source)
+	if err := p.addChild(f); err != nil {
+		return nil, errors.Wrap(err, "unable to add file")
+	}
+
+	return f, nil
+}

--- a/fs/virtualfs/directory_test.go
+++ b/fs/virtualfs/directory_test.go
@@ -1,0 +1,238 @@
+package virtualfs
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+)
+
+const (
+	defaultPermissions os.FileMode = 0777
+	dirPermissions     os.FileMode = defaultPermissions | os.ModeDir
+)
+
+func TestAddDir(t *testing.T) {
+	t.Log("Add root directory")
+
+	rootDir, err := NewDirectory("root")
+	expectSuccess(t, err)
+
+	t.Log("Add sub-directory d1")
+
+	dir, err := rootDir.AddDir("d1", defaultPermissions)
+	expectSuccess(t, err)
+	checkEquality(t, dir.Name(), "d1")
+
+	t.Log("Add duplicate sub-directory d1")
+
+	_, err = rootDir.AddDir("d1", defaultPermissions)
+	expectFailure(t, err)
+
+	t.Log("Add sub-directory with invalid name /d2")
+
+	_, err = rootDir.AddDir("/d2", defaultPermissions)
+	expectFailure(t, err)
+}
+
+func TestAddAllDirs(t *testing.T) {
+	t.Log("Add root directory")
+
+	rootDir, err := NewDirectory("root")
+	expectSuccess(t, err)
+
+	t.Log("Add a directory: root/d1")
+
+	subdir, err := rootDir.AddAllDirs("d1", defaultPermissions)
+	expectSuccess(t, err)
+	checkEquality(t, subdir.Name(), "d1")
+
+	d1 := verifyAndGetSubdir(t, rootDir, "d1")
+
+	t.Log("Add a sub-dir under an existing directory: root/d1/d2")
+
+	subdir, err = rootDir.AddAllDirs("d1/d2", defaultPermissions)
+	expectSuccess(t, err)
+	checkEquality(t, subdir.Name(), "d2")
+
+	_ = verifyAndGetSubdir(t, d1, "d2")
+
+	t.Log("Add third/fourth level dirs: root/d1/d3/d4")
+
+	subdir, err = rootDir.AddAllDirs("d1/d3/d4", defaultPermissions)
+	expectSuccess(t, err)
+	checkEquality(t, subdir.Name(), "d4")
+
+	d3 := verifyAndGetSubdir(t, d1, "d3")
+
+	_ = verifyAndGetSubdir(t, d3, "d4")
+
+	t.Log("Add a directory under a file (expect failure): root/f1/d6")
+
+	f, err := AddFileWithContent(rootDir, "f1", []byte("test"), defaultPermissions, defaultPermissions)
+	expectSuccess(t, err)
+	checkEquality(t, f.Name(), "f1")
+
+	_, err = rootDir.AddAllDirs("f1/d6", defaultPermissions)
+	expectFailure(t, err)
+}
+
+func TestAddFile(t *testing.T) {
+	t.Log("Add root directory")
+
+	rootDir, err := NewDirectory("root")
+	expectSuccess(t, err)
+
+	t.Log("Add file with stdin source: root/f1")
+
+	f, err := AddFileWithStdinSource(rootDir, "f1", defaultPermissions, defaultPermissions)
+	expectSuccess(t, err)
+
+	if f == nil {
+		t.Fatal("expected file, got nil")
+	}
+
+	checkEquality(t, f.Name(), "f1")
+
+	t.Log("Add file with stdin source at third level: root/d1/f2")
+
+	f, err = AddFileWithStdinSource(rootDir, "d1/f2", defaultPermissions, defaultPermissions)
+	expectSuccess(t, err)
+
+	if f == nil {
+		t.Fatal("expected file, got nil")
+	}
+
+	checkEquality(t, f.Name(), "f2")
+
+	d1 := verifyAndGetSubdir(t, rootDir, "d1")
+
+	e, err := d1.Child(context.Background(), "f2")
+	expectSuccess(t, err)
+
+	if e == nil {
+		t.Fatal("expected child entry, got nil")
+	}
+
+	t.Log("Add file with content at third level: root/d2/f3")
+
+	f, err = AddFileWithContent(rootDir, "d2/f3", []byte("test"), defaultPermissions, defaultPermissions)
+	expectSuccess(t, err)
+
+	if f == nil {
+		t.Fatal("expected file, got nil")
+	}
+
+	checkEquality(t, f.Name(), "f3")
+
+	d2 := verifyAndGetSubdir(t, rootDir, "d2")
+
+	e, err = d2.Child(context.Background(), "f3")
+	expectSuccess(t, err)
+
+	if e == nil {
+		t.Fatal("expected child entry, got nil")
+	}
+}
+
+func TestAddFileWithStdinSource(t *testing.T) {
+	// Create a temporary file with test data
+	content := []byte("TempFile Content")
+
+	tempFile, err := ioutil.TempFile("", "file-with-stdin-source")
+	if err != nil {
+		t.Fatalf("temp file create failed with %v", err)
+	}
+
+	defer os.Remove(tempFile.Name())
+
+	if _, err = tempFile.Write(content); err != nil {
+		t.Fatalf("temp file write failed with %v", err)
+	}
+
+	if _, err = tempFile.Seek(0, 0); err != nil {
+		t.Fatalf("temp file seek failed with %v", err)
+	}
+
+	t.Log("Add a root directory")
+
+	rootDir, err := NewDirectory("root")
+	expectSuccess(t, err)
+
+	// Add file with stdin source
+	initialStdin := os.Stdin
+
+	defer func() {
+		os.Stdin = initialStdin
+	}()
+
+	os.Stdin = tempFile
+
+	t.Log("Add a file with stdin source")
+
+	f, err := AddFileWithStdinSource(rootDir, "f1", defaultPermissions, defaultPermissions)
+	expectSuccess(t, err)
+
+	// Read and compare data
+	t.Log("Open virtual file")
+
+	r, err := f.Open(context.TODO())
+	expectSuccess(t, err)
+
+	defer r.Close()
+
+	result := make([]byte, len(content))
+
+	t.Log("Read virtual file")
+
+	if _, err = r.Read(result); err != nil {
+		t.Fatalf("reading virtual file failed with %v", err)
+	}
+
+	checkEquality(t, result, content)
+
+	if err = tempFile.Close(); err != nil {
+		t.Fatalf("temp file close failed with %v", err)
+	}
+}
+
+func expectSuccess(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("expected success, failed with %v", err)
+	}
+}
+
+func expectFailure(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected failure, but got none")
+	}
+}
+
+func checkEquality(t *testing.T, got, want interface{}) {
+	t.Helper()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Did not get expected output: (actual) %v != %v (expected)", got, want)
+	}
+}
+
+func verifyAndGetSubdir(t *testing.T, rootDir *Directory, subdirName string) *Directory {
+	t.Helper()
+
+	sub, err := rootDir.Subdir(subdirName)
+	expectSuccess(t, err)
+
+	if sub == nil {
+		t.Fatal("expected subdir, got nil")
+	}
+
+	checkEquality(t, sub.Name(), subdirName)
+	checkEquality(t, sub.Mode(), dirPermissions)
+
+	return sub
+}

--- a/fs/virtualfs/entry.go
+++ b/fs/virtualfs/entry.go
@@ -1,0 +1,56 @@
+package virtualfs
+
+import (
+	"os"
+	"time"
+
+	"github.com/kopia/kopia/fs"
+)
+
+// entry is an in-memory implementation of a directory entry.
+type entry struct {
+	name    string
+	mode    os.FileMode
+	size    int64
+	modTime time.Time
+	owner   fs.OwnerInfo
+	device  fs.DeviceInfo
+}
+
+var _ fs.Entry = (*entry)(nil)
+
+func (e *entry) Name() string {
+	return e.name
+}
+
+func (e *entry) IsDir() bool {
+	return e.mode.IsDir()
+}
+
+func (e *entry) Mode() os.FileMode {
+	return e.mode
+}
+
+func (e *entry) ModTime() time.Time {
+	return e.modTime
+}
+
+func (e *entry) Size() int64 {
+	return e.size
+}
+
+func (e *entry) Sys() interface{} {
+	return nil
+}
+
+func (e *entry) Owner() fs.OwnerInfo {
+	return e.owner
+}
+
+func (e *entry) Device() fs.DeviceInfo {
+	return e.device
+}
+
+func (e *entry) LocalFilesystemPath() string {
+	return ""
+}

--- a/fs/virtualfs/file.go
+++ b/fs/virtualfs/file.go
@@ -1,0 +1,52 @@
+package virtualfs
+
+import (
+	"bytes"
+	"context"
+	"os"
+
+	"github.com/kopia/kopia/fs"
+)
+
+// File is an in-memory implementation of fs.File.
+type File struct {
+	entry
+
+	source func() (ReaderSeekerCloser, error)
+}
+
+var _ fs.File = (*File)(nil)
+
+// Open opens the file for reading.
+func (imf *File) Open(ctx context.Context) (fs.Reader, error) {
+	r, err := imf.source()
+	if err != nil {
+		return nil, err
+	}
+
+	return &fileReader{
+		ReaderSeekerCloser: r,
+		entry:              imf,
+	}, nil
+}
+
+// FileWithSource returns a file with given name, permissions and source.
+func FileWithSource(name string, permissions os.FileMode, source func() (ReaderSeekerCloser, error)) *File {
+	return &File{
+		entry: entry{
+			name: name,
+			mode: permissions,
+			// TODO: add owner and other information
+		},
+		source: source,
+	}
+}
+
+// FileWithContent returns a file with given content.
+func FileWithContent(name string, permissions os.FileMode, content []byte) *File {
+	s := func() (ReaderSeekerCloser, error) {
+		return readSeekerWrapper{bytes.NewReader(content)}, nil
+	}
+
+	return FileWithSource(name, permissions, s)
+}

--- a/fs/virtualfs/file_reader.go
+++ b/fs/virtualfs/file_reader.go
@@ -1,0 +1,44 @@
+package virtualfs
+
+import (
+	"context"
+	"io"
+
+	"github.com/kopia/kopia/fs"
+)
+
+// ReaderSeekerCloser implements io.Reader, io.Seeker and io.Closer.
+type ReaderSeekerCloser interface {
+	io.Reader
+	io.Seeker
+	io.Closer
+}
+
+// readSeekerWrapper adds a no-op Close method to a ReadSeeker.
+type readSeekerWrapper struct {
+	io.ReadSeeker
+}
+
+func (rs readSeekerWrapper) Close() error {
+	return nil
+}
+
+// readCloserWrapper adds a no-op Seek method to a ReadCloser.
+type readCloserWrapper struct {
+	io.ReadCloser
+}
+
+func (rc readCloserWrapper) Seek(start int64, offset int) (int64, error) {
+	log(context.TODO()).Debugf("seek not supported: start %d, offset %d", start, offset)
+	return 0, nil
+}
+
+// fileReader is an in-memory implementation of fs.Reader.
+type fileReader struct {
+	ReaderSeekerCloser
+	entry fs.Entry
+}
+
+func (fr *fileReader) Entry() (fs.Entry, error) {
+	return fr.entry, nil
+}

--- a/fs/virtualfs/symlink.go
+++ b/fs/virtualfs/symlink.go
@@ -1,0 +1,20 @@
+package virtualfs
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/fs"
+)
+
+// inmemorySymlink is a mock in-memory implementation of fs.Symlink.
+type inmemorySymlink struct {
+	entry
+}
+
+var _ fs.Symlink = (*inmemorySymlink)(nil)
+
+func (imsl *inmemorySymlink) Readlink(ctx context.Context) (string, error) {
+	return "", errors.New("symlinks not supported")
+}

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -1,0 +1,27 @@
+// Package virtualfs implements an in-memory filesystem.
+package virtualfs
+
+import (
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/logging"
+)
+
+var log = logging.GetContextLoggerFunc("kopia/internal/virtualfs")
+
+// NewDirectory returns a virtual FS root directory.
+func NewDirectory(rootName string) (*Directory, error) {
+	if strings.Contains(rootName, "/") {
+		return nil, errors.New("Root name cannot contain '/'")
+	}
+
+	return &Directory{
+		entry: entry{
+			name: rootName,
+			mode: 0777 | os.ModeDir, // nolint:gomnd
+		},
+	}, nil
+}

--- a/fs/virtualfs/virtualfs_test.go
+++ b/fs/virtualfs/virtualfs_test.go
@@ -1,0 +1,46 @@
+package virtualfs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewDirectory(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		rootName string
+		expErr   bool
+	}{
+		{
+			desc:     "Root Directory success",
+			rootName: "root",
+			expErr:   false,
+		},
+		{
+			desc:     "Root directory with `/` in the name",
+			rootName: "/root",
+			expErr:   true,
+		},
+	} {
+		t.Log(tc.desc)
+
+		r, err := NewDirectory(tc.rootName)
+		if tc.expErr {
+			if err == nil {
+				t.Errorf("expected error but got none")
+			}
+		} else {
+			if err != nil {
+				t.Errorf("expected success but got err: %v", err)
+				continue
+			}
+			if r == nil {
+				t.Errorf("expected root directory, got nil")
+				continue
+			}
+			if !reflect.DeepEqual(r.Name(), tc.rootName) {
+				t.Errorf("did not get expected output: (actual) %v != %v (expected)", r.Name(), tc.rootName)
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Overview

Added a separate package to implement an in-memory filesystem. This package has helpers to support adding files with `stdin` source.

NOTE: This is based off of the existing `mockfs` package with minor enhancements. We could refactor and reuse a lot of common code. It would involve removing panics and changing dependent tests currently using `mockfs`.

### Test Plan

```
=== RUN   TestAddDir
    directory_test.go:17: Add root directory
    directory_test.go:21: Add sub-directory d1
    directory_test.go:26: Add duplicate sub-directory d1
    directory_test.go:30: Add sub-directory with invalid name /d2
--- PASS: TestAddDir (0.00s)
=== RUN   TestAddAllDirs
    directory_test.go:36: Add root directory
    directory_test.go:40: Add a directory: root/d1
    directory_test.go:46: Add a sub-dir under an existing directory: root/d1/d2
    directory_test.go:52: Add third/fourth level dirs: root/d1/d3/d4
    directory_test.go:59: Add a directory under a file (expect failure): root/f1/d6
--- PASS: TestAddAllDirs (0.00s)
=== RUN   TestAddFile
    directory_test.go:68: Add root directory
    directory_test.go:72: Add file with stdin source: root/f1
    directory_test.go:80: Add file with stdin source at third level: root/d1/f2
    directory_test.go:94: Add file with content at third level: root/d2/f3
--- PASS: TestAddFile (0.00s)
=== RUN   TestAddFileWithStdinSource
    directory_test.go:126: Add a root directory
    directory_test.go:137: Add a file with stdin source
    directory_test.go:142: Open virtual file
    directory_test.go:150: Read virtual file
--- PASS: TestAddFileWithStdinSource (0.00s)
=== RUN   TestNewDirectory
    virtualfs_test.go:25: Root Directory success
    virtualfs_test.go:25: Root directory with `/` in the name
--- PASS: TestNewDirectory (0.00s)
PASS
ok  	github.com/kopia/kopia/fs/virtualfs	0.209s
```