### PR TITLE
Upgrade to Go 1.16

### DIFF
--- a/.github/workflows/kopia-ui-pr-test.yml
+++ b/.github/workflows/kopia-ui-pr-test.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.16
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -91,7 +91,7 @@ jobs:
       uses: actions/setup-go@v2
       if: ${{ !contains(matrix.os, 'self-hosted') }}
       with:
-        go-version: ^1.15
+        go-version: ^1.16
       id: go
     - name: Install Windows-specific packages
       run: "choco install --no-progress -y make unzip curl"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kopia/kopia
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go/storage v1.12.0


### PR DESCRIPTION
* Use Go 1.16 in GHA workflows