### PR TITLE
Metadata protection for asynchronous robustness transactions

### DIFF
--- a/tests/robustness/engine/engine.go
+++ b/tests/robustness/engine/engine.go
@@ -143,6 +143,11 @@ func (e *Engine) Shutdown() error {
 			return err
 		}
 
+		err = e.saveSnapIDIndex()
+		if err != nil {
+			return err
+		}
+
 		return e.MetaStore.FlushMetadata()
 	}
 
@@ -195,6 +200,11 @@ func (e *Engine) Init(ctx context.Context) error {
 	e.CumulativeStats.RunCounter++
 
 	err = e.loadLog()
+	if err != nil {
+		return err
+	}
+
+	err = e.loadSnapIDIndex()
 	if err != nil {
 		return err
 	}

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -365,6 +365,10 @@ func TestDataPersistency(t *testing.T) {
 	dataDirWalk, err := eng.Checker.GetSnapshotMetadata(snapID)
 	testenv.AssertNoError(t, err)
 
+	// Save the snapshot ID index
+	err = eng.saveSnapIDIndex()
+	testenv.AssertNoError(t, err)
+
 	// Flush the snapshot metadata to persistent storage
 	err = eng.MetaStore.FlushMetadata()
 	testenv.AssertNoError(t, err)

--- a/tests/robustness/engine/metadata.go
+++ b/tests/robustness/engine/metadata.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 
 	"github.com/kopia/kopia/internal/clock"
-	"github.com/kopia/kopia/tests/robustness/snapmeta"
+	"github.com/kopia/kopia/tests/robustness"
 )
 
 const (
 	engineStatsStoreKey = "cumulative-engine-stats"
 	engineLogsStoreKey  = "engine-logs"
+	snapIDIndexStoreKey = "checker-snapID-index"
 )
 
 // saveLog saves the engine Log in the metadata store.
@@ -29,7 +30,7 @@ func (e *Engine) saveLog() error {
 func (e *Engine) loadLog() error {
 	b, err := e.MetaStore.Load(engineLogsStoreKey)
 	if err != nil {
-		if errors.Is(err, snapmeta.ErrKeyNotFound) {
+		if errors.Is(err, robustness.ErrKeyNotFound) {
 			// Swallow key-not-found error. May not have historical logs
 			return nil
 		}
@@ -61,7 +62,7 @@ func (e *Engine) saveStats() error {
 func (e *Engine) loadStats() error {
 	b, err := e.MetaStore.Load(engineStatsStoreKey)
 	if err != nil {
-		if errors.Is(err, snapmeta.ErrKeyNotFound) {
+		if errors.Is(err, robustness.ErrKeyNotFound) {
 			// Swallow key-not-found error. We may not have historical
 			// stats data. Initialize the action map for the cumulative stats
 			e.CumulativeStats.PerActionStats = make(map[ActionKey]*ActionStats)
@@ -74,4 +75,30 @@ func (e *Engine) loadStats() error {
 	}
 
 	return json.Unmarshal(b, &e.CumulativeStats)
+}
+
+// saveSnapIDIndex saves the Checker's snapshot ID index in the metadata store.
+func (e *Engine) saveSnapIDIndex() error {
+	snapIDIdxRaw, err := json.Marshal(e.Checker.SnapIDIndex)
+	if err != nil {
+		return err
+	}
+
+	return e.MetaStore.Store(snapIDIndexStoreKey, snapIDIdxRaw)
+}
+
+// loadSnapIDIndex loads the Checker's snapshot ID index from the metadata store.
+func (e *Engine) loadSnapIDIndex() error {
+	b, err := e.MetaStore.Load(snapIDIndexStoreKey)
+	if err != nil {
+		if errors.Is(err, robustness.ErrKeyNotFound) {
+			// Swallow key-not-found error. We may not have historical
+			// index data.
+			return nil
+		}
+
+		return err
+	}
+
+	return json.Unmarshal(b, &e.Checker.SnapIDIndex)
 }

--- a/tests/robustness/errors.go
+++ b/tests/robustness/errors.go
@@ -18,4 +18,7 @@ var (
 
 	// ErrInvalidOption is returned if an option value is invalid or missing.
 	ErrInvalidOption = errors.New("invalid option setting")
+
+	// ErrKeyNotFound is returned when the store can't find the key provided.
+	ErrKeyNotFound = errors.New("key not found")
 )

--- a/tests/robustness/persister.go
+++ b/tests/robustness/persister.go
@@ -6,14 +6,6 @@ type Store interface {
 	Store(key string, val []byte) error
 	Load(key string) ([]byte, error)
 	Delete(key string)
-	Indexer
-}
-
-// Indexer describes methods surrounding categorization of keys via a named index.
-type Indexer interface {
-	AddToIndex(key, indexName string)
-	RemoveFromIndex(key, indexName string)
-	GetKeys(indexName string) (ret []string)
 }
 
 // Persister describes the ability to flush metadata

--- a/tests/robustness/snapmeta/index.go
+++ b/tests/robustness/snapmeta/index.go
@@ -34,3 +34,14 @@ func (idx Index) GetKeys(indexName string) (ret []string) {
 
 	return ret
 }
+
+// IsKeyInIndex will return true if the given index name contains the
+// provided key.
+func (idx Index) IsKeyInIndex(key, indexName string) bool {
+	if _, ok := idx[indexName]; ok {
+		_, keyExists := idx[indexName][key]
+		return keyExists
+	}
+
+	return false
+}


### PR DESCRIPTION
Add metadata R/W locking for asynchronous accesses to robustness engine metadata.
Remove the index from the Store interface and maintain it only in Checker, where it's used.