### PR TITLE
Added first-class support for fs.ErrorEntry for directory entries that could not be read or are unknown/unsupported

### DIFF
--- a/cli/command_policy_set_error_handling.go
+++ b/cli/command_policy_set_error_handling.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	"github.com/kopia/kopia/snapshot/policy"
 )
 
@@ -10,12 +12,21 @@ var (
 	// Error handling behavior.
 	policyIgnoreFileErrors      = policySetCommand.Flag("ignore-file-errors", "Ignore errors reading files while traversing ('true', 'false', 'inherit')").Enum(booleanEnumValues...)
 	policyIgnoreDirectoryErrors = policySetCommand.Flag("ignore-dir-errors", "Ignore errors reading directories while traversing ('true', 'false', 'inherit").Enum(booleanEnumValues...)
+	policyIgnoreUnknownTypes    = policySetCommand.Flag("ignore-unknown-types", "Ignore unknown entry types in directories ('true', 'false', 'inherit").Enum(booleanEnumValues...)
 )
 
 func setErrorHandlingPolicyFromFlags(ctx context.Context, fp *policy.ErrorHandlingPolicy, changeCount *int) error {
-	if err := applyPolicyBoolPtr(ctx, "ignore file read errors", &fp.IgnoreFileErrors, *policyIgnoreFileErrors, changeCount); err != nil {
-		return err
+	if err := applyPolicyBoolPtr(ctx, "ignore file errors", &fp.IgnoreFileErrors, *policyIgnoreFileErrors, changeCount); err != nil {
+		return errors.Wrap(err, "ignore file errors")
 	}
 
-	return applyPolicyBoolPtr(ctx, "ignore dir read errors", &fp.IgnoreDirectoryErrors, *policyIgnoreDirectoryErrors, changeCount)
+	if err := applyPolicyBoolPtr(ctx, "ignore directory errors", &fp.IgnoreDirectoryErrors, *policyIgnoreDirectoryErrors, changeCount); err != nil {
+		return errors.Wrap(err, "ignore directory errors")
+	}
+
+	if err := applyPolicyBoolPtr(ctx, "ignore unknown types", &fp.IgnoreUnknownTypes, *policyIgnoreUnknownTypes, changeCount); err != nil {
+		return errors.Wrap(err, "ignore unknown types")
+	}
+
+	return nil
 }

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -186,6 +186,12 @@ func printErrorHandlingPolicy(p *policy.Policy, parents []*policy.Policy) {
 		getDefinitionPoint(p.Target(), parents, func(pol *policy.Policy) bool {
 			return pol.ErrorHandlingPolicy.IgnoreDirectoryErrors != nil
 		}))
+
+	printStdout("  Ignore unknown types:          %5v       %v\n",
+		p.ErrorHandlingPolicy.IgnoreUnknownTypesOrDefault(true),
+		getDefinitionPoint(p.Target(), parents, func(pol *policy.Policy) bool {
+			return pol.ErrorHandlingPolicy.IgnoreUnknownTypes != nil
+		}))
 }
 
 func printSchedulingPolicy(p *policy.Policy, parents []*policy.Policy) {

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -10,6 +10,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrUnknown is returned by ErrorEntry.ErrorInfo() to indicate that type of an entry is unknown.
+var ErrUnknown = errors.Errorf("unknown or unsupported entry type")
+
 // Entry represents a filesystem entry, which can be Directory, File, or Symlink.
 type Entry interface {
 	os.FileInfo
@@ -57,6 +60,13 @@ type Directory interface {
 // DirectoryWithSummary is optionally implemented by Directory that provide summary.
 type DirectoryWithSummary interface {
 	Summary(ctx context.Context) (*DirectorySummary, error)
+}
+
+// ErrorEntry represents entry in a Directory that had encountered an error or is unknown/unsupported (ErrUnknown).
+type ErrorEntry interface {
+	Entry
+
+	ErrorInfo() error
 }
 
 // ErrEntryNotFound is returned when an entry is not found.

--- a/htmlui/src/PolicyEditor.js
+++ b/htmlui/src/PolicyEditor.js
@@ -195,6 +195,7 @@ export class PolicyEditor extends Component {
                         <Form.Row>
                             {OptionalBoolean(this, "Ignore Directory Errors", "policy.errorHandling.ignoreDirectoryErrors", "inherit from parent")}
                             {OptionalBoolean(this, "Ignore File Errors", "policy.errorHandling.ignoreFileErrors", "inherit from parent")}
+                            {OptionalBoolean(this, "Ignore Unknown Types", "policy.errorHandling.ignoreUnknownTypes", "inherit from parent")}
                         </Form.Row>
                     </div>
                 </Tab>

--- a/htmlui/src/uiutil.js
+++ b/htmlui/src/uiutil.js
@@ -53,7 +53,7 @@ export function sizeWithFailures(size, summ) {
         <OverlayTrigger placement="bottom"
             delay={{ show: 0, hide: 1000 }}
             overlay={overlay}>
-            <FontAwesomeIcon color="red" icon={faExclamationTriangle} title="{caption}" />
+            <FontAwesomeIcon color="red" icon={faExclamationTriangle} title={caption} />
         </OverlayTrigger>
     </span>;
 }

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -142,6 +142,23 @@ func (imd *Directory) AddDir(name string, permissions os.FileMode) *Directory {
 	return subdir
 }
 
+// AddErrorEntry adds a fake directory with a given name and permissions.
+func (imd *Directory) AddErrorEntry(name string, permissions os.FileMode, err error) *ErrorEntry {
+	imd, name = imd.resolveSubdir(name)
+
+	ee := &ErrorEntry{
+		entry: entry{
+			name: name,
+			mode: permissions | os.ModeDir,
+		},
+		err: err,
+	}
+
+	imd.addChild(ee)
+
+	return ee
+}
+
 // AddDirDevice adds a fake directory with a given name and permissions.
 func (imd *Directory) AddDirDevice(name string, permissions os.FileMode, deviceInfo fs.DeviceInfo) *Directory {
 	imd, name = imd.resolveSubdir(name)
@@ -292,8 +309,20 @@ func NewDirectory() *Directory {
 	}
 }
 
+// ErrorEntry is mock in-memory implementation of fs.ErrorEntry.
+type ErrorEntry struct {
+	entry
+	err error
+}
+
+// ErrorInfo implements fs.ErrorErntry.
+func (e *ErrorEntry) ErrorInfo() error {
+	return e.err
+}
+
 var (
-	_ fs.Directory = &Directory{}
-	_ fs.File      = &File{}
-	_ fs.Symlink   = &inmemorySymlink{}
+	_ fs.Directory  = &Directory{}
+	_ fs.File       = &File{}
+	_ fs.Symlink    = &inmemorySymlink{}
+	_ fs.ErrorEntry = &ErrorEntry{}
 )

--- a/snapshot/policy/error_handling_policy.go
+++ b/snapshot/policy/error_handling_policy.go
@@ -2,11 +2,14 @@ package policy
 
 // ErrorHandlingPolicy controls error hadnling behavior when taking snapshots.
 type ErrorHandlingPolicy struct {
-	// IgnoreFileErrors controls whether or not snapshot operation should terminate when a file throws an error on being read
+	// IgnoreFileErrors controls whether or not snapshot operation should fail when a file throws an error on being read
 	IgnoreFileErrors *bool `json:"ignoreFileErrors,omitempty"`
 
-	// IgnoreDirectoryErrors controls whether or not snapshot operation should terminate when a directory throws an error on being read or opened
+	// IgnoreDirectoryErrors controls whether or not snapshot operation should fail when a directory throws an error on being read or opened
 	IgnoreDirectoryErrors *bool `json:"ignoreDirectoryErrors,omitempty"`
+
+	// IgnoreUnknownTypes controls whether or not snapshot operation should fail when it encounters a directory entry of an unknown type.
+	IgnoreUnknownTypes *bool `json:"ignoreUnknownTypes,omitempty"`
 }
 
 // Merge applies default values from the provided policy.
@@ -17,6 +20,10 @@ func (p *ErrorHandlingPolicy) Merge(src ErrorHandlingPolicy) {
 
 	if p.IgnoreDirectoryErrors == nil && src.IgnoreDirectoryErrors != nil {
 		p.IgnoreDirectoryErrors = newBool(*src.IgnoreDirectoryErrors)
+	}
+
+	if p.IgnoreUnknownTypes == nil && src.IgnoreUnknownTypes != nil {
+		p.IgnoreUnknownTypes = newBool(*src.IgnoreUnknownTypes)
 	}
 }
 
@@ -40,10 +47,21 @@ func (p *ErrorHandlingPolicy) IgnoreDirectoryErrorsOrDefault(def bool) bool {
 	return *p.IgnoreDirectoryErrors
 }
 
+// IgnoreUnknownTypesOrDefault returns the IgnoreUnknownTypes if it is set,
+// and returns the passed default if not.
+func (p *ErrorHandlingPolicy) IgnoreUnknownTypesOrDefault(def bool) bool {
+	if p.IgnoreUnknownTypes == nil {
+		return def
+	}
+
+	return *p.IgnoreUnknownTypes
+}
+
 // defaultErrorHandlingPolicy is the default error handling policy.
 var defaultErrorHandlingPolicy = ErrorHandlingPolicy{
 	IgnoreFileErrors:      newBool(false),
 	IgnoreDirectoryErrors: newBool(false),
+	IgnoreUnknownTypes:    newBool(true),
 }
 
 func newBool(b bool) *bool {

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -90,12 +90,7 @@ func (s *sourceSnapshots) Readdir(ctx context.Context) (fs.Entries, error) {
 			de.DirSummary = m.RootEntry.DirSummary
 		}
 
-		e, err := EntryFromDirEntry(s.rep, de)
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to create entry")
-		}
-
-		result = append(result, e)
+		result = append(result, EntryFromDirEntry(s.rep, de))
 	}
 
 	result.Sort()


### PR DESCRIPTION
This is used for things like fifos, sockets, block and character devices, etc.
Each `ErrorEntry` will propagate as snapshot error in the `Uploader` instead of being semi-silently ignored in the `localfs`.

Both localfs and repofs are expected to have ErrorEntries. The latter in case of cross-version compatibility where old version of kopia is attempting to restore directories created using new version.

The user now has a new choice whether to treat unknown filesystem errors as fatal or ignored errors during upload. The default is to ignore them - the user will see the failure in the manifest but it won't cause the entire snapshot command to fail.