### PR TITLE
server: avoid password hashing by using short-lived JWT tokens

### DIFF
--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -41,6 +41,8 @@ var (
 	serverStartHtpasswdFile   = serverStartCommand.Flag("htpasswd-file", "Path to htpasswd file that contains allowed user@hostname entries").Hidden().ExistingFile()
 	serverStartAllowRepoUsers = serverStartCommand.Flag("allow-repository-users", "Allow users defined in the repository to connect").Bool()
 
+	serverAuthCookieSingingKey = serverStartCommand.Flag("auth-cookie-signing-key", "Force particular auth cookie signing key").Envar("KOPIA_AUTH_COOKIE_SIGNING_KEY").Hidden().String()
+
 	serverStartShutdownWhenStdinClosed = serverStartCommand.Flag("shutdown-on-stdin", "Shut down the server when stdin handle has closed.").Hidden().Bool()
 )
 
@@ -59,12 +61,13 @@ func runServer(ctx context.Context, rep repo.Repository) error {
 	}
 
 	srv, err := server.New(ctx, server.Options{
-		ConfigFile:      repositoryConfigFileName(),
-		ConnectOptions:  connectOptions(),
-		RefreshInterval: *serverStartRefreshInterval,
-		MaxConcurrency:  *serverStartMaxConcurrency,
-		Authenticator:   authn,
-		Authorizer:      auth.LegacyAuthorizerForUser,
+		ConfigFile:           repositoryConfigFileName(),
+		ConnectOptions:       connectOptions(),
+		RefreshInterval:      *serverStartRefreshInterval,
+		MaxConcurrency:       *serverStartMaxConcurrency,
+		Authenticator:        authn,
+		Authorizer:           auth.LegacyAuthorizerForUser,
+		AuthCookieSigningKey: *serverAuthCookieSingingKey,
 	})
 	if err != nil {
 		return errors.Wrap(err, "unable to initialize server")

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go v1.34.29
 	github.com/bgentry/speakeasy v0.1.0
 	github.com/chmduquesne/rollinghash v4.0.0+incompatible
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/efarrer/iothrottler v0.0.1
 	github.com/fatih/color v1.9.0
 	github.com/foomo/htpasswd v0.0.0-20200116085101-e3a90e78da9c


### PR DESCRIPTION
Tokens encode the authenticated user, last for 1 minute and are signed
with HMAC-SHA-256. This improves HTTP server performance by a lot:

BEFORE: 168383 files (6.4 GB) - 3m38s
AFTER: 168383 files (6.4 GB) - 1m37s