### PR TITLE
Support for stdin streams

### DIFF
--- a/fs/entry.go
+++ b/fs/entry.go
@@ -50,6 +50,12 @@ type File interface {
 	Open(ctx context.Context) (Reader, error)
 }
 
+// StreamingFile represents an entry that is a stream.
+type StreamingFile interface {
+	Entry
+	GetReader(ctx context.Context) (io.Reader, error)
+}
+
 // Directory represents contents of a directory.
 type Directory interface {
 	Entry

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -3,6 +3,7 @@ package virtualfs
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"time"
@@ -93,9 +94,19 @@ type virtualFile struct {
 	reader io.Reader
 }
 
+var errReaderAlreadyUsed = errors.New("cannot use streaming file reader more than once")
+
 // GetReader returns the streaming file's reader.
 func (vf *virtualFile) GetReader(ctx context.Context) (io.Reader, error) {
-	return vf.reader, nil
+	if vf.reader == nil {
+		return nil, errReaderAlreadyUsed
+	}
+
+	// reader must be fetched only once
+	ret := vf.reader
+	vf.reader = nil
+
+	return ret, nil
 }
 
 // StreamingFileFromReader returns a streaming file with given name and reader.

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -1,0 +1,116 @@
+// Package virtualfs implements an in-memory abstraction fs.Directory and fs.StreamingFile.
+package virtualfs
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+
+	"github.com/kopia/kopia/fs"
+)
+
+const (
+	defaultPermissions os.FileMode = 0777
+)
+
+// virtualEntry is an in-memory implementation of a directory entry.
+type virtualEntry struct {
+	name    string
+	mode    os.FileMode
+	size    int64
+	modTime time.Time
+	owner   fs.OwnerInfo
+	device  fs.DeviceInfo
+}
+
+func (e *virtualEntry) Name() string {
+	return e.name
+}
+
+func (e *virtualEntry) IsDir() bool {
+	return e.mode.IsDir()
+}
+
+func (e *virtualEntry) Mode() os.FileMode {
+	return e.mode
+}
+
+func (e *virtualEntry) ModTime() time.Time {
+	return e.modTime
+}
+
+func (e *virtualEntry) Size() int64 {
+	return e.size
+}
+
+func (e *virtualEntry) Sys() interface{} {
+	return nil
+}
+
+func (e *virtualEntry) Owner() fs.OwnerInfo {
+	return e.owner
+}
+
+func (e *virtualEntry) Device() fs.DeviceInfo {
+	return e.device
+}
+
+func (e *virtualEntry) LocalFilesystemPath() string {
+	return ""
+}
+
+// staticDirectory is an in-memory implementation of fs.Directory.
+type staticDirectory struct {
+	virtualEntry
+	entries fs.Entries
+}
+
+// Child gets the named child of a directory.
+func (sd *staticDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {
+	return fs.ReadDirAndFindChild(ctx, sd, name)
+}
+
+// Readdir gets the contents of a directory.
+func (sd *staticDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
+	return append(fs.Entries(nil), sd.entries...), nil
+}
+
+// NewStaticDirectory returns a virtual static directory.
+func NewStaticDirectory(name string, entries fs.Entries) fs.Directory {
+	return &staticDirectory{
+		virtualEntry: virtualEntry{
+			name: name,
+			mode: defaultPermissions | os.ModeDir,
+		},
+		entries: entries,
+	}
+}
+
+// virtualFile is an implementation of fs.StreamingFile with an io.Reader.
+type virtualFile struct {
+	virtualEntry
+	reader io.Reader
+}
+
+// GetReader returns the streaming file's reader.
+func (vf *virtualFile) GetReader(ctx context.Context) (io.Reader, error) {
+	return vf.reader, nil
+}
+
+// StreamingFileFromReader returns a streaming file with given name and reader.
+func StreamingFileFromReader(name string, reader io.Reader) fs.StreamingFile {
+	return &virtualFile{
+		virtualEntry: virtualEntry{
+			name: name,
+			mode: defaultPermissions,
+		},
+		reader: reader,
+	}
+}
+
+var (
+	_ fs.Directory     = &staticDirectory{}
+	_ fs.StreamingFile = &virtualFile{}
+	_ fs.Entry         = &virtualEntry{}
+)

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -1,4 +1,4 @@
-// Package virtualfs implements an in-memory abstraction fs.Directory and fs.StreamingFile.
+// Package virtualfs implements an in-memory abstraction of fs.Directory and fs.StreamingFile.
 package virtualfs
 
 import (
@@ -97,6 +97,8 @@ type virtualFile struct {
 var errReaderAlreadyUsed = errors.New("cannot use streaming file reader more than once")
 
 // GetReader returns the streaming file's reader.
+// Note: Caller of this function has to ensure concurrency safety.
+// The file's reader is set to nil after the first call.
 func (vf *virtualFile) GetReader(ctx context.Context) (io.Reader, error) {
 	if vf.reader == nil {
 		return nil, errReaderAlreadyUsed

--- a/fs/virtualfs/virtualfs_test.go
+++ b/fs/virtualfs/virtualfs_test.go
@@ -1,0 +1,65 @@
+package virtualfs
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/kopia/kopia/fs"
+)
+
+func TestStreamingFile(t *testing.T) {
+	// Create a temporary file with test data
+	content := []byte("Temporary file content")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("error creating pipe file: %v", err)
+	}
+
+	if _, err = w.Write(content); err != nil {
+		t.Fatalf("error writing to pipe file: %v", err)
+	}
+
+	w.Close()
+
+	filename := "stream-file"
+	f := StreamingFileFromReader(filename, r)
+
+	rootDir := NewStaticDirectory("root", fs.Entries{f})
+
+	e, err := rootDir.Child(context.TODO(), filename)
+	if err != nil {
+		t.Fatalf("error getting child entry: %v", err)
+	}
+
+	if e.Name() != filename {
+		t.Fatalf("did not get expected filename: (actual) %v != %v (expected)", e.Name(), filename)
+	}
+
+	entries, err := rootDir.Readdir(context.TODO())
+	if err != nil {
+		t.Fatalf("error getting dir entries %v", err)
+	}
+
+	if len(entries) == 0 {
+		t.Errorf("expected directory with 1 entry, got %v", rootDir)
+	}
+
+	// Read and compare data
+	reader, err := f.GetReader(context.TODO())
+	if err != nil {
+		t.Fatalf("error getting streaming file reader: %v", err)
+	}
+
+	result := make([]byte, len(content))
+
+	if _, err = reader.Read(result); err != nil {
+		t.Fatalf("error reading streaming file: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, content) {
+		t.Fatalf("did not get expected file content: (actual) %v != %v (expected)", result, content)
+	}
+}

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/fs/ignorefs"
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/logging"
 	"github.com/kopia/kopia/repo/object"
@@ -231,6 +232,7 @@ func (u *Uploader) uploadStreamingFileInternal(ctx context.Context, relativePath
 	}
 
 	de.FileSize = written
+	de.ModTime = clock.Now()
 
 	atomic.AddInt32(&u.stats.TotalFileCount, 1)
 	atomic.AddInt64(&u.stats.TotalFileSize, de.FileSize)

--- a/snapshot/snapshotfs/upload_scan.go
+++ b/snapshot/snapshotfs/upload_scan.go
@@ -47,6 +47,9 @@ func (u *Uploader) scanDirectory(ctx context.Context, dir fs.Directory) (scanRes
 		case fs.File:
 			res.numFiles++
 			res.totalFileSize += e.Size()
+
+		case fs.StreamingFile:
+			res.numFiles++
 		}
 	}
 

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -494,20 +494,10 @@ func TestSnapshotCreateWithStdinStream(t *testing.T) {
 
 	w.Close()
 
-	// Use the pipe file as stdin
-	initialStdin := os.Stdin
-
-	defer func() {
-		// Reset stdin
-		os.Stdin = initialStdin
-	}()
-
-	os.Stdin = r
-
 	streamFileName := "stream-file"
-	e.PassthroughStdin = true
+	e.NextCommandStdin = r
 
-	e.RunAndExpectSuccess(t, "snapshot", "create", "--stdin-file", streamFileName)
+	e.RunAndExpectSuccess(t, "snapshot", "create", "rootdir", "--stdin-file", streamFileName)
 
 	// Make sure the scheduling policy with manual field is set and visible in the policy list, includes global policy
 	e.RunAndVerifyOutputLineCount(t, 2, "policy", "list")

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -469,6 +470,79 @@ func TestSnapshotCreateAllWithManualSnapshot(t *testing.T) {
 	// snapshot count must increase by 1 since `sharedTestDataDir1` is ignored
 	expectedSnapshotCount := sourceSnapshotCount + 1
 	e.RunAndVerifyOutputLineCount(t, expectedSnapshotCount, "snapshot", "list", "--show-identical", "-a")
+}
+
+func TestSnapshotCreateWithStdinStream(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	// Create a temporary pipe file with test data
+	content := []byte("Streaming Temporary file content")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("error creating pipe file: %v", err)
+	}
+
+	if _, err = w.Write(content); err != nil {
+		t.Fatalf("error writing to pipe file: %v", err)
+	}
+
+	w.Close()
+
+	// Use the pipe file as stdin
+	initialStdin := os.Stdin
+
+	defer func() {
+		// Reset stdin
+		os.Stdin = initialStdin
+	}()
+
+	os.Stdin = r
+
+	streamFileName := "stream-file"
+	e.PassthroughStdin = true
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", "--stdin-file", streamFileName)
+
+	// Make sure the scheduling policy with manual field is set and visible in the policy list, includes global policy
+	e.RunAndVerifyOutputLineCount(t, 2, "policy", "list")
+
+	// Obtain snapshot root id and use it for restore
+	si := e.ListSnapshotsAndExpectSuccess(t)
+	if got, want := len(si), 1; got != want {
+		t.Fatalf("got %v sources, wanted %v", got, want)
+	}
+
+	if got, want := len(si[0].Snapshots), 1; got != want {
+		t.Fatalf("got %v snapshots, wanted %v", got, want)
+	}
+
+	rootID := si[0].Snapshots[0].ObjectID
+
+	// Restore using <root-id>/stream-file directly
+	restoredStreamFile := path.Join(testutil.TempDirectory(t), streamFileName)
+	e.RunAndExpectSuccess(t, "snapshot", "restore", rootID+"/"+streamFileName, restoredStreamFile)
+
+	// Compare restored data with content
+	rFile, err := os.Open(restoredStreamFile)
+	if err != nil {
+		t.Fatalf("error opening restored file: %v", err)
+	}
+
+	gotContent := make([]byte, len(content))
+
+	if _, err := rFile.Read(gotContent); err != nil {
+		t.Fatalf("error reading restored file: %v", err)
+	}
+
+	if !reflect.DeepEqual(gotContent, content) {
+		t.Fatalf("did not get expected file contents: (actual) %v != %v (expected)", gotContent, content)
+	}
 }
 
 func appendIfMissing(slice []string, i string) []string {

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -48,6 +48,8 @@ type CLITest struct {
 
 	PassthroughStderr bool // this is for debugging only
 
+	PassthroughStdin bool // used for stdin source tests
+
 	LogsDir string
 }
 
@@ -285,6 +287,10 @@ func (e *CLITest) Run(t *testing.T, expectedError bool, args ...string) (stdout,
 
 	if e.PassthroughStderr {
 		c.Stderr = os.Stderr
+	}
+
+	if e.PassthroughStdin {
+		c.Stdin = os.Stdin
 	}
 
 	o, err := c.Output()

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -48,7 +48,7 @@ type CLITest struct {
 
 	PassthroughStderr bool // this is for debugging only
 
-	PassthroughStdin bool // used for stdin source tests
+	NextCommandStdin io.Reader // this is used for stdin source tests
 
 	LogsDir string
 }
@@ -289,9 +289,8 @@ func (e *CLITest) Run(t *testing.T, expectedError bool, args ...string) (stdout,
 		c.Stderr = os.Stderr
 	}
 
-	if e.PassthroughStdin {
-		c.Stdin = os.Stdin
-	}
+	c.Stdin = e.NextCommandStdin
+	e.NextCommandStdin = nil
 
 	o, err := c.Output()
 


### PR DESCRIPTION
## Overview

- `fs.StreamingFile` interface with a `GetReader` method to return an `io.Reader`
- `virtualfs` package to implement an in-memory static version of `fs.Directory` and `fs.StreamingFile`
- `snapshot create <rootdir> --stdin-file <file name>` creates a static directory (rootdir) with a single streaming file entry (file name) and uploads it

## Issues

- [x] [683](https://github.com/kopia/kopia/issues/683)

## Test Plan

- [x] Unit test
- [x] End to End test
- [x] Manual
```
$ cat ./kopia | ./kopia snapshot create kopiadir --stdin-file=kopia
* 0 hashing, 1 hashed (32.3 MB), 0 cached (0 B), uploaded 32.3 MB, estimating...
Created snapshot with root k299834b5c887776879bf7e680eed6542 and ID 38e21994c4625dd128a463db0d6c0226 in 0s
```
```
$ ./kopia snapshot list
k10admin@mac:kopiadir
  2021-03-03 16:17:09 PST k299834b5c887776879bf7e680eed6542 32.3 MB drwxrwxrwx files:1 dirs:1 (latest-1,annual-1,monthly-1,weekly-1,daily-1,hourly-1)
```
```
$ ./kopia manifest list
7ea93a6362f673d797bf783530fd0832        165 2021-02-28 20:59:32 PST type:maintenance
38e21994c4625dd128a463db0d6c0226        603 2021-03-03 16:17:09 PST type:snapshot hostname:mac path:kopiadir username:k10admin
7a01c9fece138de6e01adc56fed96378        105 2021-03-03 16:17:09 PST type:policy hostname:mac path:kopiadir policyType:path username:k10admin
```
```
$ ./kopia policy show 7a01c9fece138de6e01adc56fed96378
Policy for k10admin@mac:kopiadir:

Retention:
  Annual snapshots:    3           (default)
  Monthly snapshots:  24           (default)
  Weekly snapshots:    4           (default)
  Daily snapshots:     7           (default)
  Hourly snapshots:   48           (default)
  Latest snapshots:   10           (default)

Files policy:
  Ignore cache directories:        true       (default)
  No ignore rules.
  Read ignore rules from files:
    .kopiaignore                   (default)
  Scan one filesystem only:       false       (default)

Error handling policy:
  Ignore file read errors:       false       (default)
  Ignore directory read errors:  false       (default)
  Ignore unknown types:           true       (default)

Scheduling policy:
  Scheduled snapshots:
    None
  Manual snapshot:            true   (defined for this target)

Compression disabled.

No actions defined.
```
```
$ ./kopia manifest show 38e21994c4625dd128a463db0d6c0226
// id: 38e21994c4625dd128a463db0d6c0226
// length: 603
// modified: 2021-03-03 16:17:09 PST
// label username:k10admin
// label hostname:mac
// label path:kopiadir
// label type:snapshot
{
  "source": {
    "host": "mac",
    "userName": "k10admin",
    "path": "kopiadir"
  },
  "description": "",
  "startTime": "2021-03-03T16:17:09.010755-08:00",
  "endTime": "2021-03-03T16:17:09.226163-08:00",
  "stats": {
    "totalSize": 32264704,
    "excludedTotalSize": 0,
    "fileCount": 1,
    "cachedFiles": 0,
    "nonCachedFiles": 1,
    "dirCount": 1,
    "excludedFileCount": 0,
    "excludedDirCount": 0,
    "ignoredErrorCount": 0,
    "errorCount": 0
  },
  "rootEntry": {
    "name": "kopiadir",
    "type": "d",
    "mode": "0777",
    "mtime": "0001-01-01T00:00:00Z",
    "obj": "k299834b5c887776879bf7e680eed6542",
    "summ": {
      "size": 32264704,
      "files": 1,
      "symlinks": 0,
      "dirs": 1,
      "maxTime": "0001-01-01T00:00:00Z",
      "numFailed": 0
    }
  }
}