### PR TITLE
ci/cd: refactored how GH releases are published

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -4,99 +4,98 @@ on:
     branches: [ master ]
   push:
     # ci-sandbox is a branch dedicated to testing post-submit code.
-    branches: [ master, ci-sandbox, ci-refactor ]
+    branches: [ master, artifacts-pr ]
     tags:
       - v*
   schedule:
     # run on Mondays at 8AM
     - cron:  '0 8 * * 1'
+env:
+  # required by Makefile
+  UNIX_SHELL_ON_WINDOWS: true
+
+  # PUBLISH_BINARIES=true publishes the binaries to github
+  PUBLISH_BINARIES: ${{ secrets.PUBLISH_BINARIES }}
+
+  # where to publish releases for non-tagged commits
+  NON_TAG_RELEASE_REPO: ${{ secrets.NON_TAG_RELEASE_REPO }}
+
+  # encrypt various secrets stored as files
+  CREDENTIAL_ENCRYPTION_KEY: ${{ secrets.CREDENTIAL_ENCRYPTION_KEY }}
+  CREDENTIAL_ENCRYPTION_IV: ${{ secrets.CREDENTIAL_ENCRYPTION_IV }}
+
+  # Apple ID and app-specific password for notarizaton
+  APPLEID: ${{ secrets.APPLEID }}
+  APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
+  KOPIA_UI_NOTARIZE: ${{ secrets.KOPIA_UI_NOTARIZE }}
+
+  # tool to install Windows signing certificate
+  WINDOWS_SIGNING_TOOLS_URL: ${{ secrets.WINDOWS_SIGNING_TOOLS_URL }}
+  WINDOWS_SIGN_USER: ${{ secrets.WINDOWS_SIGN_USER }}
+  WINDOWS_SIGN_AUTH: ${{ secrets.WINDOWS_SIGN_AUTH }}
+  WINDOWS_CERT_SHA1: ${{ secrets.WINDOWS_CERT_SHA1 }}
+  WINDOWS_SIGN_TOOL: ${{ secrets.WINDOWS_SIGN_TOOL }}
+
+  # macOS signing certificate (base64-encoded), used by Electron Builder
+  CSC_LINK: ${{ secrets.CSC_LINK }}
+  CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+  MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+
+  # used to publish docker images
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  # used in Azure tests
+  KOPIA_AZURE_TEST_CONTAINER: ${{ secrets.KOPIA_AZURE_TEST_CONTAINER }}
+  KOPIA_AZURE_TEST_STORAGE_ACCOUNT: ${{ secrets.KOPIA_AZURE_TEST_STORAGE_ACCOUNT }}
+  KOPIA_AZURE_TEST_STORAGE_KEY: ${{ secrets.KOPIA_AZURE_TEST_STORAGE_KEY }}
+
+  # used in B2 tests
+  KOPIA_B2_TEST_BUCKET: ${{ secrets.KOPIA_B2_TEST_BUCKET }}
+  KOPIA_B2_TEST_KEY: ${{ secrets.KOPIA_B2_TEST_KEY }}
+  KOPIA_B2_TEST_KEY_ID: ${{ secrets.KOPIA_B2_TEST_KEY_ID }}
+
+  # used in GCS tests
+  KOPIA_GCS_CREDENTIALS_FILE: ${{ secrets.KOPIA_GCS_CREDENTIALS_FILE }}
+  KOPIA_GCS_TEST_BUCKET: ${{ secrets.KOPIA_GCS_TEST_BUCKET }}
+
+  # used in S3 tests
+  KOPIA_S3_TEST_ENDPOINT: ${{ secrets.KOPIA_S3_TEST_ENDPOINT }}
+  KOPIA_S3_TEST_ACCESS_KEY_ID: ${{ secrets.KOPIA_S3_TEST_ACCESS_KEY_ID }}
+  KOPIA_S3_TEST_SECRET_ACCESS_KEY: ${{ secrets.KOPIA_S3_TEST_SECRET_ACCESS_KEY }}
+  KOPIA_S3_TEST_BUCKET: ${{ secrets.KOPIA_S3_TEST_BUCKET }}
+  KOPIA_S3_TEST_REGION: ${{ secrets.KOPIA_S3_TEST_REGION }}
+  KOPIA_S3_TEST_STS_ACCESS_KEY_ID: ${{ secrets.KOPIA_S3_TEST_STS_ACCESS_KEY_ID }}
+  KOPIA_S3_TEST_STS_SECRET_ACCESS_KEY: ${{ secrets.KOPIA_S3_TEST_STS_SECRET_ACCESS_KEY }}
+  KOPIA_S3_TEST_SESSION_TOKEN: ${{ secrets.KOPIA_S3_TEST_SESSION_TOKEN }}
+
+  # used in SFTP tests
+  KOPIA_SFTP_TEST_HOST: ${{ secrets.KOPIA_SFTP_TEST_HOST }}
+  KOPIA_SFTP_TEST_PORT: ${{ secrets.KOPIA_SFTP_TEST_PORT }}
+  KOPIA_SFTP_TEST_USER: ${{ secrets.KOPIA_SFTP_TEST_USER }}
+  KOPIA_SFTP_TEST_PATH: ${{ secrets.KOPIA_SFTP_TEST_PATH }}
+  KOPIA_SFTP_KEYFILE: ${{ secrets.KOPIA_SFTP_KEYFILE }}
+  KOPIA_SFTP_KNOWN_HOSTS_FILE: ${{ secrets.KOPIA_SFTP_KNOWN_HOSTS_FILE }}
+
+  # used in WebDAV tests
+  KOPIA_WEBDAV_TEST_URL: ${{ secrets.KOPIA_WEBDAV_TEST_URL }}
+  KOPIA_WEBDAV_TEST_USERNAME: ${{ secrets.KOPIA_WEBDAV_TEST_USERNAME }}
+  KOPIA_WEBDAV_TEST_PASSWORD: ${{ secrets.KOPIA_WEBDAV_TEST_PASSWORD }}
+
+  # Code Coverage token
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 jobs:
   build:
-    env:
-      # required by Makefile
-      UNIX_SHELL_ON_WINDOWS: true
-
-      # PUBLISH_BINARIES=true publishes the binaries to github
-      PUBLISH_BINARIES: ${{ secrets.PUBLISH_BINARIES }}
-
-      # encrypt various secrets stored as files
-      CREDENTIAL_ENCRYPTION_KEY: ${{ secrets.CREDENTIAL_ENCRYPTION_KEY }}
-      CREDENTIAL_ENCRYPTION_IV: ${{ secrets.CREDENTIAL_ENCRYPTION_IV }}
-
-      # Apple ID and app-specific password for notarizaton
-      APPLEID: ${{ secrets.APPLEID }}
-      APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
-      KOPIA_UI_NOTARIZE: ${{ secrets.KOPIA_UI_NOTARIZE }}
-
-      # tool to install Windows signing certificate
-      WINDOWS_SIGNING_TOOLS_URL: ${{ secrets.WINDOWS_SIGNING_TOOLS_URL }}
-      WINDOWS_SIGN_USER: ${{ secrets.WINDOWS_SIGN_USER }}
-      WINDOWS_SIGN_AUTH: ${{ secrets.WINDOWS_SIGN_AUTH }}
-      WINDOWS_CERT_SHA1: ${{ secrets.WINDOWS_CERT_SHA1 }}     
-      WINDOWS_SIGN_TOOL: ${{ secrets.WINDOWS_SIGN_TOOL }}
-
-      # macOS signing certificate (base64-encoded), used by Electron Builder
-      CSC_LINK: ${{ secrets.CSC_LINK }}
-      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-      MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
-
-      # used to publish releases to GitHub by Electron Builder
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-      # used to publish releases to GitHub by GoReleaser
-      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-
-      # used to publish docker images
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      # used in Azure tests
-      KOPIA_AZURE_TEST_CONTAINER: ${{ secrets.KOPIA_AZURE_TEST_CONTAINER }}
-      KOPIA_AZURE_TEST_STORAGE_ACCOUNT: ${{ secrets.KOPIA_AZURE_TEST_STORAGE_ACCOUNT }}
-      KOPIA_AZURE_TEST_STORAGE_KEY: ${{ secrets.KOPIA_AZURE_TEST_STORAGE_KEY }}
-
-      # used in B2 tests
-      KOPIA_B2_TEST_BUCKET: ${{ secrets.KOPIA_B2_TEST_BUCKET }}
-      KOPIA_B2_TEST_KEY: ${{ secrets.KOPIA_B2_TEST_KEY }}
-      KOPIA_B2_TEST_KEY_ID: ${{ secrets.KOPIA_B2_TEST_KEY_ID }}
-
-      # used in GCS tests
-      KOPIA_GCS_CREDENTIALS_FILE: ${{ secrets.KOPIA_GCS_CREDENTIALS_FILE }}
-      KOPIA_GCS_TEST_BUCKET: ${{ secrets.KOPIA_GCS_TEST_BUCKET }}
-
-      # used in S3 tests
-      KOPIA_S3_TEST_ENDPOINT: ${{ secrets.KOPIA_S3_TEST_ENDPOINT }}
-      KOPIA_S3_TEST_ACCESS_KEY_ID: ${{ secrets.KOPIA_S3_TEST_ACCESS_KEY_ID }}
-      KOPIA_S3_TEST_SECRET_ACCESS_KEY: ${{ secrets.KOPIA_S3_TEST_SECRET_ACCESS_KEY }}
-      KOPIA_S3_TEST_BUCKET: ${{ secrets.KOPIA_S3_TEST_BUCKET }}
-      KOPIA_S3_TEST_REGION: ${{ secrets.KOPIA_S3_TEST_REGION }}
-      KOPIA_S3_TEST_STS_ACCESS_KEY_ID: ${{ secrets.KOPIA_S3_TEST_STS_ACCESS_KEY_ID }}
-      KOPIA_S3_TEST_STS_SECRET_ACCESS_KEY: ${{ secrets.KOPIA_S3_TEST_STS_SECRET_ACCESS_KEY }}
-      KOPIA_S3_TEST_SESSION_TOKEN: ${{ secrets.KOPIA_S3_TEST_SESSION_TOKEN }}
-
-      # used in SFTP tests
-      KOPIA_SFTP_TEST_HOST: ${{ secrets.KOPIA_SFTP_TEST_HOST }}
-      KOPIA_SFTP_TEST_PORT: ${{ secrets.KOPIA_SFTP_TEST_PORT }}
-      KOPIA_SFTP_TEST_USER: ${{ secrets.KOPIA_SFTP_TEST_USER }}
-      KOPIA_SFTP_TEST_PATH: ${{ secrets.KOPIA_SFTP_TEST_PATH }}
-      KOPIA_SFTP_KEYFILE: ${{ secrets.KOPIA_SFTP_KEYFILE }}
-      KOPIA_SFTP_KNOWN_HOSTS_FILE: ${{ secrets.KOPIA_SFTP_KNOWN_HOSTS_FILE }}
-
-      # used in WebDAV tests
-      KOPIA_WEBDAV_TEST_URL: ${{ secrets.KOPIA_WEBDAV_TEST_URL }}
-      KOPIA_WEBDAV_TEST_USERNAME: ${{ secrets.KOPIA_WEBDAV_TEST_USERNAME }}
-      KOPIA_WEBDAV_TEST_PASSWORD: ${{ secrets.KOPIA_WEBDAV_TEST_PASSWORD }}
-
-      # Code Coverage token
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest, [self-hosted, ARM64], [self-hosted, ARMHF]]
-        #os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        include:
+          - os: [self-hosted, ARM64]
+          - os: [self-hosted, ARMHF]
     name: Make
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ contains(matrix.os, 'self-hosted') }}
     steps:
     - name: Set up Go.
       uses: actions/setup-go@v2
@@ -133,3 +132,44 @@ jobs:
       run: make -j2 ci-integration-tests
     - name: Publish
       run: make ci-publish
+    - name: Upload Kopia Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: kopia
+        path: |
+          dist/*.zip
+          dist/*.tar.gz
+          dist/*.rpm
+          dist/*.deb
+          dist/*.exe
+          dist/kopia-ui/*.zip
+          dist/kopia-ui/*.tar.gz
+          dist/kopia-ui/*.dmg
+          dist/kopia-ui/*.rpm
+          dist/kopia-ui/*.deb
+          dist/kopia-ui/*.exe
+          dist/kopia-ui/*.AppImage
+          dist/kopia-ui/*.yml
+        if-no-files-found: ignore
+  publish:
+    name: Stage And Publish Artifacts
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name != 'pull_request' }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: kopia
+        path: dist
+    - name: Display structure of downloaded files
+      run: ls -lR dist/
+    - name: Install GPG Key
+      run: make -j4 ci-gpg-key
+    - name: Stage Release
+      run: make stage-release
+    - name: Push Github Release
+      run: make push-github-release
+      env:
+        GITHUB_TOKEN: ${{secrets.GH_TOKEN}}

--- a/app/Makefile
+++ b/app/Makefile
@@ -7,22 +7,17 @@ node_modules: $(npm)
 
 electron_builder_flags:=
 electron_builder_flags+=-c.extraMetadata.version=$(KOPIA_VERSION:v%=%)
+
 electron_publish_flag:=never
 
-ifeq ($(PUBLISH_BINARIES)/$(IS_PULL_REQUEST),true/false)
+ifeq ($(IS_PULL_REQUEST),false)
 
-electron_publish_flag=always
+electron_builder_flags+=-c.publish.owner=$(REPO_OWNER)
 
-ifneq ($(CI_TAG),)
-# tagged release - create draft release, but don't publish
-electron_builder_flags+=-c.publish.releaseType=release
-electron_builder_flags+=-c.publish.owner=$(REPO_OWNER)
-electron_builder_flags+=-c.publish.repo=kopia
-else
-# post-submit run, create a release in another repo
-electron_builder_flags+=-c.publish.owner=$(REPO_OWNER)
-electron_builder_flags+=-c.publish.repo=kopia-ui-release
-electron_builder_flags+=-c.publish.releaseType=release
+ifeq ($(CI_TAG),)
+ifneq ($(NON_TAG_RELEASE_REPO),)
+electron_builder_flags+=-c.publish.repo=$(NON_TAG_RELEASE_REPO)
+endif
 endif
 
 else

--- a/app/package.json
+++ b/app/package.json
@@ -50,6 +50,7 @@
     },
     "nsis": {
       "oneClick": false,
+      "artifactName": "${productName}-Setup-${version}.${ext}",
       "perMachine": false
     },
     "snap": {
@@ -128,6 +129,7 @@
     "eject": "react-scripts eject",
     "start-electron": "electron .",
     "build-electron": "electron-builder",
+    "build-electron-windows": "electron-builder -w",
     "build-electron-linux": "electron-builder -l",
     "build-electron-dir": "electron-builder --dir",
     "start-electron-prebuilt": "ELECTRON_IS_DEV=0 electron .",


### PR DESCRIPTION
- stop publishing to github directly from goreleaser and electron builder
- upload dist/ as artifact at the end of each build
- stage release in a separate directory, generated checksum, GPG sign and publish
- removed spaces from Windows setup exe
