### PR TITLE
Improvements and cleanups for connecting to kopia server

### DIFF
--- a/cli/command_cache_clear.go
+++ b/cli/command_cache_clear.go
@@ -16,8 +16,13 @@ var (
 	cacheClearCommandPartial = cacheClearCommand.Flag("partial", "Specifies the cache to clear").Enum("contents", "indexes", "metadata", "own-writes", "blob-list")
 )
 
-func runCacheClearCommand(ctx context.Context, rep repo.DirectRepository) error {
-	d := rep.CachingOptions().CacheDirectory
+func runCacheClearCommand(ctx context.Context, rep repo.Repository) error {
+	opts, err := repo.GetCachingOptions(ctx, repositoryConfigFileName())
+	if err != nil {
+		return errors.Wrap(err, "error getting caching options")
+	}
+
+	d := opts.CacheDirectory
 	if d == "" {
 		return errors.New("caching not enabled")
 	}
@@ -52,5 +57,5 @@ func clearCacheDirectory(ctx context.Context, d string) error {
 }
 
 func init() {
-	cacheClearCommand.Action(directRepositoryReadAction(runCacheClearCommand))
+	cacheClearCommand.Action(repositoryReaderAction(runCacheClearCommand))
 }

--- a/cli/command_cache_info.go
+++ b/cli/command_cache_info.go
@@ -17,20 +17,25 @@ var (
 	cacheInfoPathOnly = cacheInfoCommand.Flag("path", "Only display cache path").Bool()
 )
 
-func runCacheInfoCommand(ctx context.Context, rep repo.DirectRepository) error {
+func runCacheInfoCommand(ctx context.Context, rep repo.Repository) error {
+	opts, err := repo.GetCachingOptions(ctx, repositoryConfigFileName())
+	if err != nil {
+		return errors.Wrap(err, "error getting cache options")
+	}
+
 	if *cacheInfoPathOnly {
-		fmt.Println(rep.CachingOptions().CacheDirectory)
+		fmt.Println(opts.CacheDirectory)
 		return nil
 	}
 
-	entries, err := ioutil.ReadDir(rep.CachingOptions().CacheDirectory)
+	entries, err := ioutil.ReadDir(opts.CacheDirectory)
 	if err != nil {
 		return errors.Wrap(err, "unable to scan cache directory")
 	}
 
 	path2Limit := map[string]int64{
-		"contents": rep.CachingOptions().MaxCacheSizeBytes,
-		"metadata": rep.CachingOptions().MaxMetadataCacheSizeBytes,
+		"contents": opts.MaxCacheSizeBytes,
+		"metadata": opts.MaxMetadataCacheSizeBytes,
 	}
 
 	for _, ent := range entries {
@@ -38,7 +43,7 @@ func runCacheInfoCommand(ctx context.Context, rep repo.DirectRepository) error {
 			continue
 		}
 
-		subdir := filepath.Join(rep.CachingOptions().CacheDirectory, ent.Name())
+		subdir := filepath.Join(opts.CacheDirectory, ent.Name())
 
 		fileCount, totalFileSize, err := scanCacheDir(subdir)
 		if err != nil {
@@ -51,7 +56,7 @@ func runCacheInfoCommand(ctx context.Context, rep repo.DirectRepository) error {
 		}
 
 		if ent.Name() == "blob-list" {
-			maybeLimit = fmt.Sprintf(" (duration %vs)", rep.CachingOptions().MaxListCacheDurationSec)
+			maybeLimit = fmt.Sprintf(" (duration %vs)", opts.MaxListCacheDurationSec)
 		}
 
 		fmt.Printf("%v: %v files %v%v\n", subdir, fileCount, units.BytesStringBase10(totalFileSize), maybeLimit)
@@ -64,5 +69,5 @@ func runCacheInfoCommand(ctx context.Context, rep repo.DirectRepository) error {
 }
 
 func init() {
-	cacheInfoCommand.Action(directRepositoryReadAction(runCacheInfoCommand))
+	cacheInfoCommand.Action(repositoryReaderAction(runCacheInfoCommand))
 }

--- a/cli/command_cache_info.go
+++ b/cli/command_cache_info.go
@@ -34,8 +34,9 @@ func runCacheInfoCommand(ctx context.Context, rep repo.Repository) error {
 	}
 
 	path2Limit := map[string]int64{
-		"contents": opts.MaxCacheSizeBytes,
-		"metadata": opts.MaxMetadataCacheSizeBytes,
+		"contents":        opts.MaxCacheSizeBytes,
+		"metadata":        opts.MaxMetadataCacheSizeBytes,
+		"server-contents": opts.MaxCacheSizeBytes,
 	}
 
 	for _, ent := range entries {

--- a/cli/command_cache_set.go
+++ b/cli/command_cache_set.go
@@ -18,8 +18,11 @@ var (
 	cacheSetMaxListCacheDuration   = cacheSetParamsCommand.Flag("max-list-cache-duration", "Duration of index cache").Default("-1ns").Duration()
 )
 
-func runCacheSetCommand(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	opts := rep.CachingOptions().CloneOrDefault()
+func runCacheSetCommand(ctx context.Context, rep repo.RepositoryWriter) error {
+	opts, err := repo.GetCachingOptions(ctx, repositoryConfigFileName())
+	if err != nil {
+		return errors.Wrap(err, "error getting caching options")
+	}
 
 	changed := 0
 
@@ -53,9 +56,9 @@ func runCacheSetCommand(ctx context.Context, rep repo.DirectRepositoryWriter) er
 		return errors.Errorf("no changes")
 	}
 
-	return rep.SetCachingOptions(ctx, opts)
+	return repo.SetCachingOptions(ctx, repositoryConfigFileName(), opts)
 }
 
 func init() {
-	cacheSetParamsCommand.Action(directRepositoryWriteAction(runCacheSetCommand))
+	cacheSetParamsCommand.Action(repositoryWriterAction(runCacheSetCommand))
 }

--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -31,7 +31,7 @@ func setupConnectOptions(cmd *kingpin.CmdClause) {
 	// Set up flags shared between 'create' and 'connect'. Note that because those flags are used by both command
 	// we must use *Var() methods, otherwise one of the commands would always get default flag values.
 	cmd.Flag("persist-credentials", "Persist credentials").Default("true").BoolVar(&connectPersistCredentials)
-	cmd.Flag("cache-directory", "Cache directory").PlaceHolder("PATH").StringVar(&connectCacheDirectory)
+	cmd.Flag("cache-directory", "Cache directory").PlaceHolder("PATH").Envar("KOPIA_CACHE_DIRECTORY").StringVar(&connectCacheDirectory)
 	cmd.Flag("content-cache-size-mb", "Size of local content cache").PlaceHolder("MB").Default("5000").Int64Var(&connectMaxCacheSizeMB)
 	cmd.Flag("metadata-cache-size-mb", "Size of local metadata cache").PlaceHolder("MB").Default("5000").Int64Var(&connectMaxMetadataCacheSizeMB)
 	cmd.Flag("max-list-cache-duration", "Duration of index cache").Default("30s").Hidden().DurationVar(&connectMaxListCacheDuration)

--- a/cli/command_repository_connect_from_config.go
+++ b/cli/command_repository_connect_from_config.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"os"
 
 	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
@@ -33,16 +32,9 @@ func connectToStorageFromConfig(ctx context.Context, isNew bool) (blob.Storage, 
 }
 
 func connectToStorageFromConfigFile(ctx context.Context) (blob.Storage, error) {
-	var cfg repo.LocalConfig
-
-	f, err := os.Open(connectFromConfigFile) //nolint:gosec
+	cfg, err := repo.LoadConfigFromFile(connectFromConfigFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open config")
-	}
-	defer f.Close() //nolint:errcheck,gosec
-
-	if err := cfg.Load(f); err != nil {
-		return nil, errors.Wrap(err, "unable to load config")
 	}
 
 	return blob.NewStorage(ctx, *cfg.Storage)

--- a/htmlui/src/RepoStatus.js
+++ b/htmlui/src/RepoStatus.js
@@ -141,10 +141,6 @@ export class RepoStatus extends Component {
                                     <Form.Label>Config File</Form.Label>
                                     <Form.Control readOnly defaultValue={this.state.status.configFile} />
                                 </Form.Group>
-                                <Form.Group as={Col}>
-                                    <Form.Label>Cache Directory</Form.Label>
-                                    <Form.Control readOnly defaultValue={this.state.status.cacheDir} />
-                                </Form.Group>
                             </Form.Row>
                             <Form.Row>
                                 <Form.Group as={Col}>

--- a/internal/server/api_repo.go
+++ b/internal/server/api_repo.go
@@ -49,7 +49,6 @@ func (s *Server) handleRepoStatus(ctx context.Context, r *http.Request, body []b
 		return &serverapi.StatusResponse{
 			Connected:     true,
 			ConfigFile:    dr.ConfigFilename(),
-			CacheDir:      dr.CachingOptions().CacheDirectory,
 			Hash:          dr.ContentReader().ContentFormat().Hash,
 			Encryption:    dr.ContentReader().ContentFormat().Encryption,
 			MaxPackSize:   dr.ContentReader().ContentFormat().MaxPackSize,

--- a/internal/server/grpc_session.go
+++ b/internal/server/grpc_session.go
@@ -59,9 +59,11 @@ func (s *Server) authenticateGRPCSession(ctx context.Context) (string, error) {
 		if s.authenticator(ctx, s.rep, username, password) {
 			return username, nil
 		}
+
+		return "", status.Errorf(codes.PermissionDenied, "access denied for %v", username)
 	}
 
-	return "", status.Errorf(codes.PermissionDenied, "access denied")
+	return "", status.Errorf(codes.PermissionDenied, "missing credentials")
 }
 
 // Session handles GRPC session from a repository client.

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -20,7 +20,6 @@ import (
 type StatusResponse struct {
 	Connected    bool   `json:"connected"`
 	ConfigFile   string `json:"configFile,omitempty"`
-	CacheDir     string `json:"cacheDir,omitempty"`
 	Hash         string `json:"hash,omitempty"`
 	Encryption   string `json:"encryption,omitempty"`
 	Splitter     string `json:"splitter,omitempty"`

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -136,13 +136,19 @@ func verifyPeerCertificate(sha256Fingerprint string) func(rawCerts [][]byte, ver
 	sha256Fingerprint = strings.ToLower(sha256Fingerprint)
 
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		var serverCerts []string
+
 		for _, c := range rawCerts {
 			h := sha256.Sum256(c)
-			if hex.EncodeToString(h[:]) == sha256Fingerprint {
+			serverCert := hex.EncodeToString(h[:])
+
+			if serverCert == sha256Fingerprint {
 				return nil
 			}
+
+			serverCerts = append(serverCerts, serverCert)
 		}
 
-		return errors.Errorf("can't find certificate matching SHA256 fingerprint %q", sha256Fingerprint)
+		return errors.Errorf("can't find certificate matching SHA256 fingerprint %q (server had %v)", sha256Fingerprint, serverCerts)
 	}
 }

--- a/repo/caching.go
+++ b/repo/caching.go
@@ -1,0 +1,77 @@
+package repo
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/content"
+)
+
+// GetCachingOptions reads caching configuration for a given repository.
+func GetCachingOptions(ctx context.Context, configFile string) (*content.CachingOptions, error) {
+	lc, err := LoadConfigFromFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return lc.Caching.CloneOrDefault(), nil
+}
+
+// SetCachingOptions changes caching configuration for a given repository.
+func SetCachingOptions(ctx context.Context, configFile string, opt *content.CachingOptions) error {
+	lc, err := LoadConfigFromFile(configFile)
+	if err != nil {
+		return err
+	}
+
+	if err = setupCachingOptionsWithDefaults(ctx, configFile, lc, opt, nil); err != nil {
+		return errors.Wrap(err, "unable to set up caching")
+	}
+
+	return lc.writeToFile(configFile)
+}
+
+func setupCachingOptionsWithDefaults(ctx context.Context, configPath string, lc *LocalConfig, opt *content.CachingOptions, uniqueID []byte) error {
+	opt = opt.CloneOrDefault()
+
+	if opt.MaxCacheSizeBytes == 0 {
+		lc.Caching = &content.CachingOptions{}
+		return nil
+	}
+
+	if lc.Caching == nil {
+		lc.Caching = &content.CachingOptions{}
+	}
+
+	if opt.CacheDirectory == "" {
+		cacheDir, err := os.UserCacheDir()
+		if err != nil {
+			return errors.Wrap(err, "unable to determine cache directory")
+		}
+
+		h := sha256.New()
+		h.Write(uniqueID)           //nolint:errcheck
+		h.Write([]byte(configPath)) //nolint:errcheck
+		lc.Caching.CacheDirectory = filepath.Join(cacheDir, "kopia", hex.EncodeToString(h.Sum(nil))[0:16])
+	} else {
+		d, err := filepath.Abs(opt.CacheDirectory)
+		if err != nil {
+			return errors.Wrap(err, "unable to determine absolute cache path")
+		}
+
+		lc.Caching.CacheDirectory = d
+	}
+
+	lc.Caching.MaxCacheSizeBytes = opt.MaxCacheSizeBytes
+	lc.Caching.MaxMetadataCacheSizeBytes = opt.MaxMetadataCacheSizeBytes
+	lc.Caching.MaxListCacheDurationSec = opt.MaxListCacheDurationSec
+
+	log(ctx).Debugf("Creating cache directory '%v' with max size %v", lc.Caching.CacheDirectory, lc.Caching.MaxCacheSizeBytes)
+
+	return nil
+}

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -135,6 +135,11 @@ func LoadConfigFromFile(fileName string) (*LocalConfig, error) {
 		if lc.Caching.CacheDirectory != "" && !filepath.IsAbs(lc.Caching.CacheDirectory) {
 			lc.Caching.CacheDirectory = filepath.Join(filepath.Dir(fileName), lc.Caching.CacheDirectory)
 		}
+
+		// override cache directory from the environment variable.
+		if cd := os.Getenv("KOPIA_CACHE_DIRECTORY"); cd != "" && filepath.IsAbs(cd) {
+			lc.Caching.CacheDirectory = cd
+		}
 	}
 
 	return &lc, nil

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -1,13 +1,15 @@
 package repo
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/atomicfile"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/object"
@@ -88,26 +90,34 @@ type repositoryObjectFormat struct {
 	object.Format
 }
 
-// Load reads local configuration from the specified reader.
-func (lc *LocalConfig) Load(r io.Reader) error {
-	*lc = LocalConfig{}
-	return json.NewDecoder(r).Decode(lc)
-}
+// writeToFile writes the config to a given file.
+func (lc *LocalConfig) writeToFile(filename string) error {
+	lc2 := *lc
 
-// Save writes the configuration to the specified writer.
-func (lc *LocalConfig) Save(w io.Writer) error {
-	b, err := json.MarshalIndent(lc, "", "  ")
-	if err != nil {
-		return nil
+	if lc.Caching != nil {
+		lc2.Caching = lc.Caching.CloneOrDefault()
+
+		// try computing relative pathname from config dir to the cache dir.
+		d, err := filepath.Rel(filepath.Dir(filename), lc.Caching.CacheDirectory)
+		if err == nil {
+			lc2.Caching.CacheDirectory = d
+		}
 	}
 
-	_, err = w.Write(b)
+	b, err := json.MarshalIndent(lc2, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "error writing config file")
+	}
 
-	return errors.Wrap(err, "error saving local config")
+	if err = os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
+		return errors.Wrap(err, "unable to create config directory")
+	}
+
+	return atomicfile.Write(filename, bytes.NewReader(b))
 }
 
-// loadConfigFromFile reads the local configuration from the specified file.
-func loadConfigFromFile(fileName string) (*LocalConfig, error) {
+// LoadConfigFromFile reads the local configuration from the specified file.
+func LoadConfigFromFile(fileName string) (*LocalConfig, error) {
 	f, err := os.Open(fileName) //nolint:gosec
 	if err != nil {
 		return nil, errors.Wrap(err, "error loading config file")
@@ -116,8 +126,15 @@ func loadConfigFromFile(fileName string) (*LocalConfig, error) {
 
 	var lc LocalConfig
 
-	if err := lc.Load(f); err != nil {
-		return nil, err
+	if err := json.NewDecoder(f).Decode(&lc); err != nil {
+		return nil, errors.Wrap(err, "error decoding config json")
+	}
+
+	// cache directory is stored as relative to config file name, resolve it to absolute.
+	if lc.Caching != nil {
+		if lc.Caching.CacheDirectory != "" && !filepath.IsAbs(lc.Caching.CacheDirectory) {
+			lc.Caching.CacheDirectory = filepath.Join(filepath.Dir(fileName), lc.Caching.CacheDirectory)
+		}
 	}
 
 	return &lc, nil

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -106,14 +106,14 @@ func (lc *LocalConfig) writeToFile(filename string) error {
 
 	b, err := json.MarshalIndent(lc2, "", "  ")
 	if err != nil {
-		return errors.Wrap(err, "error writing config file")
+		return errors.Wrap(err, "error creating config file contents")
 	}
 
 	if err = os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
 		return errors.Wrap(err, "unable to create config directory")
 	}
 
-	return atomicfile.Write(filename, bytes.NewReader(b))
+	return errors.Wrap(atomicfile.Write(filename, bytes.NewReader(b)), "error writing file")
 }
 
 // LoadConfigFromFile reads the local configuration from the specified file.

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -59,9 +59,6 @@ type DirectRepository interface {
 	ConfigFilename() string
 	DeriveKey(purpose []byte, keyLength int) []byte
 	Token(password string) (string, error)
-
-	CachingOptions() *content.CachingOptions
-	SetCachingOptions(ctx context.Context, opt *content.CachingOptions) error
 }
 
 // DirectRepositoryWriter provides low-level write access to the repository.
@@ -236,11 +233,6 @@ func (r *directRepository) Flush(ctx context.Context) error {
 	}
 
 	return r.cmgr.Flush(ctx)
-}
-
-// CachingOptions returns caching options.
-func (r *directRepository) CachingOptions() *content.CachingOptions {
-	return r.cachingOptions.CloneOrDefault()
 }
 
 // ObjectFormat returns the object format.


### PR DESCRIPTION
I was manually testing the robustness of the user experience of connecting to kopia repository server. I tried emulating mistakes users might make along the way and verifying that the UX makes sense.

* The biggest issue I've noticed that we were not properly setting up cache when `kopia repository connect server` was used.
* Another notable change is that `kopia cache` commands will be allowed for server-based repositories.
* ~~Also tightened validation of usernames to enforce that they must be lowercase and matching some sane regex.~~ (moved to #873)
* `KOPIA_CACHE_DIRECTORY` environment variable can now be used to globally override the cache path for kopia (both for create/connect and when opening the repository)
* Also made some errors when connecting to the server more descriptive and actually include useful information.