### PR TITLE
server: refactored authentication and authorization

### DIFF
--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -95,9 +95,19 @@ func requestReader(reqPayload interface{}) (io.Reader, string, error) {
 	return bytes.NewReader(b.Bytes()), "application/json", nil
 }
 
+// HTTPStatusError encapsulates HTTP status error.
+type HTTPStatusError struct {
+	HTTPStatusCode int
+	ErrorMessage   string
+}
+
+func (e HTTPStatusError) Error() string {
+	return e.ErrorMessage
+}
+
 func decodeResponse(resp *http.Response, respPayload interface{}) error {
 	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("server error: %v", resp.Status)
+		return HTTPStatusError{resp.StatusCode, resp.Status}
 	}
 
 	if respPayload == nil {

--- a/internal/auth/authn.go
+++ b/internal/auth/authn.go
@@ -24,3 +24,21 @@ func AuthenticateSingleUser(expectedUsername, expectedPassword string) Authentic
 			subtle.ConstantTimeCompare([]byte(password), expectedPasswordBytes) == 1
 	}
 }
+
+// CombineAuthenticators return authenticator that applies the provided authenticators in order
+// and returns true if any of them accepts given username/password combination.
+func CombineAuthenticators(authenticators ...Authenticator) Authenticator {
+	if len(authenticators) == 0 {
+		return nil
+	}
+
+	return func(ctx context.Context, rep repo.Repository, username, password string) bool {
+		for _, a := range authenticators {
+			if a(ctx, rep, username, password) {
+				return true
+			}
+		}
+
+		return false
+	}
+}

--- a/internal/auth/authn_test.go
+++ b/internal/auth/authn_test.go
@@ -16,6 +16,25 @@ func TestAuthentication(t *testing.T) {
 	verifyAuthenticator(t, a, "user1a", "password1a", false)
 }
 
+func TestCombineAuthenticators_Empty(t *testing.T) {
+	a := auth.CombineAuthenticators()
+	if a != nil {
+		t.Fatal("combined authenticator expected to return nil for zero-length input")
+	}
+}
+
+func TestCombineAuthenticators(t *testing.T) {
+	a1 := auth.AuthenticateSingleUser("user1", "password1")
+	a2 := auth.AuthenticateSingleUser("user2", "password2")
+	a3 := auth.AuthenticateSingleUser("user3", "password3")
+
+	a := auth.CombineAuthenticators(a1, a2, a3)
+	verifyAuthenticator(t, a, "user1", "password1", true)
+	verifyAuthenticator(t, a, "user2", "password2", true)
+	verifyAuthenticator(t, a, "user3", "password3", true)
+	verifyAuthenticator(t, a, "user1", "password2", false)
+}
+
 func verifyAuthenticator(t *testing.T, a auth.Authenticator, username, password string, want bool) {
 	t.Helper()
 

--- a/internal/server/api_content.go
+++ b/internal/server/api_content.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/kopia/kopia/internal/auth"
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/content"
@@ -16,10 +15,6 @@ import (
 )
 
 func (s *Server) handleContentGet(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
-	if s.httpAuthorizationInfo(r).ContentAccessLevel() < auth.AccessLevelRead {
-		return nil, accessDeniedError()
-	}
-
 	dr, ok := s.rep.(repo.DirectRepository)
 	if !ok {
 		return nil, notFoundError("content not found")
@@ -36,10 +31,6 @@ func (s *Server) handleContentGet(ctx context.Context, r *http.Request, body []b
 }
 
 func (s *Server) handleContentInfo(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
-	if s.httpAuthorizationInfo(r).ContentAccessLevel() < auth.AccessLevelRead {
-		return nil, accessDeniedError()
-	}
-
 	dr, ok := s.rep.(repo.DirectRepository)
 	if !ok {
 		return nil, notFoundError("content not found")
@@ -62,10 +53,6 @@ func (s *Server) handleContentInfo(ctx context.Context, r *http.Request, body []
 }
 
 func (s *Server) handleContentPut(ctx context.Context, r *http.Request, data []byte) (interface{}, *apiError) {
-	if s.httpAuthorizationInfo(r).ContentAccessLevel() < auth.AccessLevelAppend {
-		return nil, accessDeniedError()
-	}
-
 	dr, ok := s.rep.(repo.DirectRepositoryWriter)
 	if !ok {
 		return nil, repositoryNotWritableError()

--- a/internal/server/api_manifest.go
+++ b/internal/server/api_manifest.go
@@ -29,7 +29,7 @@ func (s *Server) handleManifestGet(ctx context.Context, r *http.Request, body []
 		return nil, internalServerError(err)
 	}
 
-	if s.httpAuthorizationInfo(r).ManifestAccessLevel(md.Labels) < auth.AccessLevelRead {
+	if !hasManifestAccess(s, r, md.Labels, auth.AccessLevelRead) {
 		return nil, accessDeniedError()
 	}
 
@@ -58,7 +58,7 @@ func (s *Server) handleManifestDelete(ctx context.Context, r *http.Request, body
 		return nil, internalServerError(err)
 	}
 
-	if s.httpAuthorizationInfo(r).ManifestAccessLevel(em.Labels) < auth.AccessLevelFull {
+	if !hasManifestAccess(s, r, em.Labels, auth.AccessLevelFull) {
 		return nil, accessDeniedError()
 	}
 
@@ -114,7 +114,7 @@ func (s *Server) handleManifestCreate(ctx context.Context, r *http.Request, body
 		return nil, requestError(serverapi.ErrorMalformedRequest, "malformed request")
 	}
 
-	if s.httpAuthorizationInfo(r).ManifestAccessLevel(req.Metadata.Labels) < auth.AccessLevelAppend {
+	if !hasManifestAccess(s, r, req.Metadata.Labels, auth.AccessLevelAppend) {
 		return nil, accessDeniedError()
 	}
 

--- a/internal/server/api_object_get.go
+++ b/internal/server/api_object_get.go
@@ -15,6 +15,11 @@ import (
 func (s *Server) handleObjectGet(w http.ResponseWriter, r *http.Request) {
 	oidstr := mux.Vars(r)["objectID"]
 
+	if !requireUIUser(s, r) {
+		http.Error(w, "access denied", http.StatusForbidden)
+		return
+	}
+
 	oid, err := object.ParseID(oidstr)
 	if err != nil {
 		http.Error(w, "invalid object id", http.StatusBadRequest)

--- a/internal/server/server_authz_checks.go
+++ b/internal/server/server_authz_checks.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/kopia/kopia/internal/auth"
+)
+
+func requireUIUser(s *Server, r *http.Request) bool {
+	user, _, _ := r.BasicAuth()
+
+	return user == s.options.UIUser
+}
+
+func anyAuthenticatedUser(s *Server, r *http.Request) bool {
+	return true
+}
+
+func handlerWillCheckAuthorization(s *Server, r *http.Request) bool {
+	return true
+}
+
+func requireContentAccess(level auth.AccessLevel) isAuthorizedFunc {
+	return func(s *Server, r *http.Request) bool {
+		return s.httpAuthorizationInfo(r).ContentAccessLevel() >= level
+	}
+}
+
+func hasManifestAccess(s *Server, r *http.Request, labels map[string]string, level auth.AccessLevel) bool {
+	return s.httpAuthorizationInfo(r).ManifestAccessLevel(labels) >= level
+}
+
+var (
+	_ isAuthorizedFunc = requireUIUser
+	_ isAuthorizedFunc = anyAuthenticatedUser
+	_ isAuthorizedFunc = handlerWillCheckAuthorization
+)

--- a/internal/serverapi/client_wrappers.go
+++ b/internal/serverapi/client_wrappers.go
@@ -57,8 +57,8 @@ func DisconnectFromRepository(ctx context.Context, c *apiclient.KopiaAPIClient) 
 }
 
 // Shutdown invokes the 'repo/shutdown' API.
-func Shutdown(ctx context.Context, c *apiclient.KopiaAPIClient) {
-	_ = c.Post(ctx, "shutdown", &Empty{}, &Empty{})
+func Shutdown(ctx context.Context, c *apiclient.KopiaAPIClient) error {
+	return c.Post(ctx, "shutdown", &Empty{}, &Empty{})
 }
 
 // Status invokes the 'repo/status' API.


### PR DESCRIPTION
This formalizes the concept of a 'UI user' which is a local user that can call APIs the same way that UI does it.

The server will now allow access to:

- UI user (identified using `--server-username` with password specified
  using `--server-password` or `--random-password`)
- remote users with usersnames/passwords specified in `--htpasswd-file`
- remote users defined in the repository using `kopia users add`
  when `--allow-repository-users` is passed.

The UI user only has access to methods specifically designated as such
(normally APIs used by the UI + few special ones such as 'shutdown').

Remote users (identified via `user@host`) don't get access to UI APIs.

There are some APIs that can be accessed by any authenticated
caller (UI or remote):

- /api/v1/flush
- /api/v1/repo/status
- /api/v1/repo/sync
- /api/v1/repo/parameters

To make this easier to understand in code, refactored server handlers
to require specifing what kind of authorization is required
at registration time.

Fixes #693