### PR TITLE
maintenance: enable full maintenance by default with 24h interval

### DIFF
--- a/cli/auto_upgrade.go
+++ b/cli/auto_upgrade.go
@@ -44,18 +44,10 @@ func setDefaultMaintenanceParameters(ctx context.Context, rep repo.RepositoryWri
 
 	log(ctx).Noticef(`
 Kopia will perform quick maintenance of the repository automatically every %v
-when running as %v. This operation never deletes any data.
+and full maintenance every %v when running as %v.
 
-Full maintenance (which also deletes unreferenced data) is disabled by default.
-
-To run it manually use:
-
-$ kopia maintenance run --full
-
-Alternatively you can schedule full maintenance to run periodically using:
-
-$ kopia maintenance set --enable-full=true --full-interval=4h
-`, p.QuickCycle.Interval, p.Owner)
+See https://kopia.io/docs/advanced/maintenance/ for more information.
+`, p.QuickCycle.Interval, p.FullCycle.Interval, p.Owner)
 
 	return nil
 }

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -104,10 +104,10 @@ func populateRepository(ctx context.Context, password string) error {
 			return errors.Wrap(err, "unable to set global policy")
 		}
 
-		printPolicy(policy.DefaultPolicy, nil)
-		printStdout("\n")
-		printStdout("To change the policy use:\n  kopia policy set --global <options>\n")
-		printStdout("or\n  kopia policy set <dir> <options>\n")
+		printRetentionPolicy(policy.DefaultPolicy, nil)
+		printCompressionPolicy(policy.DefaultPolicy, nil)
+
+		printStderr("\nTo find more information about default policy run 'kopia policy get'.\nTo change the policy use 'kopia policy set' command.\n")
 
 		if err := setDefaultMaintenanceParameters(ctx, w); err != nil {
 			return errors.Wrap(err, "unable to set maintenance parameters")

--- a/cli/update_check.go
+++ b/cli/update_check.go
@@ -39,7 +39,6 @@ const (
 NOTICE: Kopia will check for updates on GitHub every 7 days, starting 24 hours after first use.
 To disable this behavior, set environment variable ` + checkForUpdatesEnvar + `=false
 Alternatively you can remove the file "%v".
-
 `
 	updateAvailableNoticeFormat = `
 Upgrade of Kopia from %v to %v is available.

--- a/repo/maintenance/maintenance_params.go
+++ b/repo/maintenance/maintenance_params.go
@@ -35,9 +35,8 @@ type SnapshotGCParams struct {
 func DefaultParams() Params {
 	return Params{
 		FullCycle: CycleParams{
-			// TODO: enable this when ready for public consumption
-			// Enabled:  true,
-			Interval: 7 * 24 * time.Hour,
+			Enabled:  true,
+			Interval: 24 * time.Hour, //nolint:gomnd
 		},
 		QuickCycle: CycleParams{
 			Enabled:  true,

--- a/site/content/docs/Release Notes/v0.8.md
+++ b/site/content/docs/Release Notes/v0.8.md
@@ -12,6 +12,7 @@ There were over 130 changes by 19 contributors which represents a big growth in 
 
 ### New Features:
 
+* [Full Maintenance](https://kopia.io/docs/advanced/maintenance/) is now enabled by default with an interval of 24 hours.
 * Added support for scanning only one filesystem via files policy
 * Major improvements to ignore logic to better follow [.gitignore rules](https://git-scm.com/docs/gitignore).
 * Added support for [Actions](https://kopia.io/docs/advanced/actions/) which allow running custom scripts before and after a directory is snapshotted with lots of useful applications.


### PR DESCRIPTION
Tweaked default message to print on repository creation.