### PR TITLE
server: ensure we reject access to the UI static files for users other than the UI user

### DIFF
--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -87,10 +87,10 @@ func runServer(ctx context.Context, rep repo.Repository) error {
 	mux.Handle("/api/", srv.APIHandlers(*serverStartLegacyRepositoryAPI))
 
 	if *serverStartHTMLPath != "" {
-		fileServer := serveIndexFileForKnownUIRoutes(http.Dir(*serverStartHTMLPath))
+		fileServer := srv.RequireUIUserAuth(serveIndexFileForKnownUIRoutes(http.Dir(*serverStartHTMLPath)))
 		mux.Handle("/", fileServer)
 	} else if *serverStartUI {
-		mux.Handle("/", serveIndexFileForKnownUIRoutes(server.AssetFile()))
+		mux.Handle("/", srv.RequireUIUserAuth(serveIndexFileForKnownUIRoutes(server.AssetFile())))
 	}
 
 	httpServer := &http.Server{Addr: stripProtocol(*serverAddress)}


### PR DESCRIPTION
This is for a scenario where a user provides valid username/password
but such that the username is not authorized to access the UI.

Previously we'd make it look like they got access (because they can
see the UI at leaast partially), but all API calls would fail.

With this change we're failing early with HTTP 403 and pointing the
users at a GH issue explaining what to do.

Fixes #880.