### PR TITLE
Add context to robustness engine interfaces

### DIFF
--- a/tests/robustness/engine/engine.go
+++ b/tests/robustness/engine/engine.go
@@ -101,7 +101,7 @@ type Engine struct {
 }
 
 // Shutdown makes a last snapshot then flushes the metadata and prints the final statistics.
-func (e *Engine) Shutdown() error {
+func (e *Engine) Shutdown(ctx context.Context) error {
 	// Perform a snapshot action to capture the state of the data directory
 	// at the end of the run
 	lastWriteEntry := e.EngineLog.FindLastThisRun(WriteRandomFilesActionKey)
@@ -110,7 +110,7 @@ func (e *Engine) Shutdown() error {
 	if lastWriteEntry != nil {
 		if lastSnapEntry == nil || lastSnapEntry.Idx < lastWriteEntry.Idx {
 			// Only force a final snapshot if the data tree has been modified since the last snapshot
-			e.ExecAction(SnapshotDirActionKey, make(map[string]string)) //nolint:errcheck
+			e.ExecAction(ctx, SnapshotDirActionKey, make(map[string]string)) //nolint:errcheck
 		}
 	}
 
@@ -206,5 +206,5 @@ func (e *Engine) Init(ctx context.Context) error {
 		return err
 	}
 
-	return e.Checker.VerifySnapshotMetadata()
+	return e.Checker.VerifySnapshotMetadata(ctx)
 }

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/robustness"
 	"github.com/kopia/kopia/tests/robustness/fiofilewriter"
@@ -53,7 +54,9 @@ func TestEngineWritefilesBasicFS(t *testing.T) {
 	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
 	os.Setenv(snapmeta.S3BucketNameEnvKey, "")
 
-	th, eng, err := newTestHarness(t, fsDataRepoPath, fsMetadataRepoPath)
+	ctx := testlogging.Context(t)
+
+	th, eng, err := newTestHarness(ctx, t, fsDataRepoPath, fsMetadataRepoPath)
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
 	}
@@ -61,14 +64,13 @@ func TestEngineWritefilesBasicFS(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := th.Cleanup()
+		cleanupErr := th.Cleanup(ctx)
 		testenv.AssertNoError(t, cleanupErr)
 
 		os.RemoveAll(fsRepoBaseDirPath)
 	}()
 
 	opts := map[string]string{}
-	ctx := context.TODO()
 	err = eng.Init(ctx)
 	testenv.AssertNoError(t, err)
 
@@ -113,7 +115,7 @@ func makeTempS3Bucket(t *testing.T) (bucketName string, cleanupCB func()) {
 		t.Skip("Skipping S3 tests if no creds provided")
 	}
 
-	ctx := context.Background()
+	ctx := testlogging.Context(t)
 
 	cli, err := minio.New(endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, sessionToken),
@@ -169,7 +171,9 @@ func TestWriteFilesBasicS3(t *testing.T) {
 	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
 	os.Setenv(snapmeta.S3BucketNameEnvKey, bucketName)
 
-	th, eng, err := newTestHarness(t, s3DataRepoPath, s3MetadataRepoPath)
+	ctx := testlogging.Context(t)
+
+	th, eng, err := newTestHarness(ctx, t, s3DataRepoPath, s3MetadataRepoPath)
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
 	}
@@ -177,12 +181,11 @@ func TestWriteFilesBasicS3(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := th.Cleanup()
+		cleanupErr := th.Cleanup(ctx)
 		testenv.AssertNoError(t, cleanupErr)
 	}()
 
 	opts := map[string]string{}
-	ctx := context.TODO()
 	err = eng.Init(ctx)
 	testenv.AssertNoError(t, err)
 
@@ -215,7 +218,9 @@ func TestDeleteSnapshotS3(t *testing.T) {
 	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
 	os.Setenv(snapmeta.S3BucketNameEnvKey, bucketName)
 
-	th, eng, err := newTestHarness(t, s3DataRepoPath, s3MetadataRepoPath)
+	ctx := testlogging.Context(t)
+
+	th, eng, err := newTestHarness(ctx, t, s3DataRepoPath, s3MetadataRepoPath)
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
 	}
@@ -223,12 +228,11 @@ func TestDeleteSnapshotS3(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := th.Cleanup()
+		cleanupErr := th.Cleanup(ctx)
 		testenv.AssertNoError(t, cleanupErr)
 	}()
 
 	opts := map[string]string{}
-	ctx := context.TODO()
 	err = eng.Init(ctx)
 	testenv.AssertNoError(t, err)
 
@@ -262,7 +266,9 @@ func TestSnapshotVerificationFail(t *testing.T) {
 	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
 	os.Setenv(snapmeta.S3BucketNameEnvKey, bucketName)
 
-	th, eng, err := newTestHarness(t, s3DataRepoPath, s3MetadataRepoPath)
+	ctx := testlogging.Context(t)
+
+	th, eng, err := newTestHarness(ctx, t, s3DataRepoPath, s3MetadataRepoPath)
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
 	}
@@ -270,12 +276,11 @@ func TestSnapshotVerificationFail(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := th.Cleanup()
+		cleanupErr := th.Cleanup(ctx)
 		testenv.AssertNoError(t, cleanupErr)
 	}()
 
 	opts := map[string]string{}
-	ctx := context.TODO()
 	err = eng.Init(ctx)
 	testenv.AssertNoError(t, err)
 
@@ -332,7 +337,9 @@ func TestDataPersistency(t *testing.T) {
 	dataRepoPath := filepath.Join(tempDir, "data-repo-")
 	metadataRepoPath := filepath.Join(tempDir, "metadata-repo-")
 
-	th, eng, err := newTestHarness(t, dataRepoPath, metadataRepoPath)
+	ctx := testlogging.Context(t)
+
+	th, eng, err := newTestHarness(ctx, t, dataRepoPath, metadataRepoPath)
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
 	}
@@ -340,12 +347,11 @@ func TestDataPersistency(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := th.Cleanup()
+		cleanupErr := th.Cleanup(ctx)
 		testenv.AssertNoError(t, cleanupErr)
 	}()
 
 	opts := map[string]string{}
-	ctx := context.TODO()
 	err = eng.Init(ctx)
 	testenv.AssertNoError(t, err)
 
@@ -375,13 +381,13 @@ func TestDataPersistency(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	// Create a new engine
-	th2, eng2, err := newTestHarness(t, dataRepoPath, metadataRepoPath)
+	th2, eng2, err := newTestHarness(ctx, t, dataRepoPath, metadataRepoPath)
 	testenv.AssertNoError(t, err)
 
 	defer func() {
 		th2.eng.cleanComponents()
 		th2.eng = nil
-		th2.Cleanup()
+		th2.Cleanup(ctx)
 	}()
 
 	// Connect this engine to the same data and metadata repositories -
@@ -499,7 +505,9 @@ func TestActionsFilesystem(t *testing.T) {
 	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
 	os.Setenv(snapmeta.S3BucketNameEnvKey, "")
 
-	th, eng, err := newTestHarness(t, fsDataRepoPath, fsMetadataRepoPath)
+	ctx := testlogging.Context(t)
+
+	th, eng, err := newTestHarness(ctx, t, fsDataRepoPath, fsMetadataRepoPath)
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
 	}
@@ -507,13 +515,12 @@ func TestActionsFilesystem(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := th.Cleanup()
+		cleanupErr := th.Cleanup(ctx)
 		testenv.AssertNoError(t, cleanupErr)
 
 		os.RemoveAll(fsRepoBaseDirPath)
 	}()
 
-	ctx := context.TODO()
 	err = eng.Init(ctx)
 	testenv.AssertNoError(t, err)
 
@@ -533,7 +540,7 @@ func TestActionsFilesystem(t *testing.T) {
 
 	numActions := 10
 	for loop := 0; loop < numActions; loop++ {
-		err := eng.RandomAction(actionOpts)
+		err := eng.RandomAction(ctx, actionOpts)
 		if !(err == nil || errors.Is(err, robustness.ErrNoOp)) {
 			t.Error("Hit error", err)
 		}
@@ -547,7 +554,9 @@ func TestActionsS3(t *testing.T) {
 	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
 	os.Setenv(snapmeta.S3BucketNameEnvKey, bucketName)
 
-	th, eng, err := newTestHarness(t, s3DataRepoPath, s3MetadataRepoPath)
+	ctx := testlogging.Context(t)
+
+	th, eng, err := newTestHarness(ctx, t, s3DataRepoPath, s3MetadataRepoPath)
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
 	}
@@ -555,11 +564,10 @@ func TestActionsS3(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := th.Cleanup()
+		cleanupErr := th.Cleanup(ctx)
 		testenv.AssertNoError(t, cleanupErr)
 	}()
 
-	ctx := context.TODO()
 	err = eng.Init(ctx)
 	testenv.AssertNoError(t, err)
 
@@ -579,7 +587,7 @@ func TestActionsS3(t *testing.T) {
 
 	numActions := 10
 	for loop := 0; loop < numActions; loop++ {
-		err := eng.RandomAction(actionOpts)
+		err := eng.RandomAction(ctx, actionOpts)
 		if !(err == nil || errors.Is(err, robustness.ErrNoOp)) {
 			t.Error("Hit error", err)
 		}
@@ -593,7 +601,9 @@ func TestIOLimitPerWriteAction(t *testing.T) {
 	os.Setenv(snapmeta.EngineModeEnvKey, snapmeta.EngineModeBasic)
 	os.Setenv(snapmeta.S3BucketNameEnvKey, "")
 
-	th, eng, err := newTestHarness(t, fsDataRepoPath, fsMetadataRepoPath)
+	ctx := testlogging.Context(t)
+
+	th, eng, err := newTestHarness(ctx, t, fsDataRepoPath, fsMetadataRepoPath)
 	if errors.Is(err, kopiarunner.ErrExeVariableNotSet) || errors.Is(err, fio.ErrEnvNotSet) {
 		t.Skip(err)
 	}
@@ -601,13 +611,12 @@ func TestIOLimitPerWriteAction(t *testing.T) {
 	testenv.AssertNoError(t, err)
 
 	defer func() {
-		cleanupErr := th.Cleanup()
+		cleanupErr := th.Cleanup(ctx)
 		testenv.AssertNoError(t, cleanupErr)
 
 		os.RemoveAll(fsRepoBaseDirPath)
 	}()
 
-	ctx := context.TODO()
 	err = eng.Init(ctx)
 	testenv.AssertNoError(t, err)
 
@@ -631,7 +640,7 @@ func TestIOLimitPerWriteAction(t *testing.T) {
 		},
 	}
 
-	err = eng.RandomAction(actionOpts)
+	err = eng.RandomAction(ctx, actionOpts)
 	testenv.AssertNoError(t, err)
 
 	size := 0
@@ -661,7 +670,7 @@ func TestIOLimitPerWriteAction(t *testing.T) {
 		return nil
 	}
 
-	fioPath := eng.FileWriter.DataDirectory()
+	fioPath := eng.FileWriter.DataDirectory(ctx)
 
 	// Walk the FIO data directory tree, counting the non-zero data written.
 	err = filepath.Walk(fioPath, walkFunc)
@@ -828,7 +837,7 @@ type testHarness struct {
 	eng *Engine
 }
 
-func newTestHarness(t *testing.T, dataRepoPath, metaRepoPath string) (*testHarness, *Engine, error) {
+func newTestHarness(ctx context.Context, t *testing.T, dataRepoPath, metaRepoPath string) (*testHarness, *Engine, error) {
 	t.Helper()
 
 	var (
@@ -841,32 +850,32 @@ func newTestHarness(t *testing.T, dataRepoPath, metaRepoPath string) (*testHarne
 	}
 
 	if th.fw, err = fiofilewriter.New(); err != nil {
-		th.Cleanup()
+		th.Cleanup(ctx)
 		return nil, nil, err
 	}
 
 	if th.ks, err = snapmeta.NewSnapshotter(th.baseDir); err != nil {
-		th.Cleanup()
+		th.Cleanup(ctx)
 		return nil, nil, err
 	}
 
 	if err = th.ks.ConnectOrCreateRepo(dataRepoPath); err != nil {
-		th.Cleanup()
+		th.Cleanup(ctx)
 		return nil, nil, err
 	}
 
 	if th.kp, err = snapmeta.NewPersister(th.baseDir); err != nil {
-		th.Cleanup()
+		th.Cleanup(ctx)
 		return nil, nil, err
 	}
 
 	if err = th.kp.ConnectOrCreateRepo(metaRepoPath); err != nil {
-		th.Cleanup()
+		th.Cleanup(ctx)
 		return nil, nil, err
 	}
 
 	if th.eng, err = New(th.args()); err != nil {
-		th.Cleanup()
+		th.Cleanup(ctx)
 		return nil, nil, err
 	}
 
@@ -886,11 +895,11 @@ func (th *testHarness) FioRunner() *fio.Runner {
 	return th.fw.Runner
 }
 
-func (th *testHarness) Cleanup() error {
+func (th *testHarness) Cleanup(ctx context.Context) error {
 	var err error
 
 	if th.eng != nil {
-		err = th.eng.Shutdown()
+		err = th.eng.Shutdown(ctx)
 	}
 
 	if th.fw != nil {

--- a/tests/robustness/filewriter.go
+++ b/tests/robustness/filewriter.go
@@ -1,27 +1,29 @@
 package robustness
 
+import "context"
+
 // FileWriter is an interface used for filesystem related actions.
 type FileWriter interface {
 	// DataDirectory returns the absolute path of the data directory configured.
-	DataDirectory() string
+	DataDirectory(ctx context.Context) string
 
 	// DeleteDirectoryContents deletes some of the content of a random directory,
 	// based on its input option values (none of which are required).
 	// The method returns the effective option values used and the error if any.
 	// ErrNoOp is returned if no directory is found.
-	DeleteDirectoryContents(opts map[string]string) (map[string]string, error)
+	DeleteDirectoryContents(ctx context.Context, opts map[string]string) (map[string]string, error)
 
 	// DeleteEverything deletes all content.
-	DeleteEverything() error
+	DeleteEverything(ctx context.Context) error
 
 	// DeleteRandomSubdirectory deletes a random directory, based
 	// on its input option values (none of which are required).
 	// The method returns the effective option values used and the error if any.
 	// ErrNoOp is returned if no directory is found.
-	DeleteRandomSubdirectory(opts map[string]string) (map[string]string, error)
+	DeleteRandomSubdirectory(ctx context.Context, opts map[string]string) (map[string]string, error)
 
 	// WriteRandomFiles writes a number of files in a random directory, based
 	// on its input option values (none of which are required).
 	// The method returns the effective option values used and the error if any.
-	WriteRandomFiles(opts map[string]string) (map[string]string, error)
+	WriteRandomFiles(ctx context.Context, opts map[string]string) (map[string]string, error)
 }

--- a/tests/robustness/fiofilewriter/fio_filewriter.go
+++ b/tests/robustness/fiofilewriter/fio_filewriter.go
@@ -4,6 +4,7 @@
 package fiofilewriter
 
 import (
+	"context"
 	"errors"
 	"log"
 	"math/rand"
@@ -64,7 +65,7 @@ var _ robustness.FileWriter = (*FileWriter)(nil)
 
 // DataDirectory returns the data directory configured.
 // See tests/tools/fio for details.
-func (fw *FileWriter) DataDirectory() string {
+func (fw *FileWriter) DataDirectory(ctx context.Context) string {
 	return fw.Runner.LocalDataDir
 }
 
@@ -83,7 +84,7 @@ func (fw *FileWriter) DataDirectory() string {
 // Default values are used for missing options. The method
 // returns the effective options used along with the selected depth
 // and the error if any.
-func (fw *FileWriter) WriteRandomFiles(opts map[string]string) (map[string]string, error) {
+func (fw *FileWriter) WriteRandomFiles(ctx context.Context, opts map[string]string) (map[string]string, error) {
 	// Directory depth
 	maxDirDepth := robustness.GetOptAsIntOrDefault(MaxDirDepthField, opts, defaultMaxDirDepth)
 	dirDepth := rand.Intn(maxDirDepth + 1)
@@ -167,7 +168,7 @@ func (fw *FileWriter) WriteRandomFiles(opts map[string]string) (map[string]strin
 // Default values are used for missing options. The method
 // returns the effective options used along with the selected depth
 // and the error if any. ErrNoOp is returned if no directory is found.
-func (fw *FileWriter) DeleteRandomSubdirectory(opts map[string]string) (map[string]string, error) {
+func (fw *FileWriter) DeleteRandomSubdirectory(ctx context.Context, opts map[string]string) (map[string]string, error) {
 	maxDirDepth := robustness.GetOptAsIntOrDefault(MaxDirDepthField, opts, defaultMaxDirDepth)
 	if maxDirDepth <= 0 {
 		return nil, robustness.ErrInvalidOption
@@ -202,7 +203,7 @@ func (fw *FileWriter) DeleteRandomSubdirectory(opts map[string]string) (map[stri
 // Default values are used for missing options. The method
 // returns the effective options used along with the selected depth
 // and the error if any. ErrNoOp is returned if no directory is found.
-func (fw *FileWriter) DeleteDirectoryContents(opts map[string]string) (map[string]string, error) {
+func (fw *FileWriter) DeleteDirectoryContents(ctx context.Context, opts map[string]string) (map[string]string, error) {
 	maxDirDepth := robustness.GetOptAsIntOrDefault(MaxDirDepthField, opts, defaultMaxDirDepth)
 	dirDepth := rand.Intn(maxDirDepth + 1) //nolint:gosec
 
@@ -230,8 +231,8 @@ func (fw *FileWriter) DeleteDirectoryContents(opts map[string]string) (map[strin
 }
 
 // DeleteEverything deletes all content.
-func (fw *FileWriter) DeleteEverything() error {
-	_, err := fw.DeleteDirectoryContents(map[string]string{
+func (fw *FileWriter) DeleteEverything(ctx context.Context) error {
+	_, err := fw.DeleteDirectoryContents(ctx, map[string]string{
 		MaxDirDepthField:             strconv.Itoa(0),
 		DeletePercentOfContentsField: strconv.Itoa(100),
 	})

--- a/tests/robustness/robustness_test/main_test.go
+++ b/tests/robustness/robustness_test/main_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 	dataRepoPath := path.Join(*repoPathPrefix, dataSubPath)
 	metadataRepoPath := path.Join(*repoPathPrefix, metadataSubPath)
 
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	th := &kopiaRobustnessTestHarness{}
 	th.init(ctx, dataRepoPath, metadataRepoPath)

--- a/tests/robustness/robustness_test/robustness_test.go
+++ b/tests/robustness/robustness_test/robustness_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/tests/robustness"
 	"github.com/kopia/kopia/tests/robustness/engine"
 	"github.com/kopia/kopia/tests/robustness/fiofilewriter"
@@ -27,13 +28,15 @@ func TestManySmallFiles(t *testing.T) {
 		fiofilewriter.MinNumFilesPerWriteField: strconv.Itoa(numFiles),
 	}
 
-	_, err := eng.ExecAction(engine.WriteRandomFilesActionKey, fileWriteOpts)
+	ctx := testlogging.Context(t)
+
+	_, err := eng.ExecAction(ctx, engine.WriteRandomFilesActionKey, fileWriteOpts)
 	testenv.AssertNoError(t, err)
 
-	snapOut, err := eng.ExecAction(engine.SnapshotDirActionKey, nil)
+	snapOut, err := eng.ExecAction(ctx, engine.SnapshotDirActionKey, nil)
 	testenv.AssertNoError(t, err)
 
-	_, err = eng.ExecAction(engine.RestoreSnapshotActionKey, snapOut)
+	_, err = eng.ExecAction(ctx, engine.RestoreSnapshotActionKey, snapOut)
 	testenv.AssertNoError(t, err)
 }
 
@@ -49,13 +52,15 @@ func TestOneLargeFile(t *testing.T) {
 		fiofilewriter.MinNumFilesPerWriteField: strconv.Itoa(numFiles),
 	}
 
-	_, err := eng.ExecAction(engine.WriteRandomFilesActionKey, fileWriteOpts)
+	ctx := testlogging.Context(t)
+
+	_, err := eng.ExecAction(ctx, engine.WriteRandomFilesActionKey, fileWriteOpts)
 	testenv.AssertNoError(t, err)
 
-	snapOut, err := eng.ExecAction(engine.SnapshotDirActionKey, nil)
+	snapOut, err := eng.ExecAction(ctx, engine.SnapshotDirActionKey, nil)
 	testenv.AssertNoError(t, err)
 
-	_, err = eng.ExecAction(engine.RestoreSnapshotActionKey, snapOut)
+	_, err = eng.ExecAction(ctx, engine.RestoreSnapshotActionKey, snapOut)
 	testenv.AssertNoError(t, err)
 }
 
@@ -75,13 +80,15 @@ func TestManySmallFilesAcrossDirecoryTree(t *testing.T) {
 		engine.ActionRepeaterField:             strconv.Itoa(actionRepeats),
 	}
 
-	_, err := eng.ExecAction(engine.WriteRandomFilesActionKey, fileWriteOpts)
+	ctx := testlogging.Context(t)
+
+	_, err := eng.ExecAction(ctx, engine.WriteRandomFilesActionKey, fileWriteOpts)
 	testenv.AssertNoError(t, err)
 
-	snapOut, err := eng.ExecAction(engine.SnapshotDirActionKey, nil)
+	snapOut, err := eng.ExecAction(ctx, engine.SnapshotDirActionKey, nil)
 	testenv.AssertNoError(t, err)
 
-	_, err = eng.ExecAction(engine.RestoreSnapshotActionKey, snapOut)
+	_, err = eng.ExecAction(ctx, engine.RestoreSnapshotActionKey, snapOut)
 	testenv.AssertNoError(t, err)
 }
 
@@ -105,7 +112,9 @@ func TestRandomizedSmall(t *testing.T) {
 	}
 
 	for clock.Since(st) <= *randomizedTestDur {
-		err := eng.RandomAction(opts)
+		ctx := testlogging.Context(t)
+
+		err := eng.RandomAction(ctx, opts)
 		if errors.Is(err, robustness.ErrNoOp) {
 			t.Log("Random action resulted in no-op")
 

--- a/tests/robustness/snapmeta/kopia_snapshotter.go
+++ b/tests/robustness/snapmeta/kopia_snapshotter.go
@@ -54,8 +54,8 @@ func (ks *KopiaSnapshotter) ServerCmd() *exec.Cmd {
 }
 
 // CreateSnapshot is part of Snapshotter.
-func (ks *KopiaSnapshotter) CreateSnapshot(sourceDir string, opts map[string]string) (snapID string, fingerprint []byte, snapStats *robustness.CreateSnapshotStats, err error) {
-	fingerprint, err = ks.comparer.Gather(context.TODO(), sourceDir, opts)
+func (ks *KopiaSnapshotter) CreateSnapshot(ctx context.Context, sourceDir string, opts map[string]string) (snapID string, fingerprint []byte, snapStats *robustness.CreateSnapshotStats, err error) {
+	fingerprint, err = ks.comparer.Gather(ctx, sourceDir, opts)
 	if err != nil {
 		return
 	}
@@ -79,38 +79,38 @@ func (ks *KopiaSnapshotter) CreateSnapshot(sourceDir string, opts map[string]str
 
 // RestoreSnapshot restores the snapshot with the given ID to the provided restore directory. It returns
 // fingerprint verification data of the restored snapshot directory.
-func (ks *KopiaSnapshotter) RestoreSnapshot(snapID, restoreDir string, opts map[string]string) (fingerprint []byte, err error) {
+func (ks *KopiaSnapshotter) RestoreSnapshot(ctx context.Context, snapID, restoreDir string, opts map[string]string) (fingerprint []byte, err error) {
 	err = ks.snap.RestoreSnapshot(snapID, restoreDir)
 	if err != nil {
 		return
 	}
 
-	return ks.comparer.Gather(context.TODO(), restoreDir, opts)
+	return ks.comparer.Gather(ctx, restoreDir, opts)
 }
 
 // RestoreSnapshotCompare restores the snapshot with the given ID to the provided restore directory, then verifies the data
 // that has been restored against the provided fingerprint validation data.
-func (ks *KopiaSnapshotter) RestoreSnapshotCompare(snapID, restoreDir string, validationData []byte, reportOut io.Writer, opts map[string]string) (err error) {
+func (ks *KopiaSnapshotter) RestoreSnapshotCompare(ctx context.Context, snapID, restoreDir string, validationData []byte, reportOut io.Writer, opts map[string]string) (err error) {
 	err = ks.snap.RestoreSnapshot(snapID, restoreDir)
 	if err != nil {
 		return err
 	}
 
-	return ks.comparer.Compare(context.TODO(), restoreDir, validationData, reportOut, opts)
+	return ks.comparer.Compare(ctx, restoreDir, validationData, reportOut, opts)
 }
 
 // DeleteSnapshot is part of Snapshotter.
-func (ks *KopiaSnapshotter) DeleteSnapshot(snapID string, opts map[string]string) error {
+func (ks *KopiaSnapshotter) DeleteSnapshot(ctx context.Context, snapID string, opts map[string]string) error {
 	return ks.snap.DeleteSnapshot(snapID)
 }
 
 // RunGC is part of Snapshotter.
-func (ks *KopiaSnapshotter) RunGC(opts map[string]string) error {
+func (ks *KopiaSnapshotter) RunGC(ctx context.Context, opts map[string]string) error {
 	return ks.snap.RunGC()
 }
 
 // ListSnapshots is part of Snapshotter.
-func (ks *KopiaSnapshotter) ListSnapshots() ([]string, error) {
+func (ks *KopiaSnapshotter) ListSnapshots(ctx context.Context) ([]string, error) {
 	return ks.snap.ListSnapshots()
 }
 

--- a/tests/robustness/snapshotter.go
+++ b/tests/robustness/snapshotter.go
@@ -4,6 +4,7 @@
 package robustness
 
 import (
+	"context"
 	"io"
 	"time"
 )
@@ -12,13 +13,12 @@ import (
 // for taking, restoring, deleting snapshots, and
 // tracking them by a string snapshot ID.
 type Snapshotter interface {
-	DeleteSnapshot(snapID string, opts map[string]string) error
-	RunGC(opts map[string]string) error
-	ListSnapshots() ([]string, error)
-
-	CreateSnapshot(sourceDir string, opts map[string]string) (snapID string, fingerprint []byte, stats *CreateSnapshotStats, err error)
-	RestoreSnapshot(snapID, restoreDir string, opts map[string]string) ([]byte, error)
-	RestoreSnapshotCompare(snapID, restoreDir string, validationData []byte, reportOut io.Writer, opts map[string]string) error
+	CreateSnapshot(ctx context.Context, sourceDir string, opts map[string]string) (snapID string, fingerprint []byte, stats *CreateSnapshotStats, err error)
+	RestoreSnapshot(ctx context.Context, snapID, restoreDir string, opts map[string]string) ([]byte, error)
+	RestoreSnapshotCompare(ctx context.Context, snapID, restoreDir string, validationData []byte, reportOut io.Writer, opts map[string]string) error
+	DeleteSnapshot(ctx context.Context, snapID string, opts map[string]string) error
+	RunGC(ctx context.Context, opts map[string]string) error
+	ListSnapshots(ctx context.Context) ([]string, error)
 }
 
 // CreateSnapshotStats is a struct for returning various stats from the snapshot execution.

--- a/tests/tools/fswalker/fswalker_test.go
+++ b/tests/tools/fswalker/fswalker_test.go
@@ -4,7 +4,6 @@ package fswalker
 
 import (
 	"bytes"
-	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/google/fswalker"
 	fspb "github.com/google/fswalker/proto/fswalker"
+	"github.com/kopia/kopia/internal/testlogging"
 )
 
 func TestWalkChecker_GatherCompare(t *testing.T) {
@@ -211,7 +211,7 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ctx := context.TODO()
+		ctx := testlogging.Context(t)
 
 		walk, err := chk.Gather(ctx, tmpDir, nil)
 		if err != nil {

--- a/tests/tools/fswalker/fswalker_test.go
+++ b/tests/tools/fswalker/fswalker_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/fswalker"
 	fspb "github.com/google/fswalker/proto/fswalker"
+
 	"github.com/kopia/kopia/internal/testlogging"
 )
 

--- a/tests/tools/fswalker/reporter/reporter_test.go
+++ b/tests/tools/fswalker/reporter/reporter_test.go
@@ -3,18 +3,18 @@
 package reporter
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	fspb "github.com/google/fswalker/proto/fswalker"
 
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
 func TestReporterWithFiles(t *testing.T) {
-	ctx := context.TODO()
+	ctx := testlogging.Context(t)
 
 	config := &fspb.ReportConfig{
 		Version:    1,

--- a/tests/tools/fswalker/walker/walker_test.go
+++ b/tests/tools/fswalker/walker/walker_test.go
@@ -3,7 +3,6 @@
 package walker
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -11,6 +10,7 @@ import (
 
 	fspb "github.com/google/fswalker/proto/fswalker"
 
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -32,7 +32,9 @@ func TestWalk(t *testing.T) {
 	)
 	testenv.AssertNoError(t, err)
 
-	walk, err := Walk(context.TODO(),
+	ctx := testlogging.Context(t)
+
+	walk, err := Walk(ctx,
 		&fspb.Policy{
 			Include: []string{
 				dataDir,
@@ -48,8 +50,10 @@ func TestWalk(t *testing.T) {
 }
 
 func TestWalkFail(t *testing.T) {
+	ctx := testlogging.Context(t)
+
 	_, err := Walk(
-		context.TODO(),
+		ctx,
 		&fspb.Policy{
 			Include: []string{
 				"some/nonexistent/directory",


### PR DESCRIPTION
Add context to all interface methods, exposed through engine actions to the test writer/engine user.