### PR TITLE
cleanup: cancel context when listing blobs in S3 provider

### DIFF
--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -148,6 +148,10 @@ func (s *s3Storage) getObjectNameString(b blob.ID) string {
 }
 
 func (s *s3Storage) ListBlobs(ctx context.Context, prefix blob.ID, callback func(blob.Metadata) error) error {
+	ctx, cancel := context.WithCancel(ctx)
+
+	defer cancel()
+
 	oi := s.cli.ListObjects(ctx, s.BucketName, minio.ListObjectsOptions{
 		Prefix: s.getObjectNameString(prefix),
 	})

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -27,8 +27,6 @@ const (
 type s3Storage struct {
 	Options
 
-	ctx context.Context
-
 	cli *minio.Client
 
 	downloadThrottler *iothrottler.IOThrottlerPool
@@ -244,7 +242,6 @@ func New(ctx context.Context, opt *Options) (blob.Storage, error) {
 
 	return retrying.NewWrapper(&s3Storage{
 		Options:           *opt,
-		ctx:               ctx,
 		cli:               cli,
 		downloadThrottler: downloadThrottler,
 		uploadThrottler:   uploadThrottler,


### PR DESCRIPTION
While not the case in the current implementation, when the blob metadata is not fully consumed from the channel, then the channel is never closed and the sending go routine never terminates.

Also, removes an unused member field => `s3storage.ctx`