### PR TITLE
cli: added --safety=full|none flag to maintenance commands

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -68,7 +68,7 @@ func safetyFlag(c *kingpin.CmdClause) *maintenance.SafetyParameters {
 		}
 
 		return nil
-	}).EnumVar(&str, "full", "minimal", "none")
+	}).EnumVar(&str, "full", "none")
 
 	return &result
 }

--- a/cli/command_blob_gc.go
+++ b/cli/command_blob_gc.go
@@ -11,26 +11,23 @@ import (
 )
 
 var (
-	blobGarbageCollectCommand              = blobCommands.Command("gc", "Garbage-collect unused blobs")
-	blobGarbageCollectCommandDelete        = blobGarbageCollectCommand.Flag("delete", "Whether to delete unused blobs").String()
-	blobGarbageCollectParallel             = blobGarbageCollectCommand.Flag("parallel", "Number of parallel blob scans").Default("16").Int()
-	blobGarbageCollectMinAge               = blobGarbageCollectCommand.Flag("min-age", "Garbage-collect blobs with minimum age").Default("24h").Duration()
-	blobGarbageCollectSessionExpirationAge = blobGarbageCollectCommand.Flag("session-expiration-age", "Garbage-collect blobs belonging to sessions that have not been updated recently").Default("96h").Duration()
-	blobGarbageCollectPrefix               = blobGarbageCollectCommand.Flag("prefix", "Only GC blobs with given prefix").String()
+	blobGarbageCollectCommand       = blobCommands.Command("gc", "Garbage-collect unused blobs")
+	blobGarbageCollectCommandDelete = blobGarbageCollectCommand.Flag("delete", "Whether to delete unused blobs").String()
+	blobGarbageCollectParallel      = blobGarbageCollectCommand.Flag("parallel", "Number of parallel blob scans").Default("16").Int()
+	blobGarbageCollectPrefix        = blobGarbageCollectCommand.Flag("prefix", "Only GC blobs with given prefix").String()
+	blobGarbageCollectSafety        = safetyFlag(blobGarbageCollectCommand)
 )
 
 func runBlobGarbageCollectCommand(ctx context.Context, rep repo.DirectRepositoryWriter) error {
 	advancedCommand(ctx)
 
 	opts := maintenance.DeleteUnreferencedBlobsOptions{
-		DryRun:               *blobGarbageCollectCommandDelete != "yes",
-		MinAge:               *blobGarbageCollectMinAge,
-		SessionExpirationAge: *blobGarbageCollectSessionExpirationAge,
-		Parallel:             *blobGarbageCollectParallel,
-		Prefix:               blob.ID(*blobGarbageCollectPrefix),
+		DryRun:   *blobGarbageCollectCommandDelete != "yes",
+		Parallel: *blobGarbageCollectParallel,
+		Prefix:   blob.ID(*blobGarbageCollectPrefix),
 	}
 
-	n, err := maintenance.DeleteUnreferencedBlobs(ctx, rep, opts)
+	n, err := maintenance.DeleteUnreferencedBlobs(ctx, rep, opts, *blobGarbageCollectSafety)
 	if err != nil {
 		return errors.Wrap(err, "error deleting unreferenced blobs")
 	}

--- a/cli/command_content_rewrite.go
+++ b/cli/command_content_rewrite.go
@@ -18,7 +18,7 @@ var (
 	contentRewriteFormatVersion = contentRewriteCommand.Flag("format-version", "Rewrite contents using the provided format version").Default("-1").Int()
 	contentRewritePackPrefix    = contentRewriteCommand.Flag("pack-prefix", "Only rewrite contents from pack blobs with a given prefix").String()
 	contentRewriteDryRun        = contentRewriteCommand.Flag("dry-run", "Do not actually rewrite, only print what would happen").Short('n').Bool()
-	contentRewriteMinAge        = contentRewriteCommand.Flag("min-age", "Only rewrite contents above given age").Default("1h").Duration()
+	contentRewriteSafety        = safetyFlag(contentRewriteCommand)
 )
 
 func runContentRewriteCommand(ctx context.Context, rep repo.DirectRepositoryWriter) error {
@@ -28,12 +28,11 @@ func runContentRewriteCommand(ctx context.Context, rep repo.DirectRepositoryWrit
 		ContentIDRange: contentIDRange(),
 		ContentIDs:     toContentIDs(*contentRewriteIDs),
 		FormatVersion:  *contentRewriteFormatVersion,
-		MinAge:         *contentRewriteMinAge,
 		PackPrefix:     blob.ID(*contentRewritePackPrefix),
 		Parallel:       *contentRewriteParallelism,
 		ShortPacks:     *contentRewriteShortPacks,
 		DryRun:         *contentRewriteDryRun,
-	})
+	}, *contentRewriteSafety)
 }
 
 func toContentIDs(s []string) []content.ID {

--- a/cli/command_maintenance_run.go
+++ b/cli/command_maintenance_run.go
@@ -12,6 +12,7 @@ var (
 	maintenanceRunCommand = maintenanceCommands.Command("run", "Run repository maintenance").Default()
 	maintenanceRunFull    = maintenanceRunCommand.Flag("full", "Full maintenance").Bool()
 	maintenanceRunForce   = maintenanceRunCommand.Flag("force", "Run maintenance even if not owned (unsafe)").Hidden().Bool()
+	maintenanceRunSafety  = safetyFlag(maintenanceRunCommand)
 )
 
 func runMaintenanceCommand(ctx context.Context, rep repo.DirectRepositoryWriter) error {
@@ -20,7 +21,7 @@ func runMaintenanceCommand(ctx context.Context, rep repo.DirectRepositoryWriter)
 		mode = maintenance.ModeFull
 	}
 
-	return snapshotmaintenance.Run(ctx, rep, mode, *maintenanceRunForce)
+	return snapshotmaintenance.Run(ctx, rep, mode, *maintenanceRunForce, *maintenanceRunSafety)
 }
 
 func init() {

--- a/cli/command_snapshot_gc.go
+++ b/cli/command_snapshot_gc.go
@@ -7,20 +7,17 @@ import (
 
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo"
-	"github.com/kopia/kopia/repo/maintenance"
 	"github.com/kopia/kopia/snapshot/snapshotgc"
 )
 
 var (
-	snapshotGCCommand       = snapshotCommands.Command("gc", "Mark contents as deleted which are not used by any snapshot").Hidden()
-	snapshotGCMinContentAge = snapshotGCCommand.Flag("min-age", "Minimum content age to allow deletion").Default("24h").Duration()
-	snapshotGCDelete        = snapshotGCCommand.Flag("delete", "Delete unreferenced contents").Bool()
+	snapshotGCCommand = snapshotCommands.Command("gc", "Mark contents as deleted which are not used by any snapshot").Hidden()
+	snapshotGCDelete  = snapshotGCCommand.Flag("delete", "Delete unreferenced contents").Bool()
+	snapshotGCSafety  = safetyFlag(snapshotGCCommand)
 )
 
 func runSnapshotGCCommand(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	st, err := snapshotgc.Run(ctx, rep, maintenance.SnapshotGCParams{
-		MinContentAge: *snapshotGCMinContentAge,
-	}, *snapshotGCDelete)
+	st, err := snapshotgc.Run(ctx, rep, *snapshotGCDelete, *snapshotGCSafety)
 
 	log(ctx).Infof("GC found %v unused contents (%v bytes)", st.UnusedCount, units.BytesStringBase2(st.UnusedBytes))
 	log(ctx).Infof("GC found %v unused contents that are too recent to delete (%v bytes)", st.TooRecentCount, units.BytesStringBase2(st.TooRecentBytes))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -506,7 +506,7 @@ func periodicMaintenanceOnce(ctx context.Context, rep repo.Repository) error {
 	return repo.DirectWriteSession(ctx, dr, repo.WriteSessionOptions{
 		Purpose: "periodicMaintenanceOnce",
 	}, func(w repo.DirectRepositoryWriter) error {
-		return snapshotmaintenance.Run(ctx, w, maintenance.ModeAuto, false)
+		return snapshotmaintenance.Run(ctx, w, maintenance.ModeAuto, false, maintenance.SafetyFull)
 	})
 }
 

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -311,14 +311,13 @@ func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *Ca
 	sm.committedContents = contentIndex
 
 	sm.indexBlobManager = &indexBlobManagerImpl{
-		st:                               sm.st,
-		encryptor:                        sm.encryptor,
-		hasher:                           sm.hasher,
-		timeNow:                          sm.timeNow,
-		ownWritesCache:                   owc,
-		listCache:                        listCache,
-		indexBlobCache:                   metadataCache,
-		maxEventualConsistencySettleTime: defaultEventualConsistencySettleTime,
+		st:             sm.st,
+		encryptor:      sm.encryptor,
+		hasher:         sm.hasher,
+		timeNow:        sm.timeNow,
+		ownWritesCache: owc,
+		listCache:      listCache,
+		indexBlobCache: metadataCache,
 	}
 
 	return nil

--- a/repo/content/index_blob_manager_test.go
+++ b/repo/content/index_blob_manager_test.go
@@ -496,7 +496,7 @@ func fakeCompaction(ctx context.Context, m indexBlobManager, dropDeleted bool) e
 		inputs = append(inputs, bi.Metadata)
 	}
 
-	if err := m.registerCompaction(ctx, inputs, outputs); err != nil {
+	if err := m.registerCompaction(ctx, inputs, outputs, testEventualConsistencySettleTime); err != nil {
 		return errors.Wrap(err, "compaction error")
 	}
 
@@ -702,7 +702,7 @@ func mustRegisterCompaction(t *testing.T, m indexBlobManager, inputs, outputs []
 
 	t.Logf("compacting %v to %v", inputs, outputs)
 
-	err := m.registerCompaction(testlogging.Context(t), inputs, outputs)
+	err := m.registerCompaction(testlogging.Context(t), inputs, outputs, testEventualConsistencySettleTime)
 	if err != nil {
 		t.Fatalf("failed to write index blob: %v", err)
 	}
@@ -773,12 +773,11 @@ func newIndexBlobManagerForTesting(t *testing.T, st blob.Storage, localTimeNow f
 			blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, localTimeNow),
 			localTimeNow,
 		},
-		indexBlobCache:                   passthroughContentCache{st},
-		encryptor:                        enc,
-		hasher:                           hf,
-		listCache:                        lc,
-		timeNow:                          localTimeNow,
-		maxEventualConsistencySettleTime: testIndexBlobDeleteAge,
+		indexBlobCache: passthroughContentCache{st},
+		encryptor:      enc,
+		hasher:         hf,
+		listCache:      lc,
+		timeNow:        localTimeNow,
 	}
 
 	return m

--- a/repo/maintenance/blob_gc.go
+++ b/repo/maintenance/blob_gc.go
@@ -73,7 +73,7 @@ func DeleteUnreferencedBlobs(ctx context.Context, rep repo.DirectRepositoryWrite
 	// belong to alive sessions.
 	if err := rep.ContentManager().IterateUnreferencedBlobs(ctx, prefixes, opt.Parallel, func(bm blob.Metadata) error {
 		if age := rep.Time().Sub(bm.Timestamp); age < safety.BlobDeleteMinAge {
-			log(ctx).Debugf("  preserving %v because it's too new (age: %v bm: %v)", bm.BlobID, bm.Timestamp, age)
+			log(ctx).Debugf("  preserving %v because it's too new (age: %v<%v)", bm.BlobID, age, safety.BlobDeleteMinAge)
 			return nil
 		}
 

--- a/repo/maintenance/blob_gc.go
+++ b/repo/maintenance/blob_gc.go
@@ -2,7 +2,6 @@ package maintenance
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -14,36 +13,18 @@ import (
 	"github.com/kopia/kopia/repo/content"
 )
 
-// defaultBlobGCMinAge is a default MinAge for blob GC.
-// We're setting it to 2 hours to accommodate the fact that every repository
-// will periodically flush its indexes more frequently than 1/hour.
-const defaultBlobGCMinAge = 2 * time.Hour
-
-// treat sessions that have not been updated in 4 days as expired.
-const defaultSessionExpirationAge = 4 * 24 * time.Hour
-
 // DeleteUnreferencedBlobsOptions provides option for blob garbage collection algorithm.
 type DeleteUnreferencedBlobsOptions struct {
-	Parallel             int
-	Prefix               blob.ID
-	MinAge               time.Duration
-	SessionExpirationAge time.Duration // treat sessions that have not been written for more than X time as expired
-	DryRun               bool
+	Parallel int
+	Prefix   blob.ID
+	DryRun   bool
 }
 
 // DeleteUnreferencedBlobs deletes old blobs that are no longer referenced by index entries.
 // nolint:gocyclo
-func DeleteUnreferencedBlobs(ctx context.Context, rep repo.DirectRepositoryWriter, opt DeleteUnreferencedBlobsOptions) (int, error) {
+func DeleteUnreferencedBlobs(ctx context.Context, rep repo.DirectRepositoryWriter, opt DeleteUnreferencedBlobsOptions, safety SafetyParameters) (int, error) {
 	if opt.Parallel == 0 {
 		opt.Parallel = 16
-	}
-
-	if opt.MinAge == 0 {
-		opt.MinAge = defaultBlobGCMinAge
-	}
-
-	if opt.SessionExpirationAge == 0 {
-		opt.SessionExpirationAge = defaultSessionExpirationAge
 	}
 
 	const deleteQueueSize = 100
@@ -91,14 +72,14 @@ func DeleteUnreferencedBlobs(ctx context.Context, rep repo.DirectRepositoryWrite
 	// iterate all pack blobs + session blobs and keep ones that are too young or
 	// belong to alive sessions.
 	if err := rep.ContentManager().IterateUnreferencedBlobs(ctx, prefixes, opt.Parallel, func(bm blob.Metadata) error {
-		if age := rep.Time().Sub(bm.Timestamp); age < opt.MinAge {
+		if age := rep.Time().Sub(bm.Timestamp); age < safety.BlobDeleteMinAge {
 			log(ctx).Debugf("  preserving %v because it's too new (age: %v bm: %v)", bm.BlobID, bm.Timestamp, age)
 			return nil
 		}
 
 		sid := content.SessionIDFromBlobID(bm.BlobID)
 		if s, ok := activeSessions[sid]; ok {
-			if age := rep.Time().Sub(s.CheckpointTime); age < opt.SessionExpirationAge {
+			if age := rep.Time().Sub(s.CheckpointTime); age < safety.SessionExpirationAge {
 				log(ctx).Debugf("  preserving %v because it's part of an active session (%v)", bm.BlobID, sid)
 				return nil
 			}

--- a/repo/maintenance/content_rewrite.go
+++ b/repo/maintenance/content_rewrite.go
@@ -186,6 +186,16 @@ func findContentInShortPacks(ctx context.Context, rep repo.DirectRepository, ch 
 				return nil
 			}
 
+			blobMeta, err := rep.BlobReader().GetMetadata(ctx, pi.PackID)
+			if err != nil {
+				return errors.Wrapf(err, "unable to get blob metadata %v", pi.PackID)
+			}
+
+			// pack is short but the content consumes most of it, ignore.
+			if pi.TotalSize > shortPackThresholdPercent*blobMeta.Length/100 {
+				return nil
+			}
+
 			for _, ci := range pi.ContentInfos {
 				ch <- contentInfoOrError{Info: ci}
 			}

--- a/repo/maintenance/content_rewrite.go
+++ b/repo/maintenance/content_rewrite.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -15,14 +14,11 @@ import (
 	"github.com/kopia/kopia/repo/content"
 )
 
-const defaultRewriteContentsMinAge = 2 * time.Hour
-
 const parallelContentRewritesCPUMultiplier = 2
 
 // RewriteContentsOptions provides options for RewriteContents.
 type RewriteContentsOptions struct {
 	Parallel       int
-	MinAge         time.Duration
 	ContentIDs     []content.ID
 	ContentIDRange content.IDRange
 	PackPrefix     blob.ID
@@ -40,13 +36,9 @@ type contentInfoOrError struct {
 
 // RewriteContents rewrites contents according to provided criteria and creates new
 // blobs and index entries to point at the.
-func RewriteContents(ctx context.Context, rep repo.DirectRepositoryWriter, opt *RewriteContentsOptions) error {
+func RewriteContents(ctx context.Context, rep repo.DirectRepositoryWriter, opt *RewriteContentsOptions, safety SafetyParameters) error {
 	if opt == nil {
 		return errors.Errorf("missing options")
-	}
-
-	if opt.MinAge == 0 {
-		opt.MinAge = defaultRewriteContentsMinAge
 	}
 
 	if opt.ShortPacks {
@@ -90,7 +82,7 @@ func RewriteContents(ctx context.Context, rep repo.DirectRepositoryWriter, opt *
 				}
 
 				age := rep.Time().Sub(c.Timestamp())
-				if age < opt.MinAge {
+				if age < safety.RewriteMinAge {
 					log(ctx).Debugf("Not rewriting content %v (%v bytes) from pack %v%v %v, because it's too new.", c.ID, c.Length, c.PackBlobID, optDeleted, age)
 					continue
 				}

--- a/repo/maintenance/drop_deleted_contents.go
+++ b/repo/maintenance/drop_deleted_contents.go
@@ -9,11 +9,12 @@ import (
 )
 
 // DropDeletedContents rewrites indexes while dropping deleted contents above certain age.
-func DropDeletedContents(ctx context.Context, rep repo.DirectRepositoryWriter, dropDeletedBefore time.Time) error {
+func DropDeletedContents(ctx context.Context, rep repo.DirectRepositoryWriter, dropDeletedBefore time.Time, safety SafetyParameters) error {
 	log(ctx).Infof("Dropping contents deleted before %v", dropDeletedBefore)
 
 	return rep.ContentManager().CompactIndexes(ctx, content.CompactOptions{
-		AllIndexes:        true,
-		DropDeletedBefore: dropDeletedBefore,
+		AllIndexes:                       true,
+		DropDeletedBefore:                dropDeletedBefore,
+		DisableEventualConsistencySafety: safety.DisableEventualConsistencySafety,
 	})
 }

--- a/repo/maintenance/index_compaction.go
+++ b/repo/maintenance/index_compaction.go
@@ -10,10 +10,11 @@ import (
 const maxSmallBlobsForIndexCompaction = 8
 
 // IndexCompaction rewrites index blobs to reduce their count but does not drop any contents.
-func IndexCompaction(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+func IndexCompaction(ctx context.Context, rep repo.DirectRepositoryWriter, safety SafetyParameters) error {
 	log(ctx).Infof("Compacting indexes...")
 
 	return rep.ContentManager().CompactIndexes(ctx, content.CompactOptions{
-		MaxSmallBlobs: maxSmallBlobsForIndexCompaction,
+		MaxSmallBlobs:                    maxSmallBlobsForIndexCompaction,
+		DisableEventualConsistencySafety: safety.DisableEventualConsistencySafety,
 	})
 }

--- a/repo/maintenance/maintenance_params.go
+++ b/repo/maintenance/maintenance_params.go
@@ -20,15 +20,6 @@ type Params struct {
 
 	QuickCycle CycleParams `json:"quick"`
 	FullCycle  CycleParams `json:"full"`
-
-	SnapshotGC SnapshotGCParams `json:"snapshotGC"`
-}
-
-// SnapshotGCParams contains parameters for Snapshot Garbage Collection
-// NOTE: Due to layering, the implementation of Snapshot GC is outside of repository package
-// but for simplicity we store it here.
-type SnapshotGCParams struct {
-	MinContentAge time.Duration `json:"minAge"`
 }
 
 // DefaultParams represents default values of maintenance parameters.
@@ -41,9 +32,6 @@ func DefaultParams() Params {
 		QuickCycle: CycleParams{
 			Enabled:  true,
 			Interval: 1 * time.Hour,
-		},
-		SnapshotGC: SnapshotGCParams{
-			MinContentAge: 24 * time.Hour, //nolint:gomnd
 		},
 	}
 }

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -310,7 +310,7 @@ func findSafeDropTime(runs []RunInfo, safety SafetyParameters) time.Time {
 	for _, r := range successfulRuns[1:] {
 		diff := -r.End.Sub(successfulRuns[0].Start)
 		if diff > safety.MarginBetweenSnapshotGC {
-			return r.Start.Add(-safety.ExtraDropContentFromIndexBuffer)
+			return r.Start.Add(-safety.DropContentFromIndexExtraMargin)
 		}
 	}
 

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -214,7 +214,7 @@ func runQuickMaintenance(ctx context.Context, runParams RunParameters, safety Sa
 
 	// consolidate many smaller indexes into fewer larger ones.
 	if err := ReportRun(ctx, runParams.rep, "index-compaction", func() error {
-		return IndexCompaction(ctx, runParams.rep)
+		return IndexCompaction(ctx, runParams.rep, safety)
 	}); err != nil {
 		return errors.Wrap(err, "error performing index compaction")
 	}
@@ -242,7 +242,7 @@ func runFullMaintenance(ctx context.Context, runParams RunParameters, safety Saf
 		// rewrite indexes by dropping content entries that have been marked
 		// as deleted for a long time
 		if err := ReportRun(ctx, runParams.rep, "full-drop-deleted-content", func() error {
-			return DropDeletedContents(ctx, runParams.rep, safeDropTime)
+			return DropDeletedContents(ctx, runParams.rep, safeDropTime, safety)
 		}); err != nil {
 			return errors.Wrap(err, "error dropping deleted contents")
 		}

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -14,16 +14,6 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-// safetyMarginBetweenSnapshotGC is the minimal amount of time that must pass between snapshot
-// GC cycles to allow all in-flight snapshots during earlier GC to be flushed to be flushed and
-// visible to a following GC. The uploader will automatically create a checkpoint every 45 minutes,
-// so ~1 hour should be enough but we're setting this to a higher conservative value for extra safety.
-const (
-	safetyMarginBetweenSnapshotGC = 4 * time.Hour
-
-	extraSafetyMarginBeforeDroppingContentFromIndex = -1 * time.Hour
-)
-
 var log = logging.GetContextLoggerFunc("maintenance")
 
 // Mode describes the mode of maintenance to perfor.
@@ -186,20 +176,20 @@ func RunExclusive(ctx context.Context, rep repo.DirectRepositoryWriter, mode Mod
 }
 
 // Run performs maintenance activities for a repository.
-func Run(ctx context.Context, runParams RunParameters) error {
+func Run(ctx context.Context, runParams RunParameters, safety SafetyParameters) error {
 	switch runParams.Mode {
 	case ModeQuick:
-		return runQuickMaintenance(ctx, runParams)
+		return runQuickMaintenance(ctx, runParams, safety)
 
 	case ModeFull:
-		return runFullMaintenance(ctx, runParams)
+		return runFullMaintenance(ctx, runParams, safety)
 
 	default:
 		return errors.Errorf("unknown mode %q", runParams.Mode)
 	}
 }
 
-func runQuickMaintenance(ctx context.Context, runParams RunParameters) error {
+func runQuickMaintenance(ctx context.Context, runParams RunParameters, safety SafetyParameters) error {
 	// find 'q' packs that are less than 80% full and rewrite contents in them into
 	// new consolidated packs, orphaning old packs in the process.
 	if err := ReportRun(ctx, runParams.rep, "quick-rewrite-contents", func() error {
@@ -207,7 +197,7 @@ func runQuickMaintenance(ctx context.Context, runParams RunParameters) error {
 			ContentIDRange: content.AllPrefixedIDs,
 			PackPrefix:     content.PackBlobIDPrefixSpecial,
 			ShortPacks:     true,
-		})
+		}, safety)
 	}); err != nil {
 		return errors.Wrap(err, "error rewriting metadata contents")
 	}
@@ -216,7 +206,7 @@ func runQuickMaintenance(ctx context.Context, runParams RunParameters) error {
 	if err := ReportRun(ctx, runParams.rep, "quick-delete-blobs", func() error {
 		_, err := DeleteUnreferencedBlobs(ctx, runParams.rep, DeleteUnreferencedBlobsOptions{
 			Prefix: content.PackBlobIDPrefixSpecial,
-		})
+		}, SafetyFull)
 		return err
 	}); err != nil {
 		return errors.Wrap(err, "error deleting unreferenced metadata blobs")
@@ -232,13 +222,13 @@ func runQuickMaintenance(ctx context.Context, runParams RunParameters) error {
 	return nil
 }
 
-func runFullMaintenance(ctx context.Context, runParams RunParameters) error {
+func runFullMaintenance(ctx context.Context, runParams RunParameters, safety SafetyParameters) error {
 	s, err := GetSchedule(ctx, runParams.rep)
 	if err != nil {
 		return errors.Wrap(err, "unable to get schedule")
 	}
 
-	if safeDropTime := findSafeDropTime(s.Runs["snapshot-gc"]); !safeDropTime.IsZero() {
+	if safeDropTime := findSafeDropTime(s.Runs["snapshot-gc"], safety); !safeDropTime.IsZero() {
 		log(ctx).Infof("Found safe time to drop indexes: %v", safeDropTime)
 
 		// rewrite indexes by dropping content entries that have been marked
@@ -258,14 +248,14 @@ func runFullMaintenance(ctx context.Context, runParams RunParameters) error {
 		return RewriteContents(ctx, runParams.rep, &RewriteContentsOptions{
 			ContentIDRange: content.AllIDs,
 			ShortPacks:     true,
-		})
+		}, safety)
 	}); err != nil {
 		return errors.Wrap(err, "error rewriting contents in short packs")
 	}
 
 	// delete orphaned packs after some time.
 	if err := ReportRun(ctx, runParams.rep, "full-delete-blobs", func() error {
-		_, err := DeleteUnreferencedBlobs(ctx, runParams.rep, DeleteUnreferencedBlobsOptions{})
+		_, err := DeleteUnreferencedBlobs(ctx, runParams.rep, DeleteUnreferencedBlobsOptions{}, SafetyFull)
 		return err
 	}); err != nil {
 		return errors.Wrap(err, "error deleting unreferenced blobs")
@@ -297,8 +287,8 @@ func runFullMaintenance(ctx context.Context, runParams RunParameters) error {
 // After Step 2 completes, we know for sure that all contents deleted before Step #1 has started
 // are safe to drop from the index because Step #2 has fixed them, as long as all snapshots that
 // were racing with snapshot GC in step #1 have flushed pending writes, hence the
-// safetyMarginBetweenSnapshotGC.
-func findSafeDropTime(runs []RunInfo) time.Time {
+// safety.MarginBetweenSnapshotGC.
+func findSafeDropTime(runs []RunInfo, safety SafetyParameters) time.Time {
 	var successfulRuns []RunInfo
 
 	for _, r := range runs {
@@ -319,8 +309,8 @@ func findSafeDropTime(runs []RunInfo) time.Time {
 	// Look for previous successful run such that the time between GCs exceeds the safety margin.
 	for _, r := range successfulRuns[1:] {
 		diff := -r.End.Sub(successfulRuns[0].Start)
-		if diff > safetyMarginBetweenSnapshotGC {
-			return r.Start.Add(extraSafetyMarginBeforeDroppingContentFromIndex)
+		if diff > safety.MarginBetweenSnapshotGC {
+			return r.Start.Add(-safety.ExtraDropContentFromIndexBuffer)
 		}
 	}
 

--- a/repo/maintenance/maintenance_run_test.go
+++ b/repo/maintenance/maintenance_run_test.go
@@ -45,7 +45,7 @@ func TestFindSafeDropTime(t *testing.T) {
 				{Start: t0700, End: t0715, Success: true},
 				{Start: t1300, End: t1315, Success: true},
 			},
-			wantTime: t0700.Add(extraSafetyMarginBeforeDroppingContentFromIndex),
+			wantTime: t0700.Add(-SafetyFull.ExtraDropContentFromIndexBuffer),
 		},
 		// three runs spaced enough
 		{
@@ -54,7 +54,7 @@ func TestFindSafeDropTime(t *testing.T) {
 				{Start: t0900, End: t0915, Success: true},
 				{Start: t1300, End: t1315, Success: true},
 			},
-			wantTime: t0700.Add(extraSafetyMarginBeforeDroppingContentFromIndex),
+			wantTime: t0700.Add(-SafetyFull.ExtraDropContentFromIndexBuffer),
 		},
 		// three runs spaced enough, not successful
 		{
@@ -68,7 +68,7 @@ func TestFindSafeDropTime(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		if got, want := findSafeDropTime(tc.runs), tc.wantTime; !got.Equal(want) {
+		if got, want := findSafeDropTime(tc.runs, SafetyFull), tc.wantTime; !got.Equal(want) {
 			t.Errorf("invalid safe drop time for %v: %v, want %v", tc.runs, got, want)
 		}
 	}

--- a/repo/maintenance/maintenance_run_test.go
+++ b/repo/maintenance/maintenance_run_test.go
@@ -45,7 +45,7 @@ func TestFindSafeDropTime(t *testing.T) {
 				{Start: t0700, End: t0715, Success: true},
 				{Start: t1300, End: t1315, Success: true},
 			},
-			wantTime: t0700.Add(-SafetyFull.ExtraDropContentFromIndexBuffer),
+			wantTime: t0700.Add(-SafetyFull.DropContentFromIndexExtraMargin),
 		},
 		// three runs spaced enough
 		{
@@ -54,7 +54,7 @@ func TestFindSafeDropTime(t *testing.T) {
 				{Start: t0900, End: t0915, Success: true},
 				{Start: t1300, End: t1315, Success: true},
 			},
-			wantTime: t0700.Add(-SafetyFull.ExtraDropContentFromIndexBuffer),
+			wantTime: t0700.Add(-SafetyFull.DropContentFromIndexExtraMargin),
 		},
 		// three runs spaced enough, not successful
 		{

--- a/repo/maintenance/maintenance_safety.go
+++ b/repo/maintenance/maintenance_safety.go
@@ -19,6 +19,9 @@ type SafetyParameters struct {
 	// RequireTwoGCCycles indicates that two GC cycles are required.
 	RequireTwoGCCycles bool
 
+	// DisableEventualConsistencySafety disables wait time to allow settling of eventually-consistent writes in blob stores.
+	DisableEventualConsistencySafety bool
+
 	// DropContentFromIndexExtraMargin is the amount of margin time before dropping deleted contents from indices.
 	DropContentFromIndexExtraMargin time.Duration
 
@@ -35,13 +38,14 @@ var (
 	// delays, but it is safe only if no other kopia clients are running and storage backend is
 	// strongly consistent.
 	SafetyNone = SafetyParameters{
-		BlobDeleteMinAge:                0,
-		DropContentFromIndexExtraMargin: 0,
-		MarginBetweenSnapshotGC:         0,
-		MinContentAgeSubjectToGC:        0,
-		RewriteMinAge:                   0,
-		SessionExpirationAge:            0,
-		RequireTwoGCCycles:              false,
+		BlobDeleteMinAge:                 0,
+		DropContentFromIndexExtraMargin:  0,
+		MarginBetweenSnapshotGC:          0,
+		MinContentAgeSubjectToGC:         0,
+		RewriteMinAge:                    0,
+		SessionExpirationAge:             0,
+		RequireTwoGCCycles:               false,
+		DisableEventualConsistencySafety: true,
 	}
 
 	// SafetyFull has default safety parameters which allow safe GC concurrent with snapshotting

--- a/repo/maintenance/maintenance_safety.go
+++ b/repo/maintenance/maintenance_safety.go
@@ -16,8 +16,8 @@ type SafetyParameters struct {
 	// so ~1 hour should be enough but we're setting this to a higher conservative value for extra safety.
 	MarginBetweenSnapshotGC time.Duration
 
-	// ExtraDropContentFromIndexBuffer is the amount of buffer time before previ
-	ExtraDropContentFromIndexBuffer time.Duration
+	// DropContentFromIndexExtraMargin is the amount of margin time before dropping deleted contents from indices.
+	DropContentFromIndexExtraMargin time.Duration
 
 	// Blob GC: Delete unused blobs above this age.
 	BlobDeleteMinAge time.Duration
@@ -33,7 +33,7 @@ var (
 	// strongly consistent.
 	SafetyNone = SafetyParameters{
 		BlobDeleteMinAge:                0,
-		ExtraDropContentFromIndexBuffer: 0,
+		DropContentFromIndexExtraMargin: 0,
 		MarginBetweenSnapshotGC:         0,
 		MinContentAgeSubjectToGC:        0,
 		RewriteMinAge:                   0,
@@ -44,7 +44,7 @@ var (
 	// by other Kopia clients.
 	SafetyFull = SafetyParameters{
 		BlobDeleteMinAge:                2 * time.Hour, //nolint:gomnd
-		ExtraDropContentFromIndexBuffer: time.Hour,
+		DropContentFromIndexExtraMargin: time.Hour,
 		MarginBetweenSnapshotGC:         4 * time.Hour,  //nolint:gomnd
 		MinContentAgeSubjectToGC:        24 * time.Hour, //nolint:gomnd
 		RewriteMinAge:                   2 * time.Hour,  //nolint:gomnd

--- a/repo/maintenance/maintenance_safety.go
+++ b/repo/maintenance/maintenance_safety.go
@@ -1,0 +1,53 @@
+package maintenance
+
+import "time"
+
+// SafetyParameters specifies timing parameters that affect safety of maintenance.
+type SafetyParameters struct {
+	// Do not rewrite contents younger than this age.
+	RewriteMinAge time.Duration
+
+	// Snapshot GC: MinContentAgeSubjectToGC is the minimum age of content to be subject to garbage collection.
+	MinContentAgeSubjectToGC time.Duration
+
+	// MarginBetweenSnapshotGC is the minimal amount of time that must pass between snapshot
+	// GC cycles to allow all in-flight snapshots during earlier GC to be flushed and
+	// visible to a following GC. The uploader will automatically create a checkpoint every 45 minutes,
+	// so ~1 hour should be enough but we're setting this to a higher conservative value for extra safety.
+	MarginBetweenSnapshotGC time.Duration
+
+	// ExtraDropContentFromIndexBuffer is the amount of buffer time before previ
+	ExtraDropContentFromIndexBuffer time.Duration
+
+	// Blob GC: Delete unused blobs above this age.
+	BlobDeleteMinAge time.Duration
+
+	// Blob GC: Drop incomplete session blobs above this age.
+	SessionExpirationAge time.Duration
+}
+
+// Supported safety levels.
+var (
+	// SafetyNone has safety parameters which allow full garbage collection without unnecessary
+	// delays, but it is safe only if no other kopia clients are running and storage backend is
+	// strongly consistent.
+	SafetyNone = SafetyParameters{
+		BlobDeleteMinAge:                0,
+		ExtraDropContentFromIndexBuffer: 0,
+		MarginBetweenSnapshotGC:         0,
+		MinContentAgeSubjectToGC:        0,
+		RewriteMinAge:                   0,
+		SessionExpirationAge:            0,
+	}
+
+	// SafetyFull has default safety parameters which allow safe GC concurrent with snapshotting
+	// by other Kopia clients.
+	SafetyFull = SafetyParameters{
+		BlobDeleteMinAge:                2 * time.Hour, //nolint:gomnd
+		ExtraDropContentFromIndexBuffer: time.Hour,
+		MarginBetweenSnapshotGC:         4 * time.Hour,  //nolint:gomnd
+		MinContentAgeSubjectToGC:        24 * time.Hour, //nolint:gomnd
+		RewriteMinAge:                   2 * time.Hour,  //nolint:gomnd
+		SessionExpirationAge:            96 * time.Hour, //nolint:gomnd
+	}
+)

--- a/repo/maintenance/maintenance_safety.go
+++ b/repo/maintenance/maintenance_safety.go
@@ -16,6 +16,9 @@ type SafetyParameters struct {
 	// so ~1 hour should be enough but we're setting this to a higher conservative value for extra safety.
 	MarginBetweenSnapshotGC time.Duration
 
+	// RequireTwoGCCycles indicates that two GC cycles are required.
+	RequireTwoGCCycles bool
+
 	// DropContentFromIndexExtraMargin is the amount of margin time before dropping deleted contents from indices.
 	DropContentFromIndexExtraMargin time.Duration
 
@@ -38,6 +41,7 @@ var (
 		MinContentAgeSubjectToGC:        0,
 		RewriteMinAge:                   0,
 		SessionExpirationAge:            0,
+		RequireTwoGCCycles:              false,
 	}
 
 	// SafetyFull has default safety parameters which allow safe GC concurrent with snapshotting
@@ -49,5 +53,6 @@ var (
 		MinContentAgeSubjectToGC:        24 * time.Hour, //nolint:gomnd
 		RewriteMinAge:                   2 * time.Hour,  //nolint:gomnd
 		SessionExpirationAge:            96 * time.Hour, //nolint:gomnd
+		RequireTwoGCCycles:              true,
 	}
 )

--- a/snapshot/snapshotgc/gc.go
+++ b/snapshot/snapshotgc/gc.go
@@ -158,5 +158,5 @@ func runInternal(ctx context.Context, rep repo.DirectRepositoryWriter, gcDelete 
 		return errors.Errorf("Not deleting because '--delete' flag was not set")
 	}
 
-	return nil
+	return errors.Wrap(rep.Flush(ctx), "flush error")
 }

--- a/snapshot/snapshotmaintenance/snapshotmaintenance.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance.go
@@ -12,16 +12,16 @@ import (
 )
 
 // Run runs the complete snapshot and repository maintenance.
-func Run(ctx context.Context, dr repo.DirectRepositoryWriter, mode maintenance.Mode, force bool) error {
+func Run(ctx context.Context, dr repo.DirectRepositoryWriter, mode maintenance.Mode, force bool, safety maintenance.SafetyParameters) error {
 	return maintenance.RunExclusive(ctx, dr, mode, force,
 		func(runParams maintenance.RunParameters) error {
 			// run snapshot GC before full maintenance
 			if runParams.Mode == maintenance.ModeFull {
-				if _, err := snapshotgc.Run(ctx, dr, runParams.Params.SnapshotGC, true); err != nil {
+				if _, err := snapshotgc.Run(ctx, dr, true, safety); err != nil {
 					return errors.Wrap(err, "snapshot GC failure")
 				}
 			}
 
-			return maintenance.Run(ctx, runParams)
+			return maintenance.Run(ctx, runParams, safety)
 		})
 }

--- a/tests/end_to_end_test/maintenance_test.go
+++ b/tests/end_to_end_test/maintenance_test.go
@@ -1,0 +1,56 @@
+package endtoend_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestFullMaintenance(t *testing.T) {
+	t.Parallel()
+
+	e := testenv.NewCLITest(t)
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	var snap snapshot.Manifest
+
+	// after creation we'll have kopia.repository, 1 index + 1 pack blob
+	if got, want := e.RunAndExpectSuccess(t, "blob", "list"), 3; len(got) != want {
+		t.Fatalf("unexpected number of initial blobs: %v, want %v", got, want)
+	}
+
+	mustParseJSONLines(t, e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1, "--json"), &snap)
+	e.RunAndExpectSuccess(t, "snapshot", "delete", string(snap.ID), "--delete")
+
+	e.RunAndVerifyOutputLineCount(t, 0, "snapshot", "list")
+
+	originalBlobCount := len(e.RunAndExpectSuccess(t, "blob", "list"))
+
+	e.RunAndVerifyOutputLineCount(t, 0, "maintenance", "run", "--full")
+
+	if got := len(e.RunAndExpectSuccess(t, "blob", "list")); got != originalBlobCount {
+		t.Fatalf("full maintenance is not expected to change any blobs due to safety margins (got %v, was %v)", got, originalBlobCount)
+	}
+
+	// now rerun with --safety=none
+	e.RunAndExpectSuccess(t, "maintenance", "run", "--full", "--safety=none")
+
+	if got := len(e.RunAndExpectSuccess(t, "blob", "list")); got >= originalBlobCount {
+		t.Fatalf("maintenance did not remove blobs: %v, had %v", got, originalBlobCount)
+	}
+
+	// we're expecting to have 5 blobs:
+	// - kopia.maintenance
+	// - kopia.repository
+	// - 2 index blobs
+	// - 1 q blob
+
+	const blobCountAfterFullWipeout = 5
+
+	if got, want := e.RunAndExpectSuccess(t, "blob", "list"), blobCountAfterFullWipeout; len(got) != want {
+		t.Fatalf("maintenance left unwanted blobs: %v, want %v", got, want)
+	}
+}

--- a/tests/end_to_end_test/snapshot_delete_test.go
+++ b/tests/end_to_end_test/snapshot_delete_test.go
@@ -223,7 +223,7 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 	e.RunAndExpectFailure(t, "snapshot", "delete", snapID, "--delete")
 
 	// garbage-collect to clean up the root object.
-	e.RunAndExpectSuccess(t, "snapshot", "gc", "--delete", "--min-age", "0s")
+	e.RunAndExpectSuccess(t, "snapshot", "gc", "--delete", "--safety=none")
 
 	// Run a restore on the deleted snapshot's root ID. The root should be
 	// marked as deleted but still recoverable

--- a/tests/end_to_end_test/snapshot_gc_test.go
+++ b/tests/end_to_end_test/snapshot_gc_test.go
@@ -52,8 +52,13 @@ how are you
 	// run verification
 	e.RunAndExpectSuccess(t, "snapshot", "verify")
 
-	// garbage-collect in dry run mode
+	// garbage-collect in dry run mode - this will not fail because of default safety level
+	// which only looks at contents above certain age.
 	e.RunAndExpectSuccess(t, "snapshot", "gc")
+
+	// garbage-collect in dry run mode - this will fail because of --safety=none
+	// makes contents subject to GC immediately but we're not specifying --delete flag.
+	e.RunAndExpectFailure(t, "snapshot", "gc", "--safety=none")
 
 	// data block + directory block + manifest block + manifest block from manifest deletion
 	var contentInfo []content.Info
@@ -74,7 +79,7 @@ how are you
 	time.Sleep(2 * time.Second)
 
 	// garbage-collect for real, this time without age limit
-	e.RunAndExpectSuccess(t, "snapshot", "gc", "--delete", "--min-age", "0s")
+	e.RunAndExpectSuccess(t, "snapshot", "gc", "--delete", "--safety=none")
 
 	// two contents are deleted
 	expectedContentCount -= 2

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -74,8 +74,12 @@ func NewCLITest(t *testing.T) *CLITest {
 
 	exe := os.Getenv("KOPIA_EXE")
 	if exe == "" {
-		// exe = "kopia"
-		t.Skip()
+		if os.Getenv("VSCODE_PID") != "" {
+			// we're launched from VSCode, use system-installed kopia executable.
+			exe = "kopia"
+		} else {
+			t.Skip()
+		}
 	}
 
 	// unset environment variables that disrupt tests when passed to subprocesses.


### PR DESCRIPTION
This allows selection between safe, high-latency maintenance parameters
which allow concurrent access (`full`) or low-latency which may be
unsafe in certain situations when concurrent Kopia processes are
running.

This is a breaking change for advanced CLI commands, where it removes
timing parameters and replaces them with single `--safety` option.

* 'blob gc'
* 'content rewrite'
* 'snapshot gc'

Improves #800