### PR TITLE
blob: fix puts for object-lock-enabled S3 stores

### DIFF
--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -125,7 +126,7 @@ func (s *s3Storage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes) err
 
 	var er minio.ErrorResponse
 
-	if errors.As(err, &er) && er.Code == "InvalidRequest" && er.Message == "Content-MD5 HTTP header is required for Put Object requests with Object Lock parameters" {
+	if errors.As(err, &er) && er.Code == "InvalidRequest" && strings.Contains(strings.ToLower(er.Message), "content-md5") {
 		atomic.StoreInt32(&s.sendMD5, 1) // set sendMD5 on retry
 
 		return err // nolint:wrapcheck

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -383,6 +383,24 @@ func TestNoNeedMD5Minio(t *testing.T) {
 	})
 }
 
+func TestNoNeedMD5Providers(t *testing.T) {
+	t.Parallel()
+
+	for k, env := range providerCreds {
+		env := env
+
+		t.Run(k, func(t *testing.T) {
+			ctx := testlogging.Context(t)
+			options := getProviderOptions(t, env)
+			cli := createClient(t, options)
+
+			if needMD5(ctx, cli, options.BucketName) {
+				t.Fatal("expected bucket to not require MD5 for PUT blob, but got required")
+			}
+		})
+	}
+}
+
 func testStorage(t *testutil.RetriableT, options *Options) {
 	ctx := testlogging.Context(t)
 

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -329,10 +329,7 @@ func TestNeedMD5AWS(t *testing.T) {
 		err := cli.SetBucketObjectLockConfig(ctx, options.BucketName, &lockingMode, &unit, &days)
 		noError(t, err, "could not set object lock config")
 
-		got, err := needMD5(ctx, cli, options.BucketName)
-		noError(t, err, "could not determine whether PUT blob requires MD5")
-
-		if got != true {
+		if !needMD5(ctx, cli, options.BucketName) {
 			t.Fatal("expected bucket to require MD5 for PUT blob, but got not required")
 		}
 
@@ -372,10 +369,7 @@ func TestNoNeedMD5Minio(t *testing.T) {
 		cli = createClient(t, options)
 		makeBucket(t, cli, options, false)
 
-		got, err := needMD5(ctx, cli, minioBucketName)
-		noError(t, err, "could not determine whether PUT blob requires MD5")
-
-		if got != false {
+		if needMD5(ctx, cli, minioBucketName) {
 			t.Fatal("expected bucket to not require MD5 for PUT blob, but got required")
 		}
 	})

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -120,7 +120,7 @@ func getEnv(name, defValue string) string {
 	return value
 }
 
-func getProviderOptionsAndCleanup(tb testing.TB, envName string) *Options {
+func getProviderOptions(tb testing.TB, envName string) *Options {
 	tb.Helper()
 
 	value := getEnvOrSkip(tb, envName)
@@ -134,15 +134,23 @@ func getProviderOptionsAndCleanup(tb testing.TB, envName string) *Options {
 		tb.Fatalf("options providd in '%v' must not specify a prefix", envName)
 	}
 
-	cleanupOldData(context.Background(), tb, &o, defaultCleanupAge)
+	return &o
+}
+
+func getProviderOptionsAndCleanup(tb testing.TB, envName string) *Options {
+	tb.Helper()
+
+	o := getProviderOptions(tb, envName)
+
+	cleanupOldData(context.Background(), tb, o, defaultCleanupAge)
 
 	o.Prefix = uuid.NewString() + "-"
 
 	tb.Cleanup(func() {
-		cleanupOldData(context.Background(), tb, &o, 0)
+		cleanupOldData(context.Background(), tb, o, 0)
 	})
 
-	return &o
+	return o
 }
 
 func TestS3StorageProviders(t *testing.T) {


### PR DESCRIPTION
Fixes #711

Send content MD5 when object locking retention is enabled.

From the S3 documentation:

>
> If you configure a default retention period on a bucket, requests to upload objects in such a bucket must include the Content-MD5 header.
>
> The Content-MD5 header is required for any request to upload an object with a retention period configured using Amazon S3 Object Lock.
>

Ref:
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-overview.html#object-lock-bucket-config
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html

