### PR TITLE
Handle forbidden responses for missing directories

### DIFF
--- a/repo/blob/webdav/webdav_storage_test.go
+++ b/repo/blob/webdav/webdav_storage_test.go
@@ -118,6 +118,7 @@ func transformMissingPUTs(next http.Handler) http.HandlerFunc {
 		next.ServeHTTP(rec, r)
 
 		result := rec.Result()
+		defer result.Body.Close()
 
 		// Change the status code to forbidden if returned as not found
 		if result.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
Some WebDAV implementations respond with 403 Forbidden when a missing directory is encountered.

To handle this situation, any time an error is encountered while writing a blob, we first try to create requisite directories and if that fails, we return the error.

Additionally, the original failed write call is immediately tried again (rather than using the retry logic).

Fixes #551.