### PR TITLE
switched progress tracking and ETA computation to time.Now() as it causes fake clock time to run too fast

### DIFF
--- a/cli/command_benchmark_compression.go
+++ b/cli/command_benchmark_compression.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo/compression"
 )
@@ -47,7 +47,7 @@ func runBenchmarkCompressionAction(ctx context.Context) error {
 	for name, comp := range compression.ByName {
 		log(ctx).Infof("Benchmarking compressor '%v' (%v x %v bytes)", name, *benchmarkCompressionRepeat, len(data))
 
-		t0 := clock.Now()
+		tt := timetrack.Start()
 
 		var compressedSize int64
 
@@ -79,10 +79,9 @@ func runBenchmarkCompressionAction(ctx context.Context) error {
 			}
 		}
 
-		hashTime := clock.Since(t0)
-		bytesPerSecond := float64(len(data)) * float64(cnt) / hashTime.Seconds()
+		_, perSecond := tt.Completed(float64(len(data)) * float64(cnt))
 
-		results = append(results, benchResult{compression: name, throughput: bytesPerSecond, compressedSize: compressedSize})
+		results = append(results, benchResult{compression: name, throughput: perSecond, compressedSize: compressedSize})
 	}
 
 	if *benchmarkCompressionBySize {

--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/encryption"
@@ -53,7 +53,7 @@ func runBenchmarkCryptoAction(ctx context.Context) error {
 
 			log(ctx).Infof("Benchmarking hash '%v' and encryption '%v'... (%v x %v bytes)", ha, ea, *benchmarkCryptoRepeat, len(data))
 
-			t0 := clock.Now()
+			tt := timetrack.Start()
 
 			hashCount := *benchmarkCryptoRepeat
 
@@ -65,8 +65,7 @@ func runBenchmarkCryptoAction(ctx context.Context) error {
 				}
 			}
 
-			hashTime := clock.Since(t0)
-			bytesPerSecond := float64(len(data)) * float64(hashCount) / hashTime.Seconds()
+			_, bytesPerSecond := tt.Completed(float64(len(data)) * float64(hashCount))
 
 			results = append(results, benchResult{hash: ha, encryption: ea, throughput: bytesPerSecond})
 		}

--- a/cli/command_benchmark_splitters.go
+++ b/cli/command_benchmark_splitters.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/repo/splitter"
 )
 
@@ -63,7 +63,7 @@ func runBenchmarkSplitterAction(ctx context.Context) error { //nolint:funlen
 
 		var segmentLengths []int
 
-		t0 := clock.Now()
+		tt := timetrack.Start()
 
 		for _, data := range dataBlocks {
 			s := fact()
@@ -81,7 +81,7 @@ func runBenchmarkSplitterAction(ctx context.Context) error { //nolint:funlen
 			}
 		}
 
-		dur := clock.Since(t0)
+		dur, _ := tt.Completed(0)
 
 		sort.Ints(segmentLengths)
 

--- a/cli/command_index_optimize.go
+++ b/cli/command_index_optimize.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/content"
 )
@@ -26,7 +25,7 @@ func runOptimizeCommand(ctx context.Context, rep repo.DirectRepositoryWriter) er
 	}
 
 	if age := *optimizeDropDeletedOlderThan; age > 0 {
-		opt.DropDeletedBefore = clock.Now().Add(-age)
+		opt.DropDeletedBefore = rep.Time().Add(-age)
 	}
 
 	return rep.ContentManager().CompactIndexes(ctx, opt)

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -70,9 +70,11 @@ func Initialize(ctx *kingpin.ParseContext) error {
 
 	// activate backends
 	logging.SetBackend(
-		setupConsoleBackend(),
-		setupLogFileBackend(now, suffix),
-		setupContentLogFileBackend(now, suffix),
+		multiLogger{
+			setupConsoleBackend(),
+			setupLogFileBackend(now, suffix),
+			setupContentLogFileBackend(now, suffix),
+		},
 	)
 
 	if *forceColor {
@@ -81,6 +83,22 @@ func Initialize(ctx *kingpin.ParseContext) error {
 
 	if *disableColor {
 		color.NoColor = true
+	}
+
+	return nil
+}
+
+type multiLogger []logging.Backend
+
+func (m multiLogger) Log(l logging.Level, calldepth int, rec *logging.Record) error {
+	// use clock.Now() which can be overridden in e2e tests.
+	rec.Time = clock.Now()
+
+	for _, child := range m {
+		// Shallow copy of the record for the formatted cache on Record and get the
+		// record formatter from the backend.
+		r2 := *rec
+		child.Log(l, calldepth, &r2) //nolint:errcheck
 	}
 
 	return nil

--- a/internal/timetrack/estimator.go
+++ b/internal/timetrack/estimator.go
@@ -1,0 +1,69 @@
+// Package timetrack tracks the progress and estimates completion of a task.
+package timetrack
+
+import (
+	"time"
+
+	"github.com/kopia/kopia/internal/clock"
+)
+
+// Estimator estimates the completion of a task.
+type Estimator struct {
+	startTime time.Time
+}
+
+// Timings returns task progress and timings.
+type Timings struct {
+	PercentComplete  float64
+	EstimatedEndTime time.Time
+	Remaining        time.Duration
+	SpeedPerSecond   float64
+}
+
+// Estimate estimates the completion of a task given the current progress as indicated
+// by ration of completed/total.
+func (v Estimator) Estimate(completed, total float64) (Timings, bool) {
+	now := time.Now() //nolint:forbidigo
+	elapsed := now.Sub(v.startTime)
+
+	if elapsed > 1*time.Second && total > 0 && completed > 0 {
+		completedRatio := completed / total
+		if completedRatio > 1 {
+			completedRatio = 0
+		}
+
+		if completedRatio < 0 {
+			completedRatio = 0
+		}
+
+		predictedSeconds := elapsed.Seconds() / completedRatio
+		predictedEndTime := v.startTime.Add(time.Duration(predictedSeconds) * time.Second)
+
+		dt := clock.Until(predictedEndTime).Truncate(time.Second)
+		if dt > 0 {
+			return Timings{
+				PercentComplete:  100 * completed / total,
+				EstimatedEndTime: now.Add(dt),
+				Remaining:        dt,
+				SpeedPerSecond:   completed / elapsed.Seconds(),
+			}, true
+		}
+	}
+
+	return Timings{}, false
+}
+
+// Completed computes the duration and speed (total per second).
+func (v Estimator) Completed(total float64) (totalTime time.Duration, speed float64) {
+	dur := time.Since(v.startTime) //nolint:forbidigo
+	if dur <= 0 {
+		return 0, 0
+	}
+
+	return dur, total / dur.Seconds()
+}
+
+// Start returns an Estimator object.
+func Start() Estimator {
+	return Estimator{startTime: time.Now()} //nolint:forbidigo
+}

--- a/internal/timetrack/throttle.go
+++ b/internal/timetrack/throttle.go
@@ -1,0 +1,26 @@
+package timetrack
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// Throttle throttles UI updates to a specific interval.
+type Throttle int64
+
+// ShouldOutput returns true if it's ok to produce output given the for a given time interval.
+func (t *Throttle) ShouldOutput(interval time.Duration) bool {
+	nextOutputTimeUnixNano := atomic.LoadInt64((*int64)(t))
+	if nowNano := time.Now().UnixNano(); nowNano > nextOutputTimeUnixNano { //nolint:forbidigo
+		if atomic.CompareAndSwapInt64((*int64)(t), nextOutputTimeUnixNano, nowNano+interval.Nanoseconds()) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Reset resets the throttle.
+func (t *Throttle) Reset() {
+	*t = 0
+}


### PR DESCRIPTION
This is what's causing flakes in endurance test where the time sometimes moves way too fast.