### PR TITLE
User must install npm manually on OpenBSD

### DIFF
--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -120,19 +120,17 @@ endif
 
 # put NPM in the path
 PATH:=$(node_dir)$(path_separator)$(PATH)
-OPENBSD_NPM_PATH=/usr/local/bin/npm
+ifeq ($(GOOS),$(filter $(GOOS),openbsd freebsd))
+npm=/usr/local/bin/npm
+endif
 
 $(npm):
-
 ifeq ($(GOOS),openbsd)
-# Node do not provide OpenBSD package. User must install from port/package beforehand.
-ifeq (,$(wildcard $(OPENBSD_NPM_PATH)))
-	@echo Install node with pkg_add before building UI
+	@echo Use pkg_add to install node
 	@exit 1
-endif
-	$(mkdir) $(node_base_dir)$(slash)node$(slash)bin
-	ln -s $(OPENBSD_NPM_PATH) $(node_base_dir)$(slash)node$(slash)bin
-
+else ifeq ($(GOOS),freebsd)
+	@echo Use pkg to install npm
+	@exit 1
 else
 	@echo Downloading Node v$(NODE_VERSION) with NPM path $(npm)
 	$(mkdir) $(node_base_dir)$(slash)node

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -120,8 +120,20 @@ endif
 
 # put NPM in the path
 PATH:=$(node_dir)$(path_separator)$(PATH)
+OPENBSD_NPM_PATH=/usr/local/bin/npm
 
 $(npm):
+
+ifeq ($(GOOS),openbsd)
+# Node do not provide OpenBSD package. User must install from port/package beforehand.
+ifeq (,$(wildcard $(OPENBSD_NPM_PATH)))
+	@echo Install node with pkg_add before building UI
+	@exit 1
+endif
+	$(mkdir) $(node_base_dir)$(slash)node$(slash)bin
+	ln -s $(OPENBSD_NPM_PATH) $(node_base_dir)$(slash)node$(slash)bin
+
+else
 	@echo Downloading Node v$(NODE_VERSION) with NPM path $(npm)
 	$(mkdir) $(node_base_dir)$(slash)node
 
@@ -137,6 +149,7 @@ else
 	curl -LsS https://nodejs.org/dist/v$(NODE_VERSION)/node-v$(NODE_VERSION)-darwin-x64.tar.gz | tar zx -C $(node_base_dir)
 endif
 	mv $(node_base_dir)/node-v$(NODE_VERSION)*/* $(node_base_dir)/node
+endif
 endif
 
 # linter


### PR DESCRIPTION
Node official binary is not released for OpenBSD. User must install it manually from OpenBSD ports or from packages with `pkg_add node`. This patches `tools/tools.mk` to check this in case we run on OpenBSD.

This is the last diff to get a working `make install` on OpenBSD (CLI and embedded UI)

_kopia-ui_ application won't be available anytime soon as it is an Electron app.