### PR TITLE
ui: fixed Estimate not honoring the defined policies

### DIFF
--- a/internal/server/api_estimate.go
+++ b/internal/server/api_estimate.go
@@ -85,8 +85,8 @@ func (s *Server) handleEstimate(ctx context.Context, r *http.Request, body []byt
 		ctrl.OnCancel(cancel)
 
 		policyTree, err := policy.TreeForSource(ctx, s.rep, snapshot.SourceInfo{
-			Host:     s.options.ConnectOptions.Hostname,
-			UserName: s.options.ConnectOptions.Username,
+			Host:     s.rep.ClientOptions().Hostname,
+			UserName: s.rep.ClientOptions().Username,
 			Path:     resolvedRoot,
 		})
 		if err != nil {


### PR DESCRIPTION
Fixes #1001 

The username/hostname were read from the wrong option, and were always empty strings. Verified manually that policies can be found now.