### PR TITLE
Policy path validation

### DIFF
--- a/htmlui/src/BeginRestore.js
+++ b/htmlui/src/BeginRestore.js
@@ -4,7 +4,7 @@ import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import { Link } from "react-router-dom";
 import { handleChange, RequiredBoolean, RequiredField, validateRequiredFields } from './forms';
-import { GoBackButton } from './uiutil';
+import { errorAlert, GoBackButton } from './uiutil';
 
 export class BeginRestore extends Component {
     constructor(props) {
@@ -70,11 +70,7 @@ export class BeginRestore extends Component {
             })
             this.props.history.replace("/tasks/" + result.data.id);
         }).catch(error => {
-            if (error.response.data) {
-                alert(JSON.stringify(error.response.data));
-            } else {
-                alert('failed');
-            }
+            errorAlert(error);
         });
     }
 

--- a/htmlui/src/NewSnapshot.js
+++ b/htmlui/src/NewSnapshot.js
@@ -8,7 +8,7 @@ import Form from 'react-bootstrap/Form';
 import { handleChange, validateRequiredFields } from './forms';
 import { PolicyEditor } from './PolicyEditor';
 import { TaskDetails } from './TaskDetails';
-import { cancelTask, DirectorySelector, GoBackButton, redirectIfNotConnected } from './uiutil';
+import { cancelTask, DirectorySelector, errorAlert, GoBackButton, redirectIfNotConnected } from './uiutil';
 
 export class NewSnapshot extends Component {
     constructor() {
@@ -75,11 +75,7 @@ export class NewSnapshot extends Component {
                 didEstimate: false,
             })
         }).catch(error => {
-            if (error.response.data) {
-                alert(JSON.stringify(error.response.data));
-            } else {
-                alert('failed');
-            }
+            errorAlert(error);
         });
     }
 
@@ -102,10 +98,7 @@ export class NewSnapshot extends Component {
         }).then(result => {
             this.props.history.goBack();
         }).catch(error => {
-            if (error.response) {
-                alert('Error: ' + error.response.data.error + " (" + error.response.data.code + ")");
-                return
-            }
+            errorAlert(error);
 
             this.setState({
                 error,

--- a/htmlui/src/PolicyEditor.js
+++ b/htmlui/src/PolicyEditor.js
@@ -9,7 +9,7 @@ import Form from 'react-bootstrap/Form';
 import Tab from 'react-bootstrap/Tab';
 import Tabs from 'react-bootstrap/Tabs';
 import { handleChange, OptionalBoolean, OptionalNumberField, RequiredBoolean, stateProperty, StringList } from './forms';
-import { sourceQueryStringParams } from './uiutil';
+import { errorAlert, sourceQueryStringParams } from './uiutil';
 
 function policyTypeName(s) {
     if (!s.host && !s.userName) {
@@ -124,7 +124,7 @@ export class PolicyEditor extends Component {
         axios.put(this.snapshotURL(this.props), policy).then(result => {
             this.props.close();
         }).catch(error => {
-            alert('Error saving policy: ' + JSON.stringify(error));
+            errorAlert(error, 'Error saving policy');
         });
     }
 
@@ -133,7 +133,7 @@ export class PolicyEditor extends Component {
             axios.delete(this.snapshotURL(this.props)).then(result => {
                 this.props.close();
             }).catch(error => {
-                alert('Delete error: ' + error);
+                errorAlert(error, 'Error deleting policy');
             });
         }
     }

--- a/htmlui/src/SourcesTable.js
+++ b/htmlui/src/SourcesTable.js
@@ -12,7 +12,7 @@ import Spinner from 'react-bootstrap/Spinner';
 import { Link } from 'react-router-dom';
 import { handleChange } from './forms';
 import MyTable from './Table';
-import { compare, ownerName, redirectIfNotConnected, sizeDisplayName, sizeWithFailures, sourceQueryStringParams } from './uiutil';
+import { compare, errorAlert, ownerName, redirectIfNotConnected, sizeDisplayName, sizeWithFailures, sourceQueryStringParams } from './uiutil';
 
 const localSnapshots = "Local Snapshots"
 const allSnapshots = "All Snapshots"
@@ -77,7 +77,7 @@ export class SourcesTable extends Component {
         axios.post('/api/v1/repo/sync', {}).then(result => {
             this.fetchSourcesWithoutSpinner();
         }).catch(error => {
-            alert('failed');
+            errorAlert(error);
             this.setState({
                 error,
                 isLoading: false
@@ -138,7 +138,7 @@ export class SourcesTable extends Component {
         axios.post('/api/v1/sources/cancel?' + sourceQueryStringParams(source), {}).then(result => {
             this.fetchSourcesWithoutSpinner();
         }).catch(error => {
-            alert('failed');
+            errorAlert(error);
         });
     }
 
@@ -146,7 +146,7 @@ export class SourcesTable extends Component {
         axios.post('/api/v1/sources/upload?' + sourceQueryStringParams(source), {}).then(result => {
             this.fetchSourcesWithoutSpinner();
         }).catch(error => {
-            alert('failed');
+            errorAlert(error);
         });
     }
 

--- a/htmlui/src/uiutil.js
+++ b/htmlui/src/uiutil.js
@@ -210,6 +210,20 @@ export function isAbsolutePath(p) {
     return false;
 }
 
+export function errorAlert(err, prefix) {
+    if (!prefix) {
+        prefix = "Error"
+    }
+
+    prefix += ": ";
+    
+    if (err.response && err.response.data && err.response.data.error) {
+        alert(prefix + err.response.data.error);
+    } else {
+        alert(prefix + JSON.stringify(err));
+    }
+}
+
 export function DirectorySelector(props) {
     const selectSupported = !!window.require;
 

--- a/snapshot/policy/policy.go
+++ b/snapshot/policy/policy.go
@@ -3,7 +3,8 @@ package policy
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
+
+	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/snapshot"
 )
@@ -93,6 +94,15 @@ func MergePolicies(policies []*Policy) *Policy {
 // Currently, only SchedulingPolicy is validated.
 func ValidatePolicy(pol *Policy) error {
 	return ValidateSchedulingPolicy(pol.SchedulingPolicy)
+}
+
+// validatePolicyPath validates that the provided policy path is valid and the path exists.
+func validatePolicyPath(p string) error {
+	if isSlashOrBackslash(p[len(p)-1]) && !isRootPath(p) {
+		return errors.Errorf("path cannot end with a slash or a backslash")
+	}
+
+	return nil
 }
 
 func intPtr(n int) *int {

--- a/snapshot/policy/policy_manager.go
+++ b/snapshot/policy/policy_manager.go
@@ -133,6 +133,13 @@ func SetPolicy(ctx context.Context, rep repo.RepositoryWriter, si snapshot.Sourc
 		return errors.Wrap(err, "failed to validate policy")
 	}
 
+	if si.Path != "" {
+		// verify that path does not have trailing slash or backslash, etc.
+		if err := validatePolicyPath(si.Path); err != nil {
+			return errors.Wrap(err, "invalid policy path")
+		}
+	}
+
 	md, err := rep.FindManifests(ctx, labelsForSource(si))
 	if err != nil {
 		return errors.Wrapf(err, "unable to load manifests for %v", si)
@@ -348,6 +355,15 @@ func volumeAndPath(p string) (vol, path string) {
 
 func isSlashOrBackslash(c uint8) bool {
 	return c == '/' || c == '\\'
+}
+
+func isRootPath(p string) bool {
+	if isWindowsStylePath(p) {
+		_, justPath := volumeAndPath(p)
+		return justPath == "\\" || justPath == "/" || justPath == ""
+	}
+
+	return p == "/"
 }
 
 func isWindowsStylePath(p string) bool {

--- a/snapshot/policy/policy_manager_test.go
+++ b/snapshot/policy/policy_manager_test.go
@@ -411,3 +411,33 @@ func TestApplicablePoliciesForSource(t *testing.T) {
 		})
 	}
 }
+
+func TestPolicySetInvalidPath_Valid(t *testing.T) {
+	valid := []string{
+		"/",
+		"/home",
+		"c:\\",
+		"D:\\",
+		"D:\\foo",
+		"D:\\foo/bar\\baz",
+	}
+
+	for _, v := range valid {
+		require.NoError(t, validatePolicyPath(v), v)
+	}
+}
+
+func TestPolicySetInvalidPath_Invalid(t *testing.T) {
+	valid := []string{
+		"/home/",
+		"//",
+		"\\",
+		"c:\\users\\",
+		"c:/users/",
+		"c:\\users/",
+	}
+
+	for _, v := range valid {
+		require.Error(t, validatePolicyPath(v), v)
+	}
+}


### PR DESCRIPTION
Ensure we don't allow policies on paths with trailing slash or backslash (except root). 
Unified error alerts.

Fixes #1003
Related to #1004 