### PR TITLE
ui: do not attempt running maintenance if the current user is not the maintenance owner

### DIFF
--- a/repo/maintenance/maintenance_params.go
+++ b/repo/maintenance/maintenance_params.go
@@ -22,6 +22,10 @@ type Params struct {
 	FullCycle  CycleParams `json:"full"`
 }
 
+func (p *Params) isOwnedByByThisUser(rep repo.Repository) bool {
+	return p.Owner == rep.ClientOptions().UsernameAtHost()
+}
+
 // DefaultParams represents default values of maintenance parameters.
 func DefaultParams() Params {
 	return Params{
@@ -50,6 +54,16 @@ func HasParams(ctx context.Context, rep repo.Repository) (bool, error) {
 	}
 
 	return len(md) > 0, nil
+}
+
+// IsOwnedByThisUser determines whether current user is the maintenance owner.
+func IsOwnedByThisUser(ctx context.Context, rep repo.Repository) (bool, error) {
+	p, err := GetParams(ctx, rep)
+	if err != nil {
+		return false, errors.Wrap(err, "error getting maintenance params")
+	}
+
+	return p.isOwnedByByThisUser(rep), nil
 }
 
 // GetParams returns repository-wide maintenance parameters.

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -140,10 +140,8 @@ func RunExclusive(ctx context.Context, rep repo.DirectRepositoryWriter, mode Mod
 		return errors.Wrap(err, "unable to get maintenance params")
 	}
 
-	if !force {
-		if myUsername := rep.ClientOptions().UsernameAtHost(); p.Owner != myUsername {
-			return NotOwnedError{p.Owner}
-		}
+	if !force && !p.isOwnedByByThisUser(rep) {
+		return NotOwnedError{p.Owner}
 	}
 
 	if mode == ModeAuto {


### PR DESCRIPTION
This is to avoid producing useless errors in the `Tasks` tab

Reported at https://kopia.discourse.group/t/periodic-maintenance-failed-for-client/394

