### PR TITLE
Inodes

### DIFF
--- a/fs/entry.go
+++ b/fs/entry.go
@@ -78,6 +78,11 @@ type ErrorEntry interface {
 // ErrEntryNotFound is returned when an entry is not found.
 var ErrEntryNotFound = errors.New("entry not found")
 
+// HasInode is an optional interface implemented by Entry instances that can report their inode.
+type HasInode interface {
+	GetInode() uint64
+}
+
 // ReadDirAndFindChild reads all entries from a directory and returns one by name.
 // This is a convenience function that may be helpful in implementations of Directory.Child().
 func ReadDirAndFindChild(ctx context.Context, d Directory, name string) (Entry, error) {

--- a/fs/localfs/local_fs_nonwindows.go
+++ b/fs/localfs/local_fs_nonwindows.go
@@ -29,3 +29,15 @@ func platformSpecificDeviceInfo(fi os.FileInfo) fs.DeviceInfo {
 
 	return oi
 }
+
+func platformSpecificNewFileEntry(fi os.FileInfo, parentDir string) fs.Entry {
+	pstat, ok := fi.Sys().(*syscall.Stat_t)
+	if ok {
+		return &filesystemFilePosix{
+			filesystemFile: filesystemFile{newEntry(fi, parentDir)},
+			inode:          pstat.Ino,
+		}
+	}
+
+	return &filesystemFile{newEntry(fi, parentDir)}
+}

--- a/fs/localfs/local_fs_windows.go
+++ b/fs/localfs/local_fs_windows.go
@@ -13,3 +13,7 @@ func platformSpecificOwnerInfo(fi os.FileInfo) fs.OwnerInfo {
 func platformSpecificDeviceInfo(fi os.FileInfo) fs.DeviceInfo {
 	return fs.DeviceInfo{}
 }
+
+func platformSpecificNewFileEntry(fi os.FileInfo, parentDir string) fs.Entry {
+	return &filesystemFile{newEntry(fi, parentDir)}
+}

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -15,6 +15,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	golanglog "log"
+
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
@@ -756,6 +758,10 @@ func findCachedEntry(ctx context.Context, entry fs.Entry, prevEntries []fs.Entri
 		}
 	}
 
+	inode, ok := entry.(fs.HasInode)
+	if ok {
+		golanglog.Printf("\n\n **** iNode for %v is %v", entry.Name(), inode.GetInode())
+	}
 	log(ctx).Debugf("could not find cache entry for %v", entry.Name())
 
 	return nil


### PR DESCRIPTION
NOT FOR COMMIT.

Here is the basic sketch of how I think you wanted inode info added to fs.Entry. As I've never written any production go code I needed plenty of Rob's help to put this tiny patch together and I wanted to make sure it was more or less what you were thinking before I got too far along.

We can debate whether or not the same thing should be done for the other types of local_fs entries (directories, symlinks). If directories are handled properly they could be a big win; symlinks I see no value to this change as it won't make anything materially faster for anyone.

As for building the cache in memory, let's debate that after I have a first cut of it. I'd really rather the cache was an index on the `prevEntries []fs.Entries` list that gets passed to `findCachedEntry` so that I could have this work the same way the existing metadata caching works. Would you rather debate that here in the PR or on the thread in the forum?

Thanks
osric