### PR TITLE
Benchmark: Remove superfluous = in printout

### DIFF
--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -88,7 +88,7 @@ func runBenchmarkCryptoAction(ctx context.Context) error {
 	}
 
 	printStdout("-----------------------------------------------------------------\n")
-	printStdout("Fastest option for this machine is: --block-hash==%s --encryption=%s\n", results[0].hash, results[0].encryption)
+	printStdout("Fastest option for this machine is: --block-hash=%s --encryption=%s\n", results[0].hash, results[0].encryption)
 
 	return nil
 }


### PR DESCRIPTION
This PR removes a '=' in the output message when running a benchmark. 
Example without this patch:
```shell
Fastest option for this machine is: --block-hash==BLAKE3-256-128 --encryption=CHACHA20-POLY1305-HMAC-SHA256
```
With the patch, you can copy the output directly and append it to create a new repository:
```shell
kopia repository create filesystem --path /tmp/kopia --block-hash=BLAKE3-256-128 --encryption=CHACHA20-POLY1305-HMAC-SHA256
```