### PR TITLE
cli: optimized 'kopia index recover' by leveraging partial read and parallelism

### DIFF
--- a/cli/command_index_recover.go
+++ b/cli/command_index_recover.go
@@ -2,24 +2,36 @@ package cli
 
 import (
 	"context"
+	"sync/atomic"
+	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 
+	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
 )
 
 type commandIndexRecover struct {
-	blobIDs []string
-	commit  bool
+	blobIDs       []string
+	blobPrefixes  []string
+	commit        bool
+	ignoreErrors  bool
+	parallel      int
+	deleteIndexes bool
 
 	svc appServices
 }
 
 func (c *commandIndexRecover) setup(svc appServices, parent commandParent) {
 	cmd := parent.Command("recover", "Recover indexes from pack blobs")
+	cmd.Flag("blob-prefixes", "Prefixes of pack blobs to recover from (default=all packs)").StringsVar(&c.blobPrefixes)
 	cmd.Flag("blobs", "Names of pack blobs to recover from (default=all packs)").StringsVar(&c.blobIDs)
+	cmd.Flag("parallel", "Recover parallelism").Default("1").IntVar(&c.parallel)
+	cmd.Flag("ignore-errors", "Ignore errors when recovering").BoolVar(&c.ignoreErrors)
+	cmd.Flag("delete-indexes", "Delete all indexes before recovering").BoolVar(&c.deleteIndexes)
 	cmd.Flag("commit", "Commit recovered content").BoolVar(&c.commit)
 	cmd.Action(svc.directRepositoryWriteAction(c.run))
 
@@ -29,47 +41,160 @@ func (c *commandIndexRecover) setup(svc appServices, parent commandParent) {
 func (c *commandIndexRecover) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
 	c.svc.advancedCommand(ctx)
 
-	var totalCount int
+	processedBlobCount := new(int32)
+	recoveredContentCount := new(int32)
 
 	defer func() {
-		if totalCount == 0 {
-			log(ctx).Infof("No blocks recovered.")
+		if *recoveredContentCount == 0 {
+			log(ctx).Infof("No contents recovered.")
 			return
 		}
 
 		if !c.commit {
-			log(ctx).Infof("Found %v blocks to recover, but not committed. Re-run with --commit", totalCount)
+			log(ctx).Infof("Found %v contents to recover from %v blobs, but not committed. Re-run with --commit", *recoveredContentCount, *processedBlobCount)
 		} else {
-			log(ctx).Infof("Recovered %v blocks.", totalCount)
+			log(ctx).Infof("Recovered %v contents from %v.", *recoveredContentCount, *processedBlobCount)
 		}
 	}()
 
-	if len(c.blobIDs) == 0 {
-		for _, prefix := range content.PackBlobIDPrefixes {
-			err := rep.BlobStorage().ListBlobs(ctx, prefix, func(bm blob.Metadata) error {
-				c.recoverIndexFromSinglePackFile(ctx, rep, bm.BlobID, bm.Length, &totalCount)
-				return nil
-			})
-			if err != nil {
-				return errors.Wrapf(err, "recovering indexes from prefix %q", prefix)
+	if c.deleteIndexes {
+		if err := rep.BlobReader().ListBlobs(ctx, content.IndexBlobPrefix, func(bm blob.Metadata) error {
+			if c.commit {
+				log(ctx).Infof("deleting old index blob: %v", bm.BlobID)
+				return errors.Wrap(rep.BlobStorage().DeleteBlob(ctx, bm.BlobID), "error deleting index blob")
 			}
+
+			log(ctx).Infof("would delete old index: %v (pass --commit to approve)", bm.BlobID)
+			return nil
+		}); err != nil {
+			return errors.Wrap(err, "error deleting old indexes")
 		}
 	}
 
+	if len(c.blobIDs) == 0 {
+		var prefixes []blob.ID
+
+		if len(c.blobPrefixes) > 0 {
+			for _, p := range c.blobPrefixes {
+				prefixes = append(prefixes, blob.ID(p))
+			}
+		} else {
+			prefixes = content.PackBlobIDPrefixes
+		}
+
+		return c.recoverIndexesFromAllPacks(ctx, rep, prefixes, processedBlobCount, recoveredContentCount)
+	}
+
 	for _, packFile := range c.blobIDs {
-		c.recoverIndexFromSinglePackFile(ctx, rep, blob.ID(packFile), 0, &totalCount)
+		if err := c.recoverIndexFromSinglePackFile(ctx, rep, blob.ID(packFile), 0, processedBlobCount, recoveredContentCount); err != nil && !c.ignoreErrors {
+			return errors.Wrapf(err, "error recovering index from %v", packFile)
+		}
 	}
 
 	return nil
 }
 
-func (c *commandIndexRecover) recoverIndexFromSinglePackFile(ctx context.Context, rep repo.DirectRepositoryWriter, blobID blob.ID, length int64, totalCount *int) {
-	recovered, err := rep.ContentManager().RecoverIndexFromPackBlob(ctx, blobID, length, c.commit)
-	if err != nil {
-		log(ctx).Errorf("unable to recover index from %v: %v", blobID, err)
-		return
+func (c *commandIndexRecover) recoverIndexesFromAllPacks(ctx context.Context, rep repo.DirectRepositoryWriter, prefixes []blob.ID, processedBlobCount, recoveredContentCount *int32) error {
+	discoveredBlobCount := new(int32)
+	discoveringBlobCount := new(int32)
+	tt := new(timetrack.Throttle)
+
+	// recover indexes from all pack blobs in parallel.
+	// this is actually quite fast since we typically need to read only 8KB from each blob.
+	eg, ctx := errgroup.WithContext(ctx)
+
+	go func() {
+		for _, prefix := range prefixes {
+			// nolint:errcheck
+			rep.BlobStorage().ListBlobs(ctx, prefix, func(bm blob.Metadata) error {
+				atomic.AddInt32(discoveringBlobCount, 1)
+				return nil
+			})
+		}
+
+		atomic.StoreInt32(discoveredBlobCount, atomic.LoadInt32(discoveringBlobCount))
+	}()
+
+	est := timetrack.Start()
+
+	blobCh := make(chan blob.Metadata)
+
+	// goroutine to populate blob metadata into a channel.
+	eg.Go(func() error {
+		defer close(blobCh)
+
+		for _, prefix := range prefixes {
+			if err := rep.BlobStorage().ListBlobs(ctx, prefix, func(bm blob.Metadata) error {
+				blobCh <- bm
+				return nil
+			}); err != nil {
+				return errors.Wrapf(err, "error listing blobs with prefix %q", prefix)
+			}
+		}
+
+		return nil
+	})
+
+	// N goroutines to recover from incoming blobs.
+	for i := 0; i < c.parallel; i++ {
+		worker := i
+
+		eg.Go(func() error {
+			cnt := 0
+
+			for bm := range blobCh {
+				finishedBlobs := atomic.LoadInt32(processedBlobCount)
+
+				log(ctx).Debugf("worker %v got %v", worker, cnt)
+				cnt++
+
+				if tt.ShouldOutput(time.Second) {
+					if disc := atomic.LoadInt32(discoveredBlobCount); disc > 0 {
+						e, ok := est.Estimate(float64(finishedBlobs), float64(disc))
+						if ok {
+							log(ctx).Infof("Recovered %v index entries from %v/%v blobs (%.1f %%) %v remaining %v ETA",
+								atomic.LoadInt32(recoveredContentCount),
+								finishedBlobs,
+								disc,
+								e.PercentComplete,
+								e.Remaining,
+								formatTimestamp(e.EstimatedEndTime))
+						}
+					} else {
+						log(ctx).Infof("Recovered %v index entries from %v blobs, estimating time remaining... (found %v blobs)",
+							atomic.LoadInt32(recoveredContentCount),
+							finishedBlobs,
+							atomic.LoadInt32(discoveringBlobCount))
+					}
+				}
+
+				if err := c.recoverIndexFromSinglePackFile(ctx, rep, bm.BlobID, bm.Length, processedBlobCount, recoveredContentCount); err != nil {
+					return errors.Wrapf(err, "error recovering from %v", bm.BlobID)
+				}
+			}
+
+			return nil
+		})
 	}
 
-	*totalCount += len(recovered)
-	log(ctx).Infof("Recovered %v entries from %v (commit=%v)", len(recovered), blobID, c.commit)
+	return errors.Wrap(eg.Wait(), "recovering indexes")
+}
+
+func (c *commandIndexRecover) recoverIndexFromSinglePackFile(ctx context.Context, rep repo.DirectRepositoryWriter, blobID blob.ID, length int64, processedBlobCount, recoveredContentCount *int32) error {
+	log(ctx).Debugf("recovering from %v", blobID)
+
+	recovered, err := rep.ContentManager().RecoverIndexFromPackBlob(ctx, blobID, length, c.commit)
+	if err != nil {
+		if c.ignoreErrors {
+			return nil
+		}
+
+		return errors.Wrapf(err, "unable to recover index from %v", blobID)
+	}
+
+	atomic.AddInt32(recoveredContentCount, int32(len(recovered)))
+	atomic.AddInt32(processedBlobCount, 1)
+	log(ctx).Debugf("Recovered %v entries from %v (commit=%v)", len(recovered), blobID, c.commit)
+
+	return nil
 }

--- a/repo/content/content_index_recovery.go
+++ b/repo/content/content_index_recovery.go
@@ -28,6 +28,9 @@ func (bm *WriteManager) RecoverIndexFromPackBlob(ctx context.Context, packFile b
 
 	var recovered []Info
 
+	bm.lock()
+	defer bm.unlock()
+
 	err = ndx.Iterate(AllIDs, func(i Info) error {
 		recovered = append(recovered, i)
 		if commit {

--- a/repo/content/content_index_recovery_test.go
+++ b/repo/content/content_index_recovery_test.go
@@ -24,7 +24,7 @@ func TestContentIndexRecovery(t *testing.T) {
 	}
 
 	// delete all index blobs
-	assertNoError(t, bm.st.ListBlobs(ctx, indexBlobPrefix, func(bi blob.Metadata) error {
+	assertNoError(t, bm.st.ListBlobs(ctx, IndexBlobPrefix, func(bi blob.Metadata) error {
 		log(ctx).Debugf("deleting %v", bi.BlobID)
 		return bm.st.DeleteBlob(ctx, bi.BlobID)
 	}))

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -48,10 +48,12 @@ var PackBlobIDPrefixes = []blob.ID{
 	PackBlobIDPrefixSpecial,
 }
 
+// IndexBlobPrefix is the prefix for all index blobs.
+const IndexBlobPrefix = "n"
+
 const (
 	parallelFetches          = 5                // number of parallel reads goroutines
 	flushPackIndexTimeout    = 10 * time.Minute // time after which all pending indexes are flushes
-	indexBlobPrefix          = "n"
 	defaultMinPreambleLength = 32
 	defaultMaxPreambleLength = 32
 	defaultPaddingUnit       = 4096

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -491,7 +491,7 @@ func validateIndexCount(t *testing.T, data map[blob.ID][]byte, wantIndexCount, w
 	var indexCnt, compactionLogCnt int
 
 	for blobID := range data {
-		if strings.HasPrefix(string(blobID), indexBlobPrefix) {
+		if strings.HasPrefix(string(blobID), IndexBlobPrefix) {
 			indexCnt++
 		}
 
@@ -1119,14 +1119,14 @@ func TestFlushWaitsForAllPendingWriters(t *testing.T) {
 
 	verifyBlobCount(t, data, map[blob.ID]int{
 		PackBlobIDPrefixRegular: 2,
-		indexBlobPrefix:         1,
+		IndexBlobPrefix:         1,
 	})
 
 	bm.Flush(ctx)
 
 	verifyBlobCount(t, data, map[blob.ID]int{
 		PackBlobIDPrefixRegular: 2,
-		indexBlobPrefix:         1,
+		IndexBlobPrefix:         1,
 	})
 }
 

--- a/repo/content/index_blob_manager.go
+++ b/repo/content/index_blob_manager.go
@@ -92,7 +92,7 @@ func (m *indexBlobManagerImpl) listIndexBlobs(ctx context.Context, includeInacti
 	})
 
 	eg.Go(func() error {
-		v, err := m.listAndMergeOwnWrites(ctx, indexBlobPrefix)
+		v, err := m.listAndMergeOwnWrites(ctx, IndexBlobPrefix)
 		storageIndexBlobs = v
 		return err
 	})
@@ -133,7 +133,7 @@ func (m *indexBlobManagerImpl) listIndexBlobs(ctx context.Context, includeInacti
 }
 
 func (m *indexBlobManagerImpl) flushCache() {
-	m.listCache.deleteListCache(indexBlobPrefix)
+	m.listCache.deleteListCache(IndexBlobPrefix)
 	m.listCache.deleteListCache(compactionLogBlobPrefix)
 }
 
@@ -182,7 +182,7 @@ func (m *indexBlobManagerImpl) getEncryptedBlob(ctx context.Context, blobID blob
 }
 
 func (m *indexBlobManagerImpl) writeIndexBlob(ctx context.Context, data []byte, sessionID SessionID) (blob.Metadata, error) {
-	return m.encryptAndWriteBlob(ctx, data, indexBlobPrefix, sessionID)
+	return m.encryptAndWriteBlob(ctx, data, IndexBlobPrefix, sessionID)
 }
 
 func (m *indexBlobManagerImpl) encryptAndWriteBlob(ctx context.Context, data []byte, prefix blob.ID, sessionID SessionID) (blob.Metadata, error) {

--- a/repo/content/index_blob_manager_test.go
+++ b/repo/content/index_blob_manager_test.go
@@ -681,7 +681,7 @@ func getAllFakeContentsInternal(ctx context.Context, m indexBlobManager) (map[st
 func assertBlobCounts(t *testing.T, data blobtesting.DataMap, wantN, wantM, wantL int) {
 	t.Helper()
 	require.Len(t, keysWithPrefix(data, compactionLogBlobPrefix), wantM)
-	require.Len(t, keysWithPrefix(data, indexBlobPrefix), wantN)
+	require.Len(t, keysWithPrefix(data, IndexBlobPrefix), wantN)
 	require.Len(t, keysWithPrefix(data, "l"), wantL)
 }
 


### PR DESCRIPTION
We used this while investigating and recovering repository for #1087