### PR TITLE
Add context to robustness store interface

### DIFF
--- a/tests/robustness/engine/engine.go
+++ b/tests/robustness/engine/engine.go
@@ -134,17 +134,17 @@ func (e *Engine) Shutdown(ctx context.Context) error {
 	defer e.cleanComponents()
 
 	if e.MetaStore != nil {
-		err := e.saveLog()
+		err := e.saveLog(ctx)
 		if err != nil {
 			return err
 		}
 
-		err = e.saveStats()
+		err = e.saveStats(ctx)
 		if err != nil {
 			return err
 		}
 
-		err = e.saveSnapIDIndex()
+		err = e.saveSnapIDIndex(ctx)
 		if err != nil {
 			return err
 		}
@@ -193,19 +193,19 @@ func (e *Engine) Init(ctx context.Context) error {
 		return err
 	}
 
-	err = e.loadStats()
+	err = e.loadStats(ctx)
 	if err != nil {
 		return err
 	}
 
 	e.CumulativeStats.RunCounter++
 
-	err = e.loadLog()
+	err = e.loadLog(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = e.loadSnapIDIndex()
+	err = e.loadSnapIDIndex(ctx)
 	if err != nil {
 		return err
 	}

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -298,7 +298,7 @@ func TestSnapshotVerificationFail(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get the metadata collected on that snapshot
-	ssMeta1, err := eng.Checker.GetSnapshotMetadata(snapID1)
+	ssMeta1, err := eng.Checker.GetSnapshotMetadata(ctx, snapID1)
 	require.NoError(t, err)
 
 	// Do additional writes, writing 1 extra byte than before
@@ -310,7 +310,7 @@ func TestSnapshotVerificationFail(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get the second snapshot's metadata
-	ssMeta2, err := eng.Checker.GetSnapshotMetadata(snapID2)
+	ssMeta2, err := eng.Checker.GetSnapshotMetadata(ctx, snapID2)
 	require.NoError(t, err)
 
 	// Swap second snapshot's validation data into the first's metadata
@@ -369,11 +369,11 @@ func TestDataPersistency(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get the walk data associated with the snapshot that was taken
-	dataDirWalk, err := eng.Checker.GetSnapshotMetadata(snapID)
+	dataDirWalk, err := eng.Checker.GetSnapshotMetadata(ctx, snapID)
 	require.NoError(t, err)
 
 	// Save the snapshot ID index
-	err = eng.saveSnapIDIndex()
+	err = eng.saveSnapIDIndex(ctx)
 	require.NoError(t, err)
 
 	// Flush the snapshot metadata to persistent storage
@@ -693,6 +693,8 @@ func TestIOLimitPerWriteAction(t *testing.T) {
 }
 
 func TestStatsPersist(t *testing.T) {
+	ctx := context.Background()
+
 	tmpDir, err := ioutil.TempDir("", "stats-persist-test")
 	require.NoError(t, err)
 
@@ -729,7 +731,7 @@ func TestStatsPersist(t *testing.T) {
 		},
 	}
 
-	err = eng.saveStats()
+	err = eng.saveStats(ctx)
 	require.NoError(t, err)
 
 	err = eng.MetaStore.FlushMetadata()
@@ -749,7 +751,7 @@ func TestStatsPersist(t *testing.T) {
 		MetaStore: snapStoreNew,
 	}
 
-	err = engNew.loadStats()
+	err = engNew.loadStats(ctx)
 	require.NoError(t, err)
 
 	if got, want := engNew.Stats(), eng.Stats(); got != want {
@@ -761,6 +763,8 @@ func TestStatsPersist(t *testing.T) {
 }
 
 func TestLogsPersist(t *testing.T) {
+	ctx := context.Background()
+
 	tmpDir, err := ioutil.TempDir("", "logs-persist-test")
 	require.NoError(t, err)
 
@@ -799,7 +803,7 @@ func TestLogsPersist(t *testing.T) {
 		EngineLog: logData,
 	}
 
-	err = eng.saveLog()
+	err = eng.saveLog(ctx)
 	require.NoError(t, err)
 
 	err = eng.MetaStore.FlushMetadata()
@@ -819,7 +823,7 @@ func TestLogsPersist(t *testing.T) {
 		MetaStore: snapStoreNew,
 	}
 
-	err = engNew.loadLog()
+	err = engNew.loadLog(ctx)
 	require.NoError(t, err)
 
 	if got, want := engNew.EngineLog.String(), eng.EngineLog.String(); got != want {

--- a/tests/robustness/engine/metadata.go
+++ b/tests/robustness/engine/metadata.go
@@ -3,6 +3,7 @@
 package engine
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 
@@ -17,18 +18,18 @@ const (
 )
 
 // saveLog saves the engine Log in the metadata store.
-func (e *Engine) saveLog() error {
+func (e *Engine) saveLog(ctx context.Context) error {
 	b, err := json.Marshal(e.EngineLog)
 	if err != nil {
 		return err
 	}
 
-	return e.MetaStore.Store(engineLogsStoreKey, b)
+	return e.MetaStore.Store(ctx, engineLogsStoreKey, b)
 }
 
 // loadLog loads the engine log from the metadata store.
-func (e *Engine) loadLog() error {
-	b, err := e.MetaStore.Load(engineLogsStoreKey)
+func (e *Engine) loadLog(ctx context.Context) error {
+	b, err := e.MetaStore.Load(ctx, engineLogsStoreKey)
 	if err != nil {
 		if errors.Is(err, robustness.ErrKeyNotFound) {
 			// Swallow key-not-found error. May not have historical logs
@@ -49,18 +50,18 @@ func (e *Engine) loadLog() error {
 }
 
 // saveStats saves the engine Stats in the metadata store.
-func (e *Engine) saveStats() error {
+func (e *Engine) saveStats(ctx context.Context) error {
 	cumulStatRaw, err := json.Marshal(e.CumulativeStats)
 	if err != nil {
 		return err
 	}
 
-	return e.MetaStore.Store(engineStatsStoreKey, cumulStatRaw)
+	return e.MetaStore.Store(ctx, engineStatsStoreKey, cumulStatRaw)
 }
 
 // loadStats loads the engine Stats from the metadata store.
-func (e *Engine) loadStats() error {
-	b, err := e.MetaStore.Load(engineStatsStoreKey)
+func (e *Engine) loadStats(ctx context.Context) error {
+	b, err := e.MetaStore.Load(ctx, engineStatsStoreKey)
 	if err != nil {
 		if errors.Is(err, robustness.ErrKeyNotFound) {
 			// Swallow key-not-found error. We may not have historical
@@ -78,18 +79,18 @@ func (e *Engine) loadStats() error {
 }
 
 // saveSnapIDIndex saves the Checker's snapshot ID index in the metadata store.
-func (e *Engine) saveSnapIDIndex() error {
+func (e *Engine) saveSnapIDIndex(ctx context.Context) error {
 	snapIDIdxRaw, err := json.Marshal(e.Checker.SnapIDIndex)
 	if err != nil {
 		return err
 	}
 
-	return e.MetaStore.Store(snapIDIndexStoreKey, snapIDIdxRaw)
+	return e.MetaStore.Store(ctx, snapIDIndexStoreKey, snapIDIdxRaw)
 }
 
 // loadSnapIDIndex loads the Checker's snapshot ID index from the metadata store.
-func (e *Engine) loadSnapIDIndex() error {
-	b, err := e.MetaStore.Load(snapIDIndexStoreKey)
+func (e *Engine) loadSnapIDIndex(ctx context.Context) error {
+	b, err := e.MetaStore.Load(ctx, snapIDIndexStoreKey)
 	if err != nil {
 		if errors.Is(err, robustness.ErrKeyNotFound) {
 			// Swallow key-not-found error. We may not have historical

--- a/tests/robustness/multiclient_test/framework/harness.go
+++ b/tests/robustness/multiclient_test/framework/harness.go
@@ -44,7 +44,7 @@ type TestHarness struct {
 	baseDirPath string
 	fileWriter  *MultiClientFileWriter
 	snapshotter *MultiClientSnapshotter
-	persister   *snapmeta.KopiaPersister
+	persister   *snapmeta.KopiaPersisterLight
 	engine      *engine.Engine
 
 	skipTest bool
@@ -149,16 +149,9 @@ func (th *TestHarness) getSnapshotter() bool {
 }
 
 func (th *TestHarness) getPersister() bool {
-	kp, err := snapmeta.NewPersister(th.baseDirPath)
+	kp, err := snapmeta.NewPersisterLight(th.baseDirPath)
 	if err != nil {
-		if errors.Is(err, kopiarunner.ErrExeVariableNotSet) {
-			log.Println("Skipping robustness tests because KOPIA_EXE is not set")
-
-			th.skipTest = true
-		} else {
-			log.Println("Error creating kopia Persister:", err)
-		}
-
+		log.Println("Error creating kopia Persister:", err)
 		return false
 	}
 

--- a/tests/robustness/multiclient_test/multiclient_test.go
+++ b/tests/robustness/multiclient_test/multiclient_test.go
@@ -44,10 +44,10 @@ func TestManySmallFiles(t *testing.T) {
 		_, err = eng.ExecAction(ctx, engine.WriteRandomFilesActionKey, fileWriteOpts)
 		require.NoError(t, err)
 
-		_, err = eng.ExecAction(ctx, engine.SnapshotDirActionKey, nil)
+		snapOut, err := eng.ExecAction(ctx, engine.SnapshotDirActionKey, nil)
 		assertNoError(t, err)
 
-		_, err = eng.ExecAction(ctx, engine.RestoreSnapshotActionKey, nil)
+		_, err = eng.ExecAction(ctx, engine.RestoreSnapshotActionKey, snapOut)
 		assertNoError(t, err)
 	}
 
@@ -122,7 +122,7 @@ func TestManySmallFilesAcrossDirecoryTree(t *testing.T) {
 }
 
 func TestRandomizedSmall(t *testing.T) {
-	numClients := 2
+	numClients := 4
 	st := clock.Now()
 
 	opts := engine.ActionOpts{

--- a/tests/robustness/multiclient_test/multiclient_test.go
+++ b/tests/robustness/multiclient_test/multiclient_test.go
@@ -45,10 +45,10 @@ func TestManySmallFiles(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = eng.ExecAction(ctx, engine.SnapshotDirActionKey, nil)
-		require.NoError(t, err)
+		assertNoError(t, err)
 
 		_, err = eng.ExecAction(ctx, engine.RestoreSnapshotActionKey, nil)
-		require.NoError(t, err)
+		assertNoError(t, err)
 	}
 
 	ctx := testlogging.Context(t)
@@ -175,4 +175,12 @@ func tryRandomAction(ctx context.Context, t *testing.T, opts engine.ActionOpts) 
 	}
 
 	return err
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Errorf("err: %v", err)
+	}
 }

--- a/tests/robustness/persister.go
+++ b/tests/robustness/persister.go
@@ -2,12 +2,14 @@
 
 package robustness
 
+import "context"
+
 // Store describes the ability to store and retrieve
 // a buffer of metadata, indexed by a string key.
 type Store interface {
-	Store(key string, val []byte) error
-	Load(key string) ([]byte, error)
-	Delete(key string)
+	Store(ctx context.Context, key string, val []byte) error
+	Load(ctx context.Context, key string) ([]byte, error)
+	Delete(ctx context.Context, key string)
 }
 
 // Persister describes the ability to flush metadata

--- a/tests/robustness/robustness_test/main_test.go
+++ b/tests/robustness/robustness_test/main_test.go
@@ -73,7 +73,7 @@ type kopiaRobustnessTestHarness struct {
 	baseDirPath string
 	fileWriter  *fiofilewriter.FileWriter
 	snapshotter *snapmeta.KopiaSnapshotter
-	persister   *snapmeta.KopiaPersister
+	persister   *snapmeta.KopiaPersisterLight
 	engine      *engine.Engine
 
 	skipTest bool
@@ -154,16 +154,9 @@ func (th *kopiaRobustnessTestHarness) getSnapshotter() bool {
 }
 
 func (th *kopiaRobustnessTestHarness) getPersister() bool {
-	kp, err := snapmeta.NewPersister(th.baseDirPath)
+	kp, err := snapmeta.NewPersisterLight(th.baseDirPath)
 	if err != nil {
-		if errors.Is(err, kopiarunner.ErrExeVariableNotSet) {
-			log.Println("Skipping robustness tests because KOPIA_EXE is not set")
-
-			th.skipTest = true
-		} else {
-			log.Println("Error creating kopia Persister:", err)
-		}
-
+		log.Println("Error creating kopia Persister:", err)
 		return false
 	}
 

--- a/tests/robustness/snapmeta/kopia_persister_light.go
+++ b/tests/robustness/snapmeta/kopia_persister_light.go
@@ -52,7 +52,7 @@ func (kpl *KopiaPersisterLight) ConnectOrCreateRepo(repoPath string) error {
 }
 
 // Store pushes the key value pair to the Kopia repository.
-func (kpl *KopiaPersisterLight) Store(key string, val []byte) error {
+func (kpl *KopiaPersisterLight) Store(ctx context.Context, key string, val []byte) error {
 	kpl.waitFor(key)
 	defer kpl.doneWith(key)
 
@@ -70,11 +70,11 @@ func (kpl *KopiaPersisterLight) Store(key string, val []byte) error {
 
 	log.Println("pushing metadata for", key)
 
-	return kpl.kc.SnapshotCreate(context.Background(), dirPath)
+	return kpl.kc.SnapshotCreate(ctx, dirPath)
 }
 
 // Load pulls the key value pair from the Kopia repo and returns the value.
-func (kpl *KopiaPersisterLight) Load(key string) ([]byte, error) {
+func (kpl *KopiaPersisterLight) Load(ctx context.Context, key string) ([]byte, error) {
 	kpl.waitFor(key)
 	defer kpl.doneWith(key)
 
@@ -82,7 +82,7 @@ func (kpl *KopiaPersisterLight) Load(key string) ([]byte, error) {
 
 	log.Println("pulling metadata for", key)
 
-	if err := kpl.kc.SnapshotRestore(context.Background(), dirPath); err != nil {
+	if err := kpl.kc.SnapshotRestore(ctx, dirPath); err != nil {
 		return nil, err
 	}
 
@@ -92,14 +92,14 @@ func (kpl *KopiaPersisterLight) Load(key string) ([]byte, error) {
 }
 
 // Delete deletes all snapshots associated with the given key.
-func (kpl *KopiaPersisterLight) Delete(key string) {
+func (kpl *KopiaPersisterLight) Delete(ctx context.Context, key string) {
 	kpl.waitFor(key)
 	defer kpl.doneWith(key)
 
 	log.Println("deleting metadata for", key)
 
 	dirPath, _ := kpl.getPathsFromKey(key)
-	if err := kpl.kc.SnapshotDelete(context.Background(), dirPath); err != nil {
+	if err := kpl.kc.SnapshotDelete(ctx, dirPath); err != nil {
 		log.Printf("cannot delete metadata for %s, err: %s", key, err)
 	}
 }

--- a/tests/robustness/snapmeta/kopia_persister_light.go
+++ b/tests/robustness/snapmeta/kopia_persister_light.go
@@ -1,0 +1,157 @@
+// +build darwin,amd64 linux,amd64
+
+package snapmeta
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/kopia/kopia/tests/robustness"
+	"github.com/kopia/kopia/tests/tools/kopiaclient"
+)
+
+// KopiaPersisterLight is a wrapper for KopiaClient that satisfies the Persister
+// interface.
+type KopiaPersisterLight struct {
+	kc            *kopiaclient.KopiaClient
+	keysInProcess map[string]bool
+	c             *sync.Cond
+	baseDir       string
+}
+
+type kmu struct {
+	mu sync.Mutex
+}
+
+var _ robustness.Persister = (*KopiaPersisterLight)(nil)
+
+const fileName = "data"
+
+// NewPersisterLight returns a new KopiaPersisterLight.
+func NewPersisterLight(baseDir string) (*KopiaPersisterLight, error) {
+	persistenceDir, err := os.MkdirTemp(baseDir, "kopia-persistence-root-")
+	if err != nil {
+		return nil, err
+	}
+
+	return &KopiaPersisterLight{
+		kc:            kopiaclient.NewKopiaClient(persistenceDir),
+		keysInProcess: map[string]bool{},
+		c:             sync.NewCond(&sync.Mutex{}),
+		baseDir:       persistenceDir,
+	}, nil
+}
+
+// ConnectOrCreateRepo creates a new Kopia repo or connects to an existing one if possible.
+func (kpl *KopiaPersisterLight) ConnectOrCreateRepo(repoPath string) error {
+	bucketName := os.Getenv(S3BucketNameEnvKey)
+	return kpl.kc.CreateOrConnectRepo(context.Background(), repoPath, bucketName)
+}
+
+// Store pushes the key value pair to the Kopia repository.
+func (kpl *KopiaPersisterLight) Store(key string, val []byte) error {
+	kpl.waitFor(key)
+	defer kpl.doneWith(key)
+
+	dirPath, filePath := kpl.getPathsFromKey(key)
+
+	if err := os.Mkdir(dirPath, 0o700); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filePath, val, 0o700); err != nil {
+		return err
+	}
+
+	defer kpl.removeOrLog(dirPath)
+
+	log.Println("pushing metadata for", key)
+
+	return kpl.kc.SnapshotCreate(context.Background(), dirPath)
+}
+
+// Load pulls the key value pair from the Kopia repo and returns the value.
+func (kpl *KopiaPersisterLight) Load(key string) ([]byte, error) {
+	kpl.waitFor(key)
+	defer kpl.doneWith(key)
+
+	dirPath, filePath := kpl.getPathsFromKey(key)
+
+	log.Println("pulling metadata for", key)
+
+	if err := kpl.kc.SnapshotRestore(context.Background(), dirPath); err != nil {
+		return nil, err
+	}
+
+	defer kpl.removeOrLog(dirPath)
+
+	return os.ReadFile(filePath)
+}
+
+// Delete deletes all snapshots associated with the given key.
+func (kpl *KopiaPersisterLight) Delete(key string) {
+	kpl.waitFor(key)
+	defer kpl.doneWith(key)
+
+	log.Println("deleting metadata for", key)
+
+	dirPath, _ := kpl.getPathsFromKey(key)
+	if err := kpl.kc.SnapshotDelete(context.Background(), dirPath); err != nil {
+		log.Printf("cannot delete metadata for %s, err: %s", key, err)
+	}
+}
+
+// LoadMetadata is a no-op. It is included to satisfy the Persister interface.
+func (kpl *KopiaPersisterLight) LoadMetadata() error {
+	return nil
+}
+
+// FlushMetadata is a no-op. It is included to satisfy the Persister interface.
+func (kpl *KopiaPersisterLight) FlushMetadata() error {
+	return nil
+}
+
+// GetPersistDir returns the persistence directory.
+func (kpl *KopiaPersisterLight) GetPersistDir() string {
+	return kpl.baseDir
+}
+
+// Cleanup removes the persistence directory and closes the Kopia repo.
+func (kpl *KopiaPersisterLight) Cleanup() {
+	if err := os.RemoveAll(kpl.baseDir); err != nil {
+		log.Println("cannot remove persistence dir")
+	}
+}
+
+func (kpl *KopiaPersisterLight) getPathsFromKey(key string) (dirPath, filePath string) {
+	dirPath = filepath.Join(kpl.baseDir, key)
+	filePath = filepath.Join(dirPath, fileName)
+
+	return dirPath, filePath
+}
+
+func (kpl *KopiaPersisterLight) removeOrLog(path string) {
+	if err := os.RemoveAll(path); err != nil {
+		log.Println("cannot remove path ", path)
+	}
+}
+
+func (kpl *KopiaPersisterLight) waitFor(key string) {
+	kpl.c.L.Lock()
+	for kpl.keysInProcess[key] {
+		kpl.c.Wait()
+	}
+
+	kpl.keysInProcess[key] = true
+	kpl.c.L.Unlock()
+}
+
+func (kpl *KopiaPersisterLight) doneWith(key string) {
+	kpl.c.L.Lock()
+	delete(kpl.keysInProcess, key)
+	kpl.c.L.Unlock()
+	kpl.c.Signal()
+}

--- a/tests/robustness/snapmeta/kopia_persister_light_test.go
+++ b/tests/robustness/snapmeta/kopia_persister_light_test.go
@@ -1,0 +1,130 @@
+// +build darwin,amd64 linux,amd64
+
+package snapmeta
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+)
+
+var (
+	key = "mykey"
+	val = []byte("myval")
+)
+
+func TestStoreLoadDelete(t *testing.T) {
+	repoPath, err := os.MkdirTemp("", "kopia-test-repo-")
+	assertNoError(t, err)
+
+	defer os.RemoveAll(repoPath)
+
+	kpl := initKPL(t, repoPath)
+	defer kpl.Cleanup()
+
+	kpl.testStoreLoad(t, key, val)
+	kpl.testDelete(t, key, val)
+}
+
+func TestConcurrency(t *testing.T) {
+	repoPath, err := os.MkdirTemp("", "kopia-test-repo-")
+	assertNoError(t, err)
+
+	defer os.RemoveAll(repoPath)
+
+	kpl := initKPL(t, repoPath)
+	defer kpl.Cleanup()
+
+	keys := []string{"key1", "key2", "key3"}
+	vals := [][]byte{[]byte("val1"), []byte("val2"), []byte("val3")}
+
+	t.Run("group", func(t *testing.T) {
+		for i := 0; i < 9; i++ {
+			j := i
+
+			t.Run(fmt.Sprint(i), func(t *testing.T) {
+				t.Parallel()
+				kpl.testStoreLoad(t, keys[j%3], vals[j%3])
+			})
+
+			t.Run(fmt.Sprint(i), func(t *testing.T) {
+				t.Parallel()
+				kpl.testDelete(t, keys[j%3], vals[j%3])
+			})
+		}
+	})
+}
+
+// Store and test that subsequent Load succeeds.
+func (kpl *KopiaPersisterLight) testStoreLoad(t *testing.T, key string, val []byte) {
+	err := kpl.Store(key, val)
+	assertNoError(t, err)
+
+	valOut, err := kpl.Load(key)
+	assertNoError(t, err)
+
+	if !bytes.Equal(valOut, val) {
+		t.Fatal("loaded value does not equal stored value")
+	}
+}
+
+// Delete and test that subsequent Load fails.
+func (kpl *KopiaPersisterLight) testDelete(t *testing.T, key string, val []byte) {
+	kpl.Delete(key)
+
+	_, err := kpl.Load(key)
+	log.Println("err:", err)
+
+	if err == nil {
+		t.Fatal("snapshot was not deleted properly")
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	repoPath, err := os.MkdirTemp("", "kopia-test-repo-")
+	assertNoError(t, err)
+
+	kpl := initKPL(t, repoPath)
+
+	// Store and cleanup kpl
+	err = kpl.Store(key, val)
+	assertNoError(t, err)
+
+	kpl.Cleanup()
+
+	// Re-initialize and Load
+	kpl = initKPL(t, repoPath)
+	valOut, err := kpl.Load(key)
+	assertNoError(t, err)
+
+	if !bytes.Equal(valOut, val) {
+		t.Fatal("loaded value does not equal stored value")
+	}
+
+	kpl.Cleanup()
+	os.RemoveAll(repoPath)
+}
+
+func initKPL(t *testing.T, repoPath string) *KopiaPersisterLight {
+	t.Helper()
+
+	os.Unsetenv(S3BucketNameEnvKey)
+
+	kpl, err := NewPersisterLight("")
+	assertNoError(t, err)
+
+	err = kpl.ConnectOrCreateRepo(repoPath)
+	assertNoError(t, err)
+
+	return kpl
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Errorf("err: %v", err)
+	}
+}

--- a/tests/robustness/snapmeta/simple.go
+++ b/tests/robustness/snapmeta/simple.go
@@ -3,6 +3,8 @@
 package snapmeta
 
 import (
+	"context"
+
 	"github.com/kopia/kopia/tests/robustness"
 )
 
@@ -24,7 +26,7 @@ func NewSimple() *Simple {
 }
 
 // Store implements the Storer interface Store method.
-func (s *Simple) Store(key string, val []byte) error {
+func (s *Simple) Store(ctx context.Context, key string, val []byte) error {
 	buf := make([]byte, len(val))
 	_ = copy(buf, val)
 
@@ -34,7 +36,7 @@ func (s *Simple) Store(key string, val []byte) error {
 }
 
 // Load implements the Storer interface Load method.
-func (s *Simple) Load(key string) ([]byte, error) {
+func (s *Simple) Load(ctx context.Context, key string) ([]byte, error) {
 	if buf, found := s.Data[key]; found {
 		retBuf := make([]byte, len(buf))
 		_ = copy(retBuf, buf)
@@ -46,6 +48,6 @@ func (s *Simple) Load(key string) ([]byte, error) {
 }
 
 // Delete implements the Storer interface Delete method.
-func (s *Simple) Delete(key string) {
+func (s *Simple) Delete(ctx context.Context, key string) {
 	delete(s.Data, key)
 }

--- a/tests/robustness/snapmeta/simple_test.go
+++ b/tests/robustness/snapmeta/simple_test.go
@@ -4,6 +4,7 @@ package snapmeta
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 
@@ -11,9 +12,11 @@ import (
 )
 
 func TestSimpleBasic(t *testing.T) {
+	ctx := context.Background()
+
 	simple := NewSimple()
 
-	gotData, err := simple.Load("non-existent-key")
+	gotData, err := simple.Load(ctx, "non-existent-key")
 	if !errors.Is(err, robustness.ErrKeyNotFound) {
 		t.Fatalf("Did not get expected error: %q", err)
 	}
@@ -24,9 +27,9 @@ func TestSimpleBasic(t *testing.T) {
 
 	storeKey := "key-to-store"
 	data := []byte("some stored data")
-	simple.Store(storeKey, data)
+	simple.Store(ctx, storeKey, data)
 
-	gotData, err = simple.Load(storeKey)
+	gotData, err = simple.Load(ctx, storeKey)
 	if err != nil {
 		t.Fatalf("Error getting key: %v", err)
 	}
@@ -35,9 +38,9 @@ func TestSimpleBasic(t *testing.T) {
 		t.Fatalf("Did not get the correct data")
 	}
 
-	simple.Delete(storeKey)
+	simple.Delete(ctx, storeKey)
 
-	gotData, err = simple.Load(storeKey)
+	gotData, err = simple.Load(ctx, storeKey)
 	if !errors.Is(err, robustness.ErrKeyNotFound) {
 		t.Fatalf("Did not get expected error: %q", err)
 	}

--- a/tests/tools/kopiaclient/kopiaclient.go
+++ b/tests/tools/kopiaclient/kopiaclient.go
@@ -1,0 +1,245 @@
+// +build darwin,amd64 linux,amd64
+
+// Package kopiaclient provides a client to interact with a Kopia repo.
+package kopiaclient
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/fs/localfs"
+	"github.com/kopia/kopia/internal/units"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/filesystem"
+	"github.com/kopia/kopia/repo/blob/s3"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/policy"
+	"github.com/kopia/kopia/snapshot/restore"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/tests/robustness"
+)
+
+// KopiaClient uses a Kopia repo to create, restore, and delete snapshots.
+type KopiaClient struct {
+	configPath string
+	pw         string
+}
+
+const (
+	configFileName           = "config"
+	password                 = "kj13498po&_EXAMPLE" //nolint:gosec
+	s3Endpoint               = "s3.amazonaws.com"
+	awsAccessKeyIDEnvKey     = "AWS_ACCESS_KEY_ID"
+	awsSecretAccessKeyEnvKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec
+)
+
+// NewKopiaClient returns a new KopiaClient.
+func NewKopiaClient(basePath string) *KopiaClient {
+	return &KopiaClient{
+		configPath: filepath.Join(basePath, configFileName),
+		pw:         password,
+	}
+}
+
+// CreateOrConnectRepo creates a new Kopia repo or connects to an existing one if possible.
+func (kc *KopiaClient) CreateOrConnectRepo(ctx context.Context, repoDir, bucketName string) error {
+	st, err := kc.getStorage(ctx, repoDir, bucketName)
+	if err != nil {
+		return err
+	}
+
+	if iErr := repo.Initialize(ctx, st, &repo.NewRepositoryOptions{}, kc.pw); iErr != nil {
+		if !errors.Is(iErr, repo.ErrAlreadyInitialized) {
+			return errors.Wrap(iErr, "repo is already initialized")
+		}
+
+		log.Println("connecting to existing repository")
+	}
+
+	if iErr := repo.Connect(ctx, kc.configPath, st, kc.pw, &repo.ConnectOptions{}); iErr != nil {
+		return errors.Wrap(iErr, "error connecting to repository")
+	}
+
+	return errors.Wrap(err, "unable to open repository")
+}
+
+// SnapshotCreate creates a snapshot for the given path.
+func (kc *KopiaClient) SnapshotCreate(ctx context.Context, path string) error {
+	r, err := repo.Open(ctx, kc.configPath, kc.pw, &repo.Options{})
+	if err != nil {
+		return errors.Wrap(err, "cannot get new repository writer")
+	}
+
+	rw, err := r.NewWriter(ctx, repo.WriteSessionOptions{})
+	if err != nil {
+		return errors.Wrap(err, "cannot get new repository writer")
+	}
+
+	si, err := kc.getSourceInfoFromPath(r, filepath.Base(path))
+	if err != nil {
+		return errors.Wrap(err, "cannot get source info from path")
+	}
+
+	policyTree, err := policy.TreeForSource(ctx, r, si)
+	if err != nil {
+		return errors.Wrap(err, "cannot get policy tree for source")
+	}
+
+	source, err := localfs.NewEntry(path)
+	if err != nil {
+		return errors.Wrap(err, "cannot get filesystem entry from path")
+	}
+
+	u := snapshotfs.NewUploader(rw)
+
+	man, err := u.Upload(ctx, source, policyTree, si)
+	if err != nil {
+		return errors.Wrap(err, "cannot get manifest")
+	}
+
+	log.Printf("snapshotting %v", units.BytesStringBase10(man.Stats.TotalFileSize))
+
+	if _, err := snapshot.SaveSnapshot(ctx, rw, man); err != nil {
+		return errors.Wrap(err, "cannot save snapshot")
+	}
+
+	if err := rw.Flush(ctx); err != nil {
+		return err
+	}
+
+	return r.Close(ctx)
+}
+
+// SnapshotRestore restores the latests snapshot for the given path.
+func (kc *KopiaClient) SnapshotRestore(ctx context.Context, path string) error {
+	r, err := repo.Open(ctx, kc.configPath, kc.pw, &repo.Options{})
+	if err != nil {
+		return errors.Wrap(err, "cannot get new repository writer")
+	}
+
+	mans, err := kc.getSnapshotsFromPath(ctx, r, filepath.Base(path))
+	if err != nil {
+		return err
+	}
+
+	man := kc.latestManifest(mans)
+
+	rootEntry, err := snapshotfs.FilesystemEntryFromIDWithPath(ctx, r, string(man.ID), false)
+	if err != nil {
+		return errors.Wrap(err, "cannot get filesystem entry from ID with path")
+	}
+
+	output := &restore.FilesystemOutput{TargetPath: path}
+
+	st, err := restore.Entry(ctx, r, output, rootEntry, restore.Options{})
+	if err != nil {
+		return errors.Wrap(err, "cannot restore snapshot")
+	}
+
+	log.Printf("restored %v", units.BytesStringBase10(st.RestoredTotalFileSize))
+
+	return r.Close(ctx)
+}
+
+// SnapshotDelete deletes all snapshots for a given path.
+func (kc *KopiaClient) SnapshotDelete(ctx context.Context, path string) error {
+	r, err := repo.Open(ctx, kc.configPath, kc.pw, &repo.Options{})
+	if err != nil {
+		return errors.Wrap(err, "cannot get new repository writer")
+	}
+
+	rw, err := r.NewWriter(ctx, repo.WriteSessionOptions{})
+	if err != nil {
+		return errors.Wrap(err, "cannot get new repository writer")
+	}
+
+	mans, err := kc.getSnapshotsFromPath(ctx, r, filepath.Base(path))
+	if err != nil {
+		return err
+	}
+
+	for _, man := range mans {
+		err = rw.DeleteManifest(ctx, man.ID)
+		if err != nil {
+			return errors.Wrap(err, "cannot delete manifest")
+		}
+	}
+
+	if err := rw.Flush(ctx); err != nil {
+		return err
+	}
+
+	return r.Close(ctx)
+}
+
+func (kc *KopiaClient) getStorage(ctx context.Context, repoDir, bucketName string) (st blob.Storage, err error) {
+	if bucketName != "" {
+		s3Opts := &s3.Options{
+			BucketName:      bucketName,
+			Prefix:          repoDir,
+			Endpoint:        s3Endpoint,
+			AccessKeyID:     os.Getenv(awsAccessKeyIDEnvKey),
+			SecretAccessKey: os.Getenv(awsSecretAccessKeyEnvKey),
+		}
+		st, err = s3.New(ctx, s3Opts)
+	} else {
+		if iErr := os.MkdirAll(repoDir, 0o700); iErr != nil {
+			return nil, errors.Wrap(iErr, "cannot create directory")
+		}
+
+		fsOpts := &filesystem.Options{
+			Path: repoDir,
+		}
+		st, err = filesystem.New(ctx, fsOpts)
+	}
+
+	return st, errors.Wrap(err, "unable to get storage")
+}
+
+func (kc *KopiaClient) getSnapshotsFromPath(ctx context.Context, r repo.Repository, path string) ([]*snapshot.Manifest, error) {
+	si, err := kc.getSourceInfoFromPath(r, path)
+	if err != nil {
+		return nil, err
+	}
+
+	manifests, err := snapshot.ListSnapshots(ctx, r, si)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot list snapshots")
+	}
+
+	if len(manifests) == 0 {
+		return nil, robustness.ErrKeyNotFound
+	}
+
+	return manifests, nil
+}
+
+func (kc *KopiaClient) getSourceInfoFromPath(r repo.Repository, path string) (snapshot.SourceInfo, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return snapshot.SourceInfo{}, errors.Wrap(err, "cannot get absolute path")
+	}
+
+	return snapshot.SourceInfo{
+		Host:     r.ClientOptions().Hostname,
+		UserName: r.ClientOptions().Username,
+		Path:     absPath,
+	}, nil
+}
+
+func (kc *KopiaClient) latestManifest(mans []*snapshot.Manifest) *snapshot.Manifest {
+	latest := mans[0]
+
+	for _, m := range mans {
+		if m.StartTime.After(latest.StartTime) {
+			latest = m
+		}
+	}
+
+	return latest
+}


### PR DESCRIPTION
Add context to robustness store interface. This is needed for the new persister to use the Kopia API, as many of those functions require a context to be passed in.