### PR TITLE
Added content manager internal logging

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -119,6 +119,7 @@ type App struct {
 	metricsListenAddr             string
 	keyRingEnabled                bool
 	persistCredentials            bool
+	disableInternalLog            bool
 	AdvancedCommands              string
 
 	// subcommands
@@ -139,6 +140,7 @@ type App struct {
 	mount       commandMount
 	maintenance commandMaintenance
 	repository  commandRepository
+	logs        commandLogs
 
 	// testability hooks
 	osExit       func(int) // allows replacing os.Exit() with custom code
@@ -193,6 +195,7 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("timezone", "Format time according to specified time zone (local, utc, original or time zone name)").Hidden().StringVar(&timeZone)
 	app.Flag("password", "Repository password.").Envar("KOPIA_PASSWORD").Short('p').StringVar(&c.password)
 	app.Flag("persist-credentials", "Persist credentials").Default("true").Envar("KOPIA_PERSIST_CREDENTIALS_ON_CONNECT").BoolVar(&c.persistCredentials)
+	app.Flag("disable-internal-log", "Disable internal log").Hidden().Envar("KOPIA_DISABLE_INTERNAL_LOG").BoolVar(&c.disableInternalLog)
 	app.Flag("advanced-commands", "Enable advanced (and potentially dangerous) commands.").Hidden().Envar("KOPIA_ADVANCED_COMMANDS").StringVar(&c.AdvancedCommands)
 
 	c.setupOSSpecificKeychainFlags(app)
@@ -215,6 +218,7 @@ func (c *App) setup(app *kingpin.Application) {
 	c.diff.setup(c, app)
 	c.index.setup(c, app)
 	c.list.setup(c, app)
+	c.logs.setup(c, app)
 	c.server.setup(c, app)
 	c.session.setup(c, app)
 	c.restore.setup(c, app)

--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -45,10 +45,9 @@ func (c *commandBenchmarkCrypto) run(ctx context.Context) error {
 
 	const (
 		maxEncryptionOverhead = 1024
-		maxHashSize           = 64
 	)
 
-	var hashOutput [maxHashSize]byte
+	var hashOutput [hashing.MaxHashSize]byte
 
 	encryptOutput := make([]byte, len(data)+maxEncryptionOverhead)
 

--- a/cli/command_blob_show.go
+++ b/cli/command_blob_show.go
@@ -74,7 +74,7 @@ func (c *commandBlobShow) maybeDecryptBlob(ctx context.Context, w io.Writer, rep
 
 func canDecryptBlob(b blob.ID) bool {
 	switch b[0] {
-	case 'n', 'm', 'l':
+	case '_', 'n', 'm', 'l':
 		return true
 	default:
 		return false

--- a/cli/command_logs.go
+++ b/cli/command_logs.go
@@ -1,0 +1,15 @@
+package cli
+
+type commandLogs struct {
+	list    commandLogsList
+	cleanup commandLogsCleanup
+	show    commandLogsShow
+}
+
+func (c *commandLogs) setup(svc appServices, parent commandParent) {
+	cmd := parent.Command("logs", "Commands to manipulate logs stored in the repository.").Hidden().Alias("log")
+
+	c.cleanup.setup(svc, cmd)
+	c.list.setup(svc, cmd)
+	c.show.setup(svc, cmd)
+}

--- a/cli/command_logs_cleanup.go
+++ b/cli/command_logs_cleanup.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/maintenance"
+)
+
+type commandLogsCleanup struct {
+	maxTotalSizeMB int64
+	maxCount       int
+	maxAge         time.Duration
+	dryRun         bool
+}
+
+func (c *commandLogsCleanup) setup(svc appServices, parent commandParent) {
+	cmd := parent.Command("cleanup", "Clean up logs")
+
+	cmd.Flag("max-age", "Maximal age").Default("720h").DurationVar(&c.maxAge)
+	cmd.Flag("max-count", "Maximal number of files to keep").Default("10000").IntVar(&c.maxCount)
+	cmd.Flag("max-total-size-mb", "Maximal total size in MiB").Default("1024").Int64Var(&c.maxTotalSizeMB)
+	cmd.Flag("dry-run", "Do not delete").BoolVar(&c.dryRun)
+
+	cmd.Action(svc.directRepositoryWriteAction(c.run))
+}
+
+func (c *commandLogsCleanup) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	toDelete, err := maintenance.CleanupLogs(ctx, rep, maintenance.LogRetentionOptions{
+		MaxTotalSize: c.maxTotalSizeMB << 20, //nolint:gomnd
+		MaxCount:     c.maxCount,
+		MaxAge:       c.maxAge,
+		DryRun:       c.dryRun,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error expiring logs")
+	}
+
+	if len(toDelete) > 0 {
+		if c.dryRun {
+			log(ctx).Infof("Would delete %v logs.", len(toDelete))
+		} else {
+			log(ctx).Infof("Deleted %v logs.", len(toDelete))
+		}
+	} else {
+		log(ctx).Infof("No logs found to delete.")
+	}
+
+	return nil
+}

--- a/cli/command_logs_list.go
+++ b/cli/command_logs_list.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/units"
+	"github.com/kopia/kopia/repo"
+)
+
+type commandLogsList struct {
+	out textOutput
+
+	crit logSelectionCriteria
+}
+
+func (c *commandLogsList) setup(svc appServices, parent commandParent) {
+	cmd := parent.Command("list", "List logs.").Alias("ls")
+
+	cmd.Action(svc.directRepositoryReadAction(c.run))
+
+	c.out.setup(svc)
+	c.crit.setup(cmd)
+}
+
+func (c *commandLogsList) run(ctx context.Context, rep repo.DirectRepository) error {
+	allSessions0, err := getLogSessions(ctx, rep.BlobReader())
+	if err != nil {
+		return errors.Wrap(err, "error getting log sessions")
+	}
+
+	allSessions := c.crit.filterLogSessions(allSessions0)
+
+	if len(allSessions) < len(allSessions0) {
+		defer log(ctx).Infof("NOTE: Listed %v/%v log sessions, pass --all to show all.", len(allSessions), len(allSessions0))
+	}
+
+	// output sessions
+	for _, s := range allSessions {
+		c.out.printStdout(
+			"%v %v %v %v %v\n", s.id,
+			formatTimestamp(s.startTime),
+			s.endTime.Sub(s.startTime),
+			units.BytesStringBase2(s.totalSize),
+			len(s.segments),
+		)
+	}
+
+	return nil
+}

--- a/cli/command_logs_session.go
+++ b/cli/command_logs_session.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/kingpin"
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+type logSessionInfo struct {
+	id        string
+	startTime time.Time
+	endTime   time.Time
+	segments  []blob.Metadata
+	totalSize int64
+}
+
+type logSelectionCriteria struct {
+	all         bool
+	latest      int
+	youngerThan time.Duration
+	olderThan   time.Duration
+}
+
+func (c *logSelectionCriteria) setup(cmd *kingpin.CmdClause) {
+	cmd.Flag("all", "Show all logs").BoolVar(&c.all)
+	cmd.Flag("latest", "Include last N logs").Short('n').IntVar(&c.latest)
+	cmd.Flag("younger-than", "Include logs yonger than X (e.g. '1h')").DurationVar(&c.youngerThan)
+	cmd.Flag("older-than", "Include logs older than X (e.g. '1h')").DurationVar(&c.olderThan)
+}
+
+func (c *logSelectionCriteria) any() bool {
+	return c.all || c.latest > 0 || c.youngerThan > 0 || c.olderThan > 0
+}
+
+func (c *logSelectionCriteria) filterLogSessions(allSessions []*logSessionInfo) []*logSessionInfo {
+	if c.all {
+		return allSessions
+	}
+
+	if c.youngerThan > 0 {
+		allSessions = filterLogSessions(allSessions, func(ls *logSessionInfo) bool {
+			return clock.Since(ls.startTime) < c.youngerThan
+		})
+	}
+
+	if c.olderThan > 0 {
+		allSessions = filterLogSessions(allSessions, func(ls *logSessionInfo) bool {
+			return clock.Since(ls.startTime) > c.olderThan
+		})
+	}
+
+	if c.latest > 0 && len(allSessions) > c.latest {
+		allSessions = allSessions[len(allSessions)-c.latest:]
+	}
+
+	return allSessions
+}
+
+func getLogSessions(ctx context.Context, st blob.Reader) ([]*logSessionInfo, error) {
+	sessions := map[string]*logSessionInfo{}
+
+	var allSessions []*logSessionInfo
+
+	if err := st.ListBlobs(ctx, "_log_", func(bm blob.Metadata) error {
+		parts := strings.Split(string(bm.BlobID), "_")
+
+		// nolint:gomnd
+		if len(parts) < 8 {
+			log(ctx).Errorf("invalid part count: %v skipping unrecognized log: %v", len(parts), bm.BlobID)
+			return nil
+		}
+
+		id := parts[2] + "_" + parts[3]
+
+		startTime, err := strconv.ParseInt(parts[4], 10, 64)
+		if err != nil {
+			log(ctx).Errorf("invalid start time - skipping unrecognized log: %v", bm.BlobID)
+
+			// nolint:nilerr
+			return nil
+		}
+
+		endTime, err := strconv.ParseInt(parts[5], 10, 64)
+		if err != nil {
+			log(ctx).Errorf("invalid end time - skipping unrecognized log: %v", bm.BlobID)
+
+			// nolint:nilerr
+			return nil
+		}
+
+		s := sessions[id]
+		if s == nil {
+			s = &logSessionInfo{
+				id: id,
+			}
+			sessions[id] = s
+			allSessions = append(allSessions, s)
+		}
+
+		if t := time.Unix(startTime, 0); s.startTime.IsZero() || t.Before(s.startTime) {
+			s.startTime = t
+		}
+
+		if t := time.Unix(endTime, 0); t.After(s.endTime) {
+			s.endTime = t
+		}
+
+		s.segments = append(s.segments, bm)
+		s.totalSize += bm.Length
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "error listing logs")
+	}
+
+	for _, s := range allSessions {
+		sort.Slice(s.segments, func(i, j int) bool {
+			return s.segments[i].Timestamp.Before(s.segments[j].Timestamp)
+		})
+	}
+
+	// sort sessions by start time
+	sort.Slice(allSessions, func(i, j int) bool {
+		return allSessions[i].segments[0].Timestamp.Before(allSessions[j].segments[0].Timestamp)
+	})
+
+	return allSessions, nil
+}
+
+func filterLogSessions(logs []*logSessionInfo, predicate func(l *logSessionInfo) bool) []*logSessionInfo {
+	var result []*logSessionInfo
+
+	for _, l := range logs {
+		if predicate(l) {
+			result = append(result, l)
+		}
+	}
+
+	return result
+}

--- a/cli/command_logs_show.go
+++ b/cli/command_logs_show.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+)
+
+type commandLogsShow struct {
+	logSessionIDs []string
+
+	crit logSelectionCriteria
+	out  textOutput
+}
+
+func (c *commandLogsShow) setup(svc appServices, parent commandParent) {
+	cmd := parent.Command("show", "Show contents of the log.").Alias("cat")
+
+	cmd.Arg("session-id", "Log Session ID to show").StringsVar(&c.logSessionIDs)
+
+	cmd.Action(svc.directRepositoryReadAction(c.run))
+
+	c.crit.setup(cmd)
+	c.out.setup(svc)
+}
+
+func (c *commandLogsShow) run(ctx context.Context, rep repo.DirectRepository) error {
+	sessions, err := getLogSessions(ctx, rep.BlobReader())
+	if err != nil {
+		return err
+	}
+
+	sessions = c.crit.filterLogSessions(sessions)
+
+	if len(sessions) == 0 {
+		return errors.Errorf("no logs found")
+	}
+
+	if len(c.logSessionIDs) > 0 {
+		sessions = filterLogSessions(sessions, func(l *logSessionInfo) bool {
+			for _, sid := range c.logSessionIDs {
+				if l.id == sid {
+					return true
+				}
+			}
+
+			return false
+		})
+	}
+
+	// by default show latest one
+	if !c.crit.any() {
+		sessions = sessions[len(sessions)-1:]
+		log(ctx).Infof("Showing latest log (%v)", formatTimestamp(sessions[0].startTime))
+	}
+
+	for _, s := range sessions {
+		for _, bm := range s.segments {
+			data, err := rep.BlobReader().GetBlob(ctx, bm.BlobID, 0, -1)
+			if err != nil {
+				return errors.Wrap(err, "error getting log")
+			}
+
+			data, err = rep.Crypter().DecryptBLOB(data, bm.BlobID)
+			if err != nil {
+				return errors.Wrap(err, "error decrypting log")
+			}
+
+			if err := showContentWithFlags(c.out.stdout(), bytes.NewReader(data), true, false); err != nil {
+				log(ctx).Errorf("error showing log: %v", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/cli/command_logs_show.go
+++ b/cli/command_logs_show.go
@@ -35,10 +35,6 @@ func (c *commandLogsShow) run(ctx context.Context, rep repo.DirectRepository) er
 
 	sessions = c.crit.filterLogSessions(sessions)
 
-	if len(sessions) == 0 {
-		return errors.Errorf("no logs found")
-	}
-
 	if len(c.logSessionIDs) > 0 {
 		sessions = filterLogSessions(sessions, func(l *logSessionInfo) bool {
 			for _, sid := range c.logSessionIDs {
@@ -49,6 +45,10 @@ func (c *commandLogsShow) run(ctx context.Context, rep repo.DirectRepository) er
 
 			return false
 		})
+	}
+
+	if len(sessions) == 0 {
+		return errors.Errorf("no logs found")
 	}
 
 	// by default show latest one

--- a/cli/command_logs_test.go
+++ b/cli/command_logs_test.go
@@ -59,6 +59,8 @@ func TestLogsCommands(t *testing.T) {
 	// by default cleanup retains a lot of logs.
 	e.RunAndExpectSuccess(t, "logs", "cleanup")
 	e.RunAndVerifyOutputLineCount(t, 3, "logs", "list")
+	e.RunAndExpectSuccess(t, "logs", "cleanup", "--max-count=2", "--dry-run")
+	e.RunAndVerifyOutputLineCount(t, 3, "logs", "list")
 	e.RunAndExpectSuccess(t, "logs", "cleanup", "--max-count=2")
 	e.RunAndVerifyOutputLineCount(t, 2, "logs", "list")
 	e.RunAndExpectSuccess(t, "logs", "cleanup", "--max-count=1")

--- a/cli/command_logs_test.go
+++ b/cli/command_logs_test.go
@@ -77,8 +77,11 @@ func TestLogsMaintenance(t *testing.T) {
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
+	time.Sleep(time.Second)
 	e.RunAndExpectSuccess(t, "snapshot", "create", testutil.TempDirectory(t))
+	time.Sleep(time.Second)
 	e.RunAndExpectSuccess(t, "snapshot", "create", testutil.TempDirectory(t))
+	time.Sleep(time.Second)
 	e.RunAndExpectSuccess(t, "snapshot", "create", testutil.TempDirectory(t))
 	e.RunAndVerifyOutputLineCount(t, 4, "logs", "list")
 

--- a/cli/command_logs_test.go
+++ b/cli/command_logs_test.go
@@ -1,0 +1,88 @@
+package cli_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestLogsCommands(t *testing.T) {
+	t.Parallel()
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, runner)
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	// one log from repository creation
+	e.RunAndVerifyOutputLineCount(t, 1, "logs", "list")
+
+	// verify we did not add a log
+	e.RunAndVerifyOutputLineCount(t, 1, "logs", "list")
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", testutil.TempDirectory(t))
+
+	e.RunAndVerifyOutputLineCount(t, 2, "logs", "list")
+
+	// sleep a bit so that 3rd log is reliably last in time order even if the clock is completely
+	// messed up.
+	time.Sleep(2 * time.Second)
+	e.RunAndExpectSuccess(t, "snapshot", "create", testutil.TempDirectory(t))
+
+	lines := e.RunAndVerifyOutputLineCount(t, 3, "logs", "list")
+	firstLogID := strings.Split(lines[0], " ")[0]
+	secondLogID := strings.Split(lines[1], " ")[0]
+	thirdLogID := strings.Split(lines[2], " ")[0]
+
+	firstLogLines := e.RunAndExpectSuccess(t, "logs", "show", firstLogID)
+	secondLogLines := e.RunAndExpectSuccess(t, "logs", "show", secondLogID)
+	thirdLogLines := e.RunAndExpectSuccess(t, "logs", "show", thirdLogID)
+	e.RunAndExpectFailure(t, "logs", "show", "no-such-log")
+
+	require.NotEqual(t, firstLogLines, secondLogLines)
+	require.NotEqual(t, secondLogLines, thirdLogLines)
+
+	// by default cleanup retains a lot of logs.
+	e.RunAndExpectSuccess(t, "logs", "cleanup")
+	e.RunAndVerifyOutputLineCount(t, 3, "logs", "list")
+	e.RunAndExpectSuccess(t, "logs", "cleanup", "--max-count=2")
+	e.RunAndVerifyOutputLineCount(t, 2, "logs", "list")
+	e.RunAndExpectSuccess(t, "logs", "cleanup", "--max-count=1")
+	e.RunAndVerifyOutputLineCount(t, 1, "logs", "list")
+
+	// make sure latest log survived
+	e.RunAndExpectSuccess(t, "logs", "show", thirdLogID)
+}
+
+func TestLogsMaintenance(t *testing.T) {
+	t.Parallel()
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, runner)
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", testutil.TempDirectory(t))
+	e.RunAndExpectSuccess(t, "snapshot", "create", testutil.TempDirectory(t))
+	e.RunAndExpectSuccess(t, "snapshot", "create", testutil.TempDirectory(t))
+	e.RunAndVerifyOutputLineCount(t, 4, "logs", "list")
+
+	e.RunAndExpectSuccess(t, "maintenance", "set", "--max-retained-log-count=2")
+	e.RunAndVerifyOutputLineCount(t, 5, "logs", "list")
+
+	e.RunAndExpectSuccess(t, "maintenance", "run")
+	e.RunAndVerifyOutputLineCount(t, 2, "logs", "list")
+
+	e.RunAndExpectSuccess(t, "maintenance", "set", "--max-retained-log-age=1ms")
+	e.RunAndVerifyOutputLineCount(t, 3, "logs", "list")
+
+	e.RunAndExpectSuccess(t, "maintenance", "run")
+	e.RunAndVerifyOutputLineCount(t, 0, "logs", "list")
+}

--- a/cli/command_maintenance_info.go
+++ b/cli/command_maintenance_info.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/maintenance"
 )
@@ -45,6 +46,13 @@ func (c *commandMaintenanceInfo) run(ctx context.Context, rep repo.DirectReposit
 
 	c.out.printStdout("Full Cycle:\n")
 	c.displayCycleInfo(&p.FullCycle, s.NextFullMaintenanceTime, rep)
+
+	cl := p.LogRetention.OrDefault()
+
+	c.out.printStdout("Log Retention:\n")
+	c.out.printStdout("  max count:       %v\n", cl.MaxCount)
+	c.out.printStdout("  max age of logs: %v\n", cl.MaxAge)
+	c.out.printStdout("  max total size:  %v\n", units.BytesStringBase2(cl.MaxTotalSize))
 
 	c.out.printStdout("Recent Maintenance Runs:\n")
 

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -132,7 +132,7 @@ func (c *commandRepositoryCreate) populateRepository(ctx context.Context, passwo
 
 	// nolint:wrapcheck
 	return repo.WriteSession(ctx, rep, repo.WriteSessionOptions{
-		Purpose: "populateRepository",
+		Purpose: "populate repository",
 	}, func(ctx context.Context, w repo.RepositoryWriter) error {
 		if err := policy.SetPolicy(ctx, w, policy.GlobalPolicySourceInfo, policy.DefaultPolicy); err != nil {
 			return errors.Wrap(err, "unable to set global policy")

--- a/cli/config.go
+++ b/cli/config.go
@@ -66,6 +66,8 @@ func (c *App) optionsFromFlags(ctx context.Context) *repo.Options {
 		opts.TraceStorage = log(ctx).Debugf
 	}
 
+	opts.DisableInternalLog = c.disableInternalLog
+
 	return &opts
 }
 

--- a/repo/content/blob_crypto.go
+++ b/repo/content/blob_crypto.go
@@ -50,7 +50,7 @@ func (c *Crypter) getIndexBlobIV(s blob.ID) ([]byte, error) {
 // EncryptBLOB encrypts the given data using crypter-defined key and returns a name that should
 // be used to save the blob in thre repository.
 func (c *Crypter) EncryptBLOB(data []byte, prefix blob.ID, sessionID SessionID) (blob.ID, []byte, error) {
-	var hashOutput [maxHashSize]byte
+	var hashOutput [hashing.MaxHashSize]byte
 
 	hash := c.HashFunction(hashOutput[:0], data)
 	blobID := prefix + blob.ID(hex.EncodeToString(hash))

--- a/repo/content/committed_content_index_cache_test.go
+++ b/repo/content/committed_content_index_cache_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/logging"
 )
 
 func TestCommittedContentIndexCache_Disk(t *testing.T) {
@@ -18,7 +19,7 @@ func TestCommittedContentIndexCache_Disk(t *testing.T) {
 
 	ta := faketime.NewClockTimeWithOffset(0)
 
-	testCache(t, &diskCommittedContentIndexCache{testutil.TempDirectory(t), ta.NowFunc(), 3}, ta)
+	testCache(t, &diskCommittedContentIndexCache{testutil.TempDirectory(t), ta.NowFunc(), 3, logging.Printf(t.Logf)("test")}, ta)
 }
 
 func TestCommittedContentIndexCache_Memory(t *testing.T) {

--- a/repo/content/content_cache_metadata.go
+++ b/repo/content/content_cache_metadata.go
@@ -30,9 +30,6 @@ type contentCacheForMetadata struct {
 func (c *contentCacheForMetadata) sync(ctx context.Context) error {
 	sem := make(chan struct{}, metadataCacheSyncParallelism)
 
-	log(ctx).Debugf("synchronizing metadata cache...")
-	defer log(ctx).Debugf("finished synchronizing metadata cache.")
-
 	var eg errgroup.Group
 
 	// list all blobs and fetch contents into cache in parallel.

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -98,7 +98,7 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 	keyTime := map[blob.ID]time.Time{}
 	st := blobtesting.NewMapStorage(data, keyTime, nil)
 
-	bm, err := NewManager(testlogging.Context(t), st, &FormattingOptions{
+	bm, err := NewManagerForTesting(testlogging.Context(t), st, &FormattingOptions{
 		Hash:        hashAlgo,
 		Encryption:  encryptionAlgo,
 		HMACSecret:  hmacSecret,

--- a/repo/content/content_id_to_bytes.go
+++ b/repo/content/content_id_to_bytes.go
@@ -3,6 +3,8 @@ package content
 import (
 	"bytes"
 	"encoding/hex"
+
+	"github.com/kopia/kopia/repo/hashing"
 )
 
 // unpackedContentIDPrefix is a prefix for all content IDs that are stored unpacked in the index.
@@ -40,7 +42,7 @@ func contentIDToBytes(output []byte, c ID) []byte {
 		output = append(output, 0)
 	}
 
-	var hashBuf [maxHashSize]byte
+	var hashBuf [hashing.MaxHashSize]byte
 
 	n, err := hex.Decode(hashBuf[:], []byte(c[skip:]))
 	if err != nil {

--- a/repo/content/content_index_recovery_test.go
+++ b/repo/content/content_index_recovery_test.go
@@ -25,7 +25,7 @@ func TestContentIndexRecovery(t *testing.T) {
 
 	// delete all index blobs
 	assertNoError(t, bm.st.ListBlobs(ctx, IndexBlobPrefix, func(bi blob.Metadata) error {
-		log(ctx).Debugf("deleting %v", bi.BlobID)
+		t.Logf("deleting %v", bi.BlobID)
 		return bm.st.DeleteBlob(ctx, bi.BlobID)
 	}))
 
@@ -49,7 +49,7 @@ func TestContentIndexRecovery(t *testing.T) {
 				return err
 			}
 			totalRecovered += len(infos)
-			log(ctx).Debugf("recovered %v contents", len(infos))
+			t.Logf("recovered %v contents", len(infos))
 			return nil
 		})
 		if err != nil {
@@ -76,7 +76,7 @@ func TestContentIndexRecovery(t *testing.T) {
 				return rerr
 			}
 			totalRecovered += len(infos)
-			log(ctx).Debugf("recovered %v contents", len(infos))
+			t.Logf("recovered %v contents", len(infos))
 			return nil
 		})
 		if err != nil {

--- a/repo/content/content_manager_iterate.go
+++ b/repo/content/content_manager_iterate.go
@@ -225,7 +225,7 @@ func (bm *WriteManager) IteratePacks(ctx context.Context, options IteratePackOpt
 func (bm *WriteManager) IterateUnreferencedBlobs(ctx context.Context, blobPrefixes []blob.ID, parallellism int, callback func(blob.Metadata) error) error {
 	var usedPacks sync.Map
 
-	log(ctx).Debugf("determining blobs in use")
+	bm.log.Debugf("determining blobs in use")
 	// find packs in use
 	if err := bm.IteratePacks(
 		ctx,
@@ -261,7 +261,7 @@ func (bm *WriteManager) IterateUnreferencedBlobs(ctx context.Context, blobPrefix
 		}
 	}
 
-	log(ctx).Debugf("scanning prefixes %v", prefixes)
+	bm.log.Debugf("scanning prefixes %v", prefixes)
 
 	if err := blob.IterateAllPrefixesInParallel(ctx, parallellism, bm.st, prefixes,
 		func(bm blob.Metadata) error {
@@ -276,7 +276,7 @@ func (bm *WriteManager) IterateUnreferencedBlobs(ctx context.Context, blobPrefix
 		return errors.Wrap(err, "error iterating blobs")
 	}
 
-	log(ctx).Debugf("found %v pack blobs not in use", *unusedCount)
+	bm.log.Debugf("found %v pack blobs not in use", *unusedCount)
 
 	return nil
 }

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -25,7 +25,7 @@ const maxCompressionOverheadPerContent = 16384
 const indexBlobCompactionWarningThreshold = 1000
 
 func (sm *SharedManager) maybeCompressAndEncryptDataForPacking(output *gather.WriteBuffer, data []byte, contentID ID, comp compression.HeaderID) (compression.HeaderID, error) {
-	var hashOutput [maxHashSize]byte
+	var hashOutput [hashing.MaxHashSize]byte
 
 	iv, err := getPackedContentIV(hashOutput[:], contentID)
 	if err != nil {
@@ -119,7 +119,7 @@ func (bm *WriteManager) getContentDataUnlocked(ctx context.Context, pp *pendingP
 	return bm.decryptContentAndVerify(payload, bi)
 }
 
-func (bm *WriteManager) preparePackDataContent(ctx context.Context, pp *pendingPackInfo) (packIndexBuilder, error) {
+func (bm *WriteManager) preparePackDataContent(pp *pendingPackInfo) (packIndexBuilder, error) {
 	packFileIndex := packIndexBuilder{}
 	haveContent := false
 
@@ -128,7 +128,7 @@ func (bm *WriteManager) preparePackDataContent(ctx context.Context, pp *pendingP
 			haveContent = true
 		}
 
-		formatLog(ctx).Debugf("add-to-pack %v %v p:%v %v d:%v", pp.packBlobID, info.GetContentID(), info.GetPackBlobID(), info.GetPackedLength(), info.GetDeleted())
+		bm.log.Debugf("add-to-pack %v %v p:%v %v d:%v", pp.packBlobID, info.GetContentID(), info.GetPackBlobID(), info.GetPackedLength(), info.GetDeleted())
 
 		packFileIndex.Add(info)
 	}

--- a/repo/content/index.go
+++ b/repo/content/index.go
@@ -4,10 +4,12 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/hashing"
 )
 
 const (
-	maxContentIDSize = maxHashSize + 1
+	maxContentIDSize = hashing.MaxHashSize + 1
 	unknownKeySize   = 255
 )
 

--- a/repo/content/internal_logger.go
+++ b/repo/content/internal_logger.go
@@ -54,13 +54,13 @@ func (m *internalLogManager) encryptAndWriteLogBlob(prefix blob.ID, data []byte)
 
 // NewLogger creates new logger.
 func (m *internalLogManager) NewLogger() *internalLogger {
-	var rnd [4]byte
+	var rnd [2]byte
 
 	rand.Read(rnd[:]) // nolint:errcheck
 
 	return &internalLogger{
 		m:      m,
-		prefix: blob.ID(fmt.Sprintf("_log_%v_%x", clock.Now().UTC().Format("20060102"), rnd)),
+		prefix: blob.ID(fmt.Sprintf("_log_%v_%x", clock.Now().Local().Format("20060102150405"), rnd)),
 	}
 }
 
@@ -79,6 +79,10 @@ type internalLogger struct {
 }
 
 func (l *internalLogger) enable() {
+	if l == nil {
+		return
+	}
+
 	atomic.StoreInt32(&l.enabled, 1)
 }
 

--- a/repo/content/internal_logger.go
+++ b/repo/content/internal_logger.go
@@ -1,0 +1,190 @@
+package content
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+const blobLoggerFlushThreshold = 4 << 20
+
+type internalLogManager struct {
+	ctx            context.Context
+	st             blob.Storage
+	bc             *Crypter
+	wg             sync.WaitGroup
+	timeFunc       func() time.Time
+	flushThreshold int
+}
+
+// Close closes the log manager.
+func (m *internalLogManager) Close(ctx context.Context) {
+	m.wg.Wait()
+}
+
+func (m *internalLogManager) encryptAndWriteLogBlob(prefix blob.ID, data []byte) {
+	blobID, encrypted, err := m.bc.EncryptBLOB(data, prefix, "")
+	if err != nil {
+		// this should not happen, also nothing can be done about this, we're not in a place where we can return error, log it.
+		return
+	}
+
+	m.wg.Add(1)
+
+	go func() {
+		defer m.wg.Done()
+
+		if err := m.st.PutBlob(m.ctx, blobID, gather.FromSlice(encrypted)); err != nil {
+			// nothing can be done about this, we're not in a place where we can return error, log it.
+			return
+		}
+	}()
+}
+
+// NewLogger creates new logger.
+func (m *internalLogManager) NewLogger() *internalLogger {
+	var rnd [4]byte
+
+	rand.Read(rnd[:]) // nolint:errcheck
+
+	return &internalLogger{
+		m:      m,
+		prefix: blob.ID(fmt.Sprintf("_log_%v_%x", clock.Now().UTC().Format("20060102"), rnd)),
+	}
+}
+
+// internalLogger represents a single log session that saves log files as blobs in the repository.
+// The logger starts disabled and to actually persist logs enable() must be called.
+type internalLogger struct {
+	nextChunkNumber int32 // chunk number incremented using atomic.AddInt32()
+	enabled         int32 // set by enable(), logger is ineffective until called
+
+	m         *internalLogManager
+	mu        sync.Mutex
+	buf       *bytes.Buffer
+	gzw       *gzip.Writer
+	startTime int64 // unix timestamp of the first log
+	prefix    blob.ID
+}
+
+func (l *internalLogger) enable() {
+	atomic.StoreInt32(&l.enabled, 1)
+}
+
+// Close closes the log session and saves any pending log.
+func (l *internalLogger) Close(ctx context.Context) {
+	l.mu.Lock()
+	data := l.flushAndResetLocked()
+	l.mu.Unlock()
+
+	l.maybeEncryptAndWriteChunkUnlocked(data)
+}
+
+func (l *internalLogger) nowString() string {
+	return l.m.timeFunc().UTC().Format("2006-01-02T15:04:05.000000Z")
+}
+
+func (l *internalLogger) add(level, msg string, args []interface{}) {
+	prefix := l.nowString() + " " + level + " "
+	line := strings.TrimSpace(fmt.Sprintf(prefix+msg, args...)) + "\n"
+
+	l.maybeEncryptAndWriteChunkUnlocked(l.addLineAndMaybeFlush(line))
+}
+
+func (l *internalLogger) maybeEncryptAndWriteChunkUnlocked(data []byte) {
+	if data == nil {
+		return
+	}
+
+	if atomic.LoadInt32(&l.enabled) == 0 {
+		return
+	}
+
+	endTime := l.m.timeFunc().Unix()
+
+	prefix := blob.ID(fmt.Sprintf("%v_%v_%v_%v_", l.prefix, l.startTime, endTime, atomic.AddInt32(&l.nextChunkNumber, 1)))
+
+	l.m.encryptAndWriteLogBlob(prefix, data)
+}
+
+func (l *internalLogger) addLineAndMaybeFlush(line string) []byte {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	w := l.ensureWriterInitializedLocked()
+
+	_, err := io.WriteString(w, line)
+	l.logUnexpectedError(err)
+
+	if l.buf.Len() < l.m.flushThreshold {
+		return nil
+	}
+
+	return l.flushAndResetLocked()
+}
+
+func (l *internalLogger) ensureWriterInitializedLocked() io.Writer {
+	if l.gzw == nil {
+		l.buf = new(bytes.Buffer)
+		l.gzw = gzip.NewWriter(l.buf)
+		l.startTime = l.m.timeFunc().Unix()
+	}
+
+	return l.gzw
+}
+
+func (l *internalLogger) flushAndResetLocked() []byte {
+	if l.gzw == nil {
+		return nil
+	}
+
+	l.logUnexpectedError(l.gzw.Flush())
+	l.logUnexpectedError(l.gzw.Close())
+
+	res := l.buf.Bytes()
+
+	l.buf = nil
+	l.gzw = nil
+
+	return res
+}
+
+func (l *internalLogger) logUnexpectedError(err error) {
+	if err == nil {
+		return
+	}
+}
+
+func (l *internalLogger) Debugf(msg string, args ...interface{}) {
+	l.add("DEBUG", msg, args)
+}
+
+func (l *internalLogger) Infof(msg string, args ...interface{}) {
+	l.add("INFO", msg, args)
+}
+
+func (l *internalLogger) Errorf(msg string, args ...interface{}) {
+	l.add("ERROR", msg, args)
+}
+
+// newInternalLogManager creates a new blobLogManager that will emit logs as repository blobs with a given prefix.
+func newInternalLogManager(ctx context.Context, st blob.Storage, bc *Crypter) *internalLogManager {
+	return &internalLogManager{
+		ctx:            ctx,
+		st:             st,
+		bc:             bc,
+		flushThreshold: blobLoggerFlushThreshold,
+		timeFunc:       clock.Now,
+	}
+}

--- a/repo/hashing/hashing.go
+++ b/repo/hashing/hashing.go
@@ -10,6 +10,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// MaxHashSize is the maximum hash size supported in the system.
+const MaxHashSize = 64
+
 // Parameters encapsulates all hashing-relevant parameters.
 type Parameters interface {
 	GetHashFunction() string

--- a/repo/logging/broadcast.go
+++ b/repo/logging/broadcast.go
@@ -1,0 +1,27 @@
+package logging
+
+// Broadcast is a logger that broadcasts each log message to multiple loggers.
+type Broadcast []Logger
+
+// Debugf implements Logger.
+func (b Broadcast) Debugf(msg string, args ...interface{}) {
+	for _, l := range b {
+		l.Debugf(msg, args...)
+	}
+}
+
+// Infof implements Logger.
+func (b Broadcast) Infof(msg string, args ...interface{}) {
+	for _, l := range b {
+		l.Infof(msg, args...)
+	}
+}
+
+// Errorf implements Logger.
+func (b Broadcast) Errorf(msg string, args ...interface{}) {
+	for _, l := range b {
+		l.Errorf(msg, args...)
+	}
+}
+
+var _ Logger = Broadcast{}

--- a/repo/logging/logging_test.go
+++ b/repo/logging/logging_test.go
@@ -1,0 +1,55 @@
+package logging_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/repo/logging"
+)
+
+func TestPrefix(t *testing.T) {
+	var lines []string
+
+	l0 := logging.Printf(func(msg string, args ...interface{}) {
+		lines = append(lines, fmt.Sprintf(msg, args...))
+	})("module1")
+
+	l := logging.WithPrefix("PREFIX:", l0)
+	l.Debugf("A")
+	l.Infof("B")
+	l.Errorf("C")
+
+	require.Equal(t, []string{
+		"[module1] PREFIX:A",
+		"[module1] PREFIX:B",
+		"[module1] PREFIX:C",
+	}, lines)
+}
+
+func TestBroadcast(t *testing.T) {
+	var lines []string
+
+	l0 := logging.Printf(func(msg string, args ...interface{}) {
+		lines = append(lines, fmt.Sprintf(msg, args...))
+	})("first")
+
+	l1 := logging.Printf(func(msg string, args ...interface{}) {
+		lines = append(lines, fmt.Sprintf(msg, args...))
+	})("second")
+
+	l := logging.Broadcast{l0, l1}
+	l.Debugf("A")
+	l.Infof("B")
+	l.Errorf("C")
+
+	require.Equal(t, []string{
+		"[first] A",
+		"[second] A",
+		"[first] B",
+		"[second] B",
+		"[first] C",
+		"[second] C",
+	}, lines)
+}

--- a/repo/logging/prefix.go
+++ b/repo/logging/prefix.go
@@ -1,0 +1,29 @@
+package logging
+
+// prefixLogger is a logger that attaches a prefix to each log message.
+type prefixLogger struct {
+	prefixFunc func() string
+	inner      Logger
+}
+
+// Debugf implements Logger.
+func (p *prefixLogger) Debugf(msg string, args ...interface{}) {
+	p.inner.Debugf(p.prefixFunc()+msg, args...)
+}
+
+// Infof implements Logger.
+func (p *prefixLogger) Infof(msg string, args ...interface{}) {
+	p.inner.Infof(p.prefixFunc()+msg, args...)
+}
+
+// Errorf implements Logger.
+func (p *prefixLogger) Errorf(msg string, args ...interface{}) {
+	p.inner.Errorf(p.prefixFunc()+msg, args...)
+}
+
+var _ Logger = (*prefixLogger)(nil)
+
+// WithPrefix returns a wrapper logger that attaches given prefix to each message.
+func WithPrefix(prefix string, logger Logger) Logger {
+	return &prefixLogger{func() string { return prefix }, logger}
+}

--- a/repo/logging/printf_logger.go
+++ b/repo/logging/printf_logger.go
@@ -18,7 +18,7 @@ func (l *printfLogger) Errorf(msg string, args ...interface{}) { l.printf(l.pref
 // Printf returns LoggerForModuleFunc that uses given printf-style function to print log output.
 func Printf(printf func(msg string, args ...interface{})) LoggerForModuleFunc {
 	return func(module string) Logger {
-		return &printfLogger{printf, "[" + module + "]"}
+		return &printfLogger{printf, "[" + module + "] "}
 	}
 }
 

--- a/repo/maintenance/cleanup_logs.go
+++ b/repo/maintenance/cleanup_logs.go
@@ -1,0 +1,96 @@
+package maintenance
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/units"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+// LogRetentionOptions provides options for logs retention.
+type LogRetentionOptions struct {
+	MaxTotalSize int64            `json:"maxTotalSize"`
+	MaxCount     int              `json:"maxCount"`
+	MaxAge       time.Duration    `json:"maxAge"`
+	DryRun       bool             `json:"-"`
+	TimeFunc     func() time.Time `json:"-"`
+}
+
+// OrDefault returns default LogRetentionOptions.
+func (o LogRetentionOptions) OrDefault() LogRetentionOptions {
+	if o.MaxCount == 0 && o.MaxAge == 0 && o.MaxTotalSize == 0 {
+		return defaultLogRetention()
+	}
+
+	return o
+}
+
+// defaultLogRetention returns CleanupLogsOptions applied by default during maintenance.
+func defaultLogRetention() LogRetentionOptions {
+	// nolint:gomnd
+	return LogRetentionOptions{
+		MaxTotalSize: 1 << 30,             // keep no more than 1 GiB logs
+		MaxAge:       30 * 24 * time.Hour, // no more than 30 days of data
+		MaxCount:     10000,               // no more than 10K logs
+	}
+}
+
+// CleanupLogs deletes old logs blobs beyond certain age, total size or count.
+func CleanupLogs(ctx context.Context, rep repo.DirectRepositoryWriter, opt LogRetentionOptions) ([]blob.Metadata, error) {
+	if opt.TimeFunc == nil {
+		opt.TimeFunc = clock.Now
+	}
+
+	allLogBlobs, err := blob.ListAllBlobs(ctx, rep.BlobStorage(), "_")
+	if err != nil {
+		return nil, errors.Wrap(err, "error listing logs")
+	}
+
+	// sort by time so that most recent are first
+	sort.Slice(allLogBlobs, func(i, j int) bool {
+		return allLogBlobs[i].Timestamp.After(allLogBlobs[j].Timestamp)
+	})
+
+	var totalSize int64
+
+	deletePosition := len(allLogBlobs)
+
+	for i, bm := range allLogBlobs {
+		totalSize += bm.Length
+
+		if totalSize > opt.MaxTotalSize && opt.MaxTotalSize > 0 {
+			deletePosition = i
+			break
+		}
+
+		if i >= opt.MaxCount && opt.MaxCount > 0 {
+			deletePosition = i
+			break
+		}
+
+		if age := opt.TimeFunc().Sub(bm.Timestamp); age > opt.MaxAge && opt.MaxAge != 0 {
+			deletePosition = i
+			break
+		}
+	}
+
+	toDelete := allLogBlobs[deletePosition:]
+
+	log(ctx).Debugf("Keeping %v logs of total size %v", deletePosition, units.BytesStringBase2(totalSize))
+
+	if !opt.DryRun {
+		for _, bm := range toDelete {
+			if err := rep.BlobStorage().DeleteBlob(ctx, bm.BlobID); err != nil {
+				return nil, errors.Wrapf(err, "error deleting log %v", bm.BlobID)
+			}
+		}
+	}
+
+	return toDelete, nil
+}

--- a/repo/maintenance/maintenance_params.go
+++ b/repo/maintenance/maintenance_params.go
@@ -20,6 +20,8 @@ type Params struct {
 
 	QuickCycle CycleParams `json:"quick"`
 	FullCycle  CycleParams `json:"full"`
+
+	LogRetention LogRetentionOptions `json:"logRetention"`
 }
 
 func (p *Params) isOwnedByByThisUser(rep repo.Repository) bool {
@@ -37,6 +39,7 @@ func DefaultParams() Params {
 			Enabled:  true,
 			Interval: 1 * time.Hour,
 		},
+		LogRetention: defaultLogRetention(),
 	}
 }
 

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -40,6 +40,7 @@ const (
 	TaskRewriteContentsFull       = "full-rewrite-contents"
 	TaskDropDeletedContentsFull   = "full-drop-deleted-content"
 	TaskIndexCompaction           = "index-compaction"
+	TaskCleanupLogs               = "cleanup-logs"
 )
 
 // shouldRun returns Mode if repository is due for periodic maintenance.
@@ -245,6 +246,10 @@ func runQuickMaintenance(ctx context.Context, runParams RunParameters, safety Sa
 		return errors.Wrap(err, "error performing index compaction")
 	}
 
+	if err := runTaskCleanupLogs(ctx, runParams, s); err != nil {
+		return errors.Wrap(err, "error cleaning up logs")
+	}
+
 	return nil
 }
 
@@ -261,6 +266,16 @@ func notDeletingOrphanedBlobs(ctx context.Context, s *Schedule, safety SafetyPar
 func runTaskIndexCompaction(ctx context.Context, runParams RunParameters, s *Schedule, safety SafetyParameters) error {
 	return ReportRun(ctx, runParams.rep, TaskIndexCompaction, s, func() error {
 		return IndexCompaction(ctx, runParams.rep, safety)
+	})
+}
+
+func runTaskCleanupLogs(ctx context.Context, runParams RunParameters, s *Schedule) error {
+	return ReportRun(ctx, runParams.rep, TaskCleanupLogs, s, func() error {
+		deleted, err := CleanupLogs(ctx, runParams.rep, runParams.Params.LogRetention.OrDefault())
+
+		log(ctx).Infof("Cleaned up %v logs.", len(deleted))
+
+		return err
 	})
 }
 

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -57,25 +57,25 @@ func shouldRun(ctx context.Context, rep repo.DirectRepository, p *Params) (Mode,
 	// check full cycle first, as it does more than the quick cycle
 	if p.FullCycle.Enabled {
 		if rep.Time().After(s.NextFullMaintenanceTime) {
-			log(ctx).Debugf("due for full manintenance cycle")
+			log(ctx).Debugf("due for full maintenance cycle")
 			return ModeFull, nil
 		}
 
-		log(ctx).Debugf("not due for full manintenance cycle until %v", s.NextFullMaintenanceTime)
+		log(ctx).Debugf("not due for full maintenance cycle until %v", s.NextFullMaintenanceTime)
 	} else {
-		log(ctx).Debugf("full manintenance cycle not enabled")
+		log(ctx).Debugf("full maintenance cycle not enabled")
 	}
 
 	// no time for full cycle, check quick cycle
 	if p.QuickCycle.Enabled {
 		if rep.Time().After(s.NextQuickMaintenanceTime) {
-			log(ctx).Debugf("due for quick manintenance cycle")
+			log(ctx).Debugf("due for quick maintenance cycle")
 			return ModeQuick, nil
 		}
 
-		log(ctx).Debugf("not due for quick manintenance cycle until %v", s.NextQuickMaintenanceTime)
+		log(ctx).Debugf("not due for quick maintenance cycle until %v", s.NextQuickMaintenanceTime)
 	} else {
-		log(ctx).Debugf("quick manintenance cycle not enabled")
+		log(ctx).Debugf("quick maintenance cycle not enabled")
 	}
 
 	return ModeNone, nil

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -149,7 +149,7 @@ func TestManifestInitCorruptedBlock(t *testing.T) {
 	}
 
 	// write some data to storage
-	bm, err := content.NewManager(ctx, st, f, nil, nil)
+	bm, err := content.NewManagerForTesting(ctx, st, f, nil, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestManifestInitCorruptedBlock(t *testing.T) {
 	}
 
 	// make a new content manager based on corrupted data.
-	bm, err = content.NewManager(ctx, st, f, nil, nil)
+	bm, err = content.NewManagerForTesting(ctx, st, f, nil, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -302,7 +302,7 @@ func newManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.Da
 
 	st := blobtesting.NewMapStorage(data, nil, nil)
 
-	bm, err := content.NewManager(ctx, st, &content.FormattingOptions{
+	bm, err := content.NewManagerForTesting(ctx, st, &content.FormattingOptions{
 		Hash:        hashing.DefaultAlgorithm,
 		Encryption:  encryption.DefaultAlgorithm,
 		MaxPackSize: 100000,

--- a/tests/end_to_end_test/maintenance_test.go
+++ b/tests/end_to_end_test/maintenance_test.go
@@ -20,8 +20,8 @@ func TestFullMaintenance(t *testing.T) {
 
 	var snap snapshot.Manifest
 
-	// after creation we'll have kopia.repository, 1 index + 1 pack blob
-	if got, want := e.RunAndExpectSuccess(t, "blob", "list"), 3; len(got) != want {
+	// after creation we'll have kopia.repository, 1 index + 1 pack blob + 1 log
+	if got, want := e.RunAndExpectSuccess(t, "blob", "list"), 4; len(got) != want {
 		t.Fatalf("unexpected number of initial blobs: %v, want %v", got, want)
 	}
 

--- a/tests/stress_test/stress_test.go
+++ b/tests/stress_test/stress_test.go
@@ -41,7 +41,7 @@ func stressTestWithStorage(t *testing.T, st blob.Storage, duration time.Duration
 	ctx := testlogging.Context(t)
 
 	openMgr := func() (*content.WriteManager, error) {
-		return content.NewManager(ctx, st, &content.FormattingOptions{
+		return content.NewManagerForTesting(ctx, st, &content.FormattingOptions{
 			Version:     1,
 			Hash:        "HMAC-SHA256-128",
 			Encryption:  encryption.DefaultAlgorithm,

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -183,7 +183,7 @@ func (e *CLITest) RunAndVerifyOutputLineCount(t *testing.T, wantLines int, args 
 
 	lines := e.RunAndExpectSuccess(t, args...)
 	if len(lines) != wantLines {
-		t.Errorf("unexpected list of results of 'kopia %v': %v (%v lines), wanted %v", strings.Join(args, " "), lines, len(lines), wantLines)
+		t.Fatalf("unexpected list of results of 'kopia %v': %v lines (%v) wanted %v", strings.Join(args, " "), len(lines), lines, wantLines)
 	}
 
 	return lines

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -146,7 +146,7 @@ func (e *CLITest) RunAndProcessStderr(t *testing.T, callback func(line string) b
 	// complete the scan in background without processing lines.
 	go func() {
 		for scanner.Scan() {
-			t.Logf("[stderr] %v", scanner.Text())
+			// ignore
 		}
 	}()
 


### PR DESCRIPTION
Logs are saved in a repository as encrypted, compressed blobs kept for max 30 days for troubleshooting purposes.