### PR TITLE
Add a flag to not shallowrestore small files

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -104,6 +104,7 @@ type commandRestore struct {
 	restoreIncremental            bool
 	restoreIgnoreErrors           bool
 	restoreShallowAtDepth         int32
+	minSizeForPlaceholder         int32
 }
 
 func (c *commandRestore) setup(svc appServices, parent commandParent) {
@@ -125,6 +126,7 @@ func (c *commandRestore) setup(svc appServices, parent commandParent) {
 	cmd.Flag("ignore-errors", "Ignore all errors").BoolVar(&c.restoreIgnoreErrors)
 	cmd.Flag("skip-existing", "Skip files and symlinks that exist in the output").BoolVar(&c.restoreIncremental)
 	cmd.Flag("shallow", "Shallow restore the directory hierarchy starting at this level (default is to deep restore the entire hierarchy.)").Int32Var(&c.restoreShallowAtDepth)
+	cmd.Flag("shallow-minsize", "When doing a shallow restore, write actual files instead of placeholders smaller than this size.").Int32Var(&c.minSizeForPlaceholder)
 	cmd.Action(svc.repositoryReaderAction(c.run))
 }
 
@@ -279,6 +281,7 @@ func (c *commandRestore) run(ctx context.Context, rep repo.Repository) error {
 		Incremental:            c.restoreIncremental,
 		IgnoreErrors:           c.restoreIgnoreErrors,
 		RestoreDirEntryAtDepth: c.restoreShallowAtDepth,
+		MinSizeForPlaceholder:  c.minSizeForPlaceholder,
 		ProgressCallback: func(ctx context.Context, stats restore.Stats) {
 			restoredCount := stats.RestoredFileCount + stats.RestoredDirCount + stats.RestoredSymlinkCount + stats.SkippedCount
 			enqueuedCount := stats.EnqueuedFileCount + stats.EnqueuedDirCount + stats.EnqueuedSymlinkCount

--- a/snapshot/restore/restore.go
+++ b/snapshot/restore/restore.go
@@ -69,6 +69,7 @@ type Options struct {
 	Incremental            bool  `json:"incremental"`
 	IgnoreErrors           bool  `json:"ignoreErrors"`
 	RestoreDirEntryAtDepth int32 `json:"restoreDirEntryAtDepth"`
+	MinSizeForPlaceholder  int32 `json:"minSizeForPlaceholder"`
 
 	ProgressCallback func(ctx context.Context, s Stats)
 	Cancel           chan struct{} // channel that can be externally closed to signal cancelation
@@ -78,7 +79,7 @@ type Options struct {
 func Entry(ctx context.Context, rep repo.Repository, output Output, rootEntry fs.Entry, options Options) (Stats, error) {
 	c := copier{
 		output:        output,
-		shallowoutput: makeShallowFilesystemOutput(output),
+		shallowoutput: makeShallowFilesystemOutput(output, options),
 		q:             parallelwork.NewQueue(),
 		incremental:   options.Incremental,
 		ignoreErrors:  options.IgnoreErrors,

--- a/tests/testdirtree/testdirtree.go
+++ b/tests/testdirtree/testdirtree.go
@@ -48,6 +48,7 @@ type DirectoryTreeOptions struct {
 	MaxFilesPerDirectory               int
 	MaxSymlinksPerDirectory            int
 	MaxFileSize                        int
+	MinFileSize                        int
 	MinNameLength                      int
 	MaxNameLength                      int
 	NonExistingSymlinkTargetPercentage int // 0..100
@@ -193,6 +194,10 @@ func createRandomFile(filename string, options DirectoryTreeOptions, counters *D
 	maxFileSize := int64(intOrDefault(options.MaxFileSize, 100000))
 
 	length := rand.Int63n(maxFileSize)
+
+	if mfs := int64(options.MinFileSize); length < mfs {
+		length = mfs
+	}
 
 	_, err = iocopy.Copy(f, io.LimitReader(rand.New(rand.NewSource(clock.Now().UnixNano())), length))
 	if err != nil {


### PR DESCRIPTION
When doing a shallow restore, small files might take up less size than
storing the DirectoryEntry metadata. Add a minimum file size flag that
where files below that size will be written directly instead being
represented with shallow placeholders. This improves on #710.