### PR TITLE
Fixed bug in .kopiaignore pattern matching for patterns containing a star.

### DIFF
--- a/internal/wcmatch/wcmatch.go
+++ b/internal/wcmatch/wcmatch.go
@@ -382,7 +382,8 @@ func doMatch(tokens []token, text []rune, ignoreCase bool) matchResult {
 					return wcNoMatch
 				}
 
-				t.pos = slashIndex
+				// Skip all characters up to the upcoming directory sep.
+				t.pos += slashIndex - 1
 
 				break
 			}

--- a/internal/wcmatch/wcmatch_test.go
+++ b/internal/wcmatch/wcmatch_test.go
@@ -65,6 +65,7 @@ func TestMatchWithBaseDir(t *testing.T) {
 
 func TestMatch(t *testing.T) {
 	cases := []wcCase{
+
 		// Basic
 		{"", "", true, true},
 		{"*", "", true, true},
@@ -174,6 +175,12 @@ func TestMatch(t *testing.T) {
 		{"  \tfoo", "foo", true, true},
 		{"  foo  ", "foo", true, true},
 		{" foo\\ ", "/foo ", true, true},
+
+		{"/users/user1/logs", "/users/user1/logs", true, true},
+		{"/users/**/logs", "/users/user1/logs", true, true},
+		{"/users/user?/logs", "/users/user1/logs", true, true},
+		{"/users/user*/logs", "/users/user1/logs", true, true},
+		{"/users/*/logs", "/users/user1/logs", true, true},
 	}
 
 	testHelper(t, cases)


### PR DESCRIPTION
Integrated some additional test cases to cover this bug.
Fixes #961