### PR TITLE
content: re-added missing lock accidentally removed by #1138

### DIFF
--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -137,6 +137,8 @@ func writeTempFileAtomic(dirname string, data []byte) (string, error) {
 }
 
 func (c *diskCommittedContentIndexCache) expireUnused(ctx context.Context, used []blob.ID) error {
+	c.log.Debugf("expireUnused (except %v)", used)
+
 	entries, err := ioutil.ReadDir(c.dirname)
 	if err != nil {
 		return errors.Wrap(err, "can't list cache")

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -386,7 +386,7 @@ func (bm *WriteManager) flushPackIndexesLocked(ctx context.Context) error {
 
 		// if we managed to commit the session marker blobs, the index is now fully committed
 		// and will be visible to others, including blob GC.
-		if err := bm.committedContents.addContent(ctx, indexBlobMD.BlobID, dataCopy, true); err != nil {
+		if err := bm.committedContents.addIndexBlob(ctx, indexBlobMD.BlobID, dataCopy, true); err != nil {
 			return errors.Wrap(err, "unable to add committed content")
 		}
 
@@ -678,6 +678,7 @@ func (bm *WriteManager) GetContent(ctx context.Context, contentID ID) (v []byte,
 
 	pp, bi, err := bm.getContentInfo(contentID)
 	if err != nil {
+		bm.log.Debugf("getContentInfo(%v) error %v", contentID, err)
 		return nil, err
 	}
 

--- a/repo/content/content_manager_indexes.go
+++ b/repo/content/content_manager_indexes.go
@@ -31,6 +31,11 @@ func (co *CompactOptions) maxEventualConsistencySettleTime() time.Duration {
 
 // CompactIndexes performs compaction of index blobs ensuring that # of small index blobs is below opt.maxSmallBlobs.
 func (bm *WriteManager) CompactIndexes(ctx context.Context, opt CompactOptions) error {
+	// we must hold the lock here to avoid the race with Refresh() which can reload the
+	// current set of indexes while we process them.
+	bm.mu.Lock()
+	defer bm.mu.Unlock()
+
 	bm.log.Debugf("CompactIndexes(%+v)", opt)
 
 	if err := bm.indexBlobManager.compact(ctx, opt); err != nil {


### PR DESCRIPTION
This fixes race condition between index compaction and index refresh
which was causing recent test flakes. This is not likely to happen in
real world as compaction is super rare but test was triggering it very
frequentl.

I was able to reliably repro this with a nearly complete rewrite
of a stress test (coming in separate PR). Without the fix it would fail
in 1-3 attempts, with the fix it succeeded 100 attempts of the new
stress test.

Also improved logging and fixed old terminology leftovers.