### PR TITLE
Always restore .kopiaignore

### DIFF
--- a/snapshot/restore/restore.go
+++ b/snapshot/restore/restore.go
@@ -65,11 +65,12 @@ func (s *Stats) clone() Stats {
 
 // Options provides optional restore parameters.
 type Options struct {
-	Parallel               int   `json:"parallel"`
-	Incremental            bool  `json:"incremental"`
-	IgnoreErrors           bool  `json:"ignoreErrors"`
-	RestoreDirEntryAtDepth int32 `json:"restoreDirEntryAtDepth"`
-	MinSizeForPlaceholder  int32 `json:"minSizeForPlaceholder"`
+	Parallel               int      `json:"parallel"`
+	Incremental            bool     `json:"incremental"`
+	IgnoreErrors           bool     `json:"ignoreErrors"`
+	RestoreDirEntryAtDepth int32    `json:"restoreDirEntryAtDepth"`
+	MinSizeForPlaceholder  int32    `json:"minSizeForPlaceholder"`
+	DotIgnoreFiles         []string `json:"ignoreDotFiles,omitempty"`
 
 	ProgressCallback func(ctx context.Context, s Stats)
 	Cancel           chan struct{} // channel that can be externally closed to signal cancelation

--- a/snapshot/restore/shallow_fs_output.go
+++ b/snapshot/restore/shallow_fs_output.go
@@ -64,6 +64,12 @@ func (o *ShallowFilesystemOutput) WriteFile(ctx context.Context, relativePath st
 		return o.FilesystemOutput.WriteFile(ctx, relativePath, f)
 	}
 
+	// Always restore .kopiaignore files so that they correctly apply to
+	// later snapshots.
+	if f.Name() == ".kopiaignore" {
+		return o.FilesystemOutput.WriteFile(ctx, relativePath, f)
+	}
+
 	placeholderpath, err := o.writeShallowEntry(ctx, relativePath, de)
 	if err != nil {
 		return errors.Wrap(err, "shallow WriteFile")

--- a/tests/end_to_end_test/shallowrestore_test.go
+++ b/tests/end_to_end_test/shallowrestore_test.go
@@ -114,6 +114,8 @@ func TestShallowrestoreWithMinSize(t *testing.T) {
 }
 
 func writeKopiaIgnore(t *testing.T, source string) {
+	t.Helper()
+
 	fp := filepath.Join(source, ".kopiaignore")
 	require.NoError(t, os.WriteFile(fp, []byte(".Trash\n"), 0644))
 }
@@ -776,6 +778,12 @@ func findFileDir(t *testing.T, shallow string) (dirinshallow, fileinshallow stri
 		// Really long directories can't participate in shallow restores and will
 		// be real in a shallow tree. Skip them.
 		if !restore.SafelySuffixablePath(f) {
+			continue
+		}
+
+		// .kopiaignore files are always restored and will be real in a shallow
+		// tree. Skip them.
+		if fi.Name() == ".kopiaignore" {
 			continue
 		}
 

--- a/tests/end_to_end_test/shallowrestore_test.go
+++ b/tests/end_to_end_test/shallowrestore_test.go
@@ -113,6 +113,11 @@ func TestShallowrestoreWithMinSize(t *testing.T) {
 	require.NoFileExists(t, big)
 }
 
+func writeKopiaIgnore(t *testing.T, source string) {
+	fp := filepath.Join(source, ".kopiaignore")
+	require.NoError(t, os.WriteFile(fp, []byte(".Trash\n"), 0644))
+}
+
 func TestShallowFullCycle(t *testing.T) {
 	t.Parallel()
 	runner := testenv.NewInProcRunner(t)
@@ -130,6 +135,10 @@ func TestShallowFullCycle(t *testing.T) {
 		MaxSymlinksPerDirectory:            4,
 		NonExistingSymlinkTargetPercentage: 50,
 	})
+
+	// A .kopiaignore file confuses the shallow restore
+	// cycle. Make one to demonstrate this.
+	writeKopiaIgnore(t, source)
 
 	// Some of the different mutations require a directory to exist. Let's make
 	// certain that we have one.


### PR DESCRIPTION
Always restore .kopiaignore even in shallow restores.

* fixes a bug with the handling of .kopiaignore placeholders (as noted in #710)
* keeps .kopiaignore files applicable when adding files to a partially reified restore tree