### PR TITLE
repo: big performance improvement for WriteContent with repo server

### DIFF
--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -598,6 +598,11 @@ func (r *grpcRepositoryClient) WriteContent(ctx context.Context, data []byte, pr
 		return "", errors.Wrap(err, "invalid prefix")
 	}
 
+	// we will be writing asynchronously and server will reject this write, fail early.
+	if prefix == manifest.ContentPrefix {
+		return "", errors.Errorf("writing manifest contents not allowed")
+	}
+
 	var hashOutput [128]byte
 
 	contentID := prefix + content.ID(hex.EncodeToString(r.h(hashOutput[:0], data)))

--- a/repo/recently_read.go
+++ b/repo/recently_read.go
@@ -1,0 +1,46 @@
+package repo
+
+import (
+	"sync"
+
+	"github.com/kopia/kopia/repo/content"
+)
+
+type recentlyRead struct {
+	mu          sync.Mutex
+	contentList []content.ID
+	next        int
+	contentSet  map[content.ID]struct{}
+}
+
+func (r *recentlyRead) add(contentID content.ID) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.contentSet == nil {
+		r.contentList = make([]content.ID, numRecentReadsToCache)
+		r.contentSet = make(map[content.ID]struct{})
+	}
+
+	delete(r.contentSet, r.contentList[r.next])
+	r.contentList[r.next] = contentID
+	r.contentSet[contentID] = struct{}{}
+	r.next = (r.next + 1) % len(r.contentList)
+}
+
+func (r *recentlyRead) exists(contentID content.ID) bool {
+	if r == nil {
+		return false
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, ok := r.contentSet[contentID]
+
+	return ok
+}


### PR DESCRIPTION
When re-uploading previously snapshotted directory we fetch directory
content `k<hash>` and very frequently end up writing the exact same
content. By caching last N content IDs we can avoid costly round-trip
to the server since we know that content ID was present in the session.

Also added small number of asynchronous writes, which also helps with
upload performance. Background writes are awaited before Flush().

Performance when snapshotting lots of small files (source code):

31.9 GB files:471205 dirs:75817, warm cache
Before: 260s
After: 55s (4-5x faster)