### PR TITLE
localfs: adjust build flags to support more archs

### DIFF
--- a/fs/localfs/local_fs_32bit.go
+++ b/fs/localfs/local_fs_32bit.go
@@ -1,6 +1,6 @@
-//go:build !windows && ((!amd64 && !arm64 && !arm) || darwin || openbsd)
+//go:build !windows && ((!amd64 && !arm64 && !arm && !ppc64 && !ppc64le && !s390x && !386 && !riscv64) || darwin || openbsd)
 // +build !windows
-// +build !amd64,!arm64,!arm darwin openbsd
+// +build !amd64,!arm64,!arm,!ppc64,!ppc64le,!s390x,!386,!riscv64 darwin openbsd
 
 package localfs
 

--- a/fs/localfs/local_fs_64bit.go
+++ b/fs/localfs/local_fs_64bit.go
@@ -1,8 +1,8 @@
-//go:build !windows && !openbsd && !darwin && (amd64 || arm64 || arm)
+//go:build !windows && !openbsd && !darwin && (amd64 || arm64 || arm || ppc64 || ppc64le || s390x || 386 || riscv64)
 // +build !windows
 // +build !openbsd
 // +build !darwin
-// +build amd64 arm64 arm
+// +build amd64 arm64 arm ppc64 ppc64le s390x 386 riscv64
 
 package localfs
 


### PR DESCRIPTION
Encountered while trying to update kopia to 0.8.4 in Void Linux, see https://github.com/void-linux/void-packages/pull/30146.
```
# github.com/kopia/kopia/fs/localfs
fs/localfs/local_fs_nonwindows.go:26:41: cannot use stat.Dev (type uint64) as type int32 in argument to platformSpecificWidenDev
fs/localfs/local_fs_nonwindows.go:27:42: cannot use stat.Rdev (type uint64) as type int32 in argument to platformSpecificWidenDev
```

~Should I also add goarch 386 to `.goreleaser.yml`?~
