### PR TITLE
Repository password change support

### DIFF
--- a/cli/command_repository.go
+++ b/cli/command_repository.go
@@ -1,14 +1,15 @@
 package cli
 
 type commandRepository struct {
-	connect       commandRepositoryConnect
-	create        commandRepositoryCreate
-	disconnect    commandRepositoryDisconnect
-	repair        commandRepositoryRepair
-	setClient     commandRepositorySetClient
-	setParameters commandRepositorySetParameters
-	status        commandRepositoryStatus
-	syncTo        commandRepositorySyncTo
+	connect        commandRepositoryConnect
+	create         commandRepositoryCreate
+	disconnect     commandRepositoryDisconnect
+	repair         commandRepositoryRepair
+	setClient      commandRepositorySetClient
+	setParameters  commandRepositorySetParameters
+	changePassword commandRepositoryChangePassword
+	status         commandRepositoryStatus
+	syncTo         commandRepositorySyncTo
 }
 
 func (c *commandRepository) setup(svc advancedAppServices, parent commandParent) {
@@ -22,4 +23,5 @@ func (c *commandRepository) setup(svc advancedAppServices, parent commandParent)
 	c.setParameters.setup(svc, cmd)
 	c.status.setup(svc, cmd)
 	c.syncTo.setup(svc, cmd)
+	c.changePassword.setup(svc, cmd)
 }

--- a/cli/command_repository_change_password.go
+++ b/cli/command_repository_change_password.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+)
+
+type commandRepositoryChangePassword struct {
+	svc advancedAppServices
+}
+
+func (c *commandRepositoryChangePassword) setup(svc advancedAppServices, parent commandParent) {
+	cmd := parent.Command("change-password", "Change repository password")
+
+	c.svc = svc
+	cmd.Action(svc.directRepositoryWriteAction(c.run))
+}
+
+func (c *commandRepositoryChangePassword) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	newPass, err := askForChangedRepositoryPassword(c.svc.stdout())
+	if err != nil {
+		return err
+	}
+
+	if err := rep.ChangePassword(ctx, newPass); err != nil {
+		return errors.Wrap(err, "unable to change password")
+	}
+
+	if err := c.svc.passwordPersistenceStrategy().PersistPassword(ctx, c.svc.repositoryConfigFileName(), newPass); err != nil {
+		return errors.Wrap(err, "unable to persist password")
+	}
+
+	log(ctx).Infof(`NOTE: Repository password has been changed.`)
+
+	return nil
+}

--- a/cli/command_repository_change_password.go
+++ b/cli/command_repository_change_password.go
@@ -9,20 +9,31 @@ import (
 )
 
 type commandRepositoryChangePassword struct {
+	newPassword string
+
 	svc advancedAppServices
 }
 
 func (c *commandRepositoryChangePassword) setup(svc advancedAppServices, parent commandParent) {
 	cmd := parent.Command("change-password", "Change repository password")
+	cmd.Flag("new-password", "New password").Envar("KOPIA_NEW_PASSWORD").StringVar(&c.newPassword)
 
 	c.svc = svc
 	cmd.Action(svc.directRepositoryWriteAction(c.run))
 }
 
 func (c *commandRepositoryChangePassword) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	newPass, err := askForChangedRepositoryPassword(c.svc.stdout())
-	if err != nil {
-		return err
+	var newPass string
+
+	if c.newPassword == "" {
+		n, err := askForChangedRepositoryPassword(c.svc.stdout())
+		if err != nil {
+			return err
+		}
+
+		newPass = n
+	} else {
+		newPass = c.newPassword
 	}
 
 	if err := rep.ChangePassword(ctx, newPass); err != nil {

--- a/cli/command_repository_change_password.go
+++ b/cli/command_repository_change_password.go
@@ -40,11 +40,11 @@ func (c *commandRepositoryChangePassword) run(ctx context.Context, rep repo.Dire
 		return errors.Wrap(err, "unable to change password")
 	}
 
+	log(ctx).Infof(`NOTE: Repository password has been changed.`)
+
 	if err := c.svc.passwordPersistenceStrategy().PersistPassword(ctx, c.svc.repositoryConfigFileName(), newPass); err != nil {
 		return errors.Wrap(err, "unable to persist password")
 	}
-
-	log(ctx).Infof(`NOTE: Repository password has been changed.`)
 
 	return nil
 }

--- a/cli/command_repository_change_password_test.go
+++ b/cli/command_repository_change_password_test.go
@@ -36,3 +36,11 @@ func TestRepositoryChangePassword(t *testing.T) {
 
 	env3.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache")
 }
+
+func TestRepositoryChangePassword_LegacDisallowed(t *testing.T) {
+	env1 := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
+	// pass --no-enable-password-change to create repository using old format that does
+	// not support password change.
+	env1.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache", "--no-enable-password-change")
+	env1.RunAndExpectFailure(t, "repo", "change-password", "--new-password", "newPass")
+}

--- a/cli/command_repository_change_password_test.go
+++ b/cli/command_repository_change_password_test.go
@@ -1,0 +1,38 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestRepositoryChangePassword(t *testing.T) {
+	r1 := testenv.NewInProcRunner(t)
+	r2 := testenv.NewInProcRunner(t)
+	env1 := testenv.NewCLITest(t, r1)
+	env2 := testenv.NewCLITest(t, r2)
+
+	env1.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache")
+	env1.RunAndExpectSuccess(t, "snapshot", "ls")
+
+	// connect to repo with --disable-repository-format-cache so that format blob is not cached
+	// this makes password changes immediate
+	env2.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache")
+	env2.RunAndExpectSuccess(t, "snapshot", "ls")
+
+	env1.RunAndExpectSuccess(t, "repo", "change-password", "--new-password", "newPass")
+
+	// at this point env2 stops working
+	env2.RunAndExpectFailure(t, "snapshot", "ls")
+
+	r3 := testenv.NewInProcRunner(t)
+
+	// new connections will fail when using old (default) password
+	env3 := testenv.NewCLITest(t, r3)
+	env3.RunAndExpectFailure(t, "repo", "connect", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache")
+
+	// new connections will succeed when using new password
+	r3.RepoPassword = "newPass"
+
+	env3.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache")
+}

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -24,6 +24,7 @@ type commandRepositoryCreate struct {
 	createOnly                  bool
 	createIndexVersion          int
 	createIndexEpochs           bool
+	enablePasswordChange        bool
 
 	co  connectOptions
 	svc advancedAppServices
@@ -37,6 +38,7 @@ func (c *commandRepositoryCreate) setup(svc advancedAppServices, parent commandP
 	cmd.Flag("encryption", "Content encryption algorithm.").PlaceHolder("ALGO").Default(encryption.DefaultAlgorithm).EnumVar(&c.createBlockEncryptionFormat, encryption.SupportedAlgorithms(false)...)
 	cmd.Flag("object-splitter", "The splitter to use for new objects in the repository").Default(splitter.DefaultAlgorithm).EnumVar(&c.createSplitter, splitter.SupportedAlgorithms()...)
 	cmd.Flag("create-only", "Create repository, but don't connect to it.").Short('c').BoolVar(&c.createOnly)
+	cmd.Flag("enable-password-change", "Enable password change").Hidden().Default("true").BoolVar(&c.enablePasswordChange)
 	cmd.Flag("index-version", "Force particular index version").Hidden().Envar("KOPIA_CREATE_INDEX_VERSION").IntVar(&c.createIndexVersion)
 	cmd.Flag("enable-index-epochs", "Enable index epochs").Hidden().BoolVar(&c.createIndexEpochs)
 
@@ -82,6 +84,7 @@ func (c *commandRepositoryCreate) newRepositoryOptionsFromFlags() *repo.NewRepos
 				IndexVersion:    c.createIndexVersion,
 				EpochParameters: c.epochParametersFromFlags(),
 			},
+			EnablePasswordChange: c.enablePasswordChange,
 		},
 
 		ObjectFormat: object.Format{

--- a/cli/command_repository_repair.go
+++ b/cli/command_repository_repair.go
@@ -15,7 +15,7 @@ import (
 type commandRepositoryRepair struct {
 	repairCommandRecoverFormatBlob         string
 	repairCommandRecoverFormatBlobPrefixes []string
-	repairDryDrun                          bool
+	repairDryRun                           bool
 }
 
 func (c *commandRepositoryRepair) setup(svc advancedAppServices, parent commandParent) {
@@ -23,7 +23,7 @@ func (c *commandRepositoryRepair) setup(svc advancedAppServices, parent commandP
 
 	cmd.Flag("recover-format", "Recover format blob from a copy").Default("auto").EnumVar(&c.repairCommandRecoverFormatBlob, "auto", "yes", "no")
 	cmd.Flag("recover-format-block-prefixes", "Prefixes of file names").StringsVar(&c.repairCommandRecoverFormatBlobPrefixes)
-	cmd.Flag("dry-run", "Do not modify repository").Short('n').BoolVar(&c.repairDryDrun)
+	cmd.Flag("dry-run", "Do not modify repository").Short('n').BoolVar(&c.repairDryRun)
 
 	for _, prov := range storageProviders {
 		f := prov.newFlags()
@@ -80,7 +80,7 @@ func (c *commandRepositoryRepair) recoverFormatBlob(ctx context.Context, st blob
 		err := st.ListBlobs(ctx, blob.ID(prefix), func(bi blob.Metadata) error {
 			log(ctx).Infof("looking for replica of format blob in %v...", bi.BlobID)
 			if b, err := repo.RecoverFormatBlob(ctx, st, bi.BlobID, bi.Length); err == nil {
-				if !c.repairDryDrun {
+				if !c.repairDryRun {
 					if puterr := st.PutBlob(ctx, repo.FormatBlobID, gather.FromSlice(b)); puterr != nil {
 						return errors.Wrap(puterr, "error writing format blob")
 					}

--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -67,6 +67,7 @@ func (c *commandRepositoryStatus) run(ctx context.Context, rep repo.Repository) 
 	c.out.printStdout("Splitter:            %v\n", dr.ObjectFormat().Splitter)
 	c.out.printStdout("Format version:      %v\n", dr.ContentReader().ContentFormat().Version)
 	c.out.printStdout("Content compression: %v\n", dr.ContentReader().SupportsContentCompression())
+	c.out.printStdout("Password changes:    %v\n", dr.ContentReader().ContentFormat().EnablePasswordChange)
 
 	c.out.printStdout("Max pack length:     %v\n", units.BytesStringBase2(int64(dr.ContentReader().ContentFormat().MaxPackSize)))
 	c.out.printStdout("Index Format:        v%v\n", dr.ContentReader().ContentFormat().IndexVersion)

--- a/cli/password.go
+++ b/cli/password.go
@@ -33,6 +33,26 @@ func askForNewRepositoryPassword(out io.Writer) (string, error) {
 	}
 }
 
+func askForChangedRepositoryPassword(out io.Writer) (string, error) {
+	for {
+		p1, err := askPass(out, "Enter new password: ")
+		if err != nil {
+			return "", errors.Wrap(err, "password entry")
+		}
+
+		p2, err := askPass(out, "Re-enter password for verification: ")
+		if err != nil {
+			return "", errors.Wrap(err, "password verification")
+		}
+
+		if p1 != p2 {
+			fmt.Println("Passwords don't match!")
+		} else {
+			return p1, nil
+		}
+	}
+}
+
 func askForExistingRepositoryPassword(out io.Writer) (string, error) {
 	p1, err := askPass(out, "Enter password to open repository: ")
 	if err != nil {

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -48,9 +48,10 @@ func (e *Environment) setup(t *testing.T, opts ...Options) *Environment {
 
 	opt := &repo.NewRepositoryOptions{
 		BlockFormat: content.FormattingOptions{
-			HMACSecret: []byte{},
-			Hash:       "HMAC-SHA256",
-			Encryption: encryption.DefaultAlgorithm,
+			HMACSecret:           []byte{},
+			Hash:                 "HMAC-SHA256",
+			Encryption:           encryption.DefaultAlgorithm,
+			EnablePasswordChange: true,
 		},
 		ObjectFormat: object.Format{
 			Splitter: "FIXED-1M",

--- a/internal/repotesting/repotesting_test.go
+++ b/internal/repotesting/repotesting_test.go
@@ -19,7 +19,7 @@ func TestTimeFuncWiring(t *testing.T) {
 	ft := faketime.NewTimeAdvance(time.Date(2018, time.February, 6, 0, 0, 0, 0, time.UTC), 0)
 
 	// Re open with injected time
-	rep, err := repo.Open(ctx, env.RepositoryWriter.ConfigFilename(), masterPassword, &repo.Options{TimeNowFunc: ft.NowFunc()})
+	rep, err := repo.Open(ctx, env.RepositoryWriter.ConfigFilename(), env.Password, &repo.Options{TimeNowFunc: ft.NowFunc()})
 	if err != nil {
 		t.Fatal("Failed to open repo:", err)
 	}

--- a/repo/change_password.go
+++ b/repo/change_password.go
@@ -1,0 +1,43 @@
+package repo
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// ChangePassword changes the repository password and rewrites `kopia.repository`.
+func (r *directRepository) ChangePassword(ctx context.Context, newPassword string) error {
+	f := r.formatBlob
+
+	repoConfig, err := f.decryptFormatBytes(r.masterKey)
+	if err != nil {
+		return errors.Wrap(err, "unable to decrypt repository config")
+	}
+
+	newMasterKey, err := f.deriveMasterKeyFromPassword(newPassword)
+	if err != nil {
+		return errors.Wrap(err, "unable to derive master key")
+	}
+
+	r.masterKey = newMasterKey
+
+	if err := encryptFormatBytes(f, repoConfig, newMasterKey, f.UniqueID); err != nil {
+		return errors.Wrap(err, "unable to encrypt format bytes")
+	}
+
+	if err := writeFormatBlob(ctx, r.blobs, f); err != nil {
+		return errors.Wrap(err, "unable to write format blob")
+	}
+
+	// remove cached kopia.repository blob.
+	if cd := r.cachingOptions.CacheDirectory; cd != "" {
+		if err := os.Remove(filepath.Join(r.cachingOptions.CacheDirectory, "kopia.repository")); err != nil {
+			log(ctx).Errorf("unable to remove kopia.repository: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/repo/change_password.go
+++ b/repo/change_password.go
@@ -12,19 +12,19 @@ import (
 func (r *directRepository) ChangePassword(ctx context.Context, newPassword string) error {
 	f := r.formatBlob
 
-	repoConfig, err := f.decryptFormatBytes(r.masterKey)
+	repoConfig, err := f.decryptFormatBytes(r.formatEncryptionKey)
 	if err != nil {
 		return errors.Wrap(err, "unable to decrypt repository config")
 	}
 
-	newMasterKey, err := f.deriveMasterKeyFromPassword(newPassword)
+	newFormatEncryptionKey, err := f.deriveFormatEncryptionKeyFromPassword(newPassword)
 	if err != nil {
 		return errors.Wrap(err, "unable to derive master key")
 	}
 
-	r.masterKey = newMasterKey
+	r.formatEncryptionKey = newFormatEncryptionKey
 
-	if err := encryptFormatBytes(f, repoConfig, newMasterKey, f.UniqueID); err != nil {
+	if err := encryptFormatBytes(f, repoConfig, newFormatEncryptionKey, f.UniqueID); err != nil {
 		return errors.Wrap(err, "unable to encrypt format bytes")
 	}
 

--- a/repo/change_password.go
+++ b/repo/change_password.go
@@ -17,6 +17,10 @@ func (r *directRepository) ChangePassword(ctx context.Context, newPassword strin
 		return errors.Wrap(err, "unable to decrypt repository config")
 	}
 
+	if !repoConfig.EnablePasswordChange {
+		return errors.Errorf("password changes are not supported for repositories created using Kopia v0.8 or older")
+	}
+
 	newFormatEncryptionKey, err := f.deriveFormatEncryptionKeyFromPassword(newPassword)
 	if err != nil {
 		return errors.Wrap(err, "unable to derive master key")

--- a/repo/content/content_formatting_options.go
+++ b/repo/content/content_formatting_options.go
@@ -20,6 +20,8 @@ type FormattingOptions struct {
 	HMACSecret []byte `json:"secret,omitempty"`     // HMAC secret used to generate encryption keys
 	MasterKey  []byte `json:"masterKey,omitempty"`  // master encryption key (SIV-mode encryption only)
 	MutableParameters
+
+	EnablePasswordChange bool `json:"enablePasswordChange"` // disables replication of kopia.repository blob in packs
 }
 
 // MutableParameters represents parameters of the content manager that can be mutated after the repository

--- a/repo/crypto_key_derivation_nontest.go
+++ b/repo/crypto_key_derivation_nontest.go
@@ -10,7 +10,7 @@ import (
 // defaultKeyDerivationAlgorithm is the key derivation algorithm for new configurations.
 const defaultKeyDerivationAlgorithm = "scrypt-65536-8-1"
 
-func (f *formatBlob) deriveMasterKeyFromPassword(password string) ([]byte, error) {
+func (f *formatBlob) deriveFormatEncryptionKeyFromPassword(password string) ([]byte, error) {
 	const masterKeySize = 32
 
 	switch f.KeyDerivationAlgorithm {

--- a/repo/crypto_key_derivation_testing.go
+++ b/repo/crypto_key_derivation_testing.go
@@ -11,7 +11,7 @@ import (
 // defaultKeyDerivationAlgorithm is the key derivation algorithm for new configurations.
 const defaultKeyDerivationAlgorithm = "testing-only-insecure"
 
-func (f *formatBlob) deriveMasterKeyFromPassword(password string) ([]byte, error) {
+func (f *formatBlob) deriveFormatEncryptionKeyFromPassword(password string) ([]byte, error) {
 	const masterKeySize = 32
 
 	switch f.KeyDerivationAlgorithm {

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -104,6 +104,7 @@ func repositoryObjectFormatFromOptions(opt *NewRepositoryOptions) *repositoryObj
 				IndexVersion:    applyDefaultInt(opt.BlockFormat.IndexVersion, content.DefaultIndexVersion),
 				EpochParameters: opt.BlockFormat.EpochParameters,
 			},
+			EnablePasswordChange: opt.BlockFormat.EnablePasswordChange,
 		},
 		Format: object.Format{
 			Splitter: applyDefaultString(opt.ObjectFormat.Splitter, splitter.DefaultAlgorithm),

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -58,9 +58,9 @@ func Initialize(ctx context.Context, st blob.Storage, opt *NewRepositoryOptions,
 
 	format := formatBlobFromOptions(opt)
 
-	masterKey, err := format.deriveMasterKeyFromPassword(password)
+	formatEncryptionKey, err := format.deriveFormatEncryptionKeyFromPassword(password)
 	if err != nil {
-		return errors.Wrap(err, "unable to derive master key")
+		return errors.Wrap(err, "unable to derive format encryption key")
 	}
 
 	f := repositoryObjectFormatFromOptions(opt)
@@ -68,7 +68,7 @@ func Initialize(ctx context.Context, st blob.Storage, opt *NewRepositoryOptions,
 		return errors.Wrap(err, "invalid parameters")
 	}
 
-	if err := encryptFormatBytes(format, f, masterKey, format.UniqueID); err != nil {
+	if err := encryptFormatBytes(format, f, formatEncryptionKey, format.UniqueID); err != nil {
 		return errors.Wrap(err, "unable to encrypt format bytes")
 	}
 

--- a/repo/open.go
+++ b/repo/open.go
@@ -212,6 +212,11 @@ func openWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 		DisableInternalLog:    options.DisableInternalLog,
 	}
 
+	// do not embed repository format info in pack blobs when password change is enabled.
+	if fo.EnablePasswordChange {
+		cmOpts.RepositoryFormatBytes = nil
+	}
+
 	scm, err := content.NewSharedManager(ctx, st, fo, caching, cmOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shared content manager")

--- a/repo/open.go
+++ b/repo/open.go
@@ -308,10 +308,6 @@ func formatBytesCachingEnabled(cacheDirectory string, validDuration time.Duratio
 }
 
 func readFormatBlobBytesFromCache(ctx context.Context, cachedFile string, validDuration time.Duration) ([]byte, error) {
-	if err := os.MkdirAll(filepath.Dir(cachedFile), cache.DirMode); err != nil && !os.IsExist(err) {
-		log(ctx).Errorf("unable to create cache directory: %v", err)
-	}
-
 	cst, err := os.Stat(cachedFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open cache file")
@@ -334,6 +330,12 @@ func readAndCacheFormatBlobBytes(ctx context.Context, st blob.Storage, cacheDire
 
 	if validDuration == 0 {
 		validDuration = defaultFormatBlobCacheDuration
+	}
+
+	if cacheDirectory != "" {
+		if err := os.MkdirAll(cacheDirectory, cache.DirMode); err != nil && !os.IsExist(err) {
+			log(ctx).Errorf("unable to create cache directory: %v", err)
+		}
 	}
 
 	cacheEnabled := formatBytesCachingEnabled(cacheDirectory, validDuration)

--- a/repo/parameters.go
+++ b/repo/parameters.go
@@ -14,7 +14,7 @@ import (
 func (r *directRepository) SetParameters(ctx context.Context, m content.MutableParameters) error {
 	f := r.formatBlob
 
-	repoConfig, err := f.decryptFormatBytes(r.masterKey)
+	repoConfig, err := f.decryptFormatBytes(r.formatEncryptionKey)
 	if err != nil {
 		return errors.Wrap(err, "unable to decrypt repository config")
 	}
@@ -25,7 +25,7 @@ func (r *directRepository) SetParameters(ctx context.Context, m content.MutableP
 
 	repoConfig.FormattingOptions.MutableParameters = m
 
-	if err := encryptFormatBytes(f, repoConfig, r.masterKey, f.UniqueID); err != nil {
+	if err := encryptFormatBytes(f, repoConfig, r.formatEncryptionKey, f.UniqueID); err != nil {
 		return errors.Errorf("unable to encrypt format bytes")
 	}
 

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -78,14 +78,14 @@ type DirectRepositoryWriter interface {
 }
 
 type directRepositoryParameters struct {
-	uniqueID       []byte
-	configFile     string
-	cachingOptions content.CachingOptions
-	cliOpts        ClientOptions
-	timeNow        func() time.Time
-	formatBlob     *formatBlob
-	masterKey      []byte
-	nextWriterID   *int32
+	uniqueID            []byte
+	configFile          string
+	cachingOptions      content.CachingOptions
+	cliOpts             ClientOptions
+	timeNow             func() time.Time
+	formatBlob          *formatBlob
+	formatEncryptionKey []byte
+	nextWriterID        *int32
 }
 
 // directRepository is an implementation of repository that directly manipulates underlying storage.
@@ -103,7 +103,7 @@ type directRepository struct {
 
 // DeriveKey derives encryption key of the provided length from the master key.
 func (r *directRepository) DeriveKey(purpose []byte, keyLength int) []byte {
-	return deriveKeyFromMasterKey(r.masterKey, r.uniqueID, purpose, keyLength)
+	return deriveKeyFromMasterKey(r.formatEncryptionKey, r.uniqueID, purpose, keyLength)
 }
 
 // ClientOptions returns client options.

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -74,6 +74,7 @@ type DirectRepositoryWriter interface {
 	BlobStorage() blob.Storage
 	ContentManager() *content.WriteManager
 	SetParameters(ctx context.Context, m content.MutableParameters) error
+	ChangePassword(ctx context.Context, newPassword string) error
 }
 
 type directRepositoryParameters struct {

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -103,6 +103,13 @@ type directRepository struct {
 
 // DeriveKey derives encryption key of the provided length from the master key.
 func (r *directRepository) DeriveKey(purpose []byte, keyLength int) []byte {
+	if r.cmgr.ContentFormat().EnablePasswordChange {
+		return deriveKeyFromMasterKey(r.cmgr.ContentFormat().MasterKey, r.uniqueID, purpose, keyLength)
+	}
+
+	// version of kopia <v0.9 had a bug where certain keys were derived directly from
+	// the password and not from the random master key. This made it impossible to change
+	// password.
 	return deriveKeyFromMasterKey(r.formatEncryptionKey, r.uniqueID, purpose, keyLength)
 }
 

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -443,9 +443,8 @@ func TestChangePassword(t *testing.T) {
 	require.NoError(t, env.RepositoryWriter.ChangePassword(ctx, "new-password"))
 
 	r, err := repo.Open(ctx, env.RepositoryWriter.ConfigFilename(), "new-password", nil)
-	defer r.Close(ctx)
-
 	require.NoError(t, err)
+	r.Close(ctx)
 }
 
 func verifyNotFound(ctx context.Context, t *testing.T, rep repo.Repository, objectID object.ID, testCaseID string) {

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -437,6 +437,17 @@ func TestWriteSessionFlushOnFailure(t *testing.T) {
 	verify(ctx, t, env.Repository, oid, []byte{1, 2, 3}, "test-1")
 }
 
+func TestChangePassword(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t)
+
+	require.NoError(t, env.RepositoryWriter.ChangePassword(ctx, "new-password"))
+
+	r, err := repo.Open(ctx, env.RepositoryWriter.ConfigFilename(), "new-password", nil)
+	defer r.Close(ctx)
+
+	require.NoError(t, err)
+}
+
 func verifyNotFound(ctx context.Context, t *testing.T, rep repo.Repository, objectID object.ID, testCaseID string) {
 	t.Helper()
 

--- a/tests/testenv/cli_inproc_runner.go
+++ b/tests/testenv/cli_inproc_runner.go
@@ -11,7 +11,9 @@ import (
 )
 
 // CLIInProcRunner is a CLIRunner that invokes provided commands in the current process.
-type CLIInProcRunner struct{}
+type CLIInProcRunner struct {
+	RepoPassword string
+}
 
 // Start implements CLIRunner.
 func (e *CLIInProcRunner) Start(t *testing.T, args []string) (stdout, stderr io.Reader, wait func() error, kill func()) {
@@ -23,7 +25,7 @@ func (e *CLIInProcRunner) Start(t *testing.T, args []string) (stdout, stderr io.
 	a.AdvancedCommands = "enabled"
 
 	return a.RunSubcommand(ctx, append([]string{
-		"--password", TestRepoPassword,
+		"--password", e.RepoPassword,
 	}, args...))
 }
 
@@ -35,7 +37,9 @@ func NewInProcRunner(t *testing.T) *CLIInProcRunner {
 		t.Skip("not running test since it's also included in the unit tests")
 	}
 
-	return &CLIInProcRunner{}
+	return &CLIInProcRunner{
+		RepoPassword: TestRepoPassword,
+	}
 }
 
 var _ CLIRunner = (*CLIInProcRunner)(nil)


### PR DESCRIPTION
This will only work for new repositories, since there's now a repository-wide flag that disables replication of `kopia.repository` contents in all packs.