### PR TITLE
robustness: serialize client authorization (#232)

### DIFF
--- a/tests/robustness/multiclient_test/framework/snapshotter.go
+++ b/tests/robustness/multiclient_test/framework/snapshotter.go
@@ -200,7 +200,11 @@ func (mcs *MultiClientSnapshotter) createOrGetSnapshotter(ctx context.Context) (
 	}
 
 	// Register client with server and create connection
-	if err := mcs.server.AuthorizeClient(c.ID); err != nil {
+	mcs.mu.Lock()
+	err = mcs.server.AuthorizeClient(c.ID)
+	mcs.mu.Unlock()
+
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The robustness tests have been failing intermittently with client authentication errors. I believe this is caused by trying to authorize several clients in parallel.

At a high level, the steps for client authorization include running server user add and server refresh. I think we are running into issues by having multiple clients adding users and refreshing the server in parallel.

This PR serializes client authorization to avoid this potential issue.