### PR TITLE
WebDAV and Rclone atomic writes

### DIFF
--- a/cli/storage_rclone.go
+++ b/cli/storage_rclone.go
@@ -27,6 +27,7 @@ func (c *storageRcloneFlags) setup(_ storageProviderServices, cmd *kingpin.CmdCl
 	cmd.Flag("rclone-debug", "Log rclone output").Hidden().BoolVar(&c.opt.Debug)
 	cmd.Flag("rclone-nowait-for-transfers", "Don't wait for transfers when closing storage").Hidden().BoolVar(&c.opt.NoWaitForTransfers)
 	cmd.Flag("list-parallelism", "Set list parallelism").Hidden().IntVar(&c.opt.ListParallelism)
+	cmd.Flag("atomic-writes", "Assume provider writes are atomic").Default("true").BoolVar(&c.opt.AtomicWrites)
 }
 
 func (c *storageRcloneFlags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {

--- a/cli/storage_webdav.go
+++ b/cli/storage_webdav.go
@@ -21,6 +21,7 @@ func (c *storageWebDAVFlags) setup(_ storageProviderServices, cmd *kingpin.CmdCl
 	cmd.Flag("webdav-username", "WebDAV username").Envar("KOPIA_WEBDAV_USERNAME").StringVar(&c.options.Username)
 	cmd.Flag("webdav-password", "WebDAV password").Envar("KOPIA_WEBDAV_PASSWORD").StringVar(&c.options.Password)
 	cmd.Flag("list-parallelism", "Set list parallelism").Hidden().IntVar(&c.options.ListParallelism)
+	cmd.Flag("atomic-writes", "Assume WebDAV provider implements atomic writes").BoolVar(&c.options.AtomicWrites)
 }
 
 func (c *storageWebDAVFlags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {

--- a/repo/blob/rclone/rclone_options.go
+++ b/repo/blob/rclone/rclone_options.go
@@ -12,4 +12,5 @@ type Options struct {
 	DirectoryShards    []int    `json:"dirShards"`
 	EmbeddedConfig     string   `json:"embeddedConfig,omitempty"`
 	ListParallelism    int      `json:"listParallelism,omitempty"`
+	AtomicWrites       bool     `json:"atomicWrites"`
 }

--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -120,7 +120,7 @@ func (r *rcloneStorage) processStderrStatus(ctx context.Context, statsMarker str
 		}
 
 		if strings.Contains(l, statsMarker) {
-			if strings.Contains(l, " 100%,") {
+			if strings.Contains(l, " 100%,") || strings.Contains(l, ", -,") {
 				atomic.StoreInt32(r.allTransfersComplete, 1)
 			} else {
 				atomic.StoreInt32(r.allTransfersComplete, 0)
@@ -293,6 +293,7 @@ func New(ctx context.Context, opt *Options) (blob.Storage, error) {
 		Password:                            webdavPassword,
 		TrustedServerCertificateFingerprint: hex.EncodeToString(fingerprintBytes[:]),
 		ListParallelism:                     opt.ListParallelism,
+		AtomicWrites:                        opt.AtomicWrites,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "error connecting to webdav storage")

--- a/repo/blob/rclone/rclone_storage_test.go
+++ b/repo/blob/rclone/rclone_storage_test.go
@@ -170,6 +170,7 @@ func TestRCloneProviders(t *testing.T) {
 			EmbeddedConfig:  embeddedConfig,
 			Debug:           true,
 			ListParallelism: 16,
+			AtomicWrites:    true,
 		}
 
 		t.Run("Cleanup-"+name, func(t *testing.T) {

--- a/repo/blob/webdav/webdav_options.go
+++ b/repo/blob/webdav/webdav_options.go
@@ -8,6 +8,7 @@ type Options struct {
 	Password                            string `json:"password,omitempty" kopia:"sensitive"`
 	TrustedServerCertificateFingerprint string `json:"trustedServerCertificateFingerprint,omitempty"`
 	ListParallelism                     int    `json:"listParallelism,omitempty"`
+	AtomicWrites                        bool   `json:"atomicWrites"`
 }
 
 func (fso *Options) shards() []int {


### PR DESCRIPTION
Added two flags called `--atomic-writes`:

* for `webdav` - defaults to false
* for `rclone` - defaults to true (most rclone backends support atomic writes according to the author)

This allows the `rclone` provider to be much more efficient.