### PR TITLE
force-hash: Allow fractional percentages

### DIFF
--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -28,7 +28,7 @@ type commandSnapshotCreate struct {
 	snapshotCreateDescription             string
 	snapshotCreateCheckpointInterval      time.Duration
 	snapshotCreateFailFast                bool
-	snapshotCreateForceHash               int
+	snapshotCreateForceHash               float64
 	snapshotCreateParallelUploads         int
 	snapshotCreateStartTime               string
 	snapshotCreateEndTime                 string
@@ -52,7 +52,7 @@ func (c *commandSnapshotCreate) setup(svc appServices, parent commandParent) {
 	cmd.Flag("checkpoint-interval", "Frequency for creating periodic checkpoint.").DurationVar(&c.snapshotCreateCheckpointInterval)
 	cmd.Flag("description", "Free-form snapshot description.").StringVar(&c.snapshotCreateDescription)
 	cmd.Flag("fail-fast", "Fail fast when creating snapshot.").Envar("KOPIA_SNAPSHOT_FAIL_FAST").BoolVar(&c.snapshotCreateFailFast)
-	cmd.Flag("force-hash", "Force hashing of source files for a given percentage of files [0..100]").Default("0").IntVar(&c.snapshotCreateForceHash)
+	cmd.Flag("force-hash", "Force hashing of source files for a given percentage of files [0..100]").Default("0").Float64Var(&c.snapshotCreateForceHash)
 	cmd.Flag("parallel", "Upload N files in parallel").PlaceHolder("N").Default("0").IntVar(&c.snapshotCreateParallelUploads)
 	cmd.Flag("start-time", "Override snapshot start timestamp.").StringVar(&c.snapshotCreateStartTime)
 	cmd.Flag("end-time", "Override snapshot end timestamp.").StringVar(&c.snapshotCreateEndTime)

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -782,7 +782,7 @@ func findCachedEntry(ctx context.Context, entry fs.Entry, prevEntries []fs.Entri
 
 func (u *Uploader) maybeIgnoreCachedEntry(ctx context.Context, ent fs.Entry) fs.Entry {
 	if h, ok := ent.(object.HasObjectID); ok {
-		if 100*rand.Float64() < u.ForceHashPercentage { // nolint:gomnd,gosec
+		if 100*rand.Float64() < u.ForceHashPercentage { // nolint:gosec
 			log(ctx).Debugf("re-hashing cached object: %v", h.ObjectID())
 			return nil
 		}

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -782,7 +782,7 @@ func findCachedEntry(ctx context.Context, entry fs.Entry, prevEntries []fs.Entri
 
 func (u *Uploader) maybeIgnoreCachedEntry(ctx context.Context, ent fs.Entry) fs.Entry {
 	if h, ok := ent.(object.HasObjectID); ok {
-		if 100 * rand.Float64() < u.ForceHashPercentage { // nolint:gomnd,gosec
+		if 100*rand.Float64() < u.ForceHashPercentage { // nolint:gomnd,gosec
 			log(ctx).Debugf("re-hashing cached object: %v", h.ObjectID())
 			return nil
 		}

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -57,7 +57,7 @@ type Uploader struct {
 	// probability with cached entries will be ignored, must be [0..100]
 	// 0=always use cached object entries if possible
 	// 100=never use cached entries
-	ForceHashPercentage int
+	ForceHashPercentage float64
 
 	// Number of files to hash and upload in parallel.
 	ParallelUploads int
@@ -782,7 +782,7 @@ func findCachedEntry(ctx context.Context, entry fs.Entry, prevEntries []fs.Entri
 
 func (u *Uploader) maybeIgnoreCachedEntry(ctx context.Context, ent fs.Entry) fs.Entry {
 	if h, ok := ent.(object.HasObjectID); ok {
-		if rand.Intn(100) < u.ForceHashPercentage { // nolint:gomnd,gosec
+		if 100 * rand.Float64() < u.ForceHashPercentage { // nolint:gomnd,gosec
 			log(ctx).Debugf("re-hashing cached object: %v", h.ObjectID())
 			return nil
 		}


### PR DESCRIPTION
I was passing `--force-hash=0.1` for a while before I realized that this is actually parsed as `0` and the rest is silently discarded.

This could of course be turned into an error but personally I believe that fractional percentages are useful here, especially if you create snapshots very frequently.

I run hourly snapshots and `--force-hash=0.1` if I did my math right this should result in a ~0.5% chance that a given file is not hashed within a month, which feels good enough for my regular background snapshots and keeps the load down quite a bit.