### PR TITLE
content: ensure that we always consistently pick content.Info amongst entries with identical time and deleted flag

### DIFF
--- a/repo/content/builder.go
+++ b/repo/content/builder.go
@@ -36,7 +36,7 @@ func (b packIndexBuilder) clone() packIndexBuilder {
 func (b packIndexBuilder) Add(i Info) {
 	cid := i.GetContentID()
 
-	if old, ok := b[cid]; !ok || i.GetTimestampSeconds() >= old.GetTimestampSeconds() {
+	if contentInfoGreaterThan(i, b[cid]) {
 		b[cid] = i
 	}
 }

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -732,7 +732,7 @@ func (bm *WriteManager) getContentInfo(contentID ID) (*pendingPackInfo, Info, er
 func (bm *WriteManager) ContentInfo(ctx context.Context, contentID ID) (Info, error) {
 	_, bi, err := bm.getContentInfo(contentID)
 	if err != nil {
-		bm.log.Debugf("ContentInfo(%q) - error %v", err)
+		bm.log.Debugf("ContentInfo(%q) - error %v", contentID, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
This was reported by Stephan Budach on Slack (thanks!) who provided
the log where two separate write sessions created identical content
at exactly the same time.

```
2021-07-11T06:49:30.056211Z DEBUG [writer-4:Source Manager Uploader] write-content e5a857d1505308e94a4d495833a278da new
2021-07-11T06:49:30.222525Z DEBUG [writer-4:Source Manager Uploader] add-to-pack pe5873427a445f07f92f66837bfbb5752-sfa2a7c24c8d31100106 e5a857d1505308e94a4d495833a278da p:pe5873427a445f07f92f66837bfbb5752-sfa2a7c24c8d31100106 3461377 d:false
2021-07-11T06:49:30.857310Z DEBUG [writer-2:Source Manager Uploader] write-content e5a857d1505308e94a4d495833a278da new
2021-07-11T06:49:31.982930Z DEBUG [writer-2:Source Manager Uploader] add-to-pack p24b9a682047d63b19614827b653e54eb-s583f9f99a3312721106 e5a857d1505308e94a4d495833a278da p:p24b9a682047d63b19614827b653e54eb-s583f9f99a3312721106 3461377 d:false
```

Because we made different decision w.r.t which one is active at two separate times, maintenance ended up deleting the wrong blob.

Introduced `contentInfoGreaterThan(a, b)`which is used in all 3 places where we do content ID merges.