### PR TITLE
content: automatically refresh indexes on read instead of relying on RefreshPeriodically() loop

### DIFF
--- a/repo/content/content_manager_indexes.go
+++ b/repo/content/content_manager_indexes.go
@@ -39,7 +39,7 @@ func (sm *SharedManager) Refresh(ctx context.Context) error {
 
 	t0 := clock.Now()
 
-	err := sm.loadPackIndexesUnlocked(ctx)
+	err := sm.loadPackIndexesLocked(ctx)
 	sm.log.Debugf("Refresh completed in %v", clock.Since(t0))
 
 	return err
@@ -59,7 +59,7 @@ func (sm *SharedManager) CompactIndexes(ctx context.Context, opt CompactOptions)
 	}
 
 	// reload indexes after compaction.
-	if err := sm.loadPackIndexesUnlocked(ctx); err != nil {
+	if err := sm.loadPackIndexesLocked(ctx); err != nil {
 		return errors.Wrap(err, "error re-loading indexes")
 	}
 

--- a/repo/content/content_manager_iterate.go
+++ b/repo/content/content_manager_iterate.go
@@ -143,6 +143,10 @@ func (bm *WriteManager) IterateContents(ctx context.Context, opts IterateOptions
 		_ = invokeCallback(bi)
 	}
 
+	if err := bm.maybeRefreshIndexes(ctx); err != nil {
+		return err
+	}
+
 	if err := bm.committedContents.listContents(opts.Range, invokeCallback); err != nil {
 		return err
 	}

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -2293,7 +2293,7 @@ func deleteContent(ctx context.Context, t *testing.T, bm *WriteManager, c ID) {
 func getContentInfo(t *testing.T, bm *WriteManager, c ID) Info {
 	t.Helper()
 
-	_, i, err := bm.getContentInfo(c)
+	_, i, err := bm.getContentInfo(testlogging.Context(t), c)
 	if err != nil {
 		t.Fatalf("Unable to get content info for %q: %v", c, err)
 	}

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -186,6 +186,10 @@ func RunExclusive(ctx context.Context, rep repo.DirectRepositoryWriter, mode Mod
 	log(ctx).Infof("Running %v maintenance...", runParams.Mode)
 	defer log(ctx).Infof("Finished %v maintenance.", runParams.Mode)
 
+	if err := runParams.rep.Refresh(ctx); err != nil {
+		return errors.Wrap(err, "error refreshing indexes before maintenance")
+	}
+
 	return cb(runParams)
 }
 

--- a/repo/open.go
+++ b/repo/open.go
@@ -30,9 +30,6 @@ const CacheDirMarkerFile = "CACHEDIR.TAG"
 // CacheDirMarkerHeader is the header signature for cache dir marker files.
 const CacheDirMarkerHeader = "Signature: 8a477f597d28d172789f06886806bc55"
 
-// refresh indexes every 15 minutes while the repository remains open.
-const backgroundRefreshInterval = 15 * time.Minute
-
 // defaultFormatBlobCacheDuration is the duration for which we treat cached kopia.repository
 // as valid.
 const defaultFormatBlobCacheDuration = 15 * time.Minute
@@ -264,8 +261,6 @@ func openWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 		},
 		closed: make(chan struct{}),
 	}
-
-	go dr.RefreshPeriodically(ctx, backgroundRefreshInterval)
 
 	return dr, nil
 }

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -299,25 +299,6 @@ func (r *directRepository) Refresh(ctx context.Context) error {
 	return errors.Wrap(r.cmgr.Refresh(ctx), "error refreshing content index")
 }
 
-// RefreshPeriodically periodically refreshes the repository to reflect the changes made by other hosts.
-func (r *directRepository) RefreshPeriodically(ctx context.Context, interval time.Duration) {
-	for {
-		select {
-		case <-r.closed:
-			// stop background refresh when repository is closed
-			return
-
-		case <-ctx.Done():
-			return
-
-		case <-time.After(interval):
-			if err := r.Refresh(ctx); err != nil {
-				log(ctx).Errorf("error refreshing repository: %v", err)
-			}
-		}
-	}
-}
-
 // Time returns the current local time for the repo.
 func (r *directRepository) Time() time.Time {
 	return defaultTime(r.timeNow)()


### PR DESCRIPTION
also force refresh indexes before running maintenance

Fixes #1242