### PR TITLE
splitter: optimize performance

### DIFF
--- a/repo/splitter/splitter_buzhash32.go
+++ b/repo/splitter/splitter_buzhash32.go
@@ -26,8 +26,7 @@ func (rs *buzhash32Splitter) Reset() {
 func (rs *buzhash32Splitter) NextSplitPoint(b []byte) int {
 	var fastPathBytes int
 
-	// simple optimization, if we're below minSize, there's no reason to even
-	// look at the Sum32() or maxSize
+	// until minSize, only hash the last splitterSlidingWindowSize bytes
 	if left := rs.minSize - rs.count - 1; left > 0 {
 		fastPathBytes = left
 		if fastPathBytes > len(b) {
@@ -36,11 +35,9 @@ func (rs *buzhash32Splitter) NextSplitPoint(b []byte) int {
 
 		var i int
 
-		for i = 0; i < fastPathBytes-3; i += 4 {
-			rs.rh.Roll(b[i])
-			rs.rh.Roll(b[i+1])
-			rs.rh.Roll(b[i+2])
-			rs.rh.Roll(b[i+3])
+		i = fastPathBytes - splitterSlidingWindowSize
+		if i < 0 {
+			i = 0
 		}
 
 		for ; i < fastPathBytes; i++ {
@@ -51,16 +48,18 @@ func (rs *buzhash32Splitter) NextSplitPoint(b []byte) int {
 		b = b[fastPathBytes:]
 	}
 
-	// second optimization, if we're safely below maxSize, there's no reason to check it
-	// in a loop
-	if left := rs.maxSize - rs.count - 1; left > 0 {
+	// until the max size, check if we have any splitting point
+	if left := rs.maxSize - rs.count; left > 0 {
 		fp := left
 		if fp >= len(b) {
 			fp = len(b)
 		}
 
 		for i, b := range b[0:fp] {
-			if rs.shouldSplitNoMax(b) {
+			rs.rh.Roll(b)
+			rs.count++
+
+			if rs.rh.Sum32()&rs.mask == 0 {
 				rs.count = 0
 				return fastPathBytes + i + 1
 			}
@@ -70,29 +69,13 @@ func (rs *buzhash32Splitter) NextSplitPoint(b []byte) int {
 		b = b[fp:]
 	}
 
-	for i, b := range b {
-		if rs.shouldSplitWithMaxCheck(b) {
-			rs.count = 0
-			return fastPathBytes + i + 1
-		}
+	// if we're over the max size, split
+	if rs.count >= rs.maxSize {
+		rs.count = 0
+		return fastPathBytes
 	}
 
 	return -1
-}
-
-func (rs *buzhash32Splitter) shouldSplitWithMaxCheck(b byte) bool {
-	if rs.shouldSplitNoMax(b) || rs.count >= rs.maxSize {
-		return true
-	}
-
-	return false
-}
-
-func (rs *buzhash32Splitter) shouldSplitNoMax(b byte) bool {
-	rs.rh.Roll(b)
-	rs.count++
-
-	return rs.rh.Sum32()&rs.mask == 0
 }
 
 func (rs *buzhash32Splitter) MaxSegmentSize() int {

--- a/repo/splitter/splitter_buzhash32.go
+++ b/repo/splitter/splitter_buzhash32.go
@@ -66,7 +66,6 @@ func (rs *buzhash32Splitter) NextSplitPoint(b []byte) int {
 		}
 
 		fastPathBytes += fp
-		b = b[fp:]
 	}
 
 	// if we're over the max size, split

--- a/repo/splitter/splitter_rabinkarp64.go
+++ b/repo/splitter/splitter_rabinkarp64.go
@@ -66,7 +66,6 @@ func (rs *rabinKarp64Splitter) NextSplitPoint(b []byte) int {
 		}
 
 		fastPathBytes += fp
-		b = b[fp:]
 	}
 
 	// if we're over the max size, split


### PR DESCRIPTION
1) a property of the rolling hashes is that its content only depends on the last [window size] bytes, thus there is no point hashing if we are way below minimum size.
2) inline shouldSplitNoMax: Go currently cannot inline more than one level, so having shouldSplitNoMax means Go cannot inline Roll
3) simplify shouldSplitWithMaxCheck: either we've already split due to finding a splitting point or we're at the max size and we should immediately split, no point having a loop here (note: the call to Roll was moved to shouldSplitNoMax path)

Before
```
DYNAMIC                     2564 ms count:107 min:9467 10th:2277562 25th:2971794 50th:4747177 75th:7603998 90th:8388608 max:8388608
DYNAMIC-1M-BUZHASH          2873 ms count:428 min:9467 10th:612999 25th:766808 50th:1158068 75th:1744194 90th:2097152 max:2097152
DYNAMIC-1M-RABINKARP        9713 ms count:391 min:213638 10th:623062 25th:813953 50th:1328673 75th:2097152 90th:2097152 max:2097152
DYNAMIC-2M-BUZHASH          2548 ms count:204 min:64697 10th:1210184 25th:1638276 50th:2585985 75th:3944217 90th:4194304 max:4194304
DYNAMIC-2M-RABINKARP        9993 ms count:204 min:535925 10th:1235674 25th:1675441 50th:2525341 75th:3658905 90th:4194304 max:4194304
DYNAMIC-4M-BUZHASH          2940 ms count:107 min:9467 10th:2277562 25th:2971794 50th:4747177 75th:7603998 90th:8388608 max:8388608
DYNAMIC-4M-RABINKARP        9150 ms count:110 min:535925 10th:2242307 25th:2767610 50th:4400962 75th:6813401 90th:8388608 max:8388608
DYNAMIC-8M-BUZHASH          2993 ms count:49 min:677680 10th:5260579 25th:6528562 50th:11102775 75th:16777216 90th:16777216 max:16777216
DYNAMIC-8M-RABINKARP        9577 ms count:60 min:1446246 10th:4337385 25th:5293196 50th:8419217 75th:12334953 90th:16777216 max:16777216
```

After
```
DYNAMIC                     1467 ms count:107 min:9467 10th:2277562 25th:2971794 50th:4747177 75th:7603998 90th:8388608 max:8388608
DYNAMIC-1M-BUZHASH          1501 ms count:428 min:9467 10th:612999 25th:766808 50th:1158068 75th:1744194 90th:2097152 max:2097152
DYNAMIC-1M-RABINKARP        4725 ms count:391 min:213638 10th:623062 25th:813953 50th:1328673 75th:2097152 90th:2097152 max:2097152
DYNAMIC-2M-BUZHASH          1780 ms count:204 min:64697 10th:1210184 25th:1638276 50th:2585985 75th:3944217 90th:4194304 max:4194304
DYNAMIC-2M-RABINKARP        8239 ms count:204 min:535925 10th:1235674 25th:1675441 50th:2525341 75th:3658905 90th:4194304 max:4194304
DYNAMIC-4M-BUZHASH          1527 ms count:107 min:9467 10th:2277562 25th:2971794 50th:4747177 75th:7603998 90th:8388608 max:8388608
DYNAMIC-4M-RABINKARP        6172 ms count:110 min:535925 10th:2242307 25th:2767610 50th:4400962 75th:6813401 90th:8388608 max:8388608
DYNAMIC-8M-BUZHASH          2739 ms count:49 min:677680 10th:5260579 25th:6528562 50th:11102775 75th:16777216 90th:16777216 max:16777216
DYNAMIC-8M-RABINKARP        5259 ms count:60 min:1446246 10th:4337385 25th:5293196 50th:8419217 75th:12334953 90th:16777216 max:16777216
```

Note: the benchmark is not very consistent on my laptop for some reason (maybe it's throttling).