### PR TITLE
ci: avoid double workflow executions on PRs

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,5 +1,8 @@
 name: Code Coverage
-on: [push,pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ master ]
 jobs:
   tests:
     name: Code Coverage Tests

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,5 +1,8 @@
 name: License Check
-on: [push,pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ master ]
 jobs:
   tests:
     name: License Check

--- a/.github/workflows/race-detector.yml
+++ b/.github/workflows/race-detector.yml
@@ -1,5 +1,8 @@
 name: Race Detector
-on: [push,pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ master ]
 jobs:
   integration_tests:
     name: Integration Tests


### PR DESCRIPTION
This happens when opening a PR from the same repo as the PR's target repo.