### PR TITLE
Consolidated format version flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst 
 go_source_dirs=cli fs internal repo snapshot
 all_go_sources=$(foreach d,$(go_source_dirs),$(call rwildcard,$d/,*.go)) $(wildcard *.go)
 
-all: test lint vet integration-tests integration-tests-index-v1
+all: test lint vet integration-tests
 
 include tools/tools.mk
 
@@ -155,7 +155,6 @@ ci-tests: lint vet test
 
 ci-integration-tests:
 	$(MAKE) integration-tests
-	$(MAKE) integration-tests-index-v1
 	$(MAKE) robustness-tool-tests
 
 ci-publish-coverage:
@@ -227,14 +226,12 @@ $(TESTING_ACTION_EXE): tests/testingaction/main.go
 	go build -o $(TESTING_ACTION_EXE) -tags testing github.com/kopia/kopia/tests/testingaction
 
 integration-tests: export KOPIA_EXE ?= $(KOPIA_INTEGRATION_EXE)
+integration-tests: export KOPIA_08_EXE=$(kopia08)
 integration-tests: export TESTING_ACTION_EXE ?= $(TESTING_ACTION_EXE)
 integration-tests: GOTESTSUM_FLAGS=--format=testname --no-summary=skipped --jsonfile=.tmp.integration-tests.json
-integration-tests: build-integration-test-binary $(gotestsum) $(TESTING_ACTION_EXE)
+integration-tests: build-integration-test-binary $(gotestsum) $(TESTING_ACTION_EXE) $(kopia08)
 	 $(GO_TEST) $(TEST_FLAGS) -count=$(REPEAT_TEST) -parallel $(PARALLEL) -timeout 3600s github.com/kopia/kopia/tests/end_to_end_test
 	 -$(gotestsum) tool slowest --jsonfile .tmp.integration-tests.json  --threshold 1000ms
-
-integration-tests-index-v1:
-	KOPIA_CREATE_INDEX_VERSION=1 KOPIA_ENABLE_INDEX_EPOCHS=false KOPIA_RUN_ALL_INTEGRATION_TESTS=true $(MAKE) integration-tests
 
 endurance-tests: export KOPIA_EXE ?= $(KOPIA_INTEGRATION_EXE)
 endurance-tests: export KOPIA_LOGS_DIR=$(CURDIR)/.logs

--- a/cli/command_benchmark_test.go
+++ b/cli/command_benchmark_test.go
@@ -14,7 +14,7 @@ func TestCommandBenchmarkCrypto(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "benchmark", "crypto", "--repeat=1", "--block-size=1KB", "--print-options")
 }
@@ -23,7 +23,7 @@ func TestCommandBenchmarkSpliter(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "benchmark", "splitter", "--block-count=1", "--print-options")
 }
@@ -32,7 +32,7 @@ func TestCommandBenchmarkCompression(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	testFile := filepath.Join(testutil.TempDirectory(t), "testfile.txt")
 	ioutil.WriteFile(testFile, bytes.Repeat([]byte{1, 2, 3, 4, 5, 6}, 10000), 0o600)

--- a/cli/command_blob_show_test.go
+++ b/cli/command_blob_show_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestBlobShow(t *testing.T) {
-	env := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
+func (s *formatSpecificTestSuite) TestBlobShow(t *testing.T) {
+	env := testenv.NewCLITest(t, s.formatFlags, testenv.NewInProcRunner(t))
 
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
 

--- a/cli/command_cache_set_test.go
+++ b/cli/command_cache_set_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCacheSet(t *testing.T) {
-	env := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
 
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
 

--- a/cli/command_cache_sync_test.go
+++ b/cli/command_cache_sync_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCacheClearSync(t *testing.T) {
-	env := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
 
 	emptyDir := testutil.TempDirectory(t)
 

--- a/cli/command_content_verify_test.go
+++ b/cli/command_content_verify_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestContentVerify(t *testing.T) {
-	env := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
+func (s *formatSpecificTestSuite) TestContentVerify(t *testing.T) {
+	env := testenv.NewCLITest(t, s.formatFlags, testenv.NewInProcRunner(t))
 
 	dir := testutil.TempDirectory(t)
 	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file1.txt"), bytes.Repeat([]byte{1, 2, 3, 4, 5}, 15000), 0o600))

--- a/cli/command_index_inspect_test.go
+++ b/cli/command_index_inspect_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestIndexInspect(t *testing.T) {
-	env := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
+func (s *formatSpecificTestSuite) TestIndexInspect(t *testing.T) {
+	env := testenv.NewCLITest(t, s.formatFlags, testenv.NewInProcRunner(t))
 
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
 

--- a/cli/command_logs_test.go
+++ b/cli/command_logs_test.go
@@ -15,7 +15,7 @@ func TestLogsCommands(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
@@ -74,7 +74,7 @@ func TestLogsMaintenance(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")

--- a/cli/command_repository_change_password_test.go
+++ b/cli/command_repository_change_password_test.go
@@ -3,16 +3,24 @@ package cli_test
 import (
 	"testing"
 
+	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestRepositoryChangePassword(t *testing.T) {
+func (s *formatSpecificTestSuite) TestRepositoryChangePassword(t *testing.T) {
 	r1 := testenv.NewInProcRunner(t)
 	r2 := testenv.NewInProcRunner(t)
-	env1 := testenv.NewCLITest(t, r1)
-	env2 := testenv.NewCLITest(t, r2)
+	env1 := testenv.NewCLITest(t, s.formatFlags, r1)
+	env2 := testenv.NewCLITest(t, s.formatFlags, r2)
 
 	env1.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache")
+
+	if s.formatVersion == content.FormatVersion1 {
+		env1.RunAndExpectFailure(t, "repo", "change-password", "--new-password", "newPass")
+
+		return
+	}
+
 	env1.RunAndExpectSuccess(t, "snapshot", "ls")
 
 	// connect to repo with --disable-repository-format-cache so that format blob is not cached
@@ -28,19 +36,11 @@ func TestRepositoryChangePassword(t *testing.T) {
 	r3 := testenv.NewInProcRunner(t)
 
 	// new connections will fail when using old (default) password
-	env3 := testenv.NewCLITest(t, r3)
+	env3 := testenv.NewCLITest(t, s.formatFlags, r3)
 	env3.RunAndExpectFailure(t, "repo", "connect", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache")
 
 	// new connections will succeed when using new password
 	r3.RepoPassword = "newPass"
 
 	env3.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache")
-}
-
-func TestRepositoryChangePassword_LegacDisallowed(t *testing.T) {
-	env1 := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
-	// pass --no-enable-password-change to create repository using old format that does
-	// not support password change.
-	env1.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache", "--format-version=0.8")
-	env1.RunAndExpectFailure(t, "repo", "change-password", "--new-password", "newPass")
 }

--- a/cli/command_repository_change_password_test.go
+++ b/cli/command_repository_change_password_test.go
@@ -41,6 +41,6 @@ func TestRepositoryChangePassword_LegacDisallowed(t *testing.T) {
 	env1 := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
 	// pass --no-enable-password-change to create repository using old format that does
 	// not support password change.
-	env1.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache", "--no-enable-password-change")
+	env1.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env1.RepoDir, "--disable-repository-format-cache", "--format-version=0.8")
 	env1.RunAndExpectFailure(t, "repo", "change-password", "--new-password", "newPass")
 }

--- a/cli/command_repository_set_parameters.go
+++ b/cli/command_repository_set_parameters.go
@@ -34,7 +34,7 @@ func (c *commandRepositorySetParameters) setup(svc appServices, parent commandPa
 	cmd.Flag("max-pack-size-mb", "Set max pack file size").PlaceHolder("MB").IntVar(&c.maxPackSizeMB)
 	cmd.Flag("index-version", "Set version of index format used for writing").IntVar(&c.indexFormatVersion)
 
-	cmd.Flag("upgrade", "Uprade repository to the latest format").BoolVar(&c.upgradeRepositoryFormat)
+	cmd.Flag("upgrade", "Uprade repository to the latest stable format").BoolVar(&c.upgradeRepositoryFormat)
 
 	cmd.Flag("epoch-refresh-frequency", "Epoch refresh frequency").DurationVar(&c.epochRefreshFrequency)
 	cmd.Flag("epoch-min-duration", "Minimal duration of a single epoch").DurationVar(&c.epochMinDuration)

--- a/cli/command_repository_set_parameters.go
+++ b/cli/command_repository_set_parameters.go
@@ -100,11 +100,14 @@ func (c *commandRepositorySetParameters) run(ctx context.Context, rep repo.Direc
 
 	upgradeToEpochManager := false
 
-	if c.upgradeRepositoryFormat && !mp.EpochParameters.Enabled {
-		mp.EpochParameters = epoch.DefaultParameters
-		upgradeToEpochManager = true
-		mp.IndexVersion = 2
+	if c.upgradeRepositoryFormat {
 		anyChange = true
+
+		if !mp.EpochParameters.Enabled {
+			mp.EpochParameters = epoch.DefaultParameters
+			upgradeToEpochManager = true
+			mp.IndexVersion = 2
+		}
 	}
 
 	c.setSizeMBParameter(ctx, c.maxPackSizeMB, "maximum pack size", &mp.MaxPackSize, &anyChange)

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -11,12 +11,12 @@ import (
 func TestRepositorySetParameters(t *testing.T) {
 	env := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
 
-	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir, "--index-version=1")
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir, "--format-version=1")
 	out := env.RunAndExpectSuccess(t, "repository", "status")
 
 	// default values
 	require.Contains(t, out, "Max pack length:     20 MiB")
-	require.Contains(t, out, "Index Format:        v1")
+	require.Contains(t, out, "Format version:      1")
 
 	// failure cases
 	env.RunAndExpectFailure(t, "repository", "set-parameters")
@@ -27,7 +27,6 @@ func TestRepositorySetParameters(t *testing.T) {
 	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--index-version=2", "--max-pack-size-mb=33")
 	out = env.RunAndExpectSuccess(t, "repository", "status")
 	require.Contains(t, out, "Max pack length:     33 MiB")
-	require.Contains(t, out, "Index Format:        v2")
 
 	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--max-pack-size-mb=44")
 	out = env.RunAndExpectSuccess(t, "repository", "status")
@@ -37,12 +36,12 @@ func TestRepositorySetParameters(t *testing.T) {
 func TestRepositorySetParametersUpgrade(t *testing.T) {
 	env := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
 
-	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir, "--index-version=1", "--no-enable-index-epochs")
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir, "--format-version=1")
 	out := env.RunAndExpectSuccess(t, "repository", "status")
 
 	// default values
 	require.Contains(t, out, "Max pack length:     20 MiB")
-	require.Contains(t, out, "Index Format:        v1")
+	require.Contains(t, out, "Format version:      1")
 	require.Contains(t, out, "Epoch Manager:       disabled")
 
 	env.RunAndExpectFailure(t, "index", "epoch", "list")

--- a/cli/command_snapshot_estimate_test.go
+++ b/cli/command_snapshot_estimate_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestSnapshotEstimate(t *testing.T) {
-	env := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
 
 	dir := testutil.TempDirectory(t)
 	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file1.txt"), bytes.Repeat([]byte{1, 2, 3, 4, 5}, 15000), 0o600))
@@ -48,7 +48,7 @@ func TestSnapshotEstimate(t *testing.T) {
 }
 
 func TestSnapshotEstimate_NotADirectory(t *testing.T) {
-	env := testenv.NewCLITest(t, testenv.NewInProcRunner(t))
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
 
 	dir := testutil.TempDirectory(t)
 	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file1.txt"), []byte{1, 2, 3}, 0o600))

--- a/cli/suite_test.go
+++ b/cli/suite_test.go
@@ -1,0 +1,21 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/content"
+)
+
+type formatSpecificTestSuite struct {
+	formatFlags   []string
+	formatVersion content.FormatVersion
+}
+
+func TestFormatV1(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=1"}, content.FormatVersion1})
+}
+
+func TestFormatV2(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=2"}, content.FormatVersion2})
+}

--- a/htmlui/src/SetupRepository.js
+++ b/htmlui/src/SetupRepository.js
@@ -44,6 +44,7 @@ export class SetupRepository extends Component {
             storageVerified: false,
             providerSettings: {},
             description: "My Repository",
+            formatVersion: "2",
         };
 
         this.handleChange = handleChange.bind(this);
@@ -117,6 +118,7 @@ export class SetupRepository extends Component {
             password: this.state.password,
             options: {
                 blockFormat: {
+                    version: parseInt(this.state.formatVersion),
                     hash: this.state.hash,
                     encryption: this.state.encryption,
                 },
@@ -125,10 +127,6 @@ export class SetupRepository extends Component {
                 },
             },
         };
-
-        if (this.state.indexVersion) {
-            request.options.blockFormat.indexVersion = parseInt(this.state.indexVersion)
-        }
 
         request.clientOptions = this.clientOptions();
 
@@ -367,15 +365,14 @@ export class SetupRepository extends Component {
                             </Form.Control>
                         </Form.Group>
                         <Form.Group as={Col}>
-                            <Form.Label className="required">Index Format</Form.Label>
+                            <Form.Label className="required">Repository Format</Form.Label>
                             <Form.Control as="select"
-                                name="indexVersion"
+                                name="formatVersion"
                                 onChange={this.handleChange}
-                                data-testid="control-indexVersion"
-                                value={this.state.indexVersion}>
-                                    <option value="">(default)</option>
-                                    <option value={1}>v1</option>
-                                    <option value={2}>v2 (experimental)</option>
+                                data-testid="control-formatVersion"
+                                value={this.state.formatVersion}>
+                                    <option value="2">Latest format</option>
+                                    <option value="1">Legacy format compatible with v0.8</option>
                             </Form.Control>
                         </Form.Group>
                     </Row>

--- a/internal/acl/acl_manager_test.go
+++ b/internal/acl/acl_manager_test.go
@@ -150,7 +150,7 @@ func TestEffectivePermissions(t *testing.T) {
 }
 
 func TestLoadEntries(t *testing.T) {
-	ctx, env := repotesting.NewEnvironment(t)
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	// load from nil repository
 	entries, err := acl.LoadEntries(ctx, nil, nil)

--- a/internal/auth/authn_repo_test.go
+++ b/internal/auth/authn_repo_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRepositoryAuthenticator(t *testing.T) {
 	a := auth.AuthenticateRepositoryUsers()
-	ctx, env := repotesting.NewEnvironment(t)
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	require.NoError(t, repo.WriteSession(ctx, env.Repository, repo.WriteSessionOptions{},
 		func(ctx context.Context, w repo.RepositoryWriter) error {

--- a/internal/auth/authz_test.go
+++ b/internal/auth/authz_test.go
@@ -92,21 +92,21 @@ func TestNoAccess(t *testing.T) {
 }
 
 func TestLegacyAuthorizer(t *testing.T) {
-	ctx, env := repotesting.NewEnvironment(t)
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	verifyLegacyAuthorizer(ctx, t, env.Repository, auth.LegacyAuthorizer())
 }
 
 // repository with no ACLs.
 func TestDefaultAuthorizer_NoACLs(t *testing.T) {
-	ctx, env := repotesting.NewEnvironment(t)
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	verifyLegacyAuthorizer(ctx, t, env.Repository, auth.DefaultAuthorizer())
 }
 
 // repository with default ACLs.
 func TestDefaultAuthorizer_DefaultACLs(t *testing.T) {
-	ctx, env := repotesting.NewEnvironment(t)
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	for _, e := range auth.DefaultACLs {
 		require.NoError(t, acl.AddACL(ctx, env.RepositoryWriter, e))

--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/completeset"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
@@ -837,14 +836,14 @@ func rangeCheckpointBlobPrefix(epoch1, epoch2 int) blob.ID {
 }
 
 // NewManager creates new epoch manager.
-func NewManager(st blob.Storage, params Parameters, compactor CompactionFunc, sharedBaseLogger logging.Logger) *Manager {
+func NewManager(st blob.Storage, params Parameters, compactor CompactionFunc, sharedBaseLogger logging.Logger, timeNow func() time.Time) *Manager {
 	log := logging.WithPrefix("[epoch-manager] ", sharedBaseLogger)
 
 	return &Manager{
 		st:                           st,
 		log:                          log,
 		compact:                      compactor,
-		timeFunc:                     clock.Now,
+		timeFunc:                     timeNow,
 		Params:                       params,
 		getCompleteIndexSetTooSlow:   new(int32),
 		committedStateRefreshTooSlow: new(int32),

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -103,8 +103,7 @@ func newTestEnv(t *testing.T) *epochManagerTestEnv {
 		EpochAdvanceOnCountThreshold:          15,
 		EpochAdvanceOnTotalSizeBytesThreshold: 20 << 20,
 		DeleteParallelism:                     1,
-	}, te.compact, testlogging.NewTestLogger(t))
-	m.timeFunc = te.ft.NowFunc()
+	}, te.compact, testlogging.NewTestLogger(t), te.ft.NowFunc())
 	te.mgr = m
 	te.faultyStorage = fs
 	te.data = data
@@ -123,7 +122,7 @@ func (te *epochManagerTestEnv) another() *epochManagerTestEnv {
 		faultyStorage: te.faultyStorage,
 	}
 
-	te2.mgr = NewManager(te2.st, te.mgr.Params, te2.compact, te.mgr.log)
+	te2.mgr = NewManager(te2.st, te.mgr.Params, te2.compact, te.mgr.log, te.mgr.timeFunc)
 
 	return te2
 }

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -38,7 +38,7 @@ type Options struct {
 }
 
 // setup sets up a test environment.
-func (e *Environment) setup(t *testing.T, opts ...Options) *Environment {
+func (e *Environment) setup(t *testing.T, version content.FormatVersion, opts ...Options) *Environment {
 	t.Helper()
 
 	ctx := testlogging.Context(t)
@@ -47,6 +47,7 @@ func (e *Environment) setup(t *testing.T, opts ...Options) *Environment {
 
 	opt := &repo.NewRepositoryOptions{
 		BlockFormat: content.FormattingOptions{
+			Version:              version,
 			HMACSecret:           []byte{},
 			Hash:                 "HMAC-SHA256",
 			Encryption:           encryption.DefaultAlgorithm,
@@ -228,15 +229,18 @@ func repoOptions(openOpts []func(*repo.Options)) *repo.Options {
 	return openOpt
 }
 
+// FormatNotImportant chooses arbitrary format version where it's not important to the test.
+const FormatNotImportant = content.FormatVersion2
+
 // NewEnvironment creates a new repository testing environment and ensures its cleanup at the end of the test.
-func NewEnvironment(t *testing.T, opts ...Options) (context.Context, *Environment) {
+func NewEnvironment(t *testing.T, version content.FormatVersion, opts ...Options) (context.Context, *Environment) {
 	t.Helper()
 
 	ctx := testlogging.Context(t)
 
 	var env Environment
 
-	env.setup(t, opts...)
+	env.setup(t, version, opts...)
 
 	t.Cleanup(func() {
 		env.Close(ctx, t)

--- a/internal/repotesting/repotesting_test.go
+++ b/internal/repotesting/repotesting_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestTimeFuncWiring(t *testing.T) {
-	ctx, env := NewEnvironment(t)
+	ctx, env := NewEnvironment(t, FormatNotImportant)
 
 	ft := faketime.NewTimeAdvance(time.Date(2018, time.February, 6, 0, 0, 0, 0, time.UTC), 0)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -42,7 +42,7 @@ const (
 
 // nolint:thelper
 func startServer(ctx context.Context, t *testing.T) *repo.APIServerInfo {
-	_, env := repotesting.NewEnvironment(t)
+	_, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	s, err := server.New(ctx, server.Options{
 		ConfigFile:      env.ConfigFile(),

--- a/internal/user/user_manager_test.go
+++ b/internal/user/user_manager_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestUserManager(t *testing.T) {
-	ctx, env := repotesting.NewEnvironment(t)
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	if _, err := user.GetUserProfile(ctx, env.RepositoryWriter, "alice@somehost"); !errors.Is(err, user.ErrUserNotFound) {
 		t.Fatalf("unexpected error: %v", err)

--- a/repo/blob/s3/s3_versioned_test.go
+++ b/repo/blob/s3/s3_versioned_test.go
@@ -568,7 +568,7 @@ func makeVersionsMetadata(t *testing.T, blobID blob.ID, n int, base time.Time) [
 		vs[i].Timestamp = ct
 		vs[i].Length = int64(rand.Int31())
 
-		ct = ct.Add(-time.Duration((2 + rand.Intn(10)) * int(time.Second)))
+		ct = ct.Add(-time.Duration((2 + rand.Int63n(10)) * int64(time.Second)))
 	}
 
 	vs[0].IsLatest = true

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -410,7 +410,7 @@ func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *Ca
 		indexVersion:   sm.indexVersion,
 		log:            logging.WithPrefix("[index-blob-manager] ", sm.sharedBaseLogger),
 	}
-	sm.indexBlobManagerV1.epochMgr = epoch.NewManager(cachedSt, sm.format.EpochParameters, sm.indexBlobManagerV1.compactEpoch, sm.sharedBaseLogger)
+	sm.indexBlobManagerV1.epochMgr = epoch.NewManager(cachedSt, sm.format.EpochParameters, sm.indexBlobManagerV1.compactEpoch, sm.sharedBaseLogger, sm.timeNow)
 
 	// select active index blob manager based on parameters
 	if sm.format.EpochParameters.Enabled {

--- a/repo/content/content_formatting_options.go
+++ b/repo/content/content_formatting_options.go
@@ -15,7 +15,7 @@ const (
 // FormatVersion denotes content format version.
 type FormatVersion int
 
-// supported format versions
+// Supported format versions.
 const (
 	FormatVersion1 FormatVersion = 1
 	FormatVersion2 FormatVersion = 2 // new in v0.9
@@ -34,24 +34,24 @@ type FormattingOptions struct {
 }
 
 // ResolveFormatVersion applies format options parameters based on the format version.
-func (o *FormattingOptions) ResolveFormatVersion() error {
-	switch o.Version {
+func (f *FormattingOptions) ResolveFormatVersion() error {
+	switch f.Version {
 	case FormatVersion2:
-		o.EnablePasswordChange = true
-		o.IndexVersion = v2IndexVersion
-		o.EpochParameters = epoch.DefaultParameters
+		f.EnablePasswordChange = true
+		f.IndexVersion = v2IndexVersion
+		f.EpochParameters = epoch.DefaultParameters
 
 		return nil
 
 	case FormatVersion1:
-		o.EnablePasswordChange = false
-		o.IndexVersion = v1IndexVersion
-		o.EpochParameters = epoch.Parameters{}
+		f.EnablePasswordChange = false
+		f.IndexVersion = v1IndexVersion
+		f.EpochParameters = epoch.Parameters{}
 
 		return nil
 
 	default:
-		return errors.Errorf("Unsupported format version: %v", o.Version)
+		return errors.Errorf("Unsupported format version: %v", f.Version)
 	}
 }
 

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -37,7 +37,7 @@ const (
 
 	DefaultIndexVersion = 2
 
-	legacyIndexVersion = 1
+	legacyIndexVersion = v1IndexVersion
 )
 
 // PackBlobIDPrefixes contains all possible prefixes for pack blobs.
@@ -56,13 +56,13 @@ const (
 	defaultMaxPreambleLength = 32
 	defaultPaddingUnit       = 4096
 
-	currentWriteVersion = 1
+	currentWriteVersion = FormatVersion2
 
-	minSupportedWriteVersion = 1
-	maxSupportedWriteVersion = currentWriteVersion
+	minSupportedWriteVersion = FormatVersion1
+	maxSupportedWriteVersion = FormatVersion2
 
-	minSupportedReadVersion = 1
-	maxSupportedReadVersion = currentWriteVersion
+	minSupportedReadVersion = FormatVersion1
+	maxSupportedReadVersion = FormatVersion2
 
 	indexLoadAttempts = 10
 )

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -1836,7 +1836,7 @@ func (s *contentManagerSuite) TestVersionCompatibility(t *testing.T) {
 	}
 }
 
-func (s *contentManagerSuite) verifyVersionCompat(t *testing.T, writeVersion int) {
+func (s *contentManagerSuite) verifyVersionCompat(t *testing.T, writeVersion FormatVersion) {
 	t.Helper()
 
 	ctx := testlogging.Context(t)

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -46,7 +46,7 @@ var (
 
 func TestMain(m *testing.M) { testutil.MyTestMain(m) }
 
-func TestLegacyFormat(t *testing.T) {
+func TestFormatV1(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &contentManagerSuite{
 		mutableParameters: MutableParameters{
 			IndexVersion: 1,
@@ -55,7 +55,7 @@ func TestLegacyFormat(t *testing.T) {
 	})
 }
 
-func TestEpochManager(t *testing.T) {
+func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &contentManagerSuite{
 		mutableParameters: MutableParameters{
 			MaxPackSize:     maxPackSize,

--- a/repo/maintenance/content_rewrite_test.go
+++ b/repo/maintenance/content_rewrite_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kopia/kopia/repo/object"
 )
 
-func TestContentRewrite(t *testing.T) {
+func (s *formatSpecificTestSuite) TestContentRewrite(t *testing.T) {
 	cases := []struct {
 		numPContents int
 		numQContents int
@@ -76,7 +76,7 @@ func TestContentRewrite(t *testing.T) {
 		tc := tc
 
 		t.Run(fmt.Sprintf("case-%v", tc), func(t *testing.T) {
-			ctx, env := repotesting.NewEnvironment(t)
+			ctx, env := repotesting.NewEnvironment(t, s.formatVersion)
 
 			// run N sessions to create N individual pack blobs for each content prefix
 			for i := 0; i < tc.numPContents; i++ {

--- a/repo/maintenance/maintenance_safety_test.go
+++ b/repo/maintenance/maintenance_safety_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kopia/kopia/internal/faketime"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/repo"
-	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/maintenance"
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/snapshot/snapshotmaintenance"
@@ -53,7 +52,6 @@ func (s *formatSpecificTestSuite) TestMaintenanceSafety(t *testing.T) {
 	// both 'main' and 'another' client can see it
 	t.Logf("**** MAINTENANCE #1")
 	require.NoError(t, anotherClient.Refresh(ctx))
-	require.NoError(t, env.Repository.Refresh(ctx))
 	verifyContentDeletedState(ctx, t, env.Repository, objectID, false)
 	verifyObjectReadable(ctx, t, env.Repository, objectID)
 	verifyObjectReadable(ctx, t, anotherClient, objectID)
@@ -69,8 +67,6 @@ func (s *formatSpecificTestSuite) TestMaintenanceSafety(t *testing.T) {
 	require.NoError(t, snapshotmaintenance.Run(ctx, env.RepositoryWriter, maintenance.ModeFull, true, maintenance.SafetyFull))
 	verifyContentDeletedState(ctx, t, env.Repository, objectID, true)
 
-	require.NoError(t, anotherClient.Refresh(ctx))
-	require.NoError(t, env.Repository.Refresh(ctx))
 	verifyObjectReadable(ctx, t, env.Repository, objectID)
 	verifyObjectReadable(ctx, t, anotherClient, objectID)
 
@@ -78,8 +74,6 @@ func (s *formatSpecificTestSuite) TestMaintenanceSafety(t *testing.T) {
 	ft.Advance(4 * time.Hour)
 
 	// run maintenance again - this time we'll rewrite the two objects together.
-	require.NoError(t, anotherClient.Refresh(ctx))
-	require.NoError(t, env.Repository.Refresh(ctx))
 	require.NoError(t, snapshotmaintenance.Run(ctx, env.RepositoryWriter, maintenance.ModeFull, true, maintenance.SafetyFull))
 
 	// the object is still readable using main client because it has updated indexes after
@@ -94,24 +88,14 @@ func (s *formatSpecificTestSuite) TestMaintenanceSafety(t *testing.T) {
 	t.Logf("**** MAINTENANCE #4")
 	ft.Advance(4 * time.Hour)
 	require.NoError(t, snapshotmaintenance.Run(ctx, env.RepositoryWriter, maintenance.ModeFull, true, maintenance.SafetyFull))
-	require.NoError(t, anotherClient.Refresh(ctx))
-	require.NoError(t, env.Repository.Refresh(ctx))
 	verifyObjectReadable(ctx, t, anotherClient, objectID)
 	verifyObjectReadable(ctx, t, env.Repository, objectID)
 
 	t.Logf("**** MAINTENANCE #5")
 	ft.Advance(4 * time.Hour)
 	require.NoError(t, snapshotmaintenance.Run(ctx, env.RepositoryWriter, maintenance.ModeFull, true, maintenance.SafetyFull))
-	require.NoError(t, env.RepositoryWriter.Flush(ctx))
-	require.NoError(t, env.Repository.Refresh(ctx))
 	verifyObjectNotFound(ctx, t, env.Repository, objectID)
-
-	if s.formatVersion == content.FormatVersion1 {
-		require.NoError(t, anotherClient.Refresh(ctx))
-		verifyObjectNotFound(ctx, t, anotherClient, objectID)
-	} else {
-		t.Skip()
-	}
+	verifyObjectNotFound(ctx, t, anotherClient, objectID)
 }
 
 func verifyContentDeletedState(ctx context.Context, t *testing.T, rep repo.Repository, objectID object.ID, want bool) {

--- a/repo/maintenance/maintenance_safety_test.go
+++ b/repo/maintenance/maintenance_safety_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kopia/kopia/internal/faketime"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/maintenance"
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/snapshot/snapshotmaintenance"
@@ -105,10 +106,12 @@ func (s *formatSpecificTestSuite) TestMaintenanceSafety(t *testing.T) {
 	require.NoError(t, env.Repository.Refresh(ctx))
 	verifyObjectNotFound(ctx, t, env.Repository, objectID)
 
-	t.Logf("====")
-	ft.Advance(10 * time.Hour)
-	require.NoError(t, anotherClient.Refresh(ctx))
-	verifyObjectNotFound(ctx, t, anotherClient, objectID)
+	if s.formatVersion == content.FormatVersion1 {
+		require.NoError(t, anotherClient.Refresh(ctx))
+		verifyObjectNotFound(ctx, t, anotherClient, objectID)
+	} else {
+		t.Skip()
+	}
 }
 
 func verifyContentDeletedState(ctx context.Context, t *testing.T, rep repo.Repository, objectID object.ID, want bool) {

--- a/repo/maintenance/suite_test.go
+++ b/repo/maintenance/suite_test.go
@@ -1,0 +1,20 @@
+package maintenance_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/content"
+)
+
+type formatSpecificTestSuite struct {
+	formatVersion content.FormatVersion
+}
+
+func TestFormatV1(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion1})
+}
+
+func TestFormatV2(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion2})
+}

--- a/repo/suite_test.go
+++ b/repo/suite_test.go
@@ -1,0 +1,22 @@
+package repo_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/content"
+)
+
+func TestMain(m *testing.M) { testutil.MyTestMain(m) }
+
+type formatSpecificTestSuite struct {
+	formatVersion content.FormatVersion
+}
+
+func TestFormatV1(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion1})
+}
+
+func TestFormatV2(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion2})
+}

--- a/snapshot/policy/policy_manager_test.go
+++ b/snapshot/policy/policy_manager_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPolicyManagerInheritanceTest(t *testing.T) {
-	ctx, env := repotesting.NewEnvironment(t)
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	defaultPolicyWithLabels := policyWithLabels(DefaultPolicy, map[string]string{
 		"policyType": "global",
@@ -165,7 +165,7 @@ func defaultPolicyWithKeepDaily(t *testing.T, keepDaily int) *Policy {
 }
 
 func TestPolicyManagerResolvesConflicts(t *testing.T) {
-	ctx, env := repotesting.NewEnvironment(t)
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	r1 := env.RepositoryWriter
 	r2 := env.MustOpenAnother(t)
@@ -231,7 +231,7 @@ func TestParentPathOSIndependent(t *testing.T) {
 // TestApplicablePoliciesForSource verifies that when we build a policy tree, we pick the appropriate policies
 // defined for the subtree regardless of path style (Unix or Windows).
 func TestApplicablePoliciesForSource(t *testing.T) {
-	ctx, env := repotesting.NewEnvironment(t)
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	setPols := map[snapshot.SourceInfo]*Policy{
 		// unix-style path names

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestSnapshotsAPI(t *testing.T) {
-	ctx, env := repotesting.NewEnvironment(t)
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	src1 := snapshot.SourceInfo{
 		Host:     "host-1",

--- a/snapshot/snapshotmaintenance/snapshotmaintenance_test.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance_test.go
@@ -190,6 +190,9 @@ func TestMaintenanceAutoLiveness(t *testing.T) {
 		OpenOptions: func(o *repo.Options) {
 			o.TimeNowFunc = ft.NowFunc()
 		},
+		NewRepositoryOptions: func(nro *repo.NewRepositoryOptions) {
+			nro.BlockFormat.Version = content.FormatVersion1
+		},
 	})
 
 	// create dummy snapshot.

--- a/snapshot/snapshotmaintenance/snapshotmaintenance_test.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance_test.go
@@ -31,9 +31,9 @@ type testHarness struct {
 	sourceDir *mockfs.Directory
 }
 
-func TestSnapshotGCSimple(t *testing.T) {
+func (s *formatSpecificTestSuite) TestSnapshotGCSimple(t *testing.T) {
 	ctx := testlogging.Context(t)
-	th := newTestHarness(t)
+	th := newTestHarness(t, s.formatVersion)
 
 	require.NotNil(t, th)
 	require.NotNil(t, th.sourceDir)
@@ -86,9 +86,9 @@ func TestSnapshotGCSimple(t *testing.T) {
 //   maintenance
 // - Check full maintenance can be run afterwards
 // - Verify contents.
-func TestMaintenanceReuseDirManifest(t *testing.T) {
+func (s *formatSpecificTestSuite) TestMaintenanceReuseDirManifest(t *testing.T) {
 	ctx := testlogging.Context(t)
-	th := newTestHarness(t)
+	th := newTestHarness(t, s.formatVersion)
 
 	require.NotNil(t, th)
 	require.NotNil(t, th.sourceDir)
@@ -167,7 +167,7 @@ func TestMaintenanceReuseDirManifest(t *testing.T) {
 	t.Log("root info:", pretty.Sprint(info))
 }
 
-func newTestHarness(t *testing.T) *testHarness {
+func newTestHarness(t *testing.T, formatVersion content.FormatVersion) *testHarness {
 	t.Helper()
 
 	baseTime := time.Date(2020, 9, 10, 0, 0, 0, 0, time.UTC)
@@ -176,17 +176,17 @@ func newTestHarness(t *testing.T) *testHarness {
 		sourceDir: mockfs.NewDirectory(),
 	}
 
-	_, th.Environment = repotesting.NewEnvironment(t, repotesting.Options{OpenOptions: th.fakeTimeOpenRepoOption})
+	_, th.Environment = repotesting.NewEnvironment(t, formatVersion, repotesting.Options{OpenOptions: th.fakeTimeOpenRepoOption})
 
 	require.NotNil(t, th.RepositoryWriter)
 
 	return th
 }
 
-func TestMaintenanceAutoLiveness(t *testing.T) {
+func (s *formatSpecificTestSuite) TestMaintenanceAutoLiveness(t *testing.T) {
 	ft := faketime.NewClockTimeWithOffset(0)
 
-	ctx, env := repotesting.NewEnvironment(t, repotesting.Options{
+	ctx, env := repotesting.NewEnvironment(t, s.formatVersion, repotesting.Options{
 		OpenOptions: func(o *repo.Options) {
 			o.TimeNowFunc = ft.NowFunc()
 		},

--- a/snapshot/snapshotmaintenance/suite_test.go
+++ b/snapshot/snapshotmaintenance/suite_test.go
@@ -1,0 +1,20 @@
+package snapshotmaintenance_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/content"
+)
+
+type formatSpecificTestSuite struct {
+	formatVersion content.FormatVersion
+}
+
+func TestFormatV1(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion1})
+}
+
+func TestFormatV2(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion2})
+}

--- a/tests/end_to_end_test/acl_test.go
+++ b/tests/end_to_end_test/acl_test.go
@@ -12,7 +12,7 @@ func TestACL(t *testing.T) {
 	t.Parallel()
 
 	serverRunner := testenv.NewExeRunner(t)
-	serverEnvironment := testenv.NewCLITest(t, serverRunner)
+	serverEnvironment := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, serverRunner)
 
 	defer serverEnvironment.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -55,7 +55,7 @@ func TestACL(t *testing.T) {
 	defer kill()
 
 	fooBarRunner := testenv.NewExeRunner(t)
-	foobarClientEnvironment := testenv.NewCLITest(t, fooBarRunner)
+	foobarClientEnvironment := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, fooBarRunner)
 
 	defer foobarClientEnvironment.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -71,7 +71,7 @@ func TestACL(t *testing.T) {
 	)
 
 	aliceInWonderlandRunner := testenv.NewExeRunner(t)
-	aliceInWonderlandClientEnvironment := testenv.NewCLITest(t, aliceInWonderlandRunner)
+	aliceInWonderlandClientEnvironment := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, aliceInWonderlandRunner)
 
 	defer aliceInWonderlandClientEnvironment.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/all_formats_test.go
+++ b/tests/end_to_end_test/all_formats_test.go
@@ -34,7 +34,7 @@ func TestAllFormatsSmokeTest(t *testing.T) {
 				t.Run(hashAlgo, func(t *testing.T) {
 					t.Parallel()
 
-					e := testenv.NewCLITest(t, runner)
+					e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 					defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
 					e.DefaultRepositoryCreateFlags = nil

--- a/tests/end_to_end_test/api_server_repository_test.go
+++ b/tests/end_to_end_test/api_server_repository_test.go
@@ -56,7 +56,7 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 	}
 
 	runner := testenv.NewExeRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -64,7 +64,7 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-username", "foo", "--override-hostname", "bar")
 	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
 
-	e1 := testenv.NewCLITest(t, runner)
+	e1 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 	defer e1.RunAndExpectSuccess(t, "repo", "disconnect")
 
 	// create one snapshot as not-foo@bar
@@ -204,7 +204,7 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 	}
 
 	runner2 := testenv.NewExeRunner(t)
-	e2 := testenv.NewCLITest(t, runner2)
+	e2 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner2)
 
 	defer e2.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/auto_update_test.go
+++ b/tests/end_to_end_test/auto_update_test.go
@@ -41,7 +41,7 @@ func TestAutoUpdateEnableTest(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 			runner := testenv.NewExeRunner(t)
-			e := testenv.NewCLITest(t, runner)
+			e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 			// create repo
 			args := append([]string{

--- a/tests/end_to_end_test/compression_test.go
+++ b/tests/end_to_end_test/compression_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestCompression(t *testing.T) {
+func (s *formatSpecificTestSuite) TestCompression(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, s.formatFlags, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/content_info_test.go
+++ b/tests/end_to_end_test/content_info_test.go
@@ -14,22 +14,22 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestContentListAndStats_Indexv1(t *testing.T) {
+func TestContentListAndStats_v1(t *testing.T) {
 	t.Parallel()
 	testContentListAndStats(t, "1")
 }
 
-func TestContentListAndStats_Indexv2(t *testing.T) {
+func TestContentListAndStats_v2(t *testing.T) {
 	t.Parallel()
 	testContentListAndStats(t, "2")
 }
 
 // nolint:thelper
-func testContentListAndStats(t *testing.T, indexVersion string) {
+func testContentListAndStats(t *testing.T, formatVersion string) {
 	runner := testenv.NewInProcRunner(t)
 	e := testenv.NewCLITest(t, runner)
 
-	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--index-version", indexVersion)
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--format-version", formatVersion)
 
 	require.Empty(t, e.RunAndExpectSuccess(t, "content", "list", "--deleted-only"))
 	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--compression", "pgzip")

--- a/tests/end_to_end_test/content_info_test.go
+++ b/tests/end_to_end_test/content_info_test.go
@@ -14,22 +14,12 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestContentListAndStats_v1(t *testing.T) {
-	t.Parallel()
-	testContentListAndStats(t, "1")
-}
-
-func TestContentListAndStats_v2(t *testing.T) {
-	t.Parallel()
-	testContentListAndStats(t, "2")
-}
-
 // nolint:thelper
-func testContentListAndStats(t *testing.T, formatVersion string) {
+func (s *formatSpecificTestSuite) TestContentListAndStats(t *testing.T) {
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, s.formatFlags, runner)
 
-	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--format-version", formatVersion)
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
 	require.Empty(t, e.RunAndExpectSuccess(t, "content", "list", "--deleted-only"))
 	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--compression", "pgzip")

--- a/tests/end_to_end_test/diff_test.go
+++ b/tests/end_to_end_test/diff_test.go
@@ -17,7 +17,7 @@ func TestDiff(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/index_optimize_test.go
+++ b/tests/end_to_end_test/index_optimize_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestIndexOptimize(t *testing.T) {
+func (s *formatSpecificTestSuite) TestIndexOptimize(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, s.formatFlags, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/index_recover_test.go
+++ b/tests/end_to_end_test/index_recover_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestIndexRecover(t *testing.T) {
+func (s *formatSpecificTestSuite) TestIndexRecover(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, s.formatFlags, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 

--- a/tests/end_to_end_test/maintenance_test.go
+++ b/tests/end_to_end_test/maintenance_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestFullMaintenance(t *testing.T) {
+func (s *formatSpecificTestSuite) TestFullMaintenance(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, s.formatFlags, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--disable-internal-log")
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")

--- a/tests/end_to_end_test/policy_test.go
+++ b/tests/end_to_end_test/policy_test.go
@@ -14,7 +14,7 @@ func TestDefaultGlobalPolicy(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 

--- a/tests/end_to_end_test/repository_connect_test.go
+++ b/tests/end_to_end_test/repository_connect_test.go
@@ -15,7 +15,7 @@ func TestFilesystemRequiresAbsolutePaths(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectFailure(t, "repo", "create", "filesystem", "--path", "./relative-path")
 }
@@ -29,7 +29,7 @@ func TestFilesystemSupportsTildeToReferToHome(t *testing.T) {
 	}
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	subdir := "repo-" + uuid.NewString()
 	fullPath := filepath.Join(home, subdir)
@@ -48,7 +48,7 @@ func TestReconnect(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 	e.RunAndExpectSuccess(t, "repo", "disconnect")
@@ -60,7 +60,7 @@ func TestReconnectUsingToken(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 	lines := e.RunAndExpectSuccess(t, "repo", "status", "-t", "-s")

--- a/tests/end_to_end_test/repository_repair_test.go
+++ b/tests/end_to_end_test/repository_repair_test.go
@@ -3,33 +3,19 @@ package endtoend_test
 import (
 	"testing"
 
+	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
 // when password change is enabled, replicas of kopia.repository are not embedded in blobs
 // so `kopia repository repair` will not work.
-func TestRepositoryRepair_PasswordChangeEnabled(t *testing.T) {
+func (s *formatSpecificTestSuite) TestRepositoryRepair(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, s.formatFlags, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
-	e.RunAndExpectSuccess(t, "blob", "rm", "kopia.repository")
-	e.RunAndExpectSuccess(t, "repo", "disconnect")
-
-	e.RunAndExpectFailure(t, "repo", "repair", "filesystem", "--path", e.RepoDir)
-}
-
-func TestRepositoryRepair_PasswordChangeDisabled(t *testing.T) {
-	t.Parallel()
-
-	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
-
-	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
-
-	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--format-version=1")
 
 	e.RunAndExpectSuccess(t, "snapshot", "create", ".")
 	e.RunAndExpectSuccess(t, "snapshot", "list", ".")
@@ -47,9 +33,11 @@ func TestRepositoryRepair_PasswordChangeDisabled(t *testing.T) {
 	// this will fail because the format blob in the repository is not found
 	e.RunAndExpectFailure(t, "repo", "connect", "filesystem", "--path", e.RepoDir)
 
-	// now run repair, which will recover the format blob from one of the pack blobs.
-	e.RunAndExpectSuccess(t, "repo", "repair", "filesystem", "--path", e.RepoDir)
+	if s.formatVersion == content.FormatVersion1 {
+		// now run repair, which will recover the format blob from one of the pack blobs.
+		e.RunAndExpectSuccess(t, "repo", "repair", "filesystem", "--path", e.RepoDir)
 
-	// now connect can succeed
-	e.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", e.RepoDir)
+		// now connect can succeed
+		e.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", e.RepoDir)
+	}
 }

--- a/tests/end_to_end_test/repository_repair_test.go
+++ b/tests/end_to_end_test/repository_repair_test.go
@@ -29,7 +29,7 @@ func TestRepositoryRepair_PasswordChangeDisabled(t *testing.T) {
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
-	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--no-enable-password-change")
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--format-version=1")
 
 	e.RunAndExpectSuccess(t, "snapshot", "create", ".")
 	e.RunAndExpectSuccess(t, "snapshot", "list", ".")

--- a/tests/end_to_end_test/repository_set_client_test.go
+++ b/tests/end_to_end_test/repository_set_client_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestRepositorySetClient(t *testing.T) {
+func (s *formatSpecificTestSuite) TestRepositorySetClient(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, s.formatFlags, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/repository_sync_test.go
+++ b/tests/end_to_end_test/repository_sync_test.go
@@ -12,7 +12,7 @@ func TestRepositorySync(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -41,7 +41,7 @@ func TestRepositorySync(t *testing.T) {
 	}
 
 	// now create a whole new repository
-	e2 := testenv.NewCLITest(t, runner)
+	e2 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e2.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/restore_fail_test.go
+++ b/tests/end_to_end_test/restore_fail_test.go
@@ -32,7 +32,7 @@ func TestRestoreFail(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewExeRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -40,7 +40,7 @@ func TestRestoreCommand(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
@@ -156,7 +156,7 @@ func TestSnapshotRestore(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -333,7 +333,7 @@ func TestRestoreSymlinkWithoutTarget(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -369,7 +369,7 @@ func TestRestoreSymlinkWithNonSymlinkOverwrite(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -414,7 +414,7 @@ func TestRestoreSnapshotOfSingleFile(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -59,7 +59,7 @@ func TestServerStart(t *testing.T) {
 	ctx := testlogging.Context(t)
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -175,7 +175,7 @@ func TestServerCreateAndConnectViaAPI(t *testing.T) {
 	ctx := testlogging.Context(t)
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -242,7 +242,7 @@ func TestConnectToExistingRepositoryViaAPI(t *testing.T) {
 	ctx := testlogging.Context(t)
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-hostname=fake-hostname", "--override-username=fake-username")
 	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
 	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
@@ -320,7 +320,7 @@ func TestServerStartInsecure(t *testing.T) {
 	ctx := testlogging.Context(t)
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/shallowrestore_test.go
+++ b/tests/end_to_end_test/shallowrestore_test.go
@@ -29,7 +29,7 @@ func TestShallowrestore(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -72,7 +72,7 @@ func TestShallowrestoreWithMinSize(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -116,7 +116,7 @@ func TestShallowrestoreWithMinSize(t *testing.T) {
 func TestShallowFullCycle(t *testing.T) {
 	t.Parallel()
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -414,7 +414,7 @@ func addForeignSnapshotTree(m *mutatorArgs) {
 func TestShallowifyTree(t *testing.T) {
 	t.Parallel()
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -447,7 +447,7 @@ func TestPlaceholderAndRealFails(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -508,7 +508,7 @@ func TestForeignReposCauseErrors(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/snapshot_actions_test.go
+++ b/tests/end_to_end_test/snapshot_actions_test.go
@@ -25,7 +25,7 @@ func TestSnapshotActionsBeforeSnapshotRoot(t *testing.T) {
 	}
 
 	runner := testenv.NewExeRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -160,7 +160,7 @@ func TestSnapshotActionsBeforeAfterFolder(t *testing.T) {
 	}
 
 	runner := testenv.NewExeRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--enable-actions")
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
@@ -229,7 +229,7 @@ func TestSnapshotActionsEmbeddedScript(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--enable-actions")
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
@@ -301,7 +301,7 @@ func TestSnapshotActionsEnable(t *testing.T) {
 			t.Parallel()
 
 			runner := testenv.NewExeRunner(t)
-			e := testenv.NewCLITest(t, runner)
+			e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 			defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/snapshot_copy_move_history_test.go
+++ b/tests/end_to_end_test/snapshot_copy_move_history_test.go
@@ -12,7 +12,7 @@ func TestSnapshotCopy(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -24,7 +24,7 @@ func TestSnapshotCreate(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -86,7 +86,7 @@ func TestTagging(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -113,7 +113,7 @@ func TestTaggingBadTags(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -133,7 +133,7 @@ func TestStartTimeOverride(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1, "--start-time", "2000-01-01 01:01:00 UTC")
@@ -153,7 +153,7 @@ func TestEndTimeOverride(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1, "--end-time", "2000-01-01 01:01:00 UTC")
@@ -174,7 +174,7 @@ func TestInvalidTimeOverride(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 	e.RunAndExpectFailure(t, "snapshot", "create", sharedTestDataDir1, "--start-time", "2000-01-01 01:01:00 UTC", "--end-time", "1999-01-01 01:01:00 UTC")
@@ -184,7 +184,7 @@ func TestSnapshottingCacheDirectory(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
@@ -486,7 +486,7 @@ func TestSnapshotCreateWithIgnore(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			runner := testenv.NewInProcRunner(t)
-			e := testenv.NewCLITest(t, runner)
+			e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 			baseDir := testutil.TempDirectory(t)
 
@@ -532,7 +532,7 @@ func TestSnapshotCreateAllWithManualSnapshot(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
@@ -560,7 +560,7 @@ func TestSnapshotCreateWithStdinStream(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewExeRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)

--- a/tests/end_to_end_test/snapshot_delete_test.go
+++ b/tests/end_to_end_test/snapshot_delete_test.go
@@ -110,7 +110,7 @@ func testSnapshotDelete(t *testing.T, argMaker deleteArgMaker, expectDeleteSucce
 	t.Helper()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -146,7 +146,7 @@ func TestSnapshotDeleteTypeCheck(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -179,7 +179,7 @@ func TestSnapshotDeleteRestore(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/snapshot_fail_test.go
+++ b/tests/end_to_end_test/snapshot_fail_test.go
@@ -22,7 +22,7 @@ func TestSnapshotNonexistent(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -241,7 +241,7 @@ func testSnapshotFail(t *testing.T, isFailFast bool, snapshotCreateFlags, snapsh
 					t.Parallel()
 
 					runner := testenv.NewExeRunner(t)
-					e := testenv.NewCLITest(t, runner)
+					e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 					defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 

--- a/tests/end_to_end_test/snapshot_gc_test.go
+++ b/tests/end_to_end_test/snapshot_gc_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestSnapshotGC(t *testing.T) {
+func (s *formatSpecificTestSuite) TestSnapshotGC(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, s.formatFlags, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 

--- a/tests/end_to_end_test/snapshot_migrate_test.go
+++ b/tests/end_to_end_test/snapshot_migrate_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestSnapshotMigrate(t *testing.T) {
+func (s *formatSpecificTestSuite) TestSnapshotMigrate(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, s.formatFlags, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -31,7 +31,7 @@ func TestSnapshotMigrate(t *testing.T) {
 	sourceSnapshotCount := len(e.RunAndExpectSuccess(t, "snapshot", "list", ".", "-a"))
 	sourcePolicyCount := len(e.RunAndExpectSuccess(t, "policy", "list"))
 
-	dstenv := testenv.NewCLITest(t, runner)
+	dstenv := testenv.NewCLITest(t, s.formatFlags, runner)
 
 	dstenv.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", dstenv.RepoDir)
 

--- a/tests/end_to_end_test/snapshot_verify_test.go
+++ b/tests/end_to_end_test/snapshot_verify_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/kopia/kopia/tests/testenv"
 )
 
-func TestSnapshotVerifyTest(t *testing.T) {
+func (s *formatSpecificTestSuite) TestSnapshotVerifyTest(t *testing.T) {
 	t.Parallel()
 
 	runner := testenv.NewInProcRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, s.formatFlags, runner)
 
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 

--- a/tests/end_to_end_test/suite_test.go
+++ b/tests/end_to_end_test/suite_test.go
@@ -1,0 +1,21 @@
+package endtoend_test
+
+import (
+	"testing"
+
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/content"
+)
+
+type formatSpecificTestSuite struct {
+	formatFlags   []string
+	formatVersion content.FormatVersion
+}
+
+func TestFormatV1(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=1"}, content.FormatVersion1})
+}
+
+func TestFormatV2(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=2"}, content.FormatVersion2})
+}

--- a/tests/endurance_test/endurance_test.go
+++ b/tests/endurance_test/endurance_test.go
@@ -61,7 +61,7 @@ func (d webdavDirWithFakeClock) OpenFile(ctx context.Context, fname string, flag
 
 func TestEndurance(t *testing.T) {
 	runner := testenv.NewExeRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	tmpDir, err := ioutil.TempDir("", "endurance")
 	if err != nil {
@@ -234,7 +234,7 @@ func enduranceRunner(t *testing.T, runnerID int, fakeTimeServer, webdavServer st
 	t.Helper()
 
 	runner := testenv.NewExeRunner(t)
-	e := testenv.NewCLITest(t, runner)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	runner.Environment = append(runner.Environment,
 		"KOPIA_FAKE_CLOCK_ENDPOINT="+fakeTimeServer,

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -43,8 +43,11 @@ type CLITest struct {
 	DefaultRepositoryCreateFlags []string
 }
 
+// RepoFormatNotImportant chooses arbitrary format version where it's not important to the test.
+var RepoFormatNotImportant []string
+
 // NewCLITest creates a new instance of *CLITest.
-func NewCLITest(t *testing.T, runner CLIRunner) *CLITest {
+func NewCLITest(t *testing.T, repoCreateFlags []string, runner CLIRunner) *CLITest {
 	t.Helper()
 	configDir := testutil.TempDirectory(t)
 
@@ -65,11 +68,12 @@ func NewCLITest(t *testing.T, runner CLIRunner) *CLITest {
 
 	var formatFlags []string
 
+	formatFlags = append(formatFlags, repoCreateFlags...)
+
 	if testutil.ShouldReduceTestComplexity() {
-		formatFlags = []string{
+		formatFlags = append(formatFlags,
 			"--encryption", "CHACHA20-POLY1305-HMAC-SHA256",
-			"--block-hash", "BLAKE2S-256",
-		}
+			"--block-hash", "BLAKE2S-256")
 	}
 
 	return &CLITest{
@@ -170,9 +174,9 @@ func (e *CLITest) cmdArgs(args []string) []string {
 func (e *CLITest) Run(t *testing.T, expectedError bool, args ...string) (stdout, stderr []string, err error) {
 	t.Helper()
 
+	args = e.cmdArgs(args)
 	t.Logf("running 'kopia %v'", strings.Join(args, " "))
 
-	args = e.cmdArgs(args)
 	t0 := clock.Now()
 
 	stdoutReader, stderrReader, wait, _ := e.Runner.Start(t, args)

--- a/tools/gettool/checksums.txt
+++ b/tools/gettool/checksums.txt
@@ -19,6 +19,12 @@ https://github.com/gotestyourself/gotestsum/releases/download/v1.7.0/gotestsum_1
 https://github.com/gotestyourself/gotestsum/releases/download/v1.7.0/gotestsum_1.7.0_linux_arm64.tar.gz: ee57c91abadc464a7cd9f8abbffe94a673aab7deeb9af8c17b96de4bb8f37e41
 https://github.com/gotestyourself/gotestsum/releases/download/v1.7.0/gotestsum_1.7.0_linux_armv6.tar.gz: 53638cb0021ed31d74f99c9327ad1fecad42e0dbdfd3676730798369360e1bf1
 https://github.com/gotestyourself/gotestsum/releases/download/v1.7.0/gotestsum_1.7.0_windows_amd64.tar.gz: 7ae12ddb171375f0c14d6a09dd27a5c1d1fc72edeea674e3d6e7489a533b40c1
+https://github.com/kopia/kopia/releases/download/v0.8.4/kopia-0.8.4-linux-arm.tar.gz: 31e9ecd9600dc60f98d4777fb64043b3431ad758dc7ba57d9a7661a103946d6f
+https://github.com/kopia/kopia/releases/download/v0.8.4/kopia-0.8.4-linux-arm64.tar.gz: 3ad81fd7e856ec177b737130710823ef0e64a344be1233d9a7ef456c78e535f2
+https://github.com/kopia/kopia/releases/download/v0.8.4/kopia-0.8.4-linux-x64.tar.gz: 118e3eece462d6e5bd8e357f6cbb48eabaecc3a22b99c804b54eaba6f6f1b7d5
+https://github.com/kopia/kopia/releases/download/v0.8.4/kopia-0.8.4-macOS-arm64.tar.gz: 1b4e2f151ca0db80a7e0ee7b164697af7c6aaeae58f0846952693da327e46af7
+https://github.com/kopia/kopia/releases/download/v0.8.4/kopia-0.8.4-macOS-x64.tar.gz: 818e466f8404d9d4805a4b86386d8388e90979b54ffa87f1858890cf13311902
+https://github.com/kopia/kopia/releases/download/v0.8.4/kopia-0.8.4-windows-x64.zip: 25529dffea8ecfd1206cd6e8eb76e45bdcdd334fc99ccb14683fe56c34426837
 https://github.com/rclone/rclone/releases/download/v1.56.0/rclone-v1.56.0-linux-amd64.zip: d23d0c1f295a7399114b9a07fa987e7dc216dbe989b5d88530eb01d3c87c9c1f
 https://github.com/rclone/rclone/releases/download/v1.56.0/rclone-v1.56.0-linux-arm.zip: 955e8412ad58aa45ee195deaf5cd8cacbb9b823ad3b17e1817a03143034da878
 https://github.com/rclone/rclone/releases/download/v1.56.0/rclone-v1.56.0-linux-arm64.zip: 861fe019ac96ac55b5e0e97c8d6138773a11b64f8cbd3530f51f56eb6009326c

--- a/tools/gettool/gettool.go
+++ b/tools/gettool/gettool.go
@@ -78,6 +78,15 @@ var tools = map[string]ToolInfo{
 			"arm": "armv6",
 		},
 	},
+	"kopia": {
+		urlTemplate: "https://github.com/kopia/kopia/releases/download/vVERSION/kopia-VERSION-GOOS-GOARCH.EXT",
+		archMap: map[string]string{
+			"amd64": "x64",
+		},
+		osMap: map[string]string{
+			"darwin": "macOS",
+		},
+	},
 	"rclone": {
 		urlTemplate: "https://github.com/rclone/rclone/releases/download/vVERSION/rclone-vVERSION-GOOS-GOARCH.zip",
 		osMap:       map[string]string{"darwin": "osx"},

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -165,6 +165,14 @@ gotestsum=$(gotestsum_dir)$(slash)gotestsum$(exe_suffix)
 $(gotestsum):
 	go run github.com/kopia/kopia/tools/gettool --tool gotestsum:$(GOTESTSUM_VERSION) --output-dir $(gotestsum_dir)
 
+# kopia 0.8 for backwards compat testing
+kopia08_version=0.8.4
+kopia08_dir=$(TOOLS_DIR)$(slash)kopia-$(kopia08_version)
+kopia08=$(kopia08_dir)$(slash)kopia-$(kopia08_version)$(exe_suffix)
+
+$(kopia08):
+	go run github.com/kopia/kopia/tools/gettool --tool kopia:$(kopia08_version) --output-dir $(kopia08_dir)
+
 MINIO_MC_PATH=$(TOOLS_DIR)/bin/mc$(exe_suffix)
 
 $(MINIO_MC_PATH):
@@ -262,7 +270,7 @@ endif
 verify-all-tool-checksums:
 	go run github.com/kopia/kopia/tools/gettool --test-all \
 	  --output-dir /tmp/all-tools \
-	  --tool node:$(NODE_VERSION),linter:$(GOLANGCI_LINT_VERSION),hugo:$(HUGO_VERSION),rclone:$(RCLONE_VERSION),gotestsum:$(GOTESTSUM_VERSION),goreleaser:$(GORELEASER_VERSION)
+	  --tool node:$(NODE_VERSION),linter:$(GOLANGCI_LINT_VERSION),hugo:$(HUGO_VERSION),rclone:$(RCLONE_VERSION),gotestsum:$(GOTESTSUM_VERSION),goreleaser:$(GORELEASER_VERSION),kopia:0.8.4
 
 all-tools: $(gotestsum) $(npm) $(linter) $(maybehugo)
 


### PR DESCRIPTION
Replaced individual parameters to select new repository features with --format-version=2
Enhanced testing to exercise both formats more extensively.