### PR TITLE
cli: added support for passing bare filename for --config-file parameter

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -200,7 +200,7 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("initial-update-check-delay", "Initial delay before first time update check").Default("24h").Hidden().Envar("KOPIA_INITIAL_UPDATE_CHECK_DELAY").DurationVar(&c.initialUpdateCheckDelay)
 	app.Flag("update-check-interval", "Interval between update checks").Default("168h").Hidden().Envar("KOPIA_UPDATE_CHECK_INTERVAL").DurationVar(&c.updateCheckInterval)
 	app.Flag("update-available-notify-interval", "Interval between update notifications").Default("1h").Hidden().Envar("KOPIA_UPDATE_NOTIFY_INTERVAL").DurationVar(&c.updateAvailableNotifyInterval)
-	app.Flag("config-file", "Specify the config file to use.").Default(defaultConfigFileName()).Envar("KOPIA_CONFIG_PATH").StringVar(&c.configPath)
+	app.Flag("config-file", "Specify the config file to use").Default("repository.config").Envar("KOPIA_CONFIG_PATH").StringVar(&c.configPath)
 	app.Flag("trace-storage", "Enables tracing of storage operations.").Default("true").Hidden().BoolVar(&c.traceStorage)
 	app.Flag("metrics-listen-addr", "Expose Prometheus metrics on a given host:port").Hidden().StringVar(&c.metricsListenAddr)
 	app.Flag("enable-pprof", "Expose pprof handlers").Hidden().BoolVar(&c.enablePProf)

--- a/cli/config.go
+++ b/cli/config.go
@@ -72,11 +72,13 @@ func (c *App) optionsFromFlags(ctx context.Context) *repo.Options {
 }
 
 func (c *App) repositoryConfigFileName() string {
-	return c.configPath
-}
+	if filepath.Base(c.configPath) != c.configPath {
+		return c.configPath
+	}
 
-func defaultConfigFileName() string {
-	return filepath.Join(ospath.ConfigDir(), "repository.config")
+	// bare filename specified without any directory (absolute or relative)
+	// resolve against OS-specific directory.
+	return filepath.Join(ospath.ConfigDir(), c.configPath)
 }
 
 func resolveSymlink(path string) (string, error) {


### PR DESCRIPTION
When --`config-file` is passed as a filename without any directory
(absolute or relative) it is resolved in OS-specific
config path.

For example on macOS:

`--config-file foo.config`

resolves to:

`~/Library/Application Support/kopia/foo.config`
