### PR TITLE
cache: when cache validation fails, properly reset output buffer

### DIFF
--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -56,6 +56,8 @@ func (c *PersistentCache) GetOrLoad(ctx context.Context, key string, fetch func(
 		return nil
 	}
 
+	output.Reset()
+
 	if err := fetch(output); err != nil {
 		stats.Record(ctx, MetricMissErrors.M(1))
 


### PR DESCRIPTION
Previously when cache validation failed, we would leave output buffer in the non-empty state, which caused invalid reads.

It's unclear exactly why cache validation failed in the case described in #1294 (could be bit flips or some credentials problem) but this should fix it.

Fixes #1294