### PR TITLE
blob: support for custom blob store sharding

### DIFF
--- a/cli/command_blob.go
+++ b/cli/command_blob.go
@@ -4,6 +4,7 @@ type commandBlob struct {
 	delete commandBlobDelete
 	gc     commandBlobGC
 	list   commandBlobList
+	shards commandBlobShards
 	show   commandBlobShow
 	stats  commandBlobStats
 }
@@ -14,6 +15,7 @@ func (c *commandBlob) setup(svc appServices, parent commandParent) {
 	c.delete.setup(svc, cmd)
 	c.gc.setup(svc, cmd)
 	c.list.setup(svc, cmd)
+	c.shards.setup(svc, cmd)
 	c.show.setup(svc, cmd)
 	c.stats.setup(svc, cmd)
 }

--- a/cli/command_blob_shards.go
+++ b/cli/command_blob_shards.go
@@ -1,0 +1,11 @@
+package cli
+
+type commandBlobShards struct {
+	modify commandBlobShardsModify
+}
+
+func (c *commandBlobShards) setup(svc appServices, parent commandParent) {
+	cmd := parent.Command("shards", "Manipulate shards in a blob store").Hidden()
+
+	c.modify.setup(svc, cmd)
+}

--- a/cli/command_blob_shards_modify.go
+++ b/cli/command_blob_shards_modify.go
@@ -1,0 +1,275 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/sharded"
+)
+
+type commandBlobShardsModify struct {
+	rootPath         string
+	defaultShardSpec string
+	overrideSpecs    []string
+	removeOverrides  []string
+	dryRun           bool
+	unshardedLength  int
+
+	out textOutput
+}
+
+func (c *commandBlobShardsModify) setup(svc appServices, parent commandParent) {
+	c.unshardedLength = -1
+
+	cmd := parent.Command("modify", "Perform low-level resharding of blob storage").Hidden().Alias("reshard")
+	cmd.Flag("i-am-sure-kopia-is-not-running", "Confirm that no other instance of kopia is running").Required().Bool()
+	cmd.Flag("path", "Sharded directory path").Required().ExistingDirVar(&c.rootPath)
+	cmd.Flag("default-shards", "Default specification 'n1,..nN' or 'flat')").StringVar(&c.defaultShardSpec)
+	cmd.Flag("override", "Override specification 'prefix=n1,..nN')").StringsVar(&c.overrideSpecs)
+	cmd.Flag("remove-override", "Override specification 'prefix=n1,..nN')").StringsVar(&c.removeOverrides)
+	cmd.Flag("unsharded-length", "Minimum sharded length").IntVar(&c.unshardedLength)
+	cmd.Flag("dry-run", "Dry run").BoolVar(&c.dryRun)
+	cmd.Action(svc.noRepositoryAction(c.run))
+
+	c.out.setup(svc)
+}
+
+func (c *commandBlobShardsModify) getParameters(dotShardsFile string) (*sharded.Parameters, error) {
+	// nolint:gosec
+	f, err := os.Open(dotShardsFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to open shards file")
+	}
+
+	p := &sharded.Parameters{}
+	if err := p.Load(f); err != nil {
+		return nil, errors.Wrap(err, "error loading parameters")
+	}
+
+	return p, nil
+}
+
+func parseShardSpec(shards string) ([]int, error) {
+	result := []int{}
+
+	if shards == "flat" {
+		return result, nil
+	}
+
+	parts := strings.Split(shards, ",")
+
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+
+		v, err := strconv.Atoi(p)
+		if err != nil || v < 0 {
+			return nil, errors.Errorf("invalid shard specification")
+		}
+
+		result = append(result, v)
+	}
+
+	return result, nil
+}
+
+func prefixAndShardsWithout(pas []sharded.PrefixAndShards, without blob.ID) []sharded.PrefixAndShards {
+	result := []sharded.PrefixAndShards{}
+
+	for _, it := range pas {
+		if it.Prefix != without {
+			result = append(result, it)
+		}
+	}
+
+	return result
+}
+
+func (c *commandBlobShardsModify) applyParameterChangesFromFlags(p *sharded.Parameters) error {
+	if c.defaultShardSpec != "" {
+		v, err := parseShardSpec(c.defaultShardSpec)
+		if err != nil {
+			return errors.Errorf("invalid --default-shards")
+		}
+
+		p.DefaultShards = v
+	}
+
+	for _, ov := range c.removeOverrides {
+		p.Overrides = prefixAndShardsWithout(p.Overrides, blob.ID(ov))
+	}
+
+	for _, ov := range c.overrideSpecs {
+		parts := strings.Split(ov, "=")
+		if len(parts) <= 1 {
+			return errors.Errorf("invalid override %q, must be prefix=n1,..,nM", ov)
+		}
+
+		v, err := parseShardSpec(parts[1])
+		if err != nil {
+			return errors.Errorf("invalid override %q, must be prefix=n1,..,nM", ov)
+		}
+
+		p.Overrides = append(
+			prefixAndShardsWithout(p.Overrides, blob.ID(parts[0])),
+			sharded.PrefixAndShards{
+				Prefix: blob.ID(parts[0]),
+				Shards: v,
+			})
+	}
+
+	if c.unshardedLength != -1 {
+		p.UnshardedLength = c.unshardedLength
+	}
+
+	return nil
+}
+
+func (c *commandBlobShardsModify) run(ctx context.Context) error {
+	var numMoved, numUnchanged, numRemoved int
+
+	dotShardsFile := filepath.Join(c.rootPath, sharded.ParametersFile)
+
+	log(ctx).Infof("Reading .shards file.")
+
+	srcPar, err := c.getParameters(dotShardsFile)
+	if err != nil {
+		return err
+	}
+
+	dstPar := srcPar.Clone()
+
+	if err2 := c.applyParameterChangesFromFlags(dstPar); err2 != nil {
+		return err2
+	}
+
+	log(ctx).Infof("Moving files...")
+
+	if err2 := c.renameBlobs(ctx, c.rootPath, "", dstPar, &numMoved, &numUnchanged); err2 != nil {
+		return errors.Wrap(err2, "error processing directory")
+	}
+
+	if c.dryRun {
+		log(ctx).Infof("Would move %v file, %v unchanged.", numMoved, numUnchanged)
+
+		return nil
+	}
+
+	log(ctx).Infof("Moved %v files, %v unchanged.", numMoved, numUnchanged)
+	log(ctx).Infof("Removing empty directories...")
+
+	if _, err2 := c.removeEmptyDirs(ctx, c.rootPath, &numRemoved); err2 != nil {
+		return errors.Wrap(err2, "error removing empty directories")
+	}
+
+	log(ctx).Infof("Removed %v empty directories...", numRemoved)
+	log(ctx).Infof("Writing new .shards file.")
+
+	of, err := os.Create(dotShardsFile)
+	if err != nil {
+		return errors.Wrap(err, "error creating .shards file")
+	}
+	defer of.Close() //nolint:errcheck,gosec
+
+	return errors.Wrap(dstPar.Save(of), "error saving .shards file")
+}
+
+func (c *commandBlobShardsModify) removeEmptyDirs(ctx context.Context, dir string, numRemoved *int) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, errors.Wrap(err, "error reading directory")
+	}
+
+	isEmpty := true
+
+	for _, ent := range entries {
+		// nolint:nestif
+		if ent.IsDir() {
+			childPath := path.Join(dir, ent.Name())
+
+			subDirEmpty, err := c.removeEmptyDirs(ctx, childPath, numRemoved)
+			if err != nil {
+				return false, err
+			}
+
+			if !subDirEmpty {
+				isEmpty = false
+			} else {
+				c.out.printStdout("rmdir %v\n", childPath)
+
+				*numRemoved++
+
+				if !c.dryRun {
+					if err := os.Remove(childPath); err != nil {
+						log(ctx).Errorf("Unable to remove directory %v", childPath)
+
+						isEmpty = false
+					}
+				}
+			}
+		} else {
+			isEmpty = false
+		}
+	}
+
+	return isEmpty, nil
+}
+
+func (c *commandBlobShardsModify) renameBlobs(ctx context.Context, dir, prefix string, params *sharded.Parameters, numMoved, numUnchanged *int) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return errors.Wrap(err, "error reading directory")
+	}
+
+	for _, ent := range entries {
+		// nolint:nestif
+		if ent.IsDir() {
+			if err := c.renameBlobs(ctx, path.Join(dir, ent.Name()), prefix+ent.Name(), params, numMoved, numUnchanged); err != nil {
+				return err
+			}
+		} else if strings.HasSuffix(ent.Name(), sharded.CompleteBlobSuffix) {
+			blobID := prefix + strings.TrimSuffix(ent.Name(), sharded.CompleteBlobSuffix)
+
+			destDir, destBlobID := params.GetShardDirectoryAndBlob(c.rootPath, blob.ID(blobID))
+			srcFile := path.Join(dir, ent.Name())
+			destFile := fmt.Sprintf("%v/%v%v", destDir, destBlobID, sharded.CompleteBlobSuffix)
+
+			if srcFile == destFile {
+				log(ctx).Debugf("Unchanged: %v", srcFile)
+
+				*numUnchanged++
+			} else {
+				c.out.printStdout("mv %v %v\n", srcFile, destFile)
+
+				if !c.dryRun {
+					err := os.Rename(srcFile, destFile)
+					if os.IsNotExist(err) {
+						// nolint:gomnd
+						if err2 := os.MkdirAll(destDir, 0o700); err2 != nil {
+							return errors.Wrap(err2, "error creating directory")
+						}
+
+						err = os.Rename(srcFile, destFile)
+					}
+
+					if err != nil {
+						return errors.Wrap(err, "error moving")
+					}
+				}
+
+				*numMoved++
+			}
+		}
+	}
+
+	return nil
+}

--- a/cli/command_blob_shards_modify_test.go
+++ b/cli/command_blob_shards_modify_test.go
@@ -1,0 +1,61 @@
+package cli_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/repo/blob/sharded"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestBlobShardsModify(t *testing.T) {
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+
+	someQBlob := strings.Split(env.RunAndExpectSuccess(t, "blob", "list", "--prefix=q")[0], " ")[0]
+
+	// verify default sharding is 3,3
+	require.FileExists(t, filepath.Join(env.RepoDir, someQBlob[0:3], someQBlob[3:6], someQBlob[6:]+sharded.CompleteBlobSuffix))
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
+
+	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--default-shards=5,5", "--i-am-sure-kopia-is-not-running")
+
+	// verify new sharding is 5,5
+	require.FileExists(t, filepath.Join(env.RepoDir, someQBlob[0:5], someQBlob[5:10], someQBlob[10:]+sharded.CompleteBlobSuffix))
+	require.NoFileExists(t, filepath.Join(env.RepoDir, someQBlob[0:3], someQBlob[3:6], someQBlob[6:]+sharded.CompleteBlobSuffix))
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
+
+	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--unsharded-length=0", "--i-am-sure-kopia-is-not-running")
+
+	require.FileExists(t, filepath.Join(env.RepoDir, someQBlob[0:5], someQBlob[5:10], someQBlob[10:]+sharded.CompleteBlobSuffix))
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia/.repo/sitory.f"))
+	require.NoFileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
+
+	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=kop=2,,,2", "--i-am-sure-kopia-is-not-running")
+	require.FileExists(t, filepath.Join(env.RepoDir, "ko/pi/a.repository.f"))
+	require.NoFileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
+
+	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--remove-override=nosuchprefix", "--remove-override=kop", "--i-am-sure-kopia-is-not-running")
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia/.repo/sitory.f"))
+
+	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--i-am-sure-kopia-is-not-running")
+
+	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=kop=flat", "--i-am-sure-kopia-is-not-running", "--dry-run")
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia/.repo/sitory.f"))
+
+	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=kop=flat", "--i-am-sure-kopia-is-not-running")
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
+
+	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=kop=4,4", "--i-am-sure-kopia-is-not-running")
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopi/a.re/pository.f"))
+
+	// some invalid cases
+	env.RunAndExpectFailure(t, "blob", "shards", "modify", "--path", env.RepoDir, "--default-shards=invalid", "--i-am-sure-kopia-is-not-running")
+	env.RunAndExpectFailure(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=x", "--i-am-sure-kopia-is-not-running")
+	env.RunAndExpectFailure(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=x=aaa", "--i-am-sure-kopia-is-not-running")
+	env.RunAndExpectFailure(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=2,-1", "--i-am-sure-kopia-is-not-running")
+}

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -33,7 +33,6 @@ var log = logging.GetContextLoggerFunc("sftp")
 
 const (
 	sftpStorageType         = "sftp"
-	fsStorageChunkSuffix    = ".f"
 	tempFileRandomSuffixLen = 8
 
 	packetSize = 1 << 15
@@ -590,7 +589,6 @@ func New(ctx context.Context, opts *Options) (blob.Storage, error) {
 		sharded.Storage{
 			Impl:            impl,
 			RootPath:        opts.Path,
-			Suffix:          fsStorageChunkSuffix,
 			Shards:          opts.shards(),
 			ListParallelism: opts.ListParallelism,
 		},

--- a/repo/blob/sharded/sharded_parameters.go
+++ b/repo/blob/sharded/sharded_parameters.go
@@ -1,0 +1,102 @@
+// Package sharded implements common support for sharded blob providers, such as filesystem or webdav.
+package sharded
+
+import (
+	"encoding/json"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/blob"
+)
+
+// ParametersFile is the name of the hidden parameters file in a sharded storage.
+const ParametersFile = ".shards"
+
+const defaultMinShardedBlobIDLength = 20
+
+// PrefixAndShards defines shards to use for a particular blob ID prefix.
+type PrefixAndShards struct {
+	Prefix blob.ID `json:"prefix"`
+	Shards []int   `json:"shards"`
+}
+
+// Parameters contains sharded storage configuration optionally persisted in the storage itself.
+type Parameters struct {
+	DefaultShards   []int             `json:"default"`
+	UnshardedLength int               `json:"maxNonShardedLength"`
+	Overrides       []PrefixAndShards `json:"overrides,omitempty"`
+}
+
+// DefaultParameters constructs Parameters based on the provided shards specification.
+func DefaultParameters(shards []int) *Parameters {
+	return &Parameters{
+		DefaultShards:   shards,
+		UnshardedLength: defaultMinShardedBlobIDLength,
+	}
+}
+
+// Load loads the Parameters from the provided reader.
+func (p *Parameters) Load(r io.Reader) error {
+	return errors.Wrap(json.NewDecoder(r).Decode(p), "error parsing JSON")
+}
+
+// Save saves the parameters to the provided writer.
+func (p *Parameters) Save(w io.Writer) error {
+	return errors.Wrap(json.NewEncoder(w).Encode(p), "error writing JSON")
+}
+
+func cloneShards(v []int) []int {
+	if v != nil {
+		return append(([]int(nil)), v...)
+	}
+
+	return nil
+}
+
+// Clone returns a clone of sharding parameters.
+func (p *Parameters) Clone() *Parameters {
+	var clonedOverrides []PrefixAndShards
+
+	for _, o := range p.Overrides {
+		clonedOverrides = append(clonedOverrides, PrefixAndShards{o.Prefix, cloneShards(o.Shards)})
+	}
+
+	return &Parameters{
+		DefaultShards:   cloneShards(p.DefaultShards),
+		UnshardedLength: p.UnshardedLength,
+		Overrides:       clonedOverrides,
+	}
+}
+
+func (p *Parameters) getShardsForBlobID(id blob.ID) []int {
+	for _, o := range p.Overrides {
+		if strings.HasPrefix(string(id), string(o.Prefix)) {
+			return o.Shards
+		}
+	}
+
+	return p.DefaultShards
+}
+
+// GetShardDirectoryAndBlob gets that sharded directory and blob ID for a provided blob.
+func (p *Parameters) GetShardDirectoryAndBlob(rootPath string, blobID blob.ID) (string, blob.ID) {
+	shardPath := rootPath
+
+	if len(blobID) <= p.UnshardedLength {
+		return shardPath, blobID
+	}
+
+	for _, size := range p.getShardsForBlobID(blobID) {
+		if len(blobID) <= size {
+			break
+		}
+
+		shardPath = path.Join(shardPath, string(blobID[0:size]))
+		blobID = blobID[size:]
+	}
+
+	return shardPath, blobID
+}

--- a/repo/blob/sharded/sharded_test.go
+++ b/repo/blob/sharded/sharded_test.go
@@ -1,15 +1,23 @@
 package sharded_test
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/filesystem"
+	"github.com/kopia/kopia/repo/blob/sharded"
 )
 
 func TestShardedFileStorage(t *testing.T) {
@@ -50,4 +58,183 @@ func TestShardedFileStorage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestShardedFileStorageShardingMap(t *testing.T) {
+	cases := []struct {
+		desc            string
+		shardMapJSON    string
+		blobFilePathMap map[blob.ID]string
+	}{
+		{
+			"case1",
+			`
+			{
+				"default": [3,2,1],
+				"overrides": [
+					{ "prefix": "p", "shards": [2,2] },
+					{ "prefix": "x", "shards": [1,1,1] }
+				],
+				"maxNonShardedLength": 2
+			}`,
+			map[blob.ID]string{
+				// non-sharded because of ID length
+				"ab": "ab.f",
+
+				// sharded according to default shards - 3,2,1
+				"defaultsharded": "def/au/l/tsharded.f",
+
+				// sharded according to first override
+				"phello":   "ph/el/lo.f",
+				"pgoodbye": "pg/oo/dbye.f",
+
+				// second override
+				"xhello": "x/h/e/llo.f",
+				"xbye":   "x/b/y/e.f",
+				"xo":     "xo.f",
+			},
+		},
+		{
+			"shorter-than-nonsharded-length",
+			`
+			{
+				"default": [3,3],
+				"maxNonShardedLength": 10
+			}`,
+			map[blob.ID]string{
+				"foobarbar":    "foobarbar.f",
+				"foobarbarbar": "foo/bar/barbar.f",
+			},
+		},
+		{
+			"shorter-than-shards",
+			`
+			{
+				"default": [3,3],
+				"maxNonShardedLength": 0
+			}`,
+			map[blob.ID]string{
+				"fo":      "fo.f",
+				"foo":     "foo.f",
+				"foob":    "foo/b.f",
+				"fooba":   "foo/ba.f",
+				"foobar":  "foo/bar.f",
+				"foobar2": "foo/bar/2.f",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := testlogging.Context(t)
+
+			path := testutil.TempDirectory(t)
+
+			r, err := filesystem.New(ctx, &filesystem.Options{
+				Path: path,
+			})
+			require.NoError(t, err)
+
+			dotShardsFile := filepath.Join(path, ".shards")
+
+			// write shards file
+			require.NoError(t, ioutil.WriteFile(dotShardsFile, []byte(tc.shardMapJSON), 0o600))
+
+			var allBlobIDs []blob.ID
+
+			for blobID, wantFilename := range tc.blobFilePathMap {
+				require.NoError(t, r.PutBlob(ctx, blobID, gather.FromSlice([]byte("foo"))))
+				require.FileExists(t, filepath.Join(path, wantFilename))
+
+				allBlobIDs = append(allBlobIDs, blobID)
+			}
+
+			for _, blobID := range allBlobIDs {
+				for i := 0; i < len(blobID); i++ {
+					prefix := blobID[0:i]
+
+					var wantMatches []blob.ID
+
+					for _, b2 := range allBlobIDs {
+						if strings.HasPrefix(string(b2), string(prefix)) {
+							wantMatches = append(wantMatches, b2)
+						}
+					}
+
+					blobtesting.AssertListResultsIDs(ctx, t, r, prefix, wantMatches...)
+				}
+			}
+		})
+	}
+}
+
+func TestShardedFileStorageShardingMap_Invalid(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+
+	path := testutil.TempDirectory(t)
+
+	r, err := filesystem.New(ctx, &filesystem.Options{
+		Path: path,
+	})
+	require.NoError(t, err)
+
+	dotShardsFile := filepath.Join(path, ".shards")
+
+	// write malformed shards file
+	require.NoError(t, ioutil.WriteFile(dotShardsFile, []byte{1, 2, 3}, 0o600))
+
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	require.Error(t, r.PutBlob(ctx, "someblob", gather.FromSlice([]byte("foo"))))
+
+	// delete invalid .shards file
+	require.NoError(t, os.Remove(dotShardsFile))
+
+	// now putting the blob will succeed
+	require.NoError(t, r.PutBlob(ctx, "someblob", gather.FromSlice([]byte("foo"))))
+
+	// write malformed file again, but will be ignored since it was successfully loaded
+	// in this session.
+	require.NoError(t, ioutil.WriteFile(dotShardsFile, []byte{1, 2, 3}, 0o600))
+
+	require.NoError(t, r.PutBlob(ctx, "someblob2", gather.FromSlice([]byte("foo"))))
+}
+
+func TestClone(t *testing.T) {
+	p := &sharded.Parameters{
+		DefaultShards:   []int{1, 2, 3},
+		UnshardedLength: 4,
+		Overrides: []sharded.PrefixAndShards{
+			{"x", []int{3, 2, 1}},
+			{"y", []int{4, 3, 2}},
+		},
+	}
+
+	var buf1 bytes.Buffer
+
+	require.NoError(t, p.Save(&buf1))
+
+	var buf2 bytes.Buffer
+
+	p2 := p.Clone()
+	require.NoError(t, p2.Save(&buf2))
+
+	require.Equal(t, buf1.String(), buf2.String())
+
+	// change 'p' in place, p2 should not change
+	p.DefaultShards[0]++
+	p.UnshardedLength++
+	p.Overrides[0].Prefix = "zz"
+	p.Overrides[0].Shards[2]++
+
+	var buf2after bytes.Buffer
+
+	require.NoError(t, p2.Save(&buf2after))
+
+	require.Equal(t, buf2.String(), buf2after.String())
 }

--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	davStorageType       = "webdav"
-	fsStorageChunkSuffix = ".f"
+	davStorageType = "webdav"
 
 	defaultFilePerm = 0o600
 	defaultDirPerm  = 0o700
@@ -246,7 +245,6 @@ func New(ctx context.Context, opts *Options) (blob.Storage, error) {
 				cli:     cli,
 			},
 			RootPath:        "",
-			Suffix:          fsStorageChunkSuffix,
 			Shards:          opts.shards(),
 			ListParallelism: opts.ListParallelism,
 		},


### PR DESCRIPTION
This is experimental.

The .shards file can reside in the root of any blob storage that uses
sharding (filesystem/sftp/webdav) and can specify rules for sharding.

```
{
  "default": [3,2,1],
  "overrides": [
    { "prefix": "p", "shards": [2,2] },
    { "prefix": "x", "shards": [1,1,1] }
  ],
  "maxNonshardedLength": 2
}
```

With this in place we'll be later able to do resharding of the
repository to optimize get/put/list performance for both repositories
and caches.