### PR TITLE
ui: fixed directory selector and browse buttons

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,10 @@
     ],
     "extraResources": [
       {
+        "from": "public/preload.js",
+        "to": "."
+      },
+      {
         "from": "resources/${os}",
         "to": ".",
         "filter": [
@@ -136,14 +140,10 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "last 1 electron version"
     ],
     "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
+      "last 1 electron version"
     ]
   }
 }

--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -32,8 +32,7 @@ function showRepoWindow(repoID) {
     title: 'Kopia UI Loading...',
     autoHideMenuBar: true,
     webPreferences: {
-      nodeIntegration: true,
-      enableRemoteModule: true,
+      preload: path.join(__dirname, 'preload.js'),
     },
   })
 
@@ -125,6 +124,18 @@ app.on('certificate-error', (event, webContents, url, error, certificate, callba
 
 // Ignore
 app.on('window-all-closed', function () { })
+
+ipcMain.handle('select-dir', async (event, arg) => {
+  const result = await dialog.showOpenDialog({
+    properties: ['openDirectory']
+  });
+  
+  if (result.filePaths) {
+    return result.filePaths[0];
+  } else {
+    return null;
+  };
+})
 
 ipcMain.on('server-status-updated', updateTrayContextMenu);
 ipcMain.on('launch-at-startup-updated', updateTrayContextMenu);

--- a/app/public/preload.js
+++ b/app/public/preload.js
@@ -1,0 +1,15 @@
+const { contextBridge, shell, ipcRenderer } = require("electron");
+
+console.log('preloading...', contextBridge, shell);
+
+contextBridge.exposeInMainWorld("kopiaUI", {
+    "selectDirectory": function (onSelected) {
+        ipcRenderer.invoke('select-dir').then(v => {
+            onSelected(v);
+        });
+    },
+    "browseDirectory": function(path) {
+        shell.openPath(path);
+    },
+})
+

--- a/htmlui/src/DirectoryObject.js
+++ b/htmlui/src/DirectoryObject.js
@@ -85,13 +85,12 @@ export class DirectoryObject extends Component {
     }
 
     browseMounted() {
-        if (!window.require) {
+        if (!window.kopiaUI) {
             alert('Directory browsing is not supported in a web browser. Use Kopia UI.');
             return;
         }
 
-        const { shell } = window.require('electron').remote;
-        shell.openItem(this.state.mountInfo.path)
+        window.kopiaUI.browseDirectory(this.state.mountInfo.path);
     }
 
     copyPath() {
@@ -115,8 +114,6 @@ export class DirectoryObject extends Component {
             return <Spinner animation="border" variant="primary" />;
         }
 
-        const browsingSupported = !!window.require;
-
         return <div className="padded">
             <Row>
                 <Col>
@@ -124,7 +121,7 @@ export class DirectoryObject extends Component {
             &nbsp;
             { this.state.mountInfo.path ? <>
             <Button size="sm" variant="info" onClick={this.unmount} >Unmount</Button>
-            {browsingSupported && <>
+            {window.kopiaUI && <>
             &nbsp;
             <Button size="sm" variant="info" onClick={this.browseMounted} >Browse</Button>
             </>}

--- a/htmlui/src/preload.js
+++ b/htmlui/src/preload.js
@@ -1,7 +1,0 @@
-const { dialog } = require("electron");
-
-window.selectDirectory = function () {
-    return dialog.showOpenDialogSync({
-        properties: ['openDirectory']
-    });
-}

--- a/htmlui/src/uiutil.js
+++ b/htmlui/src/uiutil.js
@@ -165,26 +165,6 @@ export function GoBackButton(props) {
     return <Button size="sm" variant="outline-secondary" {...props}><FontAwesomeIcon icon={faChevronLeft} /> Return </Button>;
 }
 
-function selectDirectory(onSelected) {
-    // populated in 'preload.js' in Electron
-    if (!window.require) {
-        alert('Directory selection is not supported in a web browser.\n\nPlease enter path manually.');
-        return;
-    }
-
-    const { dialog } = window.require('electron').remote;
-    try {
-        let dir = dialog.showOpenDialogSync({
-            properties: ['openDirectory']
-        });
-        if (dir) {
-            onSelected(dir[0]);
-        }
-    } catch (e) {
-        window.alert('Error: ' + e);
-    }
-}
-
 export function sourceQueryStringParams(src) {
     return 'userName=' + encodeURIComponent(src.userName) + '&host=' + encodeURIComponent(src.host) + '&path=' + encodeURIComponent(src.path);
 }
@@ -225,17 +205,15 @@ export function errorAlert(err, prefix) {
 }
 
 export function DirectorySelector(props) {
-    const selectSupported = !!window.require;
-
     let { onDirectorySelected, ...inputProps } = props;
 
-    if (!selectSupported) {
+    if (!window.kopiaUI) {
         return <Form.Control size="sm" {...inputProps} />
     }
 
     return <InputGroup>
         <FormControl size="sm" {...inputProps} />
-        <Button size="sm" onClick={() => selectDirectory(onDirectorySelected)}>
+        <Button size="sm" onClick={() => window.kopiaUI.selectDirectory(onDirectorySelected)}>
             <FontAwesomeIcon icon={faFolderOpen} />
         </Button>
     </InputGroup>;


### PR DESCRIPTION
This fixes a regression after upgrading to more recent Electron.

This change implements clean `window.kopiaUI` API that can be used
to detect whether we're running inside KopiaUI shell vs in a browser
and follows latest security recommendation from Electron. All
browser-to-electron bridge code is now in `preload.js`.

Fixes #1309