### PR TITLE
repo: allow reusing of object writer buffers

### DIFF
--- a/internal/gather/gather_bytes.go
+++ b/internal/gather/gather_bytes.go
@@ -172,6 +172,7 @@ func (b Bytes) WriteTo(w io.Writer) (int64, error) {
 // FromSlice creates Bytes from the specified slice.
 func FromSlice(b []byte) Bytes {
 	var r Bytes
+
 	r.sliceBuf[0] = b
 	r.Slices = r.sliceBuf[:]
 

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -33,6 +33,19 @@ func (b *WriteBuffer) Close() {
 	b.inner.invalidate()
 }
 
+// CloneContiguous initializes the write buffer with a contiguous (single-slice) copy of the provided
+// slices.
+func (b *WriteBuffer) CloneContiguous(byt Bytes) []byte {
+	contig := b.MakeContiguous(byt.Length())
+	output := contig[:0]
+
+	for _, s := range byt.Slices {
+		output = append(output, s...)
+	}
+
+	return contig
+}
+
 // MakeContiguous ensures the write buffer consists of exactly one contiguous single slice of the provided length
 // and returns the slice.
 func (b *WriteBuffer) MakeContiguous(length int) []byte {

--- a/internal/gather/gather_write_buffer_test.go
+++ b/internal/gather/gather_write_buffer_test.go
@@ -81,3 +81,16 @@ func TestGatherWriteBufferContig(t *testing.T) {
 	require.Equal(t, theCap, len(b))
 	require.Equal(t, theCap, cap(b))
 }
+
+func TestGatherWriteBufferCloneContig(t *testing.T) {
+	var w WriteBuffer
+	defer w.Close()
+
+	w.Append([]byte{1, 2, 3})
+	w.Append([]byte{4, 5, 6})
+
+	var w2 WriteBuffer
+	contig := w2.CloneContiguous(w.Bytes())
+
+	require.Equal(t, []byte{1, 2, 3, 4, 5, 6}, contig)
+}

--- a/internal/repotesting/reconnectable_storage.go
+++ b/internal/repotesting/reconnectable_storage.go
@@ -31,13 +31,13 @@ type reconnectableStorageOptions struct {
 // newReconnectableStorage wraps the provided storage that may or may not be round-trippable
 // in a wrapper that globally caches storage instance and ensures its connection info is
 // round-trippable.
-func newReconnectableStorage(t *testing.T, st blob.Storage) blob.Storage {
-	t.Helper()
+func newReconnectableStorage(tb testing.TB, st blob.Storage) blob.Storage {
+	tb.Helper()
 
 	st2 := reconnectableStorage{st, &reconnectableStorageOptions{UUID: uuid.NewString()}}
 
 	reconnectableStorageByUUID.Store(st2.opt.UUID, st2)
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		reconnectableStorageByUUID.Delete(st2.opt.UUID)
 	})
 

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -38,11 +38,11 @@ type Options struct {
 }
 
 // setup sets up a test environment.
-func (e *Environment) setup(t *testing.T, version content.FormatVersion, opts ...Options) *Environment {
-	t.Helper()
+func (e *Environment) setup(tb testing.TB, version content.FormatVersion, opts ...Options) *Environment {
+	tb.Helper()
 
-	ctx := testlogging.Context(t)
-	e.configDir = testutil.TempDirectory(t)
+	ctx := testlogging.Context(tb)
+	e.configDir = testutil.TempDirectory(tb)
 	openOpt := &repo.Options{}
 
 	opt := &repo.NewRepositoryOptions{
@@ -71,7 +71,7 @@ func (e *Environment) setup(t *testing.T, version content.FormatVersion, opts ..
 	}
 
 	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, openOpt.TimeNowFunc)
-	st = newReconnectableStorage(t, st)
+	st = newReconnectableStorage(tb, st)
 	e.st = st
 
 	if e.Password == "" {
@@ -79,49 +79,49 @@ func (e *Environment) setup(t *testing.T, version content.FormatVersion, opts ..
 	}
 
 	if err := repo.Initialize(ctx, st, opt, e.Password); err != nil {
-		t.Fatalf("err: %v", err)
+		tb.Fatalf("err: %v", err)
 	}
 
 	if err := repo.Connect(ctx, e.ConfigFile(), st, e.Password, nil); err != nil {
-		t.Fatalf("can't connect: %v", err)
+		tb.Fatalf("can't connect: %v", err)
 	}
 
 	e.connected = true
 
 	rep, err := repo.Open(ctx, e.ConfigFile(), e.Password, openOpt)
 	if err != nil {
-		t.Fatalf("can't open: %v", err)
+		tb.Fatalf("can't open: %v", err)
 	}
 
 	e.Repository = rep
 
 	_, e.RepositoryWriter, err = rep.(repo.DirectRepository).NewDirectWriter(ctx, repo.WriteSessionOptions{Purpose: "test"})
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
-	t.Cleanup(func() { rep.Close(ctx) })
+	tb.Cleanup(func() { rep.Close(ctx) })
 
 	return e
 }
 
 // Close closes testing environment.
-func (e *Environment) Close(ctx context.Context, t *testing.T) {
-	t.Helper()
+func (e *Environment) Close(ctx context.Context, tb testing.TB) {
+	tb.Helper()
 
 	if err := e.RepositoryWriter.Close(ctx); err != nil {
-		t.Fatalf("unable to close: %v", err)
+		tb.Fatalf("unable to close: %v", err)
 	}
 
 	if e.connected {
 		if err := repo.Disconnect(ctx, e.ConfigFile()); err != nil {
-			t.Errorf("error disconnecting: %v", err)
+			tb.Errorf("error disconnecting: %v", err)
 		}
 	}
 
 	if err := os.Remove(e.configDir); err != nil {
 		// should be empty, assuming Disconnect was successful
-		t.Errorf("error removing config directory: %v", err)
+		tb.Errorf("error removing config directory: %v", err)
 	}
 }
 
@@ -131,47 +131,47 @@ func (e *Environment) ConfigFile() string {
 }
 
 // MustReopen closes and reopens the repository.
-func (e *Environment) MustReopen(t *testing.T, openOpts ...func(*repo.Options)) {
-	t.Helper()
+func (e *Environment) MustReopen(tb testing.TB, openOpts ...func(*repo.Options)) {
+	tb.Helper()
 
-	ctx := testlogging.Context(t)
+	ctx := testlogging.Context(tb)
 
 	err := e.RepositoryWriter.Close(ctx)
 	if err != nil {
-		t.Fatalf("close error: %v", err)
+		tb.Fatalf("close error: %v", err)
 	}
 
 	rep, err := repo.Open(ctx, e.ConfigFile(), e.Password, repoOptions(openOpts))
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		tb.Fatalf("err: %v", err)
 	}
 
-	t.Cleanup(func() { rep.Close(ctx) })
+	tb.Cleanup(func() { rep.Close(ctx) })
 
 	_, e.RepositoryWriter, err = rep.(repo.DirectRepository).NewDirectWriter(ctx, repo.WriteSessionOptions{Purpose: "test"})
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		tb.Fatalf("err: %v", err)
 	}
 }
 
 // MustOpenAnother opens another repository backend by the same storage.
-func (e *Environment) MustOpenAnother(t *testing.T) repo.RepositoryWriter {
-	t.Helper()
+func (e *Environment) MustOpenAnother(tb testing.TB) repo.RepositoryWriter {
+	tb.Helper()
 
-	ctx := testlogging.Context(t)
+	ctx := testlogging.Context(tb)
 
 	rep2, err := repo.Open(ctx, e.ConfigFile(), e.Password, &repo.Options{})
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		tb.Fatalf("err: %v", err)
 	}
 
-	t.Cleanup(func() {
+	tb.Cleanup(func() {
 		rep2.Close(ctx)
 	})
 
 	_, w, err := rep2.NewWriter(ctx, repo.WriteSessionOptions{Purpose: "test"})
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	return w
@@ -179,43 +179,43 @@ func (e *Environment) MustOpenAnother(t *testing.T) repo.RepositoryWriter {
 
 // MustConnectOpenAnother opens another repository backend by the same storage,
 // with independent config and cache options.
-func (e *Environment) MustConnectOpenAnother(t *testing.T, openOpts ...func(*repo.Options)) repo.Repository {
-	t.Helper()
+func (e *Environment) MustConnectOpenAnother(tb testing.TB, openOpts ...func(*repo.Options)) repo.Repository {
+	tb.Helper()
 
-	ctx := testlogging.Context(t)
+	ctx := testlogging.Context(tb)
 
-	config := filepath.Join(testutil.TempDirectory(t), "kopia.config")
+	config := filepath.Join(testutil.TempDirectory(tb), "kopia.config")
 	connOpts := &repo.ConnectOptions{
 		CachingOptions: content.CachingOptions{
-			CacheDirectory: testutil.TempDirectory(t),
+			CacheDirectory: testutil.TempDirectory(tb),
 		},
 	}
 
 	if err := repo.Connect(ctx, config, e.st, e.Password, connOpts); err != nil {
-		t.Fatal("can't connect:", err)
+		tb.Fatal("can't connect:", err)
 	}
 
 	rep, err := repo.Open(ctx, e.ConfigFile(), e.Password, repoOptions(openOpts))
 	if err != nil {
-		t.Fatal("can't open:", err)
+		tb.Fatal("can't open:", err)
 	}
 
 	return rep
 }
 
 // VerifyBlobCount verifies that the underlying storage contains the specified number of blobs.
-func (e *Environment) VerifyBlobCount(t *testing.T, want int) {
-	t.Helper()
+func (e *Environment) VerifyBlobCount(tb testing.TB, want int) {
+	tb.Helper()
 
 	var got int
 
-	_ = e.RepositoryWriter.BlobReader().ListBlobs(testlogging.Context(t), "", func(_ blob.Metadata) error {
+	_ = e.RepositoryWriter.BlobReader().ListBlobs(testlogging.Context(tb), "", func(_ blob.Metadata) error {
 		got++
 		return nil
 	})
 
 	if got != want {
-		t.Errorf("got unexpected number of BLOBs: %v, wanted %v", got, want)
+		tb.Errorf("got unexpected number of BLOBs: %v, wanted %v", got, want)
 	}
 }
 
@@ -235,17 +235,17 @@ func repoOptions(openOpts []func(*repo.Options)) *repo.Options {
 const FormatNotImportant = content.FormatVersion2
 
 // NewEnvironment creates a new repository testing environment and ensures its cleanup at the end of the test.
-func NewEnvironment(t *testing.T, version content.FormatVersion, opts ...Options) (context.Context, *Environment) {
-	t.Helper()
+func NewEnvironment(tb testing.TB, version content.FormatVersion, opts ...Options) (context.Context, *Environment) {
+	tb.Helper()
 
-	ctx := testlogging.Context(t)
+	ctx := testlogging.Context(tb)
 
 	var env Environment
 
-	env.setup(t, version, opts...)
+	env.setup(tb, version, opts...)
 
-	t.Cleanup(func() {
-		env.Close(ctx, t)
+	tb.Cleanup(func() {
+		env.Close(ctx, tb)
 	})
 
 	return ctx, &env

--- a/internal/repotesting/repotesting_test.go
+++ b/internal/repotesting/repotesting_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/faketime"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/mockfs"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/content"
@@ -43,7 +44,7 @@ func TestTimeFuncWiring(t *testing.T) {
 	// verify wiring for the content layer
 	nt := ft.Advance(20 * time.Second)
 
-	cid, err := env.RepositoryWriter.ContentManager().WriteContent(ctx, []byte("foo"), "", content.NoCompression)
+	cid, err := env.RepositoryWriter.ContentManager().WriteContent(ctx, gather.FromSlice([]byte("foo")), "", content.NoCompression)
 	if err != nil {
 		t.Fatal("failed to write content:", err)
 	}

--- a/internal/server/api_content.go
+++ b/internal/server/api_content.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/compression"
@@ -83,7 +84,7 @@ func (s *Server) handleContentPut(ctx context.Context, r *http.Request, data []b
 		}
 	}
 
-	actualCID, err := dr.ContentManager().WriteContent(ctx, data, prefix, comp)
+	actualCID, err := dr.ContentManager().WriteContent(ctx, gather.FromSlice(data), prefix, comp)
 	if err != nil {
 		return nil, internalServerError(err)
 	}

--- a/internal/server/grpc_session.go
+++ b/internal/server/grpc_session.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/kopia/kopia/internal/auth"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/grpcapi"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/compression"
@@ -231,7 +232,7 @@ func handleWriteContentRequest(ctx context.Context, dw repo.DirectRepositoryWrit
 		return accessDeniedResponse()
 	}
 
-	contentID, err := dw.ContentManager().WriteContent(ctx, req.GetData(), content.ID(req.GetPrefix()), compression.HeaderID(req.GetCompression()))
+	contentID, err := dw.ContentManager().WriteContent(ctx, gather.FromSlice(req.GetData()), content.ID(req.GetPrefix()), compression.HeaderID(req.GetCompression()))
 	if err != nil {
 		return errorResponse(err)
 	}

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -117,11 +117,11 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 
 	defer bm.Close(ctx)
 
-	cases := [][]byte{
-		{},
-		{1, 2, 3},
-		make([]byte, 256),
-		bytes.Repeat([]byte{1, 2, 3, 5}, 1024),
+	cases := []gather.Bytes{
+		gather.FromSlice([]byte{}),
+		gather.FromSlice([]byte{1, 2, 3}),
+		gather.FromSlice(make([]byte, 256)),
+		gather.FromSlice(bytes.Repeat([]byte{1, 2, 3, 5}, 1024)),
 	}
 
 	for _, b := range cases {
@@ -138,7 +138,7 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 			return
 		}
 
-		if got, want := b2, b; !bytes.Equal(got, want) {
+		if got, want := b2, b.ToByteSlice(); !bytes.Equal(got, want) {
 			t.Errorf("content %q data mismatch: got %x, wanted %x", contentID, got, want)
 			return
 		}
@@ -153,7 +153,7 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 			return
 		}
 
-		if got, want := b3, b; !bytes.Equal(got, want) {
+		if got, want := b3, b.ToByteSlice(); !bytes.Equal(got, want) {
 			t.Errorf("content %q data mismatch: got %x, wanted %x", contentID, got, want)
 			return
 		}

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/content"
 )
 
@@ -96,7 +97,9 @@ func (m *committedManifestManager) writeEntriesLocked(ctx context.Context, entri
 		man.Entries = append(man.Entries, e)
 	}
 
-	var buf bytes.Buffer
+	var buf gather.WriteBuffer
+	defer buf.Close()
+
 	gz := gzip.NewWriter(&buf)
 	mustSucceed(json.NewEncoder(gz).Encode(man))
 	mustSucceed(gz.Flush())

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/compression"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/logging"
@@ -40,7 +41,7 @@ const TypeLabelKey = "type"
 type contentManager interface {
 	Revision() int64
 	GetContent(ctx context.Context, contentID content.ID) ([]byte, error)
-	WriteContent(ctx context.Context, data []byte, prefix content.ID, comp compression.HeaderID) (content.ID, error)
+	WriteContent(ctx context.Context, data gather.Bytes, prefix content.ID, comp compression.HeaderID) (content.ID, error)
 	DeleteContent(ctx context.Context, contentID content.ID) error
 	IterateContents(ctx context.Context, options content.IterateOptions, callback content.IterateCallback) error
 	DisableIndexFlush(ctx context.Context)

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -99,6 +99,10 @@ func (w *objectWriter) Close() error {
 		w.splitter.Close()
 	}
 
+	w.buffer.Close()
+
+	w.om.closedWriter(w)
+
 	return nil
 }
 
@@ -200,7 +204,7 @@ func (w *objectWriter) prepareAndWriteContentChunk(chunkID int, data gather.Byte
 		return errors.Wrap(err, "unable to prepare content bytes")
 	}
 
-	contentID, err := w.om.contentMgr.WriteContent(w.ctx, contentBytes.ToByteSlice(), w.prefix, comp)
+	contentID, err := w.om.contentMgr.WriteContent(w.ctx, contentBytes, w.prefix, comp)
 	if err != nil {
 		return errors.Wrapf(err, "unable to write content chunk %v of %v: %v", chunkID, w.description, err)
 	}

--- a/repo/repo_benchmarks_test.go
+++ b/repo/repo_benchmarks_test.go
@@ -1,0 +1,62 @@
+package repo_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/repo/object"
+)
+
+func BenchmarkWriterDedup1M(b *testing.B) {
+	ctx, env := repotesting.NewEnvironment(b, content.FormatVersion2)
+	dataBuf := make([]byte, 4<<20)
+
+	writer := env.RepositoryWriter.NewObjectWriter(ctx, object.WriterOptions{})
+	writer.Write(dataBuf)
+	_, err := writer.Result()
+	require.NoError(b, err)
+	writer.Close()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// write exactly the same data
+		writer := env.RepositoryWriter.NewObjectWriter(ctx, object.WriterOptions{})
+		writer.Write(dataBuf)
+		writer.Result()
+		writer.Close()
+	}
+}
+
+func BenchmarkWriterNoDedup1M(b *testing.B) {
+	ctx, env := repotesting.NewEnvironment(b, content.FormatVersion2)
+	dataBuf := make([]byte, 4<<20)
+	chunkSize := 32
+	offset := 0
+
+	_, err := rand.Read(dataBuf)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// write exactly the same data
+		writer := env.RepositoryWriter.NewObjectWriter(ctx, object.WriterOptions{})
+
+		if i+chunkSize > len(dataBuf) {
+			chunkSize++
+
+			offset = 0
+		}
+
+		writer.Write(dataBuf[offset : offset+chunkSize])
+		writer.Result()
+		writer.Close()
+
+		offset++
+	}
+}

--- a/tests/repository_stress_test/repository_stress_test.go
+++ b/tests/repository_stress_test/repository_stress_test.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo"
@@ -365,7 +366,7 @@ func writeRandomContent(ctx context.Context, r repo.DirectRepositoryWriter, rs *
 	data := make([]byte, 1000)
 	cryptorand.Read(data)
 
-	contentID, err := r.ContentManager().WriteContent(ctx, data, "", content.NoCompression)
+	contentID, err := r.ContentManager().WriteContent(ctx, gather.FromSlice(data), "", content.NoCompression)
 	if err != nil {
 		return errors.Wrap(err, "WriteContent error")
 	}

--- a/tests/stress_test/stress_test.go
+++ b/tests/stress_test/stress_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
@@ -97,7 +98,7 @@ func stressWorker(ctx context.Context, t *testing.T, deadline time.Time, openMgr
 
 		dataCopy := append([]byte{}, data...)
 
-		contentID, err := bm.WriteContent(ctx, data, "", content.NoCompression)
+		contentID, err := bm.WriteContent(ctx, gather.FromSlice(data), "", content.NoCompression)
 		if err != nil {
 			t.Errorf("err: %v", err)
 			return


### PR DESCRIPTION
This reduces memory consumption and speeds up backups.

1. Backing up kopia repository (3.5 GB files:133102 dirs:20074):

before: 25s, 490 MB
after: 21s, 445 MB

2. Large files (14.8 GB, 76 files)

before: 30s, 597 MB
after: 28s, 495 MB

All tests repeated 5 times for clean local filesystem repo.