### PR TITLE
upload: memory usage and speed improvements

### DIFF
--- a/internal/gather/gather_bytes.go
+++ b/internal/gather/gather_bytes.go
@@ -136,17 +136,22 @@ func (b Bytes) Reader() io.Reader {
 	}
 }
 
-// ToByteSlice returns contents as a newly-allocated byte slice.
-func (b Bytes) ToByteSlice() []byte {
+// AppendToSlice appends the contents to the provided slice.
+func (b Bytes) AppendToSlice(output []byte) []byte {
 	b.assertValid()
-
-	output := []byte{}
 
 	for _, v := range b.Slices {
 		output = append(output, v...)
 	}
 
 	return output
+}
+
+// ToByteSlice returns contents as a newly-allocated byte slice.
+func (b Bytes) ToByteSlice() []byte {
+	b.assertValid()
+
+	return b.AppendToSlice(make([]byte, 0, b.Length()))
 }
 
 // WriteTo writes contents to the specified writer and returns number of bytes written.

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -33,19 +33,6 @@ func (b *WriteBuffer) Close() {
 	b.inner.invalidate()
 }
 
-// CloneContiguous initializes the write buffer with a contiguous (single-slice) copy of the provided
-// slices.
-func (b *WriteBuffer) CloneContiguous(byt Bytes) []byte {
-	contig := b.MakeContiguous(byt.Length())
-	output := contig[:0]
-
-	for _, s := range byt.Slices {
-		output = append(output, s...)
-	}
-
-	return contig
-}
-
 // MakeContiguous ensures the write buffer consists of exactly one contiguous single slice of the provided length
 // and returns the slice.
 func (b *WriteBuffer) MakeContiguous(length int) []byte {

--- a/internal/gather/gather_write_buffer_chunk.go
+++ b/internal/gather/gather_write_buffer_chunk.go
@@ -24,13 +24,13 @@ var (
 	defaultAllocator = &chunkAllocator{
 		name:            "default",
 		chunkSize:       1 << 16, // nolint:gomnd
-		maxFreeListSize: 512,     // nolint:gomnd
+		maxFreeListSize: 2048,    // nolint:gomnd
 	}
 
 	// contiguousAllocator is used for short-term buffers for encryption.
 	contiguousAllocator = &chunkAllocator{
 		name:            "contiguous",
-		chunkSize:       16<<20 + 128, // nolint:gomnd
+		chunkSize:       8<<20 + 128, // nolint:gomnd
 		maxFreeListSize: runtime.NumCPU(),
 	}
 )

--- a/internal/gather/gather_write_buffer_chunk.go
+++ b/internal/gather/gather_write_buffer_chunk.go
@@ -27,10 +27,17 @@ var (
 		maxFreeListSize: 2048,    // nolint:gomnd
 	}
 
-	// contiguousAllocator is used for short-term buffers for encryption.
-	contiguousAllocator = &chunkAllocator{
-		name:            "contiguous",
+	// typicalContiguousAllocator is used for short-term buffers for encryption.
+	typicalContiguousAllocator = &chunkAllocator{
+		name:            "mid-size contiguous",
 		chunkSize:       8<<20 + 128, // nolint:gomnd
+		maxFreeListSize: runtime.NumCPU(),
+	}
+
+	// maxContiguousAllocator is used for short-term buffers for encryption.
+	maxContiguousAllocator = &chunkAllocator{
+		name:            "contiguous",
+		chunkSize:       16<<20 + 128, // nolint:gomnd
 		maxFreeListSize: runtime.NumCPU(),
 	}
 )
@@ -155,5 +162,6 @@ func (a *chunkAllocator) dumpStats(ctx context.Context, prefix string) {
 // DumpStats logs the allocator statistics.
 func DumpStats(ctx context.Context) {
 	defaultAllocator.dumpStats(ctx, "default")
-	contiguousAllocator.dumpStats(ctx, "contig")
+	typicalContiguousAllocator.dumpStats(ctx, "typical-contig")
+	maxContiguousAllocator.dumpStats(ctx, "contig")
 }

--- a/internal/gather/gather_write_buffer_chunk_test.go
+++ b/internal/gather/gather_write_buffer_chunk_test.go
@@ -70,7 +70,7 @@ func TestContigAllocatorChunkSize(t *testing.T) {
 	for _, s := range splitter.SupportedAlgorithms() {
 		mss := splitter.GetFactory(s)().MaxSegmentSize()
 
-		if got, want := contiguousAllocator.chunkSize, mss+maxOverhead; got < want {
+		if got, want := maxContiguousAllocator.chunkSize, mss+maxOverhead; got < want {
 			t.Errorf("contiguous allocator chunk size too small: %v, want %v ", got, want)
 		}
 	}

--- a/internal/gather/gather_write_buffer_chunk_test.go
+++ b/internal/gather/gather_write_buffer_chunk_test.go
@@ -3,6 +3,8 @@ package gather
 import (
 	"bytes"
 	"testing"
+
+	"github.com/kopia/kopia/repo/splitter"
 )
 
 func TestWriteBufferChunk(t *testing.T) {
@@ -57,5 +59,19 @@ func TestWriteBufferChunk(t *testing.T) {
 	chunk4 := all.allocChunk()
 	if got, want := chunk4[0:6], []byte("chunk2"); !bytes.Equal(got, want) {
 		t.Errorf("got wrong chunk data %q, want %q", string(got), string(want))
+	}
+}
+
+func TestContigAllocatorChunkSize(t *testing.T) {
+	// verify that contiguous allocator has chunk size big enough for all splitter results
+	// + some minimal overhead.
+	const maxOverhead = 128
+
+	for _, s := range splitter.SupportedAlgorithms() {
+		mss := splitter.GetFactory(s)().MaxSegmentSize()
+
+		if got, want := contiguousAllocator.chunkSize, mss+maxOverhead; got < want {
+			t.Errorf("contiguous allocator chunk size too small: %v, want %v ", got, want)
+		}
 	}
 }

--- a/internal/gather/gather_write_buffer_test.go
+++ b/internal/gather/gather_write_buffer_test.go
@@ -81,16 +81,3 @@ func TestGatherWriteBufferContig(t *testing.T) {
 	require.Equal(t, theCap, len(b))
 	require.Equal(t, theCap, cap(b))
 }
-
-func TestGatherWriteBufferCloneContig(t *testing.T) {
-	var w WriteBuffer
-	defer w.Close()
-
-	w.Append([]byte{1, 2, 3})
-	w.Append([]byte{4, 5, 6})
-
-	var w2 WriteBuffer
-	contig := w2.CloneContiguous(w.Bytes())
-
-	require.Equal(t, []byte{1, 2, 3, 4, 5, 6}, contig)
-}

--- a/internal/gather/gather_write_buffer_test.go
+++ b/internal/gather/gather_write_buffer_test.go
@@ -76,8 +76,28 @@ func TestGatherWriteBufferContig(t *testing.T) {
 	defer w.Close()
 
 	// allocate more than contig allocator can provide
-	theCap := contiguousAllocator.chunkSize + 10
+	theCap := maxContiguousAllocator.chunkSize + 10
 	b := w.MakeContiguous(theCap)
 	require.Equal(t, theCap, len(b))
 	require.Equal(t, theCap, cap(b))
+}
+
+func TestGatherWriteBufferAllocatorSelector(t *testing.T) {
+	var w WriteBuffer
+	defer w.Close()
+
+	w.MakeContiguous(1)
+	require.Equal(t, w.alloc, typicalContiguousAllocator)
+
+	w.MakeContiguous(typicalContiguousAllocator.chunkSize)
+	require.Equal(t, w.alloc, typicalContiguousAllocator)
+
+	w.MakeContiguous(typicalContiguousAllocator.chunkSize + 1)
+	require.Equal(t, w.alloc, maxContiguousAllocator)
+
+	w.MakeContiguous(maxContiguousAllocator.chunkSize)
+	require.Equal(t, w.alloc, maxContiguousAllocator)
+
+	w.MakeContiguous(maxContiguousAllocator.chunkSize + 1)
+	require.Nil(t, w.alloc)
 }

--- a/repo/content/content_index_recovery.go
+++ b/repo/content/content_index_recovery.go
@@ -35,7 +35,10 @@ func (bm *WriteManager) RecoverIndexFromPackBlob(ctx context.Context, packFile b
 	err = ndx.Iterate(AllIDs, func(i Info) error {
 		recovered = append(recovered, i)
 		if commit {
-			bm.packIndexBuilder.Add(i)
+			// 'i' is ephemeral and will depend on temporary buffers which
+			// won't be available when this function returns, we need to
+			// convert it to durable struct.
+			bm.packIndexBuilder.Add(ToInfoStruct(i))
 		}
 		return nil
 	})

--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -621,15 +621,12 @@ func (r *grpcRepositoryClient) WriteContent(ctx context.Context, data gather.Byt
 	r.asyncWritesSemaphore <- struct{}{}
 
 	// clone so that caller can reuse the buffer
-	var cloneBuf gather.WriteBuffer
-	clone := cloneBuf.CloneContiguous(data)
+	clone := data.ToByteSlice()
 
 	r.asyncWritesWG.Go(func() error {
 		defer func() {
 			// release semaphore
 			<-r.asyncWritesSemaphore
-
-			defer cloneBuf.Close()
 		}()
 
 		return r.doWrite(ctxutil.Detach(ctx), contentID, clone, prefix, comp)

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -486,6 +486,21 @@ func (u *Uploader) foreachEntryUnlessCanceled(ctx context.Context, parallel int,
 		return nil
 	}
 
+	if parallel == 1 {
+		for _, entry := range entries {
+			if u.IsCanceled() {
+				return errCanceled
+			}
+
+			entryRelativePath := path.Join(relativePath, entry.Name())
+			if err := cb(ctx, entry, entryRelativePath); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
 	ch := make(chan fs.Entry)
 	eg, ctx := errgroup.WithContext(ctx)
 


### PR DESCRIPTION
Test cases:

Large source code directory:

Before: average 26s, 481 MB RAM
After: average 24.25s, 377 MB RAM (22% less)

Large directory (11 GB ISOs, movies, large photos):

Before: average 14.75s, 520 MB RAM
After: average 12.25s, 408 MB RAM (22% less)