### PR TITLE
cli: linux: read KOPIA_USE_KEYRING env

### DIFF
--- a/cli/password_linux.go
+++ b/cli/password_linux.go
@@ -5,5 +5,5 @@ import (
 )
 
 func (c *App) setupOSSpecificKeychainFlags(app *kingpin.Application) {
-	app.Flag("use-keyring", "Use Gnome Keyring for storing repository password.").Default("false").BoolVar(&c.keyRingEnabled)
+	app.Flag("use-keyring", "Use Gnome Keyring for storing repository password.").Default("false").Envar("KOPIA_USE_KEYRING").BoolVar(&c.keyRingEnabled)
 }


### PR DESCRIPTION
On Linux, Keyring is disabled by default and `--use-keyring` must be specified on every command-line invocation, which gets quite annoying.

This PR allows enabling keyring from environment variable instead.

Example
```
$ ./kopia snapshot list
Enter password to open repository:
$ export KOPIA_USE_KEYRING=1
$ ./kopia snapshot list
[list of snapshots]
```

P.S. It would be great if you can add a `hacktoberfest-accepted` label so this PR can count for Hacktoberfest. This works even if the main repo doesn't have a `hacktoberfest` topic.