### PR TITLE
add conditional to KopiaUI makefile to build macos arm64 and x64 versions

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -48,6 +48,11 @@ unexport CSC_KEY_PASSWORD
 
 endif
 
+# build x86_64 and apple silicon binaries
+ifeq ($(GOOS),darwin)
+electron_builder_flags+=--x64 --arm64
+endif
+
 dev: node_modules/.up-to-date
 	$(npm) $(npm_flags) run dev
 


### PR DESCRIPTION
hello!

i noticed in activity monitor that KopiaUI was running under the Intel architecture, which struck me as odd so i did some investigating. it seems that even though the embedded app is universal, the main app is x86_64 only, which causes it to call the intel version of the embedded library.

```
/Applications/KopiaUI.app/Contents
❯ file MacOS/KopiaUI
MacOS/KopiaUI: Mach-O 64-bit executable x86_64

/Applications/KopiaUI.app/Contents
❯ file Resources/server/kopia
Resources/server/kopia: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
Resources/server/kopia (for architecture x86_64):       Mach-O 64-bit executable x86_64
Resources/server/kopia (for architecture arm64):        Mach-O 64-bit executable arm64
```

i added a couple new lines to the Makefile to create an arm64 release. i tried self signing the resulting app but gatekeeper still argued with me so i wasn't able to test, but running `file` revewaled the KopiaUI file was now arm64.

there is a way to [make universal electron apps](https://github.com/electron/universal) but it would bring the app size up to 700mb or so, which seems excessive.