### PR TITLE
Remove unnecessary subdirectory from Windows archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ ifneq ($(WINDOWS_SIGN_TOOL),)
 endif
 	mkdir -p dist/kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64
 	cp dist/kopia_windows_amd64/kopia.exe LICENSE README.md dist/kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64
-	(cd dist && zip -r kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64.zip kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64)
+	(cd dist && zip -r kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64.zip kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64/*)
 	rm -rf dist/kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64
 
 # On Linux use use goreleaser which will build Kopia for all supported Linux architectures
@@ -408,6 +408,6 @@ perf-benchmark-test-all:
 	$(MAKE) perf-benchmark-test PERF_BENCHMARK_VERSION=0.7.0~rc1
 
 perf-benchmark-results:
-	gcloud compute scp $(PERF_BENCHMARK_INSTANCE):psrecord-* tests/perf_benchmark --zone=$(PERF_BENCHMARK_INSTANCE_ZONE) 
+	gcloud compute scp $(PERF_BENCHMARK_INSTANCE):psrecord-* tests/perf_benchmark --zone=$(PERF_BENCHMARK_INSTANCE_ZONE)
 	gcloud compute scp $(PERF_BENCHMARK_INSTANCE):repo-size-* tests/perf_benchmark --zone=$(PERF_BENCHMARK_INSTANCE_ZONE)
 	(cd tests/perf_benchmark && go run process_results.go)

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ ifneq ($(WINDOWS_SIGN_TOOL),)
 endif
 	mkdir -p dist/kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64
 	cp dist/kopia_windows_amd64/kopia.exe LICENSE README.md dist/kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64
-	(cd dist && zip -r kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64.zip kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64/*)
+	(cd dist && zip -r kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64.zip kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64)
 	rm -rf dist/kopia-$(KOPIA_VERSION_NO_PREFIX)-windows-x64
 
 # On Linux use use goreleaser which will build Kopia for all supported Linux architectures
@@ -408,6 +408,6 @@ perf-benchmark-test-all:
 	$(MAKE) perf-benchmark-test PERF_BENCHMARK_VERSION=0.7.0~rc1
 
 perf-benchmark-results:
-	gcloud compute scp $(PERF_BENCHMARK_INSTANCE):psrecord-* tests/perf_benchmark --zone=$(PERF_BENCHMARK_INSTANCE_ZONE)
+	gcloud compute scp $(PERF_BENCHMARK_INSTANCE):psrecord-* tests/perf_benchmark --zone=$(PERF_BENCHMARK_INSTANCE_ZONE) 
 	gcloud compute scp $(PERF_BENCHMARK_INSTANCE):repo-size-* tests/perf_benchmark --zone=$(PERF_BENCHMARK_INSTANCE_ZONE)
 	(cd tests/perf_benchmark && go run process_results.go)

--- a/tools/scoop-kopia.json.template
+++ b/tools/scoop-kopia.json.template
@@ -1,15 +1,15 @@
 {
     "version": "VERSION",
+    "description": "Fast and secure open source backup.",
+    "homepage": "https://kopia.io/",
+    "license": "Apache-2.0",
     "architecture": {
         "64bit": {
             "url": "https://github.com/SOURCE_REPO/releases/download/vVERSION/kopia-VERSION-windows-x64.zip",
             "bin": [
-                "kopia-VERSION-windows-x64/kopia.exe"
+                "kopia.exe"
             ],
             "hash": "HASH_WINDOWS_AMD64"
         }
-    },
-    "homepage": "https://kopia.io/",
-    "license": "Apache-2.0",
-    "description": "Fast and secure open source backup."
+    }
 }

--- a/tools/scoop-kopia.json.template
+++ b/tools/scoop-kopia.json.template
@@ -9,7 +9,8 @@
             "bin": [
                 "kopia.exe"
             ],
-            "hash": "HASH_WINDOWS_AMD64"
+            "hash": "HASH_WINDOWS_AMD64",
+            "extract_dir": "kopia-VERSION-windows-x64"
         }
     }
 }


### PR DESCRIPTION
A few months ago, I opened https://github.com/kopia/scoop-bucket/issues/1. Didn't seem to gain any traction, so here's my attempt to address the issue.

The issue is that Kopia is the only app I've seen that after the Scoop installation, still has version number towards its binary. For example, if my Scoop app is at C:\Scoop, kopia.exe is set at C:\Scoop\apps\kopia\current\kopia-0.9.0-rc3-windows-x64\kopia.exe. Most other apps would have C:\Scoop\apps\kopia\current\kopia.exe instead. The extra subdirectory is unnecessary.

The problem of this version-based subdirectory is that user can no longer have a stable path to the executable after updates. The stable path is the reason why we have the "current" junction point in Scoop. One may argue that since we already have shim, why still care about the actual path to executable. Well, the shim is not always perfect. It is extra command line layer, which could mess up with things. For example, I have some application that loads an application in a special way with special [STARTUPINFO](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow). The shim would drop all the settings.

The fix is simple: just don't package the directory when archiving. I only changed the structure for Windows zip, because I don't know if changing it across the board would trigger errors in other publishing means. Also updated the scoop template.