### PR TITLE
add simple selector for #1320

### DIFF
--- a/htmlui/src/Table.js
+++ b/htmlui/src/Table.js
@@ -59,7 +59,8 @@ export default function MyTable({ columns, data }) {
     gotoPage,
     nextPage,
     previousPage,
-    state: { pageIndex },
+    setPageSize,
+    state: { pageIndex, pageSize },
   } = useTable({
     columns,
     data,
@@ -80,13 +81,14 @@ export default function MyTable({ columns, data }) {
     <Pagination size="sm" variant="dark">
       <Pagination.First onClick={() => gotoPage(0)} disabled={!canPreviousPage} />
       <Pagination.Prev onClick={() => previousPage()} disabled={!canPreviousPage} />
+      {paginationItems(pageOptions.length, pageIndex+1, gotoPage)}
       <Pagination.Next onClick={() => nextPage()} disabled={!canNextPage} />
       <Pagination.Last onClick={() => gotoPage(pageCount - 1)} disabled={!canNextPage} />
     </Pagination>
-
-    &nbsp;
     <Pagination size="sm" variant="dark">
-      {paginationItems(pageOptions.length, pageIndex+1, gotoPage)}
+    <select value={pageSize} onChange={e => {setPageSize(Number(e.target.value))}}>
+      {[10, 20, 30, 40, 50, 100].map(pageSize => (<option key={pageSize} value={pageSize}>Show {pageSize}</option>))}
+    </select>
     </Pagination>
     </>;
 


### PR DESCRIPTION
another small PR for #1320, it's nothing pretty but it does work :)

i also merged the individual page bar into the area between the arrows to keep things a bit neater.

before (taken from KopiaUI):
![](https://kuroneko.zyradyl.moe/zyradyl/Screen-Shot-0003-10-04-20-28-23.png)

after:

new bar + selector:
![](https://kuroneko.zyradyl.moe/zyradyl/Screen-Shot-0003-10-04-20-19-37.png)

options:
![](https://kuroneko.zyradyl.moe/zyradyl/Screen-Shot-0003-10-04-20-29-24.png)

resized page:
![](https://kuroneko.zyradyl.moe/zyradyl/Screen-Shot-0003-10-04-20-30-01.png)

example of what it looks like when there are more than 20 pages (had to tweak page size for a demo):
![](https://kuroneko.zyradyl.moe/zyradyl/Screen-Shot-0003-10-04-20-31-45.png)

