### PR TITLE
replace hardcoded instances of '.f' with CompleteBlobSuffix

### DIFF
--- a/cli/command_blob_shards_modify_test.go
+++ b/cli/command_blob_shards_modify_test.go
@@ -20,38 +20,38 @@ func TestBlobShardsModify(t *testing.T) {
 
 	// verify default sharding is 3,3
 	require.FileExists(t, filepath.Join(env.RepoDir, someQBlob[0:3], someQBlob[3:6], someQBlob[6:]+sharded.CompleteBlobSuffix))
-	require.FileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia.repository"+sharded.CompleteBlobSuffix))
 
 	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--default-shards=5,5", "--i-am-sure-kopia-is-not-running")
 
 	// verify new sharding is 5,5
 	require.FileExists(t, filepath.Join(env.RepoDir, someQBlob[0:5], someQBlob[5:10], someQBlob[10:]+sharded.CompleteBlobSuffix))
 	require.NoFileExists(t, filepath.Join(env.RepoDir, someQBlob[0:3], someQBlob[3:6], someQBlob[6:]+sharded.CompleteBlobSuffix))
-	require.FileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia.repository"+sharded.CompleteBlobSuffix))
 
 	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--unsharded-length=0", "--i-am-sure-kopia-is-not-running")
 
 	require.FileExists(t, filepath.Join(env.RepoDir, someQBlob[0:5], someQBlob[5:10], someQBlob[10:]+sharded.CompleteBlobSuffix))
-	require.FileExists(t, filepath.Join(env.RepoDir, "kopia/.repo/sitory.f"))
-	require.NoFileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia/.repo/sitory"+sharded.CompleteBlobSuffix))
+	require.NoFileExists(t, filepath.Join(env.RepoDir, "kopia.repository"+sharded.CompleteBlobSuffix))
 
 	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=kop=2,,,2", "--i-am-sure-kopia-is-not-running")
-	require.FileExists(t, filepath.Join(env.RepoDir, "ko/pi/a.repository.f"))
-	require.NoFileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
+	require.FileExists(t, filepath.Join(env.RepoDir, "ko/pi/a.repository"+sharded.CompleteBlobSuffix))
+	require.NoFileExists(t, filepath.Join(env.RepoDir, "kopia.repository"+sharded.CompleteBlobSuffix))
 
 	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--remove-override=nosuchprefix", "--remove-override=kop", "--i-am-sure-kopia-is-not-running")
-	require.FileExists(t, filepath.Join(env.RepoDir, "kopia/.repo/sitory.f"))
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia/.repo/sitory"+sharded.CompleteBlobSuffix))
 
 	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--i-am-sure-kopia-is-not-running")
 
 	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=kop=flat", "--i-am-sure-kopia-is-not-running", "--dry-run")
-	require.FileExists(t, filepath.Join(env.RepoDir, "kopia/.repo/sitory.f"))
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia/.repo/sitory"+sharded.CompleteBlobSuffix))
 
 	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=kop=flat", "--i-am-sure-kopia-is-not-running")
-	require.FileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopia.repository"+sharded.CompleteBlobSuffix))
 
 	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--override=kop=4,4", "--i-am-sure-kopia-is-not-running")
-	require.FileExists(t, filepath.Join(env.RepoDir, "kopi/a.re/pository.f"))
+	require.FileExists(t, filepath.Join(env.RepoDir, "kopi/a.re/pository"+sharded.CompleteBlobSuffix))
 
 	// some invalid cases
 	env.RunAndExpectFailure(t, "blob", "shards", "modify", "--path", env.RepoDir, "--default-shards=invalid", "--i-am-sure-kopia-is-not-running")

--- a/repo/blob/sharded/sharded_test.go
+++ b/repo/blob/sharded/sharded_test.go
@@ -79,19 +79,19 @@ func TestShardedFileStorageShardingMap(t *testing.T) {
 			}`,
 			map[blob.ID]string{
 				// non-sharded because of ID length
-				"ab": "ab.f",
+				"ab": "ab" + sharded.CompleteBlobSuffix,
 
 				// sharded according to default shards - 3,2,1
-				"defaultsharded": "def/au/l/tsharded.f",
+				"defaultsharded": "def/au/l/tsharded" + sharded.CompleteBlobSuffix,
 
 				// sharded according to first override
-				"phello":   "ph/el/lo.f",
-				"pgoodbye": "pg/oo/dbye.f",
+				"phello":   "ph/el/lo" + sharded.CompleteBlobSuffix,
+				"pgoodbye": "pg/oo/dbye" + sharded.CompleteBlobSuffix,
 
 				// second override
-				"xhello": "x/h/e/llo.f",
-				"xbye":   "x/b/y/e.f",
-				"xo":     "xo.f",
+				"xhello": "x/h/e/llo" + sharded.CompleteBlobSuffix,
+				"xbye":   "x/b/y/e" + sharded.CompleteBlobSuffix,
+				"xo":     "xo" + sharded.CompleteBlobSuffix,
 			},
 		},
 		{
@@ -102,8 +102,8 @@ func TestShardedFileStorageShardingMap(t *testing.T) {
 				"maxNonShardedLength": 10
 			}`,
 			map[blob.ID]string{
-				"foobarbar":    "foobarbar.f",
-				"foobarbarbar": "foo/bar/barbar.f",
+				"foobarbar":    "foobarbar" + sharded.CompleteBlobSuffix,
+				"foobarbarbar": "foo/bar/barbar" + sharded.CompleteBlobSuffix,
 			},
 		},
 		{
@@ -114,12 +114,12 @@ func TestShardedFileStorageShardingMap(t *testing.T) {
 				"maxNonShardedLength": 0
 			}`,
 			map[blob.ID]string{
-				"fo":      "fo.f",
-				"foo":     "foo.f",
-				"foob":    "foo/b.f",
-				"fooba":   "foo/ba.f",
-				"foobar":  "foo/bar.f",
-				"foobar2": "foo/bar/2.f",
+				"fo":      "fo" + sharded.CompleteBlobSuffix,
+				"foo":     "foo" + sharded.CompleteBlobSuffix,
+				"foob":    "foo/b" + sharded.CompleteBlobSuffix,
+				"fooba":   "foo/ba" + sharded.CompleteBlobSuffix,
+				"foobar":  "foo/bar" + sharded.CompleteBlobSuffix,
+				"foobar2": "foo/bar/2" + sharded.CompleteBlobSuffix,
 			},
 		},
 	}

--- a/tests/end_to_end_test/repository_connect_test.go
+++ b/tests/end_to_end_test/repository_connect_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/kopia/kopia/repo/blob/sharded"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -39,7 +40,7 @@ func TestFilesystemSupportsTildeToReferToHome(t *testing.T) {
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path=~/"+subdir)
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
-	if _, err := os.Stat(filepath.Join(fullPath, "kopia.repository.f")); err != nil {
+	if _, err := os.Stat(filepath.Join(fullPath, "kopia.repository"+sharded.CompleteBlobSuffix)); err != nil {
 		t.Fatalf("error: %v", err)
 	}
 }


### PR DESCRIPTION
while looking through and tinkering with things for #1350, i noticed that some of the test routines rely on a hardcoded value of `CompleteBlobSuffix = ".f"`. this just switches those out with a reference to the variable.

it's very possible the hardcode was intentional, especially considering that changing the suffix would mean needing to implement an upgrade mechanism, but i thought i'd submit a PR just in case it was an oversight. 😅 