### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,13 @@ linters-settings:
     statements: 60
   forbidigo:
     forbid:
+    - ioutil.Discard # use io.Discard
+    - ioutil.NopCloser # use io.NopCloser
+    - ioutil.ReadAll # use io.ReadAll
+    - ioutil.ReadFile # use os.ReadFile
+    - ioutil.TempDir # use os.MkdirTemp
+    - ioutil.TempFile # use os.CreateTemp
+    - ioutil.WriteFile # use os.WriteFile
     - time.Now # use clock.Now
     - time.Since # use clock.Since
     - time.Until # use clock.Until
@@ -100,7 +107,7 @@ issues:
         - dupl
     - text: "Line contains TODO"
       linters:
-        - godox 
+        - godox
     - text: ".*Magic number\\: [01],"
       linters:
         - gomnd

--- a/cli/command_benchmark_test.go
+++ b/cli/command_benchmark_test.go
@@ -2,7 +2,7 @@ package cli_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -35,7 +35,7 @@ func TestCommandBenchmarkCompression(t *testing.T) {
 	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	testFile := filepath.Join(testutil.TempDirectory(t), "testfile.txt")
-	ioutil.WriteFile(testFile, bytes.Repeat([]byte{1, 2, 3, 4, 5, 6}, 10000), 0o600)
+	os.WriteFile(testFile, bytes.Repeat([]byte{1, 2, 3, 4, 5, 6}, 10000), 0o600)
 
 	e.RunAndExpectSuccess(t, "benchmark", "compression", "--data-file", testFile, "--repeat=2", "--verify-stable", "--print-options")
 	e.RunAndExpectSuccess(t, "benchmark", "compression", "--data-file", testFile, "--repeat=2", "--by-size")

--- a/cli/command_content_verify_test.go
+++ b/cli/command_content_verify_test.go
@@ -2,7 +2,7 @@ package cli_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,7 +17,7 @@ func (s *formatSpecificTestSuite) TestContentVerify(t *testing.T) {
 	env := testenv.NewCLITest(t, s.formatFlags, testenv.NewInProcRunner(t))
 
 	dir := testutil.TempDirectory(t)
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file1.txt"), bytes.Repeat([]byte{1, 2, 3, 4, 5}, 15000), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), bytes.Repeat([]byte{1, 2, 3, 4, 5}, 15000), 0o600))
 
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
 	env.RunAndExpectSuccess(t, "content", "verify")

--- a/cli/command_policy_set_actions.go
+++ b/cli/command_policy_set_actions.go
@@ -80,7 +80,7 @@ func (c *policyActionFlags) setActionCommandFromFlags(ctx context.Context, actio
 	*changeCount++
 
 	if c.policySetPersistActionScript {
-		script, err := os.ReadFile(value) //nolint:gosec
+		script, err := os.ReadFile(value)
 		if err != nil {
 			return errors.Wrap(err, "unable to read script file")
 		}

--- a/cli/command_policy_set_actions.go
+++ b/cli/command_policy_set_actions.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -80,7 +80,7 @@ func (c *policyActionFlags) setActionCommandFromFlags(ctx context.Context, actio
 	*changeCount++
 
 	if c.policySetPersistActionScript {
-		script, err := ioutil.ReadFile(value) //nolint:gosec
+		script, err := os.ReadFile(value) //nolint:gosec
 		if err != nil {
 			return errors.Wrap(err, "unable to read script file")
 		}

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -175,7 +174,7 @@ func (c *commandServerStart) run(ctx context.Context, rep repo.Repository) error
 
 		go func() {
 			// consume all stdin and close the server when it closes
-			ioutil.ReadAll(os.Stdin) //nolint:errcheck
+			io.ReadAll(os.Stdin) //nolint:errcheck
 			log(ctx).Infof("Shutting down server...")
 			httpServer.Shutdown(ctx) //nolint:errcheck
 		}()
@@ -244,7 +243,7 @@ func maybeReadIndexBytes(fs http.FileSystem) []byte {
 
 	defer rootFile.Close() //nolint:errcheck
 
-	rd, err := ioutil.ReadAll(rootFile)
+	rd, err := io.ReadAll(rootFile)
 	if err != nil {
 		return nil
 	}

--- a/cli/command_snapshot_estimate_test.go
+++ b/cli/command_snapshot_estimate_test.go
@@ -2,7 +2,6 @@ package cli_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,10 +16,10 @@ func TestSnapshotEstimate(t *testing.T) {
 	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
 
 	dir := testutil.TempDirectory(t)
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file1.txt"), bytes.Repeat([]byte{1, 2, 3, 4, 5}, 15000), 0o600))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file2.txt"), bytes.Repeat([]byte{2, 3, 4, 5, 6}, 10000), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), bytes.Repeat([]byte{1, 2, 3, 4, 5}, 15000), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file2.txt"), bytes.Repeat([]byte{2, 3, 4, 5, 6}, 10000), 0o600))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0o755))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "subdir", "file2.txt"), bytes.Repeat([]byte{3, 4, 5, 6, 7}, 5000), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "subdir", "file2.txt"), bytes.Repeat([]byte{3, 4, 5, 6, 7}, 5000), 0o600))
 
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
 	out := env.RunAndExpectSuccess(t, "snapshot", "estimate", dir)
@@ -51,7 +50,7 @@ func TestSnapshotEstimate_NotADirectory(t *testing.T) {
 	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
 
 	dir := testutil.TempDirectory(t)
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file1.txt"), []byte{1, 2, 3}, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file1.txt"), []byte{1, 2, 3}, 0o600))
 
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
 	env.RunAndExpectFailure(t, "snapshot", "estimate", filepath.Join(dir, "file1.txt"))

--- a/cli/command_snapshot_verify.go
+++ b/cli/command_snapshot_verify.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"sync"
 
@@ -194,7 +194,7 @@ func (v *verifier) readEntireObject(ctx context.Context, oid object.ID, path str
 	}
 	defer r.Close() //nolint:errcheck
 
-	return errors.Wrap(iocopy.JustCopy(ioutil.Discard, r), "unable to read data")
+	return errors.Wrap(iocopy.JustCopy(io.Discard, r), "unable to read data")
 }
 
 func (c *commandSnapshotVerify) run(ctx context.Context, rep repo.Repository) error {

--- a/cli/show_utils.go
+++ b/cli/show_utils.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/pkg/errors"
@@ -41,7 +40,7 @@ func showContentWithFlags(w io.Writer, rd io.Reader, unzip, indentJSON bool) err
 			return errors.Wrap(err, "errors indenting JSON")
 		}
 
-		rd = ioutil.NopCloser(&buf2)
+		rd = io.NopCloser(&buf2)
 	}
 
 	if err := iocopy.JustCopy(w, rd); err != nil {

--- a/cli/storage_gcs.go
+++ b/cli/storage_gcs.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
@@ -30,7 +30,7 @@ func (c *storageGCSFlags) setup(_ storageProviderServices, cmd *kingpin.CmdClaus
 
 func (c *storageGCSFlags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {
 	if c.embedCredentials {
-		data, err := ioutil.ReadFile(c.options.ServiceAccountCredentialsFile)
+		data, err := os.ReadFile(c.options.ServiceAccountCredentialsFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to open service account credentials file")
 		}

--- a/cli/storage_rclone.go
+++ b/cli/storage_rclone.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 
 	"github.com/alecthomas/kingpin"
 	"github.com/pkg/errors"
@@ -36,7 +36,7 @@ func (c *storageRcloneFlags) connect(ctx context.Context, isNew bool) (blob.Stor
 	}
 
 	if c.embedRCloneConfigFile != "" {
-		cfg, err := ioutil.ReadFile(c.embedRCloneConfigFile)
+		cfg, err := os.ReadFile(c.embedRCloneConfigFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to read rclone config file")
 		}

--- a/cli/storage_sftp.go
+++ b/cli/storage_sftp.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/alecthomas/kingpin"
@@ -44,7 +44,7 @@ func (c *storageSFTPFlags) getOptions() (*sftp.Options, error) {
 	if !sftpo.ExternalSSH {
 		if c.embedCredentials {
 			if sftpo.KeyData == "" {
-				d, err := ioutil.ReadFile(sftpo.Keyfile)
+				d, err := os.ReadFile(sftpo.Keyfile)
 				if err != nil {
 					return nil, errors.Wrap(err, "unable to read key file")
 				}
@@ -54,7 +54,7 @@ func (c *storageSFTPFlags) getOptions() (*sftp.Options, error) {
 			}
 
 			if sftpo.KnownHostsData == "" && sftpo.KnownHostsFile != "" {
-				d, err := ioutil.ReadFile(sftpo.KnownHostsFile)
+				d, err := os.ReadFile(sftpo.KnownHostsFile)
 				if err != nil {
 					return nil, errors.Wrap(err, "unable to read known hosts file")
 				}

--- a/cli/storage_sftp_test.go
+++ b/cli/storage_sftp_test.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,8 +17,8 @@ func TestSFTPOptions(t *testing.T) {
 	myKeyFile := filepath.Join(td, "my-key")
 	myKnownHostsFile := filepath.Join(td, "my-known-hosts")
 
-	require.NoError(t, ioutil.WriteFile(myKeyFile, []byte("fake-key-data"), 0o600))
-	require.NoError(t, ioutil.WriteFile(myKnownHostsFile, []byte("fake-known-hosts-data"), 0o600))
+	require.NoError(t, os.WriteFile(myKeyFile, []byte("fake-key-data"), 0o600))
+	require.NoError(t, os.WriteFile(myKnownHostsFile, []byte("fake-known-hosts-data"), 0o600))
 
 	cases := []struct {
 		input   storageSFTPFlags

--- a/fs/localfs/local_fs_test.go
+++ b/fs/localfs/local_fs_test.go
@@ -2,7 +2,6 @@ package localfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,9 +46,9 @@ func TestFiles(t *testing.T) {
 	}
 
 	// Now list a directory with 3 files.
-	assertNoError(t, ioutil.WriteFile(filepath.Join(tmp, "f3"), []byte{1, 2, 3}, 0o777))
-	assertNoError(t, ioutil.WriteFile(filepath.Join(tmp, "f2"), []byte{1, 2, 3, 4}, 0o777))
-	assertNoError(t, ioutil.WriteFile(filepath.Join(tmp, "f1"), []byte{1, 2, 3, 4, 5}, 0o777))
+	assertNoError(t, os.WriteFile(filepath.Join(tmp, "f3"), []byte{1, 2, 3}, 0o777))
+	assertNoError(t, os.WriteFile(filepath.Join(tmp, "f2"), []byte{1, 2, 3, 4}, 0o777))
+	assertNoError(t, os.WriteFile(filepath.Join(tmp, "f1"), []byte{1, 2, 3, 4, 5}, 0o777))
 
 	assertNoError(t, os.Mkdir(filepath.Join(tmp, "z"), 0o777))
 	assertNoError(t, os.Mkdir(filepath.Join(tmp, "y"), 0o777))

--- a/fs/localfs/shallow_fs.go
+++ b/fs/localfs/shallow_fs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -65,7 +64,7 @@ func WriteShallowPlaceholder(path string, de *snapshot.DirEntry) (string, error)
 }
 
 func dirEntryFromPlaceholder(path string) (*snapshot.DirEntry, error) {
-	b, err := ioutil.ReadFile(atomicfile.MaybePrefixLongFilenameOnWindows(path))
+	b, err := os.ReadFile(atomicfile.MaybePrefixLongFilenameOnWindows(path))
 	if err != nil {
 		return nil, errors.Wrap(err, "dirEntryFromPlaceholder reading placeholder")
 	}

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 
@@ -115,7 +114,7 @@ func decodeResponse(resp *http.Response, respPayload interface{}) error {
 	}
 
 	if b, ok := respPayload.(*[]byte); ok {
-		v, err := ioutil.ReadAll(resp.Body)
+		v, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Wrap(err, "unable to read response")
 		}

--- a/internal/blobtesting/eventually_consistent.go
+++ b/internal/blobtesting/eventually_consistent.go
@@ -2,7 +2,7 @@ package blobtesting
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/rand"
 	"strings"
@@ -157,7 +157,7 @@ func (s *eventuallyConsistentStorage) PutBlob(ctx context.Context, id blob.ID, d
 		return err
 	}
 
-	d, err := ioutil.ReadAll(data.Reader())
+	d, err := io.ReadAll(data.Reader())
 	if err != nil {
 		return errors.Wrap(err, "invalid data")
 	}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -296,7 +295,7 @@ func (c *Comparer) output(msg string, args ...interface{}) {
 
 // NewComparer creates a comparer for a given repository that will output the results to a given writer.
 func NewComparer(out io.Writer) (*Comparer, error) {
-	tmp, err := ioutil.TempDir("", "kopia")
+	tmp, err := os.MkdirTemp("", "kopia")
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating temp directory")
 	}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,7 +22,7 @@ var log = logging.GetContextLoggerFunc("editor")
 // It creates a temporary file with 'initial' contents and repeatedly invokes the editor until the provided 'parse' function
 // returns nil result indicating success. The 'parse' function is passed the contents of edited files without # line comments.
 func EditLoop(ctx context.Context, fname, initial string, parse func(updated string) error) error {
-	tmpDir, err := ioutil.TempDir("", "kopia")
+	tmpDir, err := os.MkdirTemp("", "kopia")
 	if err != nil {
 		return errors.Wrap(err, "unable to create temp directory")
 	}
@@ -32,7 +31,7 @@ func EditLoop(ctx context.Context, fname, initial string, parse func(updated str
 	defer os.RemoveAll(tmpDir) //nolint:errcheck
 
 	// nolint:gomnd
-	if err := ioutil.WriteFile(tmpFile, []byte(initial), 0o600); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(initial), 0o600); err != nil {
 		return errors.Wrap(err, "unable to write file to edit")
 	}
 

--- a/internal/gather/gather_bytes_test.go
+++ b/internal/gather/gather_bytes_test.go
@@ -2,7 +2,7 @@ package gather
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -83,7 +83,7 @@ func TestGatherBytes(t *testing.T) {
 		}
 
 		// reader
-		all, err := ioutil.ReadAll(b.Reader())
+		all, err := io.ReadAll(b.Reader())
 		if err != nil {
 			t.Errorf("unable to read: %v", err)
 		}

--- a/internal/mount/mount_fuse.go
+++ b/internal/mount/mount_fuse.go
@@ -5,7 +5,6 @@ package mount
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -48,7 +47,7 @@ func Directory(ctx context.Context, entry fs.Directory, mountPoint string, mount
 	if mountPoint == "*" {
 		var err error
 
-		mountPoint, err = ioutil.TempDir("", "kopia-mount")
+		mountPoint, err = os.MkdirTemp("", "kopia-mount")
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating temp directory")
 		}

--- a/internal/passwordpersist/passwordpersist_file.go
+++ b/internal/passwordpersist/passwordpersist_file.go
@@ -3,7 +3,6 @@ package passwordpersist
 import (
 	"context"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -17,7 +16,7 @@ const passwordFileMode = 0o600
 type filePasswordStorage struct{}
 
 func (filePasswordStorage) GetPassword(ctx context.Context, configFile string) (string, error) {
-	b, err := ioutil.ReadFile(passwordFileName(configFile))
+	b, err := os.ReadFile(passwordFileName(configFile))
 	if os.IsNotExist(err) {
 		return "", ErrPasswordNotFound
 	}
@@ -41,7 +40,7 @@ func (filePasswordStorage) PersistPassword(ctx context.Context, configFile, pass
 	log(ctx).Debugf("Saving password to file %v.", fn)
 
 	// nolint:wrapcheck
-	return ioutil.WriteFile(fn, []byte(base64.StdEncoding.EncodeToString([]byte(password))), passwordFileMode)
+	return os.WriteFile(fn, []byte(base64.StdEncoding.EncodeToString([]byte(password))), passwordFileMode)
 }
 
 func (filePasswordStorage) DeletePassword(ctx context.Context, configFile string) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,13 +4,13 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -257,7 +257,7 @@ func (s *Server) handleAPIPossiblyNotConnected(isAuthorized isAuthorizedFunc, f 
 		// we must pre-read request body before acquiring the lock as it sometimes leads to deadlock
 		// in HTTP/2 server.
 		// See https://github.com/golang/go/issues/40816
-		body, berr := ioutil.ReadAll(r.Body)
+		body, berr := io.ReadAll(r.Body)
 		if berr != nil {
 			http.Error(w, "error reading request body", http.StatusInternalServerError)
 			return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -297,7 +297,7 @@ func mustReadObject(ctx context.Context, t *testing.T, r repo.Repository, oid ob
 	or, err := r.OpenObject(ctx, oid)
 	require.NoError(t, err)
 
-	data, err := ioutil.ReadAll(or)
+	data, err := io.ReadAll(or)
 	require.NoError(t, err)
 
 	// verify data is read back the same.

--- a/internal/testutil/race.go
+++ b/internal/testutil/race.go
@@ -1,3 +1,4 @@
+//go:build race
 // +build race
 
 package testutil

--- a/internal/testutil/tmpdir.go
+++ b/internal/testutil/tmpdir.go
@@ -124,7 +124,6 @@ func dumpLogs(t *testing.T, dirname string) {
 func dumpLogFile(t *testing.T, fname string) {
 	t.Helper()
 
-	// nolint:gosec
 	data, err := os.ReadFile(fname)
 	if err != nil {
 		t.Error(err)

--- a/internal/testutil/tmpdir.go
+++ b/internal/testutil/tmpdir.go
@@ -24,7 +24,7 @@ var interestingLengths = []int{10, 50, 100, 240, 250, 260, 270}
 
 // GetInterestingTempDirectoryName returns interesting directory name used for testing.
 func GetInterestingTempDirectoryName() (string, error) {
-	td, err := ioutil.TempDir("", "kopia-test")
+	td, err := os.MkdirTemp("", "kopia-test")
 	if err != nil {
 		return "", errors.Wrap(err, "unable to create temp directory")
 	}
@@ -125,7 +125,7 @@ func dumpLogFile(t *testing.T, fname string) {
 	t.Helper()
 
 	// nolint:gosec
-	data, err := ioutil.ReadFile(fname)
+	data, err := os.ReadFile(fname)
 	if err != nil {
 		t.Error(err)
 		return

--- a/internal/throttle/round_tripper_test.go
+++ b/internal/throttle/round_tripper_test.go
@@ -3,7 +3,6 @@ package throttle
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -43,8 +42,8 @@ func (fp *fakePool) AddReader(r io.ReadCloser) (io.ReadCloser, error) {
 
 //nolint:gocyclo
 func TestRoundTripper(t *testing.T) {
-	downloadBody := ioutil.NopCloser(bytes.NewReader([]byte("data1")))
-	uploadBody := ioutil.NopCloser(bytes.NewReader([]byte("data1")))
+	downloadBody := io.NopCloser(bytes.NewReader([]byte("data1")))
+	uploadBody := io.NopCloser(bytes.NewReader([]byte("data1")))
 
 	base := &baseRoundTripper{
 		responses: make(map[*http.Request]*http.Response),

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -110,7 +109,7 @@ func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes) er
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	throttled, err := az.uploadThrottler.AddReader(ioutil.NopCloser(data.Reader()))
+	throttled, err := az.uploadThrottler.AddReader(io.NopCloser(data.Reader()))
 	if err != nil {
 		// nolint:wrapcheck
 		return err

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -4,14 +4,14 @@ package b2
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/efarrer/iothrottler"
 	"github.com/pkg/errors"
-	backblaze "gopkg.in/kothar/go-backblaze.v0"
+	"gopkg.in/kothar/go-backblaze.v0"
 
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/iocopy"
@@ -149,7 +149,7 @@ func translateError(err error) error {
 }
 
 func (s *b2Storage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
-	throttled, err := s.uploadThrottler.AddReader(ioutil.NopCloser(data.Reader()))
+	throttled, err := s.uploadThrottler.AddReader(io.NopCloser(data.Reader()))
 	if err != nil {
 		return translateError(err)
 	}

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -192,7 +192,7 @@ func toBandwidth(bytesPerSecond int) iothrottler.Bandwidth {
 }
 
 func tokenSourceFromCredentialsFile(ctx context.Context, fn string, scopes ...string) (oauth2.TokenSource, error) {
-	data, err := os.ReadFile(fn) //nolint:gosec
+	data, err := os.ReadFile(fn)
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading credentials file")
 	}

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	gcsclient "cloud.google.com/go/storage"
@@ -192,7 +192,7 @@ func toBandwidth(bytesPerSecond int) iothrottler.Bandwidth {
 }
 
 func tokenSourceFromCredentialsFile(ctx context.Context, fn string, scopes ...string) (oauth2.TokenSource, error) {
-	data, err := ioutil.ReadFile(fn) //nolint:gosec
+	data, err := os.ReadFile(fn) //nolint:gosec
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading credentials file")
 	}

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -75,7 +75,7 @@ func gunzip(d []byte) ([]byte, error) {
 
 	defer z.Close()
 
-	return ioutil.ReadAll(z)
+	return io.ReadAll(z)
 }
 
 func mustGetOptionsOrSkip(t *testing.T, prefix string) *gcs.Options {

--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -188,7 +187,7 @@ func (r *rcloneStorage) runRCloneAndWaitForServerAddress(ctx context.Context, c 
 // nolint:funlen
 func New(ctx context.Context, opt *Options) (blob.Storage, error) {
 	// generate directory for all temp files.
-	td, err := ioutil.TempDir("", "kopia-rclone")
+	td, err := os.MkdirTemp("", "kopia-rclone")
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting temporary dir")
 	}
@@ -263,7 +262,7 @@ func New(ctx context.Context, opt *Options) (blob.Storage, error) {
 		tmpConfigFile := filepath.Join(r.temporaryDir, "rclone.conf")
 
 		// nolint:gomnd
-		if err = ioutil.WriteFile(tmpConfigFile, []byte(opt.EmbeddedConfig), 0o600); err != nil {
+		if err = os.WriteFile(tmpConfigFile, []byte(opt.EmbeddedConfig), 0o600); err != nil {
 			return nil, errors.Wrap(err, "unable to write config file")
 		}
 

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -7,14 +7,13 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/efarrer/iothrottler"
-	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/pkg/errors"
 
@@ -138,7 +137,7 @@ func (s *s3Storage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes) err
 }
 
 func (s *s3Storage) putBlob(ctx context.Context, b blob.ID, data blob.Bytes) (versionMetadata, error) {
-	throttled, err := s.uploadThrottler.AddReader(ioutil.NopCloser(data.Reader()))
+	throttled, err := s.uploadThrottler.AddReader(io.NopCloser(data.Reader()))
 	if err != nil {
 		return versionMetadata{}, errors.Wrap(err, "AddReader")
 	}

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/google/uuid"
-	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7"
 	miniocreds "github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/stretchr/testify/require"
 

--- a/repo/blob/s3/s3_versioned.go
+++ b/repo/blob/s3/s3_versioned.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	minio "github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7"
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/repo/blob"

--- a/repo/blob/s3/s3_versioned_test.go
+++ b/repo/blob/s3/s3_versioned_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"path"
@@ -263,7 +262,7 @@ func TestGetBlobWithVersion(t *testing.T) {
 
 					require.NoError(t, err)
 
-					c, err := ioutil.ReadAll(bv.contents(t).Reader())
+					c, err := io.ReadAll(bv.contents(t).Reader())
 
 					require.NoError(t, err)
 					require.Equal(t, c, b.ToByteSlice())

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -290,7 +289,7 @@ func (s *sftpStorage) Close(ctx context.Context) error {
 }
 
 func writeKnownHostsDataStringToTempFile(data string) (string, error) {
-	tf, err := ioutil.TempFile("", "kopia-known-hosts")
+	tf, err := os.CreateTemp("", "kopia-known-hosts")
 	if err != nil {
 		return "", errors.Wrap(err, "error creating temp file")
 	}
@@ -351,7 +350,7 @@ func getSigner(opt *Options) (ssh.Signer, error) {
 			return nil, errors.Errorf("key file path must be absolute")
 		}
 
-		privateKeyData, err = ioutil.ReadFile(opt.Keyfile)
+		privateKeyData, err = os.ReadFile(opt.Keyfile)
 		if err != nil {
 			return nil, errors.Wrap(err, "error reading private key file")
 		}

--- a/repo/blob/sftp/sftp_storage_test.go
+++ b/repo/blob/sftp/sftp_storage_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -35,7 +34,7 @@ const (
 func mustGetLocalTmpDir(t *testing.T) string {
 	t.Helper()
 
-	tmpDir, err := ioutil.TempDir(".", ".creds")
+	tmpDir, err := os.MkdirTemp(".", ".creds")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +149,7 @@ func startDockerSFTPServerOrSkip(t *testing.T, idRSA string) (host string, port 
 
 		t.Logf("knownHostsData: %s", knownHostsData)
 
-		ioutil.WriteFile(knownHostsFile, knownHostsData, 0o600)
+		os.WriteFile(knownHostsFile, knownHostsData, 0o600)
 
 		t.Logf("SFTP server OK on host:%q port:%v. Known hosts file: %v", host, port, knownHostsFile)
 
@@ -210,7 +209,7 @@ func TestInvalidServerFailsFast(t *testing.T) {
 	knownHostsFile := filepath.Join(tmpDir, "known_hosts")
 
 	mustRunCommand(t, "ssh-keygen", "-t", "rsa", "-P", "", "-f", idRSA)
-	ioutil.WriteFile(knownHostsFile, nil, 0o600)
+	os.WriteFile(knownHostsFile, nil, 0o600)
 
 	t0 := clock.Now()
 
@@ -227,7 +226,7 @@ func TestSFTPStorageRelativeKeyFile(t *testing.T) {
 	t.Parallel()
 
 	kh := filepath.Join(t.TempDir(), "some-relative-path")
-	require.NoError(t, ioutil.WriteFile(kh, []byte{}, 0o600))
+	require.NoError(t, os.WriteFile(kh, []byte{}, 0o600))
 
 	opt := &sftp.Options{
 		Path:           "/upload",
@@ -300,7 +299,7 @@ func createSFTPStorage(ctx context.Context, t *testing.T, host string, port int,
 func mustReadFileToString(t *testing.T, fname string) string {
 	t.Helper()
 
-	data, err := ioutil.ReadFile(fname)
+	data, err := os.ReadFile(fname)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/blob/sharded/sharded_test.go
+++ b/repo/blob/sharded/sharded_test.go
@@ -3,7 +3,6 @@ package sharded_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,7 +42,7 @@ func TestShardedFileStorage(t *testing.T) {
 					DirectoryShards: shardSpec,
 				})
 
-				ioutil.WriteFile(filepath.Join(path, "foreign-file"), []byte{1, 2, 3}, 0o600)
+				os.WriteFile(filepath.Join(path, "foreign-file"), []byte{1, 2, 3}, 0o600)
 
 				if r == nil || err != nil {
 					t.Errorf("unexpected result: %v %v", r, err)
@@ -140,7 +139,7 @@ func TestShardedFileStorageShardingMap(t *testing.T) {
 			dotShardsFile := filepath.Join(path, ".shards")
 
 			// write shards file
-			require.NoError(t, ioutil.WriteFile(dotShardsFile, []byte(tc.shardMapJSON), 0o600))
+			require.NoError(t, os.WriteFile(dotShardsFile, []byte(tc.shardMapJSON), 0o600))
 
 			var allBlobIDs []blob.ID
 
@@ -185,7 +184,7 @@ func TestShardedFileStorageShardingMap_Invalid(t *testing.T) {
 	dotShardsFile := filepath.Join(path, ".shards")
 
 	// write malformed shards file
-	require.NoError(t, ioutil.WriteFile(dotShardsFile, []byte{1, 2, 3}, 0o600))
+	require.NoError(t, os.WriteFile(dotShardsFile, []byte{1, 2, 3}, 0o600))
 
 	var tmp gather.WriteBuffer
 	defer tmp.Close()
@@ -200,7 +199,7 @@ func TestShardedFileStorageShardingMap_Invalid(t *testing.T) {
 
 	// write malformed file again, but will be ignored since it was successfully loaded
 	// in this session.
-	require.NoError(t, ioutil.WriteFile(dotShardsFile, []byte{1, 2, 3}, 0o600))
+	require.NoError(t, os.WriteFile(dotShardsFile, []byte{1, 2, 3}, 0o600))
 
 	require.NoError(t, r.PutBlob(ctx, "someblob2", gather.FromSlice([]byte("foo"))))
 }

--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -114,11 +114,11 @@ func (c *diskCommittedContentIndexCache) addContentToCache(ctx context.Context, 
 
 func writeTempFileAtomic(dirname string, data []byte) (string, error) {
 	// write to a temp file to avoid race where two processes are writing at the same time.
-	tf, err := ioutil.TempFile(dirname, "tmp")
+	tf, err := os.CreateTemp(dirname, "tmp")
 	if err != nil {
 		if os.IsNotExist(err) {
 			os.MkdirAll(dirname, cache.DirMode) //nolint:errcheck
-			tf, err = ioutil.TempFile(dirname, "tmp")
+			tf, err = os.CreateTemp(dirname, "tmp")
 		}
 	}
 

--- a/repo/content/packindex_test.go
+++ b/repo/content/packindex_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -333,7 +333,7 @@ func TestPackIndexV2TooManyUniqueFormats(t *testing.T) {
 		})
 	}
 
-	require.NoError(t, b.buildV2(ioutil.Discard))
+	require.NoError(t, b.buildV2(io.Discard))
 
 	// add one more to push it over the edge
 	b.Add(&InfoStruct{
@@ -342,7 +342,7 @@ func TestPackIndexV2TooManyUniqueFormats(t *testing.T) {
 		CompressionHeaderID: compression.HeaderID(5000),
 	})
 
-	err := b.buildV2(ioutil.Discard)
+	err := b.buildV2(io.Discard)
 	require.Error(t, err)
 	require.Equal(t, err.Error(), "unsupported - too many unique formats 256 (max 255)")
 }

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"runtime"
 	"runtime/debug"
@@ -328,7 +327,7 @@ func verifyFull(ctx context.Context, t *testing.T, om *Manager, oid ID, want []b
 
 	defer r.Close()
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("unable to read all: %v", err)
 	}
@@ -617,7 +616,7 @@ func TestReader(t *testing.T) {
 			continue
 		}
 
-		d, err := ioutil.ReadAll(reader)
+		d, err := io.ReadAll(reader)
 		if err != nil {
 			t.Errorf("cannot read all data for %v: %v", objectID, err)
 			continue

--- a/repo/open.go
+++ b/repo/open.go
@@ -2,7 +2,6 @@ package repo
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -317,7 +316,7 @@ func readFormatBlobBytesFromCache(ctx context.Context, cachedFile string, validD
 		return nil, errors.Errorf("cached file too old")
 	}
 
-	return ioutil.ReadFile(cachedFile) //nolint:gosec,wrapcheck
+	return os.ReadFile(cachedFile) //nolint:gosec,wrapcheck
 }
 
 func readAndCacheFormatBlobBytes(ctx context.Context, st blob.Storage, cacheDirectory string, validDuration time.Duration) ([]byte, error) {

--- a/repo/open.go
+++ b/repo/open.go
@@ -316,7 +316,7 @@ func readFormatBlobBytesFromCache(ctx context.Context, cachedFile string, validD
 		return nil, errors.Errorf("cached file too old")
 	}
 
-	return os.ReadFile(cachedFile) //nolint:gosec,wrapcheck
+	return os.ReadFile(cachedFile) //nolint:wrapcheck
 }
 
 func readAndCacheFormatBlobBytes(ctx context.Context, st blob.Storage, cacheDirectory string, validDuration time.Duration) ([]byte, error) {

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -3,7 +3,7 @@ package repo_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"runtime/debug"
 	"testing"
@@ -278,7 +278,7 @@ func TestFormats(t *testing.T) {
 				continue
 			}
 
-			bytesRead, err := ioutil.ReadAll(rc)
+			bytesRead, err := io.ReadAll(rc)
 			if err != nil {
 				t.Errorf("error reading: %v", err)
 			}

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -3,7 +3,7 @@ package snapshotfs
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -164,7 +164,7 @@ func (rsl *repositorySymlink) Readlink(ctx context.Context) (string, error) {
 
 	defer r.Close() //nolint:errcheck
 
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to read object: %v", rsl.metadata.ObjectID)
 	}

--- a/snapshot/snapshotfs/upload_actions.go
+++ b/snapshot/snapshotfs/upload_actions.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -68,7 +67,7 @@ func (hc *actionContext) ensureInitialized(ctx context.Context, actionType, dirP
 	hc.SourcePath = dirPathOrEmpty
 	hc.SnapshotPath = hc.SourcePath
 
-	wd, err := ioutil.TempDir("", "kopia-action")
+	wd, err := os.MkdirTemp("", "kopia-action")
 	if err != nil {
 		return errors.Wrap(err, "error temporary directory for action execution")
 	}
@@ -102,7 +101,7 @@ func prepareCommandForAction(ctx context.Context, actionType string, h *policy.A
 	switch {
 	case h.Script != "":
 		scriptFile := filepath.Join(workDir, actionType+actionScriptExtension())
-		if err := ioutil.WriteFile(scriptFile, []byte(h.Script), actionScriptPermissions); err != nil {
+		if err := os.WriteFile(scriptFile, []byte(h.Script), actionScriptPermissions); err != nil {
 			cancel()
 
 			return nil, nil, errors.Wrap(err, "error writing script for execution")

--- a/tests/end_to_end_test/api_server_repository_test.go
+++ b/tests/end_to_end_test/api_server_repository_test.go
@@ -2,7 +2,7 @@ package endtoend_test
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -86,7 +86,7 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 		e.RunAndExpectSuccess(t, "server", "users", "add", "foo@bar", "--user-password", "baz")
 	} else {
 		htpasswordFile := filepath.Join(e.ConfigDir, "htpasswd.txt")
-		ioutil.WriteFile(htpasswordFile, htpasswdFileContents, 0o755)
+		os.WriteFile(htpasswordFile, htpasswdFileContents, 0o755)
 		serverStartArgs = append(serverStartArgs, "--htpasswd-file", htpasswordFile)
 	}
 

--- a/tests/end_to_end_test/compression_test.go
+++ b/tests/end_to_end_test/compression_test.go
@@ -1,7 +1,7 @@
 package endtoend_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -49,7 +49,7 @@ func (s *formatSpecificTestSuite) TestCompression(t *testing.T) {
 	}
 
 	// add a file that compresses well
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(strings.Join(dataLines, "\n")), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(strings.Join(dataLines, "\n")), 0o600))
 
 	e.RunAndExpectSuccess(t, "snapshot", "create", dataDir)
 	sources := clitestutil.ListSnapshotsAndExpectSuccess(t, e)

--- a/tests/end_to_end_test/content_info_test.go
+++ b/tests/end_to_end_test/content_info_test.go
@@ -2,7 +2,7 @@ package endtoend_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -25,7 +25,7 @@ func (s *formatSpecificTestSuite) TestContentListAndStats(t *testing.T) {
 	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--compression", "pgzip")
 
 	srcDir := testutil.TempDirectory(t)
-	ioutil.WriteFile(filepath.Join(srcDir, "compressible.txt"),
+	os.WriteFile(filepath.Join(srcDir, "compressible.txt"),
 		bytes.Repeat([]byte{1, 2, 3, 4}, 1000),
 		0o600,
 	)

--- a/tests/end_to_end_test/diff_test.go
+++ b/tests/end_to_end_test/diff_test.go
@@ -1,7 +1,6 @@
 package endtoend_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,11 +30,11 @@ func TestDiff(t *testing.T) {
 
 	// create some directories and files
 	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, "foo"), 0o700))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
 hello world
 how are you
 `), 0o600))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file2"), []byte(`
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "some-file2"), []byte(`
 quick brown
 fox jumps
 over the lazy
@@ -44,7 +43,7 @@ dog
 	e.RunAndExpectSuccess(t, "snapshot", "create", dataDir)
 
 	// change some files
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file2"), []byte(`
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "some-file2"), []byte(`
 quick brown
 fox jumps
 over the lazy

--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -470,7 +470,7 @@ func verifyUIServedWithCorrectTitle(t *testing.T, cli *apiclient.KopiaAPIClient,
 
 	defer resp.Body.Close()
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	// make sure the UI correctly inserts prefix from KOPIA_UI_TITLE_PREFIX

--- a/tests/end_to_end_test/shallowrestore_test.go
+++ b/tests/end_to_end_test/shallowrestore_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -554,7 +553,7 @@ func TestForeignReposCauseErrors(t *testing.T) {
 		buffy := &bytes.Buffer{}
 		encoder := json.NewEncoder(buffy)
 		require.NoError(t, encoder.Encode(s.de))
-		require.NoError(t, ioutil.WriteFile(depath, buffy.Bytes(), 0o444))
+		require.NoError(t, os.WriteFile(depath, buffy.Bytes(), 0o444))
 		e.RunAndExpectFailure(t, "snapshot", "create", source)
 		require.NoError(t, os.RemoveAll(spath))
 	}
@@ -590,7 +589,7 @@ func getShallowDirEntry(t *testing.T, fpath string) *snapshot.DirEntry {
 			p += s
 		}
 
-		b, err = ioutil.ReadFile(p)
+		b, err = os.ReadFile(p)
 		if err == nil {
 			break
 		}

--- a/tests/end_to_end_test/snapshot_actions_test.go
+++ b/tests/end_to_end_test/snapshot_actions_test.go
@@ -2,7 +2,6 @@ package endtoend_test
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -330,7 +329,7 @@ func TestSnapshotActionsEnable(t *testing.T) {
 func tmpfileWithContents(t *testing.T, contents string) string {
 	t.Helper()
 
-	f, err := ioutil.TempFile("", "kopia-test")
+	f, err := os.CreateTemp("", "kopia-test")
 	verifyNoError(t, err)
 
 	f.WriteString(contents)

--- a/tests/end_to_end_test/snapshot_delete_test.go
+++ b/tests/end_to_end_test/snapshot_delete_test.go
@@ -118,7 +118,7 @@ func testSnapshotDelete(t *testing.T, argMaker deleteArgMaker, expectDeleteSucce
 
 	dataDir := testutil.TempDirectory(t)
 	require.NoError(t, os.MkdirAll(dataDir, 0o777))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
 hello world
 how are you
 `), 0o600))

--- a/tests/end_to_end_test/snapshot_gc_test.go
+++ b/tests/end_to_end_test/snapshot_gc_test.go
@@ -1,7 +1,6 @@
 package endtoend_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +26,7 @@ func (s *formatSpecificTestSuite) TestSnapshotGC(t *testing.T) {
 
 	dataDir := testutil.TempDirectory(t)
 	require.NoError(t, os.MkdirAll(dataDir, 0o777))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "some-file1"), []byte(`
 hello world
 how are you
 `), 0o600))

--- a/tests/endurance_test/endurance_test.go
+++ b/tests/endurance_test/endurance_test.go
@@ -3,7 +3,6 @@ package endurance_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http/httptest"
@@ -65,7 +64,7 @@ func TestEndurance(t *testing.T) {
 	runner := testenv.NewExeRunner(t)
 	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
-	tmpDir, err := ioutil.TempDir("", "endurance")
+	tmpDir, err := os.MkdirTemp("", "endurance")
 	if err != nil {
 		t.Fatalf("unable to get temp dir: %v", err)
 	}
@@ -214,7 +213,7 @@ func actionAddNewSource(t *testing.T, e *testenv.CLITest, s *runnerState) {
 		return
 	}
 
-	srcDir, err := ioutil.TempDir("", "kopiasrc")
+	srcDir, err := os.MkdirTemp("", "kopiasrc")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/tests/repository_stress_test/repository_stress_test.go
+++ b/tests/repository_stress_test/repository_stress_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	cryptorand "crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -196,7 +195,7 @@ func runStress(t *testing.T, opt *StressOptions) {
 
 	ctx := testlogging.Context(t)
 
-	tmpPath, err := ioutil.TempDir("", "kopia")
+	tmpPath, err := os.MkdirTemp("", "kopia")
 	if err != nil {
 		t.Fatalf("unable to create temp directory")
 	}

--- a/tests/robustness/checker/checker.go
+++ b/tests/robustness/checker/checker.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -45,7 +44,7 @@ type Checker struct {
 // NewChecker instantiates a new Checker, returning its pointer. A temporary
 // directory is created to mount restored data.
 func NewChecker(snapIssuer robustness.Snapshotter, snapmetaStore robustness.Store, restoreDir string) (*Checker, error) {
-	restoreDir, err := ioutil.TempDir(restoreDir, "restore-data-")
+	restoreDir, err := os.MkdirTemp(restoreDir, "restore-data-")
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +238,7 @@ func (chk *Checker) TakeSnapshot(ctx context.Context, sourceDir string, opts map
 // resulting tree using the saved snapshot data.
 func (chk *Checker) RestoreSnapshot(ctx context.Context, snapID string, reportOut io.Writer, opts map[string]string) error {
 	// Make an independent directory for the restore
-	restoreSubDir, err := ioutil.TempDir(chk.RestoreDir, fmt.Sprintf("restore-snap-%v", snapID))
+	restoreSubDir, err := os.MkdirTemp(chk.RestoreDir, fmt.Sprintf("restore-snap-%v", snapID))
 	if err != nil {
 		return err
 	}

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -317,7 +316,7 @@ func TestSnapshotVerificationFail(t *testing.T) {
 	// Swap second snapshot's validation data into the first's metadata
 	ssMeta1.ValidationData = ssMeta2.ValidationData
 
-	restoreDir, err := ioutil.TempDir(eng.Checker.RestoreDir, fmt.Sprintf("restore-snap-%v", snapID1))
+	restoreDir, err := os.MkdirTemp(eng.Checker.RestoreDir, fmt.Sprintf("restore-snap-%v", snapID1))
 	require.NoError(t, err)
 
 	defer os.RemoveAll(restoreDir)
@@ -654,7 +653,7 @@ func TestIOLimitPerWriteAction(t *testing.T) {
 	// written to it, due to the I/O limit.
 	walkFunc := func(path string, info fs.FileInfo, err error) error {
 		if !info.IsDir() && info.Size() > 0 {
-			fileContentB, err := ioutil.ReadFile(path)
+			fileContentB, err := os.ReadFile(path)
 			require.NoError(t, err)
 
 			nonZeroByteCount := 0
@@ -696,7 +695,7 @@ func TestIOLimitPerWriteAction(t *testing.T) {
 func TestStatsPersist(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "stats-persist-test")
+	tmpDir, err := os.MkdirTemp("", "stats-persist-test")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
@@ -766,7 +765,7 @@ func TestStatsPersist(t *testing.T) {
 func TestLogsPersist(t *testing.T) {
 	ctx := context.Background()
 
-	tmpDir, err := ioutil.TempDir("", "logs-persist-test")
+	tmpDir, err := os.MkdirTemp("", "logs-persist-test")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
@@ -850,7 +849,7 @@ func newTestHarness(ctx context.Context, t *testing.T, dataRepoPath, metaRepoPat
 		err error
 	)
 
-	if th.baseDir, err = ioutil.TempDir("", "engine-data-"); err != nil {
+	if th.baseDir, err = os.MkdirTemp("", "engine-data-"); err != nil {
 		return nil, nil, err
 	}
 

--- a/tests/robustness/multiclient_test/framework/harness.go
+++ b/tests/robustness/multiclient_test/framework/harness.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -92,7 +91,7 @@ func (th *TestHarness) init(ctx context.Context) {
 }
 
 func (th *TestHarness) makeBaseDir() bool {
-	baseDir, err := ioutil.TempDir("", "engine-data-")
+	baseDir, err := os.MkdirTemp("", "engine-data-")
 	if err != nil {
 		log.Println("Error creating temp dir:", err)
 		return false

--- a/tests/robustness/multiclient_test/framework/snapshotter.go
+++ b/tests/robustness/multiclient_test/framework/snapshotter.go
@@ -6,8 +6,8 @@ package framework
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
+	"os"
 	"os/exec"
 	"strconv"
 	"sync"
@@ -190,7 +190,7 @@ func (mcs *MultiClientSnapshotter) createOrGetSnapshotter(ctx context.Context) (
 	}
 
 	// Create new ClientSnapshotter
-	clientDir, err := ioutil.TempDir(mcs.baseDirPath, "client-")
+	clientDir, err := os.MkdirTemp(mcs.baseDirPath, "client-")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/robustness/robustness_test/main_test.go
+++ b/tests/robustness/robustness_test/main_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -100,7 +99,7 @@ func (th *kopiaRobustnessTestHarness) init(ctx context.Context, dataRepoPath, me
 }
 
 func (th *kopiaRobustnessTestHarness) makeBaseDir() bool {
-	baseDir, err := ioutil.TempDir("", "engine-data-")
+	baseDir, err := os.MkdirTemp("", "engine-data-")
 	if err != nil {
 		log.Println("Error creating temp dir:", err)
 		return false

--- a/tests/robustness/snapmeta/kopia_persister.go
+++ b/tests/robustness/snapmeta/kopia_persister.go
@@ -6,7 +6,6 @@ package snapmeta
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,12 +26,12 @@ var _ robustness.Persister = (*KopiaPersister)(nil)
 // NewPersister returns a Kopia based Persister.
 // ConnectOrCreateRepo must be invoked to enable the interface.
 func NewPersister(baseDir string) (*KopiaPersister, error) {
-	localDir, err := ioutil.TempDir(baseDir, "kopia-local-metadata-")
+	localDir, err := os.MkdirTemp(baseDir, "kopia-local-metadata-")
 	if err != nil {
 		return nil, err
 	}
 
-	persistenceDir, err := ioutil.TempDir(localDir, "kopia-persistence-root")
+	persistenceDir, err := os.MkdirTemp(localDir, "kopia-persistence-root")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/testingaction/main.go
+++ b/tests/testingaction/main.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"flag"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -28,7 +27,7 @@ func main() {
 	flag.Parse()
 
 	if fn := *saveEnvironmentToFile; fn != "" {
-		if err := ioutil.WriteFile(fn, []byte(strings.Join(os.Environ(), "\n")), 0o600); err != nil {
+		if err := os.WriteFile(fn, []byte(strings.Join(os.Environ(), "\n")), 0o600); err != nil {
 			log.Fatalf("error writing environment file: %v", err)
 		}
 	}
@@ -56,7 +55,7 @@ func main() {
 			log.Fatalf("unexpected file found: %v", fn)
 		}
 
-		if err := ioutil.WriteFile(fn, nil, 0o600); err != nil {
+		if err := os.WriteFile(fn, nil, 0o600); err != nil {
 			log.Fatalf("unable to create file: %v", err)
 		}
 	}

--- a/tests/tools/fio/fio.go
+++ b/tests/tools/fio/fio.go
@@ -93,7 +93,7 @@ func NewRunner() (fr *Runner, err error) {
 
 	var Exe string
 
-	dataDir, err := ioutil.TempDir(localDataPath, "fio-data-")
+	dataDir, err := os.MkdirTemp(localDataPath, "fio-data-")
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create temp directory for fio runner")
 	}

--- a/tests/tools/fio/workload.go
+++ b/tests/tools/fio/workload.go
@@ -215,7 +215,7 @@ func (fr *Runner) writeFilesAtDepth(fromDirPath string, depth, branchDepth int, 
 		var err error
 
 		// Couldn't find a subdir, create one instead
-		subdirPath, err = ioutil.TempDir(fromDirPath, "dir_")
+		subdirPath, err = os.MkdirTemp(fromDirPath, "dir_")
 		if err != nil {
 			return errors.Wrapf(err, "unable to create temp dir at %v", fromDirPath)
 		}

--- a/tests/tools/fswalker/fswalker_test.go
+++ b/tests/tools/fswalker/fswalker_test.go
@@ -5,7 +5,6 @@ package fswalker
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,7 +54,7 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 				GlobalFilterMatchers: nil,
 			},
 			fileTreeMaker: func(rootDir string) error {
-				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
+				return os.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
 			},
 			fileTreeModifier: func(rootDir string) error { return nil },
 			wantErr:          false,
@@ -66,10 +65,10 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 				GlobalFilterMatchers: nil,
 			},
 			fileTreeMaker: func(rootDir string) error {
-				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
+				return os.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
 			},
 			fileTreeModifier: func(rootDir string) error {
-				ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some different data"), 0o700)
+				os.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some different data"), 0o700)
 				return nil
 			},
 			wantErr: true,
@@ -87,11 +86,11 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 					return err
 				}
 
-				return ioutil.WriteFile(filepath.Join(subdir, "test-file"), []byte("some data"), 0o700)
+				return os.WriteFile(filepath.Join(subdir, "test-file"), []byte("some data"), 0o700)
 			},
 			fileTreeModifier: func(rootDir string) error {
 				subdir := filepath.Join(rootDir, "some", "really", "really", "very", "substantially", "deep", "directory", "tree")
-				return ioutil.WriteFile(filepath.Join(subdir, "test-file"), []byte("some different data"), 0o700)
+				return os.WriteFile(filepath.Join(subdir, "test-file"), []byte("some different data"), 0o700)
 			},
 			wantErr: true,
 		},
@@ -104,7 +103,7 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 				return nil
 			},
 			fileTreeModifier: func(rootDir string) error {
-				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
+				return os.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
 			},
 			wantErr: true,
 		},
@@ -114,7 +113,7 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 				GlobalFilterMatchers: nil,
 			},
 			fileTreeMaker: func(rootDir string) error {
-				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
+				return os.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
 			},
 			fileTreeModifier: func(rootDir string) error {
 				return os.Remove(filepath.Join(rootDir, "test-file"))
@@ -127,7 +126,7 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 				GlobalFilterMatchers: nil,
 			},
 			fileTreeMaker: func(rootDir string) error {
-				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
+				return os.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
 			},
 			fileTreeModifier: func(rootDir string) error {
 				return os.Chmod(filepath.Join(rootDir, "test-file"), 0o000)
@@ -157,10 +156,10 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 				},
 			},
 			fileTreeMaker: func(rootDir string) error {
-				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
+				return os.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
 			},
 			fileTreeModifier: func(rootDir string) error {
-				ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some different data"), 0o700)
+				os.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some different data"), 0o700)
 				return nil
 			},
 			wantErr: true,
@@ -175,10 +174,10 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 				},
 			},
 			fileTreeMaker: func(rootDir string) error {
-				return ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
+				return os.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some data"), 0o700)
 			},
 			fileTreeModifier: func(rootDir string) error {
-				ioutil.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some different data"), 0o700)
+				os.WriteFile(filepath.Join(rootDir, "test-file"), []byte("some different data"), 0o700)
 				return nil
 			},
 			wantErr: false,
@@ -201,7 +200,7 @@ func TestWalkChecker_GatherCompare(t *testing.T) {
 			},
 		}
 
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tests/tools/fswalker/protofile/protofile.go
+++ b/tests/tools/fswalker/protofile/protofile.go
@@ -4,7 +4,7 @@ package protofile
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 
 	// nolint:staticcheck
 	"github.com/golang/protobuf/proto"
@@ -22,5 +22,5 @@ func WriteTextProto(path string, pb proto.Message) error {
 	blob = bytes.ReplaceAll(blob, []byte("<"), []byte("{"))
 	blob = bytes.ReplaceAll(blob, []byte(">"), []byte("}"))
 
-	return ioutil.WriteFile(path, blob, 0o644) //nolint:gosec
+	return os.WriteFile(path, blob, 0o644) //nolint:gosec
 }

--- a/tests/tools/fswalker/reporter/reporter.go
+++ b/tests/tools/fswalker/reporter/reporter.go
@@ -6,7 +6,6 @@ package reporter
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	"github.com/google/fswalker"
@@ -71,7 +70,7 @@ func ReportFiles(ctx context.Context, config *fspb.ReportConfig, beforeFile, aft
 }
 
 func writeTempConfigFile(config *fspb.ReportConfig) (string, error) {
-	f, err := ioutil.TempFile("", "fswalker-report-config-")
+	f, err := os.CreateTemp("", "fswalker-report-config-")
 	if err != nil {
 		return "", err
 	}

--- a/tests/tools/fswalker/walker/walker.go
+++ b/tests/tools/fswalker/walker/walker.go
@@ -6,7 +6,6 @@ package walker
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 
 	"github.com/google/fswalker"
@@ -23,7 +22,7 @@ const (
 // Walk performs a walk governed by the contents of the provided
 // Policy, and returns the pointer to the Walk.
 func Walk(ctx context.Context, policy *fspb.Policy) (*fspb.Walk, error) { //nolint:interfacer
-	f, err := ioutil.TempFile("", "fswalker-policy-")
+	f, err := os.CreateTemp("", "fswalker-policy-")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/tools/fswalker/walker/walker_test.go
+++ b/tests/tools/fswalker/walker/walker_test.go
@@ -4,7 +4,6 @@
 package walker
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestWalk(t *testing.T) {
-	dataDir, err := ioutil.TempDir("", "walk-data-")
+	dataDir, err := os.MkdirTemp("", "walk-data-")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(dataDir)

--- a/tests/tools/kopiarunner/kopia_snapshotter.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -369,7 +368,7 @@ func (ks *KopiaSnapshotter) ConnectOrCreateRepoWithServer(serverAddr string, arg
 
 	var tempDirErr error
 
-	if tempDir, tempDirErr = ioutil.TempDir("", "kopia"); tempDirErr != nil {
+	if tempDir, tempDirErr = os.MkdirTemp("", "kopia"); tempDirErr != nil {
 		return nil, "", tempDirErr
 	}
 
@@ -445,7 +444,7 @@ func (ks *KopiaSnapshotter) setServerPermissions(args ...string) error {
 }
 
 func getFingerPrintFromCert(path string) (string, error) {
-	pemData, err := ioutil.ReadFile(path) //nolint:gosec
+	pemData, err := os.ReadFile(path) //nolint:gosec
 	if err != nil {
 		return "", err
 	}

--- a/tests/tools/kopiarunner/kopia_snapshotter_exe_test.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter_exe_test.go
@@ -3,7 +3,6 @@ package kopiarunner
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -11,15 +10,15 @@ import (
 )
 
 func TestParseSnapListAllExeTest(t *testing.T) {
-	baseDir, err := ioutil.TempDir("", t.Name())
+	baseDir, err := os.MkdirTemp("", t.Name())
 	require.NoError(t, err)
 
 	defer os.RemoveAll(baseDir)
 
-	repoDir, err := ioutil.TempDir(baseDir, "repo")
+	repoDir, err := os.MkdirTemp(baseDir, "repo")
 	require.NoError(t, err)
 
-	sourceDir, err := ioutil.TempDir(baseDir, "source")
+	sourceDir, err := os.MkdirTemp(baseDir, "source")
 	require.NoError(t, err)
 
 	ks, err := NewKopiaSnapshotter(repoDir)

--- a/tests/tools/kopiarunner/kopiarun.go
+++ b/tests/tools/kopiarunner/kopiarun.go
@@ -4,7 +4,6 @@ package kopiarunner
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -34,7 +33,7 @@ func NewRunner(baseDir string) (*Runner, error) {
 		return nil, ErrExeVariableNotSet
 	}
 
-	configDir, err := ioutil.TempDir(baseDir, "kopia-config")
+	configDir, err := os.MkdirTemp(baseDir, "kopia-config")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since kopia has upgraded to Go 1.17 (#1256), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.