### PR TITLE
refactor: move from ioutil.ReadDir to os.ReadDir

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters-settings:
     - ioutil.Discard # use io.Discard
     - ioutil.NopCloser # use io.NopCloser
     - ioutil.ReadAll # use io.ReadAll
+    - ioutil.ReadDir # use os.ReadDir
     - ioutil.ReadFile # use os.ReadFile
     - ioutil.TempDir # use os.MkdirTemp
     - ioutil.TempFile # use os.CreateTemp

--- a/cli/command_cache_info.go
+++ b/cli/command_cache_info.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -39,7 +39,7 @@ func (c *commandCacheInfo) run(ctx context.Context, rep repo.Repository) error {
 		return nil
 	}
 
-	entries, err := ioutil.ReadDir(opts.CacheDirectory)
+	entries, err := os.ReadDir(opts.CacheDirectory)
 	if err != nil {
 		return errors.Wrap(err, "unable to scan cache directory")
 	}

--- a/internal/testutil/tmpdir.go
+++ b/internal/testutil/tmpdir.go
@@ -2,7 +2,6 @@ package testutil
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -102,7 +101,7 @@ func TempLogDirectory(t *testing.T) string {
 func dumpLogs(t *testing.T, dirname string) {
 	t.Helper()
 
-	entries, err := ioutil.ReadDir(dirname)
+	entries, err := os.ReadDir(dirname)
 	if err != nil {
 		t.Errorf("unable to read %v: %v", dirname, err)
 

--- a/tests/end_to_end_test/snapshot_delete_test.go
+++ b/tests/end_to_end_test/snapshot_delete_test.go
@@ -1,7 +1,6 @@
 package endtoend_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -246,10 +245,10 @@ func assertEmptyDir(t *testing.T, dir string) {
 	t.Helper()
 
 	// Make sure the restore did not happen from the deleted snapshot
-	fileInfo, err := ioutil.ReadDir(dir)
+	dirEntries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 
-	if len(fileInfo) != 0 {
+	if len(dirEntries) != 0 {
 		t.Fatalf("expected nothing to be restored")
 	}
 }

--- a/tests/perf_benchmark/process_results.go
+++ b/tests/perf_benchmark/process_results.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -116,7 +115,7 @@ func parseRepoSize(fname string) (int64, error) {
 }
 
 func main() {
-	files, err := ioutil.ReadDir(".")
+	files, err := os.ReadDir(".")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tests/tools/fio/fio.go
+++ b/tests/tools/fio/fio.go
@@ -7,7 +7,6 @@ package fio
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -190,16 +189,21 @@ func (fr *Runner) verifySetupWithTestWrites() error {
 		return errors.Wrap(err, "unable to perform writes")
 	}
 
-	fl, err := ioutil.ReadDir(filepath.Join(fr.LocalDataDir, subDirPath))
+	dirEntries, err := os.ReadDir(filepath.Join(fr.LocalDataDir, subDirPath))
 	if err != nil {
 		return errors.Wrapf(err, "error reading path %v", subDirPath)
 	}
 
-	if got, want := len(fl), nrFiles; got != want {
+	if got, want := len(dirEntries), nrFiles; got != want {
 		return errors.Errorf("did not find the expected number of files %v != %v (expected)", got, want)
 	}
 
-	for _, fi := range fl {
+	for _, entry := range dirEntries {
+		fi, err := entry.Info()
+		if err != nil {
+			return errors.Wrap(err, "unable to read file info")
+		}
+
 		if got, want := fi.Size(), int64(fileSizeB); got != want {
 			return errors.Errorf("did not get expected file size from writes %v != %v (expected)", got, want)
 		}

--- a/tests/tools/fio/workload.go
+++ b/tests/tools/fio/workload.go
@@ -1,7 +1,6 @@
 package fio
 
 import (
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -133,14 +132,14 @@ func (fr *Runner) DeleteContentsAtDepth(relBasePath string, depth int, prob floa
 	fullBasePath := filepath.Join(fr.LocalDataDir, relBasePath)
 
 	return fr.operateAtDepth(fullBasePath, depth, func(dirPath string) error {
-		fileInfoList, err := ioutil.ReadDir(dirPath)
+		dirEntries, err := os.ReadDir(dirPath)
 		if err != nil {
 			return err
 		}
 
-		for _, fi := range fileInfoList {
+		for _, entry := range dirEntries {
 			if rand.Float32() < prob {
-				path := filepath.Join(dirPath, fi.Name())
+				path := filepath.Join(dirPath, entry.Name())
 				err = os.RemoveAll(path)
 				if err != nil {
 					return err
@@ -164,16 +163,16 @@ func (fr *Runner) operateAtDepth(path string, depth int, f func(string) error) e
 		return f(path)
 	}
 
-	fileInfoList, err := ioutil.ReadDir(path)
+	dirEntries, err := os.ReadDir(path)
 	if err != nil {
 		return errors.Wrapf(err, "unable to read dir at path %v", path)
 	}
 
 	var dirList []string
 
-	for _, fi := range fileInfoList {
-		if fi.IsDir() {
-			dirList = append(dirList, filepath.Join(path, fi.Name()))
+	for _, entry := range dirEntries {
+		if entry.IsDir() {
+			dirList = append(dirList, filepath.Join(path, entry.Name()))
 		}
 	}
 
@@ -225,16 +224,16 @@ func (fr *Runner) writeFilesAtDepth(fromDirPath string, depth, branchDepth int, 
 }
 
 func pickRandSubdirPath(dirPath string) (subdirPath string) {
-	fileInfoList, err := ioutil.ReadDir(dirPath)
+	dirEntries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return ""
 	}
 
-	// Find all entries that are directories, record each of their fileInfoList indexes
-	dirIdxs := make([]int, 0, len(fileInfoList))
+	// Find all entries that are directories, record each of their dirEntries indexes
+	dirIdxs := make([]int, 0, len(dirEntries))
 
-	for idx, fi := range fileInfoList {
-		if fi.IsDir() {
+	for idx, entry := range dirEntries {
+		if entry.IsDir() {
 			dirIdxs = append(dirIdxs, idx)
 		}
 	}
@@ -243,9 +242,9 @@ func pickRandSubdirPath(dirPath string) (subdirPath string) {
 		return ""
 	}
 
-	// Pick a random index from the list of indexes of fileInfo entries known to be directories.
+	// Pick a random index from the list of indexes of DirEntry entries known to be directories.
 	randDirIdx := dirIdxs[rand.Intn(len(dirIdxs))] //nolint:gosec
-	randDirInfo := fileInfoList[randDirIdx]
+	randDirInfo := dirEntries[randDirIdx]
 
 	return filepath.Join(dirPath, randDirInfo.Name())
 }

--- a/tests/tools/fio/workload_test.go
+++ b/tests/tools/fio/workload_test.go
@@ -1,7 +1,6 @@
 package fio
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,16 +24,21 @@ func TestWriteFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	fullPath := filepath.Join(r.LocalDataDir, relativeWritePath)
-	dir, err := ioutil.ReadDir(fullPath)
+	dirEntries, err := os.ReadDir(fullPath)
 	require.NoError(t, err)
 
-	if got, want := len(dir), numFiles; got != want {
+	if got, want := len(dirEntries), numFiles; got != want {
 		t.Errorf("Did not get expected number of files %v (actual) != %v (expected", got, want)
 	}
 
 	sizeTot := int64(0)
 
-	for _, fi := range dir {
+	for _, entry := range dirEntries {
+		fi, err := entry.Info()
+		if err != nil {
+			t.Fatalf("Failed to read file info: %v", err)
+		}
+
 		sizeTot += fi.Size()
 	}
 


### PR DESCRIPTION
This PR is an addition to #1360 (see https://github.com/kopia/kopia/pull/1360#discussion_r723279310).

Things to note:
1. `os.ReadDir` is not a direct replacement for `ioutil.ReadDir`, unlike all other functions in `io/ioutil`
2. `os.ReadDir` returns a slice of [os.DirEntry](https://golang.org/pkg/os/#DirEntry), while `ioutil.ReadDir` returns a slice of [fs.FileInfo](https://golang.org/pkg/io/fs/#FileInfo). The biggest difference is the lack of `Size()`, `ModTime()`, and `Sys()` method in the `os.DirEntry` interface.
3. To get the `Size()`, `ModTime()`, or `Sys()` of a file or folder from `os.DirEntry`, we need to call `Info()` first and do an additional error handling.

The `os.ReadDir` was proposed in https://github.com/golang/go/issues/41467. According to the [documentation for `ioutil.ReadDir`](https://pkg.go.dev/io/ioutil#ReadDir) starting from Go 1.16, it is recommended to use `os.ReadDir` as it is a more efficient and correct implementation.
