### PR TITLE
logging: added memoization of Logger instances per context

### DIFF
--- a/fs/cachefs/cache.go
+++ b/fs/cachefs/cache.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kopia/kopia/repo/object"
 )
 
-var log = logging.GetContextLoggerFunc("kopia/cachefs")
+var log = logging.Module("kopia/cachefs")
 
 const dirCacheExpiration = 24 * time.Hour
 

--- a/fs/ignorefs/ignorefs.go
+++ b/fs/ignorefs/ignorefs.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kopia/kopia/snapshot/policy"
 )
 
-var log = logging.GetContextLoggerFunc("ignorefs")
+var log = logging.Module("ignorefs")
 
 // IgnoreCallback is a function called by ignorefs to report whenever a file or directory is being ignored while listing its parent.
 type IgnoreCallback func(path string, metadata fs.Entry)

--- a/htmlui/htmlui.go
+++ b/htmlui/htmlui.go
@@ -19,7 +19,7 @@ var data embed.FS
 func AssetFile() http.FileSystem {
 	f, err := fs.Sub(data, "build")
 	if err != nil {
-		logging.GetContextLoggerFunc("htmluil")(context.Background()).Errorf("Build time error: could not embed htmlui")
+		logging.Module("htmlui")(context.Background()).Errorf("Build time error: could not embed htmlui")
 		panic("could not embed htmlui")
 	}
 

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("client")
+var log = logging.Module("client")
 
 // KopiaAPIClient provides helper methods for communicating with Kopia API server.
 type KopiaAPIClient struct {

--- a/internal/auth/authn.go
+++ b/internal/auth/authn.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("auth")
+var log = logging.Module("auth")
 
 // Authenticator verifies that the provided username/password is valid.
 type Authenticator interface {

--- a/internal/blobtesting/faulty.go
+++ b/internal/blobtesting/faulty.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("faulty-storage")
+var log = logging.Module("faulty-storage")
 
 // Fault describes the behavior of a single fault.
 type Fault struct {

--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("cache")
+var log = logging.Module("cache")
 
 const (
 	// DefaultSweepFrequency is how frequently the contents of cache are sweeped to remove excess data.

--- a/internal/connection/reconnector.go
+++ b/internal/connection/reconnector.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("connection")
+var log = logging.Module("connection")
 
 // Connection encapsulates a single connection.
 type Connection interface {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -19,7 +19,7 @@ import (
 
 const dirMode = 0o700
 
-var log = logging.GetContextLoggerFunc("diff")
+var log = logging.Module("diff")
 
 // Comparer outputs diff information between two filesystems.
 type Comparer struct {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("editor")
+var log = logging.Module("editor")
 
 // EditLoop launches OS-specific editor (VI, notepad.exe or another editor configured through environment variables)
 // It creates a temporary file with 'initial' contents and repeatedly invokes the editor until the provided 'parse' function

--- a/internal/fshasher/fshasher.go
+++ b/internal/fshasher/fshasher.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("kopia/internal/fshasher")
+var log = logging.Module("kopia/internal/fshasher")
 
 // Hash computes a recursive hash of e using the given hasher h.
 func Hash(ctx context.Context, e fs.Entry) ([]byte, error) {

--- a/internal/fusemount/fusefs.go
+++ b/internal/fusemount/fusefs.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("fuse")
+var log = logging.Module("fuse")
 
 const fakeBlockSize = 4096
 

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("gather")
+var log = logging.Module("gather")
 
 // WriteBuffer is a write buffer for content of unknown size that manages
 // data in a series of byte slices of uniform size.

--- a/internal/listcache/listcache.go
+++ b/internal/listcache/listcache.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("listcache")
+var log = logging.Module("listcache")
 
 type listCacheStorage struct {
 	blob.Storage

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -76,7 +76,7 @@ func Attach(app *kingpin.Application) {
 	lf.setup(app)
 }
 
-var log = repologging.GetContextLoggerFunc("kopia")
+var log = repologging.Module("kopia")
 
 const (
 	logFileNamePrefix = "kopia-"

--- a/internal/memtrack/memtrack.go
+++ b/internal/memtrack/memtrack.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("memtrack")
+var log = logging.Module("memtrack")
 
 type tracker struct {
 	name                                  string

--- a/internal/mount/mount.go
+++ b/internal/mount/mount.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("mount")
+var log = logging.Module("mount")
 
 // Controller allows controlling mounts.
 type Controller interface {

--- a/internal/ownwrites/ownwrites.go
+++ b/internal/ownwrites/ownwrites.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("ownwrites")
+var log = logging.Module("ownwrites")
 
 const (
 	sweepFrequency = 5 * time.Minute

--- a/internal/passwordpersist/passwordpersist.go
+++ b/internal/passwordpersist/passwordpersist.go
@@ -15,7 +15,7 @@ var ErrPasswordNotFound = errors.Errorf("password not found")
 // ErrUnsupported is returned when a password storage is not supported.
 var ErrUnsupported = errors.Errorf("password storage not supported")
 
-var log = logging.GetContextLoggerFunc("passwordpersist")
+var log = logging.Module("passwordpersist")
 
 // Strategy encapsulates persisting and fetching passwords.
 type Strategy interface {

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -46,7 +46,7 @@ var DefaultOptions = Options{
 
 const blobIDLength = 16
 
-var log = logging.GetContextLoggerFunc("providervalidation")
+var log = logging.Module("providervalidation")
 
 // ValidateProvider runs a series of tests against provided storage to validate that
 // it can be used with Kopia.

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("retry")
+var log = logging.Module("retry")
 
 var (
 	maxAttempts             = 10

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,7 +28,7 @@ import (
 	"github.com/kopia/kopia/snapshot/snapshotmaintenance"
 )
 
-var log = logging.GetContextLoggerFunc("kopia/server")
+var log = logging.Module("kopia/server")
 
 const (
 	maintenanceAttemptFrequency = 10 * time.Minute

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -29,7 +29,7 @@ const (
 	certificateFileMode = 0o600
 )
 
-var log = logging.GetContextLoggerFunc("tls")
+var log = logging.Module("tls")
 
 // GenerateServerCertificate generates random TLS certificate and key.
 func GenerateServerCertificate(ctx context.Context, keySize int, certValid time.Duration, names []string) (*x509.Certificate, *rsa.PrivateKey, error) {

--- a/internal/uitask/uitask_test.go
+++ b/internal/uitask/uitask_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	log        = logging.GetContextLoggerFunc("uitasktest")
-	ignoredLog = logging.GetContextLoggerFunc(content.FormatLogModule)
+	log        = logging.Module("uitasktest")
+	ignoredLog = logging.Module(content.FormatLogModule)
 )
 
 func TestUITask(t *testing.T) {

--- a/internal/webdavmount/webdavmount.go
+++ b/internal/webdavmount/webdavmount.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("kopia/webdavmount")
+var log = logging.Module("kopia/webdavmount")
 
 var (
 	_ os.FileInfo = webdavFileInfo{}

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	app := cli.NewApp()
 	kp := kingpin.New("kopia", "Kopia - Fast And Secure Open-Source Backup").Author("http://kopia.github.io/")
 
-	logging.SetDefault(func(module string) logging.Logger {
+	app.SetLoggerFactory(func(module string) logging.Logger {
 		return gologging.MustGetLogger(module)
 	})
 

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -23,7 +23,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("repo/filesystem")
+var log = logging.Module("repo/filesystem")
 
 const (
 	fsStorageType           = "filesystem"

--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -32,7 +32,7 @@ const (
 	rcloneStartupTimeout = 15 * time.Second
 )
 
-var log = logging.GetContextLoggerFunc("rclone")
+var log = logging.Module("rclone")
 
 type rcloneStorage struct {
 	blob.Storage // the underlying WebDAV storage used to implement all methods.

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -28,7 +28,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("sftp")
+var log = logging.Module("sftp")
 
 const (
 	sftpStorageType         = "sftp"

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -21,7 +21,7 @@ import (
 // CompleteBlobSuffix is the extension for sharded blobs that have completed writing.
 const CompleteBlobSuffix = ".f"
 
-var log = logging.GetContextLoggerFunc("sharded")
+var log = logging.Module("sharded")
 
 // Impl must be implemented by underlying provided.
 type Impl interface {

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -531,7 +531,7 @@ func NewSharedManager(ctx context.Context, st blob.Storage, f *FormattingOptions
 	var internalLog *internalLogger
 
 	// capture logger (usually console or log file) associated with current context.
-	sharedBaseLogger := logging.GetContextLoggerFunc(FormatLogModule)(ctx)
+	sharedBaseLogger := logging.Module(FormatLogModule)(ctx)
 
 	if !opts.DisableInternalLog {
 		internalLog = ilm.NewLogger()

--- a/repo/logging/ctx.go
+++ b/repo/logging/ctx.go
@@ -1,16 +1,35 @@
 package logging
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
 type contextKey string
 
-const loggerKey contextKey = "logger"
+const loggerCacheKey contextKey = "logger"
+
+type loggerCache struct {
+	createLoggerForModule LoggerFactory
+	loggers               sync.Map
+}
+
+func (s *loggerCache) getLogger(module string) Logger {
+	v, ok := s.loggers.Load(module)
+	if !ok {
+		v, _ = s.loggers.LoadOrStore(module, s.createLoggerForModule(module))
+	}
+
+	return v.(Logger)
+}
 
 // WithLogger returns a derived context with associated logger.
-func WithLogger(ctx context.Context, l LoggerForModuleFunc) context.Context {
+func WithLogger(ctx context.Context, l LoggerFactory) context.Context {
 	if l == nil {
 		l = getNullLogger
 	}
 
-	return context.WithValue(ctx, loggerKey, l)
+	return context.WithValue(ctx, loggerCacheKey, &loggerCache{
+		createLoggerForModule: l,
+	})
 }

--- a/repo/logging/logging_test.go
+++ b/repo/logging/logging_test.go
@@ -1,6 +1,7 @@
 package logging_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -52,4 +53,15 @@ func TestBroadcast(t *testing.T) {
 		"[first] C",
 		"[second] C",
 	}, lines)
+}
+
+func BenchmarkLogger(b *testing.B) {
+	mod1 := logging.Module("mod1")
+	ctx := logging.WithLogger(context.Background(), logging.Printf(b.Logf))
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		mod1(ctx)
+	}
 }

--- a/repo/logging/null_logger.go
+++ b/repo/logging/null_logger.go
@@ -6,6 +6,8 @@ func (nullLogger) Debugf(msg string, args ...interface{}) {}
 func (nullLogger) Infof(msg string, args ...interface{})  {}
 func (nullLogger) Errorf(msg string, args ...interface{}) {}
 
+var nullLoggerInstance = nullLogger{}
+
 func getNullLogger(module string) Logger {
-	return nullLogger{}
+	return nullLoggerInstance
 }

--- a/repo/logging/printf_logger.go
+++ b/repo/logging/printf_logger.go
@@ -16,14 +16,14 @@ func (l *printfLogger) Infof(msg string, args ...interface{})  { l.printf(l.pref
 func (l *printfLogger) Errorf(msg string, args ...interface{}) { l.printf(l.prefix+msg, args...) }
 
 // Printf returns LoggerForModuleFunc that uses given printf-style function to print log output.
-func Printf(printf func(msg string, args ...interface{})) LoggerForModuleFunc {
+func Printf(printf func(msg string, args ...interface{})) LoggerFactory {
 	return func(module string) Logger {
 		return &printfLogger{printf, "[" + module + "] "}
 	}
 }
 
 // Writer returns LoggerForModuleFunc that uses given writer for log output.
-func Writer(w io.Writer) LoggerForModuleFunc {
+func Writer(w io.Writer) LoggerFactory {
 	printf := func(msg string, args ...interface{}) {
 		msg = fmt.Sprintf(msg, args...)
 

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.GetContextLoggerFunc("maintenance")
+var log = logging.Module("maintenance")
 
 const maxClockSkew = 5 * time.Minute
 

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -24,7 +24,7 @@ const (
 	manifestIDLength        = 16
 )
 
-var log = logging.GetContextLoggerFunc("kopia/manifest")
+var log = logging.Module("kopia/manifest")
 
 // ErrNotFound is returned when the metadata item is not found.
 var ErrNotFound = errors.New("not found")

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kopia/kopia/repo/splitter"
 )
 
-var log = logging.GetContextLoggerFunc("object")
+var log = logging.Module("object")
 
 const indirectContentPrefix = "x"
 

--- a/repo/open.go
+++ b/repo/open.go
@@ -49,7 +49,7 @@ const cacheDirMarkerContents = CacheDirMarkerHeader + `
 #   http://www.brynosaurus.com/cachedir/
 `
 
-var log = logging.GetContextLoggerFunc("kopia/repo")
+var log = logging.Module("kopia/repo")
 
 // Options provides configuration parameters for connection to a repository.
 type Options struct {

--- a/snapshot/manager.go
+++ b/snapshot/manager.go
@@ -31,7 +31,7 @@ const (
 	loadSnapshotsConcurrency = 50 // number of snapshots to load in parallel
 )
 
-var log = logging.GetContextLoggerFunc("kopia/snapshot")
+var log = logging.Module("kopia/snapshot")
 
 // ListSources lists all snapshot sources in a given repository.
 func ListSources(ctx context.Context, rep repo.Repository) ([]SourceInfo, error) {

--- a/snapshot/policy/policy_manager.go
+++ b/snapshot/policy/policy_manager.go
@@ -35,7 +35,7 @@ const typeKey = manifest.TypeLabelKey
 // GlobalPolicySourceInfo is a source where global policy is attached.
 var GlobalPolicySourceInfo = snapshot.SourceInfo{}
 
-var log = logging.GetContextLoggerFunc("kopia/snapshot/policy")
+var log = logging.Module("kopia/snapshot/policy")
 
 // GetEffectivePolicy calculates effective snapshot policy for a given source by combining the source-specifc policy (if any)
 // with parent policies. The source must contain a path.

--- a/snapshot/restore/restore.go
+++ b/snapshot/restore/restore.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kopia/kopia/snapshot"
 )
 
-var log = logging.GetContextLoggerFunc("restore")
+var log = logging.Module("restore")
 
 // Output encapsulates output for restore operation.
 type Output interface {

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -32,7 +32,7 @@ import (
 // DefaultCheckpointInterval is the default frequency of mid-upload checkpointing.
 const DefaultCheckpointInterval = 45 * time.Minute
 
-var log = logging.GetContextLoggerFunc("snapshotfs")
+var log = logging.Module("snapshotfs")
 
 var errCanceled = errors.New("canceled")
 

--- a/snapshot/snapshotgc/gc.go
+++ b/snapshot/snapshotgc/gc.go
@@ -20,7 +20,7 @@ import (
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
 
-var log = logging.GetContextLoggerFunc("snapshotgc")
+var log = logging.Module("snapshotgc")
 
 func oidOf(entry fs.Entry) object.ID {
 	return entry.(object.HasObjectID).ObjectID()


### PR DESCRIPTION
This has minor improvement on memory allocations due to logging, but not really that significant. Will be used to migrate to another logger library.

Also renamed some logging helpers.

#1345 