### PR TITLE
Unicode Filename testing & Switches for test selection

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -23,6 +23,10 @@ env:
   NON_TAG_RELEASE_REPO: ${{ secrets.NON_TAG_RELEASE_REPO }}
   # RPM and APT packages GCS bucket/hostname.
   PACKAGES_HOST: ${{ secrets.PACKAGES_HOST }}
+  # set (to any value other than false) to trigger random unicode filenames testing (logs may be difficult to read)
+  ENABLE_UNICODE_FILENAMES: ${{ secrets.ENABLE_UNICODE_FILENAMES }}
+  # set (to any value other than false) to trigger very long filenames testing
+  ENABLE_LONG_FILENAMES: ${{ secrets.ENABLE_LONG_FILENAMES }}
 jobs:
   build:
     strategy:

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -54,6 +54,30 @@ func ShouldReduceTestComplexity() bool {
 	return strings.Contains(runtime.GOARCH, "arm")
 }
 
+// ShouldSkipUnicodeFilenames returns true if:
+// an environmental variable is unset, set to false, test is running on ARM, or if running race detection.
+func ShouldSkipUnicodeFilenames() bool {
+	val, enable := os.LookupEnv("ENABLE_UNICODE_FILENAMES")
+
+	if !enable || isRaceDetector || strings.EqualFold(val, "false") {
+		return true
+	}
+
+	return strings.Contains(runtime.GOARCH, "arm")
+}
+
+// ShouldSkipLongFilenames returns true if:
+// an environmental variable is unset, set to false, test is running on ARM, or if running race detection.
+func ShouldSkipLongFilenames() bool {
+	val, enable := os.LookupEnv("ENABLE_LONG_FILENAMES")
+
+	if !enable || isRaceDetector || strings.EqualFold(val, "false") {
+		return true
+	}
+
+	return strings.Contains(runtime.GOARCH, "arm")
+}
+
 // MyTestMain runs tests and verifies some post-run invariants.
 func MyTestMain(m *testing.M) {
 	v := m.Run()

--- a/tests/end_to_end_test/main_test.go
+++ b/tests/end_to_end_test/main_test.go
@@ -28,10 +28,13 @@ func oneTimeSetup() error {
 		return errors.Wrap(err, "unable to create data directory")
 	}
 
-	// make sure the base directory is quite long to trigger very long filenames on Windows.
-	if n, targetLen := len(sharedTestDataDirBase), 270; n < targetLen {
-		sharedTestDataDirBase = filepath.Join(sharedTestDataDirBase, strings.Repeat("f", targetLen-n))
-		os.MkdirAll(sharedTestDataDirBase, 0o700)
+	// if enabled, make sure the base directory is quite long to trigger very long filenames on Windows
+	// skipped during race detection, on ARM, and by default to keep logs cleaner
+	if !testutil.ShouldSkipLongFilenames() {
+		if n, targetLen := len(sharedTestDataDirBase), 270; n < targetLen {
+			sharedTestDataDirBase = filepath.Join(sharedTestDataDirBase, strings.Repeat("f", targetLen-n))
+			os.MkdirAll(sharedTestDataDirBase, 0o700)
+		}
 	}
 
 	var counters1, counters2, counters3 testdirtree.DirectoryTreeCounters


### PR DESCRIPTION
hello! i think i got it this time around.

two new env variables are added to the workflow, one for the random unicode filename generation and one for the long filename test. 

based on the comment above `MaybeSimplifyFilesystem`, i thought it might be wise to have long filenames and unicode filenames disabled based on the same requirements, in addition to having them disabled by default to prevent log file clutter.

there's also a few more checks now on writing out the unicode filenames because [APFS doesn't handle unicode quite as expected](https://eclecticlight.co/2021/05/08/explainer-unicode-normalization-and-apfs/). the first, `utf8.ValidRune` checks that the rune can be represented properly in UTF8, and is probably overkill but it did resolve a weird edge case i found. i'm also normalizing the string from `randomUnicodeName` to NFKD before passing it off to be written. Windows/Linux will gracefully handle converting that to NFC, where as mac has the potential to choke on a non-normalized string.

lastly, i clipped the CJK character range because there are a few rarely used runes at the end of it that cause the test to choke, and a user wouldn't be able to name a file using those runes anyways (at least on mac)