### PR TITLE
KopiaUI: add cli flag framework and starting flags

### DIFF
--- a/app/public/cli.js
+++ b/app/public/cli.js
@@ -1,0 +1,149 @@
+const log = require("electron-log")
+const fs = require('fs');
+const path = require('path');
+
+const { app } = require("electron")
+
+const cliArgs = process.argv
+const configFileSuffix = ".config";
+
+let hasCliConfigFlag = false;
+let hasPortableFlag = false;
+let hasLogDirFlag = false;
+let hasCacheDirFlag = false;
+
+function invalidConfigFile(file) {
+    log.error(`invalid configuration file passed on command line: ${file}`);
+    console.log(`Error: Invalid configuration file passed on command line.\
+                 File Name: ${file}\
+                 Valid configuration files end in ${configFileSuffix}.\
+                 Exiting...`);
+    app.exit(1);
+}
+
+function configFileNotFound(file) {
+    log.error(`unable to locate configuration file: ${file}`);
+    console.log(`Error: Unable to verify existance of configuration file.\
+                 File Name: ${file}\
+                 Please check that the path is correct and try again.\
+                 Exiting...`);
+    app.exit(1);
+}
+
+// this isn't pretty but it doesn't require any additional dependencies.
+function outputHelp() {
+    console.log(`usage: ${app.getPath('exe')} [<flags>]`);
+    console.log(``);
+    console.log(`KopiaUI - Fast And Secure Open-Source Backup`);
+    console.log(``);
+    console.log(`Flags:`);
+    console.log(`    --help                    Shows this help message.`);
+    console.log(`    --portable                Runs the UI in portable mode.`)
+    console.log(`    --config-file="<file>"    Specify the configuration file used.`);
+    console.log(`    --log-dir="<dir>"         Specify the directory where logs should be stored.`)
+    console.log(`    --cache-directory="<dir>  Specify the directory where cache files should be stored.`);
+    console.log(``);
+    console.log(`Usage Notes:`);
+    console.log(`    You can call each flag multiple times without causing an error.`);
+    console.log(`    However, only --config-file will have each file read and opened in the UI.`);
+    console.log(`    For cache-directory and log-dir, only the first invokation will be used.`);
+    console.log(``);
+    console.log(`    log-dir will place repository logs into the provided directory regardless`);
+    console.log(`    of additional flags.`);
+    console.log(``);
+    console.log(`    Because --cache-directory rewrites part of the repository configuration, it is only`);
+    console.log(`    used when either --config-file or --portable is called.`)
+    console.log(``);
+    console.log(`    Calling --portable without additional options will launch the UI in portable mode,`);
+    console.log(`    and create the required directory structure.`);
+    console.log(``);
+    console.log(`    Calling --portable with --config-file will place the repository's cache and log`);
+    console.log(`    files in the same directory as the configuration file.`);
+    console.log(``);
+    console.log(`    Calling --config-file without --portable will use the standard Kopia directory`);
+    console.log(`    locations.`);
+    console.log(``);
+    console.log(`    Calling --config-file will put the UI into a manual configuration mode, and you`);
+    console.log(`    will not be able to connect to new repositories. Please use the kopia command`);
+    console.log(`    to create your repository configurations via the following layout:`);
+    console.log(`        kopia --config-file=<path>/<file>.config repository connect <args>`);
+}
+
+module.exports = {
+
+    hasPortableFlag() {
+        return hasPortableFlag;
+    },
+
+    hasCliConfigFlag() {
+        return hasCliConfigFlag;
+    },
+
+    hasLogDirFlag() {
+        return hasLogDirFlag;
+    },
+
+    hasCacheDirFlag() {
+        return hasCacheDirFlag;
+    },
+
+    parseCliFlags() {
+        if (cliArgs.some(f => f.includes("--config-file"))) {
+            hasCliConfigFlag = true;
+        }
+        if (cliArgs.some(f => f.includes("--portable"))) {
+            hasPortableFlag = true;
+        }
+        if (cliArgs.some(f => f.includes("--log-dir"))) {
+            hasLogDirFlag = true;
+        }
+        if (cliArgs.some(f => f.includes("--cache-directory"))) {
+            hasCacheDirFlag = true;
+        }
+        if (cliArgs.some(f => f.includes("--help"))) {
+            outputHelp();
+            app.exit(0);
+        }
+    },
+
+    returnCliConfig() {
+        let result = {}
+
+        cliArgs.forEach(i => {
+            if (i.includes("--config-file")) {
+                let file = i.replace("--config-file=", "");
+                if (!file.includes(configFileSuffix)) {
+                    invalidConfigFile(file);
+                }
+                if (!fs.existsSync(file)) {
+                    configFileNotFound(file);
+                }
+                let repoID = path.basename(file, configFileSuffix);
+                result[repoID] = path.resolve(file);
+            }
+        })
+
+        return result;
+    },
+
+    returnCliLogDir() {
+        cliArgs.forEach(i => {
+            if (i.includes("--log-dir=")) {
+                return i.replace("--log-dir=", "").replace('"', "");
+            }
+        })
+    },
+
+    returnCliCacheDir() {
+        cliArgs.forEach(i => {
+            if (i.includes("--cache-directory=")) {
+                return i.replace("--cache-directory=", "").replace('"', "");
+            }
+        })
+    },
+
+    returnConfigFileSuffix() {
+        return configFileSuffix;
+    }
+
+}

--- a/app/public/config.js
+++ b/app/public/config.js
@@ -1,14 +1,69 @@
 const fs = require('fs');
 const path = require('path');
-const Electron = require('electron');
-const log = require("electron-log");
+const { app, ipcMain } = require("electron");
+const { hasCliConfigFlag, returnConfigFileSuffix, returnCliConfig, hasPortableFlag, hasLogDirFlag, returnCliLogDir, hasCacheDirFlag, returnCliCacheDir } = require('./cli');
 
 let configs = {};
-const configFileSuffix = ".config";
 
 let configDir = "";
 let isPortable = false;
 let firstRun = false;
+
+function checkForPortableConfig() {
+    if (hasPortableFlag() && hasCliConfigFlag()) {
+        isPortable = true;
+    } else {
+        globalConfigDir();
+    }
+    return isPortable;
+}
+
+function updateCacheDir(repoID) {
+    if (firstRun) {
+        return;
+    }
+    let configuration = JSON.parse(fs.readFileSync(configs[repoID]));
+    let cacheDir = "";
+
+    if (hasCliConfigFlag() && isPortable) {
+        // put the cache directory for the repository next to its config
+        // still add repoID to the path in the event there are multiple configs in one folder
+        cacheDir = path.join(path.dirname(configs[repoID]), "cache", repoID);
+    }
+    if (hasCliConfigFlag() && !isPortable) {
+        // put the cache directory in the standard non-portable location
+        cacheDir = path.join(app.getPath("appData"), "kopia", "cache", repoID);
+    }
+    if (!hasCliConfigFlag() && isPortable) {
+        // put the cache directory in the standard portable location
+        cacheDir = path.join(configDir, "cache", repoID);
+    }
+    if (hasCacheDirFlag()) {
+        // put manually specified cache directory last so it overrides above options
+        cacheDir = returnCliCacheDir();
+    }
+
+    configuration.caching.cacheDirectory = path.resolve(cacheDir);
+    fs.writeFileSync(configs[repoID], JSON.stringify(configuration, null, 2));
+
+    // return the new directory for logging purposes
+    return cacheDir;
+}
+
+function returnLogDir(repoID) {
+    if (hasLogDirFlag()) {
+        return returnCliLogDir;
+    }
+    if (hasCliConfigFlag() && isPortable) {
+        // put the log directory for the repository next to its config
+        // still add repoID to the path in the event there are multiple configs in one folder
+        return path.resolve(path.join(path.dirname(configs[repoID]), "logs", repoID));
+    }
+    if (!hasCliConfigFlag() && isPortable) {
+        // put the log directory in the standard portable location
+        return path.resolve(path.join(configDir, "logs", repoID));
+    }
+}
 
 // returns the list of directories to be checked for portable configurations
 function portableConfigDirs() {
@@ -18,20 +73,34 @@ function portableConfigDirs() {
         result.push(process.env.KOPIA_UI_PORTABLE_CONFIG_DIR);
     }
 
-    if (process.platform == "darwin") {
+    if (process.platform === "darwin") {
         // on Mac support 'repositories' directory next to the KopiaUI.app
-        result.push(path.join(path.dirname(Electron.app.getPath("exe")), "..", "..", "..", "repositories"));
+        result.push(path.join(path.dirname(app.getPath("exe")), "..", "..", "..", "repositories"));
     } else {
         // on other platforms support 'repositories' directory next to directory
         // containing executable or 'repositories' subdirectory.
-        result.push(path.join(path.dirname(Electron.app.getPath("exe")), "repositories"));
-        result.push(path.join(path.dirname(Electron.app.getPath("exe")), "..", "repositories"));
+        result.push(path.join(path.dirname(app.getPath("exe")), "repositories"));
+        result.push(path.join(path.dirname(app.getPath("exe")), "..", "repositories"));
     }
 
     return result;
 }
 
+function buildPortableLayout() {
+    let dir = "";
+    if (process.platform === "darwin") {
+        dir = path.join(path.dirname(app.getPath("exe")), "..", "..", "..", "repositories");
+        fs.mkdirSync(dir, { recursive: true, mode: parseInt('0700',8) });
+
+    } else {
+        dir = path.join(path.dirname(app.getPath("exe")), "repositories")
+        fs.mkdirSync(dir, { recursive: true, mode: parseInt('0700',8) });
+    }
+    configDir = dir;
+}
+
 function globalConfigDir() {
+
     if (!configDir) {
         // try portable config dirs in order.
         portableConfigDirs().forEach(d => {
@@ -39,7 +108,7 @@ function globalConfigDir() {
                 return;
             }
             
-            d = path.normalize(d)
+            d = path.normalize(d);
 
             if (!fs.existsSync(d)) {
                 return;
@@ -49,10 +118,15 @@ function globalConfigDir() {
             isPortable = true;
         });
 
+        if (!configDir && hasPortableFlag()) {
+            buildPortableLayout();
+            isPortable = true;
+        }
+
         // still not set, fall back to per-user config dir.
         // we use the same directory that is used by Kopia CLI.
         if (!configDir) {
-            configDir = path.join(Electron.app.getPath("appData"), "kopia");
+            configDir = path.join(app.getPath("appData"), "kopia");
         }
     }
 
@@ -79,16 +153,16 @@ function addNewConfig() {
         id = "repository-" + new Date().valueOf();
     }
 
-    configs[id] = true;
+    configs[id] = path.join(configDir, id);
     return id;
 }
 
-Electron.ipcMain.on('config-list-fetch', (event, arg) => {
+ipcMain.on('config-list-fetch', (event, arg) => {
     emitConfigListUpdated();
 });
 
 function emitConfigListUpdated() {
-    Electron.ipcMain.emit('config-list-updated-event', allConfigs());
+    ipcMain.emit('config-list-updated-event', allConfigs());
 };
 
 function deleteConfigIfDisconnected(repoID) {
@@ -97,7 +171,7 @@ function deleteConfigIfDisconnected(repoID) {
         return false;
     }
 
-    if (!fs.existsSync(path.join(globalConfigDir(), repoID + configFileSuffix))) {
+    if (!fs.existsSync(configs[repoID])) {
         delete (configs[repoID]);
         emitConfigListUpdated();
         return true;
@@ -106,26 +180,57 @@ function deleteConfigIfDisconnected(repoID) {
     return false;
 }
 
+function loadConfigsFromDir() {
+    fs.mkdirSync(globalConfigDir(), { recursive: true, mode: parseInt('0700',8) });
+    let entries = fs.readdirSync(globalConfigDir());
+
+    entries.filter(e => path.extname(e) === returnConfigFileSuffix()).forEach(v => {
+        const repoID = v.replace(returnConfigFileSuffix(), "");
+        configs[repoID] = path.join(globalConfigDir(), repoID + returnConfigFileSuffix());
+    });
+
+    if (!configs["repository"]) {
+        configs["repository"] = path.join(configDir, "repository.config");
+        firstRun = true;
+    }
+}
+
 module.exports = {
+
+    returnConfigPath(repoID) {
+        return configs[repoID];
+    },
+
+    returnLogDir(repoID) {
+        return returnLogDir(repoID);
+    },
+
+    updateCacheDir(repoID) {
+        return updateCacheDir(repoID);
+    },
+
     loadConfigs() {
-        fs.mkdirSync(globalConfigDir(), { recursive: true, mode: 0700 });
-        let entries = fs.readdirSync(globalConfigDir());
+        if (hasCliConfigFlag()) {
+            configs = returnCliConfig();
+        } else {
+            loadConfigsFromDir();
+        }
+    },
 
-        let count = 0;
-        entries.filter(e => path.extname(e) == configFileSuffix).forEach(v => {
-            const repoID = v.replace(configFileSuffix, "");
-            configs[repoID] = true;
-            count++;
-        });
-
-        if (!configs["repository"]) {
-            configs["repository"] = true;
-            firstRun = true;
+    setUserData() {
+        checkForPortableConfig();
+        if (isPortable) {
+            if (hasCliConfigFlag()) {
+              // in cli portable mode, we will put caches next to each folder, so set this to temp to avoid clutter.
+              app.setPath('userData', path.join(app.getPath("temp"), "KopiaUiCache"));
+            } else {
+              // in standard portable mode, write cache under 'repositories'
+              app.setPath('userData', path.join(configDir, 'cache'));
+            }
         }
     },
 
     isPortableConfig() {
-        globalConfigDir();
         return isPortable;
     },
 
@@ -141,16 +246,5 @@ module.exports = {
 
     addNewConfig,
 
-    allConfigs,
-
-    configForRepo(repoID) {
-        let c = configs[repoID];
-        if (c) {
-            return c;
-        }
-
-        configs[repoID] = true;
-        emitConfigListUpdated();
-        return c;
-    }
+    allConfigs
 }


### PR DESCRIPTION
this got a bit larger than i anticipated it being, and at this point i could use another set of eyes on it.

this modifies the UI to be able to parse specified cli flags in addition to the normal electron flags that can be passed. to start with, i added `--portable`, `--cache-directory`, `--log-dir`, `--help`, and `--config-file` to match the kopia cli, and to close #367.

this opens up a couple new features:
- calling the UI executable with just `--portable` will create the portable directory structure if it does not already exist.
- calling the UI executable with just `--config-file` will start the UI with connection(s) to the specified repository(ies). the cache/log location will be the same as the non-portable app.
- combining the two will put the cache-directory and the log-directory for each repository right next to the .config file.
- calling `--log-dir` will overwrite the log directory, period. so the UI will read configs from either portable/standard locations, but write log files to the specified location.
- calling `--cache-directory` by itself doesn't accomplish anything, because of the potential to mess up configs in the standard location
- there's a help output now that i tried to make match the cli

because the cache-directory is located in the config file, i wrote an update routine. this could probably be moved into the main binary, but i wasn't sure if that was desired/wanted there.

i also fixed misc. linter issues that i noticed.

i'm gonna leave this as a draft for the time being, no rush on reviewing it.