### PR TITLE
logging: fixed logging from parallel work queue

### DIFF
--- a/internal/parallelwork/parallel_work_queue.go
+++ b/internal/parallelwork/parallel_work_queue.go
@@ -61,7 +61,7 @@ func (v *Queue) enqueue(ctx context.Context, front bool, callback CallbackFunc) 
 func (v *Queue) Process(ctx context.Context, workers int) error {
 	defer v.reportProgress(ctx)
 
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(ctx)
 
 	for i := 0; i < workers; i++ {
 		eg.Go(func() error {


### PR DESCRIPTION
#1387 was caused by invalid context propagation passing context without a logger to callbacks.

Fixes #1387