### PR TITLE
localfs: added ReadDir() benchmark

### DIFF
--- a/fs/localfs/localfs_benchmark_test.go
+++ b/fs/localfs/localfs_benchmark_test.go
@@ -1,0 +1,61 @@
+package localfs_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/kopia/kopia/fs/localfs"
+)
+
+func BenchmarkReadDir0(b *testing.B) {
+	benchmarkReadDirWithCount(b, 0)
+}
+
+func BenchmarkReadDir1(b *testing.B) {
+	benchmarkReadDirWithCount(b, 1)
+}
+
+func BenchmarkReadDir2(b *testing.B) {
+	benchmarkReadDirWithCount(b, 2)
+}
+
+func BenchmarkReadDir10(b *testing.B) {
+	benchmarkReadDirWithCount(b, 10)
+}
+
+func BenchmarkReadDir100(b *testing.B) {
+	benchmarkReadDirWithCount(b, 100)
+}
+
+func BenchmarkReadDir1000(b *testing.B) {
+	benchmarkReadDirWithCount(b, 1000)
+}
+
+func BenchmarkReadDir10000(b *testing.B) {
+	benchmarkReadDirWithCount(b, 10000)
+}
+
+func benchmarkReadDirWithCount(b *testing.B, fileCount int) {
+	b.Helper()
+
+	b.StopTimer()
+
+	td := b.TempDir()
+
+	for i := 0; i < fileCount; i++ {
+		os.WriteFile(filepath.Join(td, uuid.NewString()), []byte{1, 2, 3, 4}, 0o644)
+	}
+
+	b.StartTimer()
+
+	ctx := context.Background()
+
+	for i := 0; i < b.N; i++ {
+		dir, _ := localfs.Directory(td)
+		dir.Readdir(ctx)
+	}
+}


### PR DESCRIPTION
```
$ go test -benchmem -count 5 -benchtime 5s -run=^$ -bench "^BenchmarkReadDir.*$" ./fs/localfs

goos: darwin
goarch: amd64
pkg: github.com/kopia/kopia/fs/localfs
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
BenchmarkReadDir0-8       	  206330	     28408 ns/op	    1880 B/op	      11 allocs/op
BenchmarkReadDir0-8       	  209636	     28399 ns/op	    1928 B/op	      11 allocs/op
BenchmarkReadDir0-8       	  208366	     28569 ns/op	    1880 B/op	      11 allocs/op
BenchmarkReadDir0-8       	  203073	     28888 ns/op	    1880 B/op	      11 allocs/op
BenchmarkReadDir0-8       	  209492	     28477 ns/op	    1928 B/op	      11 allocs/op
BenchmarkReadDir1-8       	  163614	     37236 ns/op	    3736 B/op	      21 allocs/op
BenchmarkReadDir1-8       	  151528	     38796 ns/op	    3736 B/op	      21 allocs/op
BenchmarkReadDir1-8       	  161023	     38420 ns/op	    3736 B/op	      21 allocs/op
BenchmarkReadDir1-8       	  153543	     37262 ns/op	    3736 B/op	      21 allocs/op
BenchmarkReadDir1-8       	  165090	     36362 ns/op	    3736 B/op	      21 allocs/op
BenchmarkReadDir2-8       	  137521	     43338 ns/op	    4456 B/op	      30 allocs/op
BenchmarkReadDir2-8       	  138085	     43866 ns/op	    4456 B/op	      30 allocs/op
BenchmarkReadDir2-8       	  136701	     43389 ns/op	    4456 B/op	      30 allocs/op
BenchmarkReadDir2-8       	  138116	     43342 ns/op	    4456 B/op	      30 allocs/op
BenchmarkReadDir2-8       	  138170	     43379 ns/op	    4456 B/op	      30 allocs/op
BenchmarkReadDir10-8      	   62124	     96602 ns/op	   10104 B/op	      76 allocs/op
BenchmarkReadDir10-8      	   60532	     97361 ns/op	   10104 B/op	      76 allocs/op
BenchmarkReadDir10-8      	   61009	     97615 ns/op	   10104 B/op	      76 allocs/op
BenchmarkReadDir10-8      	   62072	     96550 ns/op	   10104 B/op	      76 allocs/op
BenchmarkReadDir10-8      	   62220	     95925 ns/op	   10104 B/op	      76 allocs/op
BenchmarkReadDir100-8     	    8028	    716714 ns/op	   80763 B/op	     544 allocs/op
BenchmarkReadDir100-8     	    8066	    712266 ns/op	   80755 B/op	     544 allocs/op
BenchmarkReadDir100-8     	    8047	    712203 ns/op	   80755 B/op	     544 allocs/op
BenchmarkReadDir100-8     	    8107	    711148 ns/op	   80752 B/op	     544 allocs/op
BenchmarkReadDir100-8     	    8127	    709227 ns/op	   80753 B/op	     544 allocs/op
BenchmarkReadDir1000-8    	    1558	   3861176 ns/op	  689409 B/op	    5137 allocs/op
BenchmarkReadDir1000-8    	    1566	   3848730 ns/op	  689414 B/op	    5137 allocs/op
BenchmarkReadDir1000-8    	    1516	   3838727 ns/op	  689412 B/op	    5137 allocs/op
BenchmarkReadDir1000-8    	    1550	   3833432 ns/op	  689415 B/op	    5137 allocs/op
BenchmarkReadDir1000-8    	    1557	   3966338 ns/op	  689408 B/op	    5137 allocs/op
BenchmarkReadDir10000-8   	     178	  33901454 ns/op	 7282295 B/op	   51046 allocs/op
BenchmarkReadDir10000-8   	     177	  33865198 ns/op	 7282296 B/op	   51046 allocs/op
BenchmarkReadDir10000-8   	     172	  34687834 ns/op	 7282354 B/op	   51047 allocs/op
BenchmarkReadDir10000-8   	     174	  34483220 ns/op	 7282359 B/op	   51047 allocs/op
BenchmarkReadDir10000-8   	     178	  34227937 ns/op	 7282307 B/op	   51047 allocs/op
PASS
ok  	github.com/kopia/kopia/fs/localfs	268.048s
```