### PR TITLE
ui: fixed snapshotting UNC roots

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters-settings:
     - time.Now # use clock.Now
     - time.Since # use clock.Since
     - time.Until # use clock.Until
+    - filepath.IsAbs # use ospath.IsAbs which supports windows UNC paths
   gocognit:
     min-complexity: 40
   gocyclo:

--- a/cli/storage_filesystem.go
+++ b/cli/storage_filesystem.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/alecthomas/kingpin"
@@ -44,7 +43,7 @@ func (c *storageFilesystemFlags) connect(ctx context.Context, isNew bool) (blob.
 
 	fso.Path = ospath.ResolveUserFriendlyPath(fso.Path, false)
 
-	if !filepath.IsAbs(fso.Path) {
+	if !ospath.IsAbs(fso.Path) {
 		return nil, errors.Errorf("filesystem repository path must be absolute")
 	}
 

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -3,11 +3,12 @@ package atomicfile
 
 import (
 	"io"
-	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/natefinch/atomic"
+
+	"github.com/kopia/kopia/internal/ospath"
 )
 
 // Do not prefix files shorter than this, we are intentionally using less than MAX_PATH
@@ -31,7 +32,7 @@ func MaybePrefixLongFilenameOnWindows(fname string) string {
 
 	fname = strings.TrimPrefix(fname, "\\\\?\\")
 
-	if !filepath.IsAbs(fname) {
+	if !ospath.IsAbs(fname) {
 		// only convert absolute paths
 		return fname
 	}

--- a/internal/cache/cache_storage.go
+++ b/internal/cache/cache_storage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/ctxutil"
+	"github.com/kopia/kopia/internal/ospath"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/filesystem"
 )
@@ -28,7 +29,7 @@ func NewStorageOrNil(ctx context.Context, cacheDir string, maxBytes int64, subdi
 		return nil, nil
 	}
 
-	if !filepath.IsAbs(cacheDir) {
+	if !ospath.IsAbs(cacheDir) {
 		return nil, errors.Errorf("cache dir %q was not absolute", cacheDir)
 	}
 

--- a/internal/ospath/ospath_test.go
+++ b/internal/ospath/ospath_test.go
@@ -1,0 +1,71 @@
+package ospath_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/ospath"
+)
+
+func TestIsAbs(t *testing.T) {
+	var absCases []string
+
+	notAbsCases := []string{
+		"foo",
+		"foo/",
+		"foo/bar",
+		"./foo",
+		"./foo/bar",
+		"../foo",
+		"../foo/",
+		"../foo/bar",
+		".",
+		"..",
+		"../",
+		"../..",
+	}
+
+	if runtime.GOOS == "windows" {
+		absCases = append(absCases,
+			"c:\\",
+			"c:\\foo",
+			"c:\\foo\\",
+			"c:\\foo\\bar",
+			"\\\\host\\share",
+			"\\\\host\\share\\",
+			"\\\\host\\share\\subdir",
+		)
+
+		notAbsCases = append(notAbsCases,
+			"..\\",
+			"..\\..",
+			"foo",
+			"foo\\",
+			"foo\\bar",
+			".\\foo",
+			".\\foo\\bar",
+			"..\\foo",
+			"..\\foo\\",
+			"..\\foo\\bar",
+			"\\\\host",
+			"\\\\host\\",
+		)
+	} else {
+		absCases = append(absCases,
+			"/",
+			"/foo",
+			"/foo/",
+			"/foo/bar",
+		)
+	}
+
+	for _, tc := range absCases {
+		require.True(t, ospath.IsAbs(tc), tc)
+	}
+
+	for _, tc := range notAbsCases {
+		require.False(t, ospath.IsAbs(tc), tc)
+	}
+}

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -22,6 +21,7 @@ import (
 	"github.com/kopia/kopia/internal/connection"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/iocopy"
+	"github.com/kopia/kopia/internal/ospath"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/retrying"
 	"github.com/kopia/kopia/repo/blob/sharded"
@@ -325,7 +325,7 @@ func getHostKeyCallback(opt *Options) (ssh.HostKeyCallback, error) {
 		return knownhosts.New(tmpFile)
 	}
 
-	if f := opt.knownHostsFile(); !filepath.IsAbs(f) {
+	if f := opt.knownHostsFile(); !ospath.IsAbs(f) {
 		return nil, errors.Errorf("known hosts path must be absolute")
 	}
 
@@ -346,7 +346,7 @@ func getSigner(opt *Options) (ssh.Signer, error) {
 	} else {
 		var err error
 
-		if f := opt.Keyfile; !filepath.IsAbs(f) {
+		if f := opt.Keyfile; !ospath.IsAbs(f) {
 			return nil, errors.Errorf("key file path must be absolute")
 		}
 

--- a/repo/connect.go
+++ b/repo/connect.go
@@ -3,11 +3,11 @@ package repo
 import (
 	"context"
 	"os"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/ospath"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
 )
@@ -86,7 +86,7 @@ func Disconnect(ctx context.Context, configFile string) error {
 	}
 
 	if cfg.Caching != nil && cfg.Caching.CacheDirectory != "" {
-		if !filepath.IsAbs(cfg.Caching.CacheDirectory) {
+		if !ospath.IsAbs(cfg.Caching.CacheDirectory) {
 			return errors.Errorf("cache directory was not absolute, refusing to delete")
 		}
 

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/atomicfile"
+	"github.com/kopia/kopia/internal/ospath"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/object"
@@ -141,12 +142,12 @@ func LoadConfigFromFile(fileName string) (*LocalConfig, error) {
 
 	// cache directory is stored as relative to config file name, resolve it to absolute.
 	if lc.Caching != nil {
-		if lc.Caching.CacheDirectory != "" && !filepath.IsAbs(lc.Caching.CacheDirectory) {
+		if lc.Caching.CacheDirectory != "" && !ospath.IsAbs(lc.Caching.CacheDirectory) {
 			lc.Caching.CacheDirectory = filepath.Join(filepath.Dir(fileName), lc.Caching.CacheDirectory)
 		}
 
 		// override cache directory from the environment variable.
-		if cd := os.Getenv("KOPIA_CACHE_DIRECTORY"); cd != "" && filepath.IsAbs(cd) {
+		if cd := os.Getenv("KOPIA_CACHE_DIRECTORY"); cd != "" && ospath.IsAbs(cd) {
 			lc.Caching.CacheDirectory = cd
 		}
 	}

--- a/repo/local_config_test.go
+++ b/repo/local_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kopia/kopia/internal/ospath"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/content"
 )
@@ -31,7 +32,7 @@ func TestLocalConfig_withCaching(t *testing.T) {
 	loadedLC, err := LoadConfigFromFile(cfgFile)
 	require.NoError(t, err)
 
-	if filepath.IsAbs(rawLC.Caching.CacheDirectory) {
+	if ospath.IsAbs(rawLC.Caching.CacheDirectory) {
 		t.Fatalf("cache directory must be stored relative, was %v", rawLC.Caching.CacheDirectory)
 	}
 

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -97,6 +97,10 @@ TOOLS_DIR:=$(SELF_DIR)$(slash).tools
 
 retry:=$(SELF_DIR)/retry.sh
 
+ifeq ($(GOOS),windows)
+retry:=
+endif
+
 # tool versions
 GOLANGCI_LINT_VERSION=1.42.1
 NODE_VERSION=14.17.6


### PR DESCRIPTION
This was caused by additional resolution of path names only done in UI,
which caused `\\hostname\share `to be treated as relative and resolved
against the home directory.

Fixes #1385
Fixes #1362