### PR TITLE
epoch: do not fail on moving deletion watermark backwards

### DIFF
--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -182,7 +182,9 @@ func (e *Manager) AdvanceDeletionWatermark(ctx context.Context, ts time.Time) er
 	}
 
 	if ts.Before(cs.DeletionWatermark) {
-		return errors.Errorf("deletion watermark time cannot move backwards")
+		e.log.Debugf("ignoring attempt to move deletion watermark time backwards (%v < %v)", ts.Format(time.RFC3339), cs.DeletionWatermark.Format(time.RFC3339))
+
+		return nil
 	}
 
 	blobID := blob.ID(fmt.Sprintf("%v%v", string(DeletionWatermarkBlobPrefix), ts.Unix()))

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -464,7 +464,7 @@ func verifySequentialWrites(t *testing.T, te *epochManagerTestEnv) {
 		if indexNum%13 == 0 {
 			ts := te.ft.NowFunc()().Truncate(time.Second)
 			require.NoError(t, te.mgr.AdvanceDeletionWatermark(ctx, ts))
-			require.Error(t, te.mgr.AdvanceDeletionWatermark(ctx, ts.Add(-time.Second)))
+			require.NoError(t, te.mgr.AdvanceDeletionWatermark(ctx, ts.Add(-time.Second)))
 			lastDeletionWatermark = ts
 		}
 	}


### PR DESCRIPTION
This is a legitimate possiblity if someone uses `--safety=none` followed
by regular maintenance.

Fixes #1312