### PR TITLE
clock: switched to using wall clock time

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,9 +13,9 @@ linters-settings:
     - ioutil.TempDir # use os.MkdirTemp
     - ioutil.TempFile # use os.CreateTemp
     - ioutil.WriteFile # use os.WriteFile
-    - time.Now # use clock.Now
-    - time.Since # use clock.Since
-    - time.Until # use clock.Until
+    - time.Now # use clock.WallClockTime except for local duration measurement
+    - time.Since # use only for local duration measurement
+    - time.Until # use only for local duration measurement
     - filepath.IsAbs # use ospath.IsAbs which supports windows UNC paths
   gocognit:
     min-complexity: 40

--- a/cli/command_logs_session.go
+++ b/cli/command_logs_session.go
@@ -48,13 +48,13 @@ func (c *logSelectionCriteria) filterLogSessions(allSessions []*logSessionInfo) 
 
 	if c.youngerThan > 0 {
 		allSessions = filterLogSessions(allSessions, func(ls *logSessionInfo) bool {
-			return clock.Since(ls.startTime) < c.youngerThan
+			return clock.WallClockTime().Sub(ls.startTime) < c.youngerThan
 		})
 	}
 
 	if c.olderThan > 0 {
 		allSessions = filterLogSessions(allSessions, func(ls *logSessionInfo) bool {
-			return clock.Since(ls.startTime) > c.olderThan
+			return clock.WallClockTime().Sub(ls.startTime) > c.olderThan
 		})
 	}
 

--- a/cli/command_maintenance_info.go
+++ b/cli/command_maintenance_info.go
@@ -97,7 +97,7 @@ func (c *commandMaintenanceInfo) displayCycleInfo(cp *maintenance.CycleParams, t
 		c.out.printStdout("  interval: %v\n", cp.Interval)
 
 		if rep.Time().Before(t) {
-			c.out.printStdout("  next run: %v (in %v)\n", formatTimestamp(t), clock.Until(t).Truncate(time.Second))
+			c.out.printStdout("  next run: %v (in %v)\n", formatTimestamp(t), t.Sub(clock.WallClockTime()).Truncate(time.Second))
 		} else {
 			c.out.printStdout("  next run: now\n")
 		}

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -268,7 +268,7 @@ func (c *commandServerStart) serveIndexFileForKnownUIRoutes(fs http.FileSystem) 
 		}
 
 		if r.URL.Path == "/" && indexBytes != nil {
-			http.ServeContent(w, r, "/", clock.Now(), bytes.NewReader(indexBytes))
+			http.ServeContent(w, r, "/", clock.WallClockTime(), bytes.NewReader(indexBytes))
 			return
 		}
 

--- a/cli/update_check.go
+++ b/cli/update_check.go
@@ -89,8 +89,8 @@ func (c *App) getUpdateState() (*updateState, error) {
 func (c *App) maybeInitializeUpdateCheck(ctx context.Context, co *connectOptions) {
 	if co.connectCheckForUpdates {
 		us := &updateState{
-			NextCheckTime:  clock.Now().Add(c.initialUpdateCheckDelay),
-			NextNotifyTime: clock.Now().Add(c.initialUpdateCheckDelay),
+			NextCheckTime:  clock.WallClockTime().Add(c.initialUpdateCheckDelay),
+			NextNotifyTime: clock.WallClockTime().Add(c.initialUpdateCheckDelay),
 		}
 		if err := c.writeUpdateState(us); err != nil {
 			log(ctx).Debugf("error initializing update state")
@@ -182,8 +182,8 @@ func (c *App) maybeCheckForUpdates(ctx context.Context) (string, error) {
 		return "", nil
 	}
 
-	if clock.Now().After(us.NextNotifyTime) {
-		us.NextNotifyTime = clock.Now().Add(c.updateAvailableNotifyInterval)
+	if clock.WallClockTime().After(us.NextNotifyTime) {
+		us.NextNotifyTime = clock.WallClockTime().Add(c.updateAvailableNotifyInterval)
 		if err := c.writeUpdateState(us); err != nil {
 			return "", errors.Wrap(err, "unable to write update state")
 		}
@@ -196,7 +196,7 @@ func (c *App) maybeCheckForUpdates(ctx context.Context) (string, error) {
 }
 
 func (c *App) maybeCheckGithub(ctx context.Context, us *updateState) error {
-	if !clock.Now().After(us.NextCheckTime) {
+	if !clock.WallClockTime().After(us.NextCheckTime) {
 		return nil
 	}
 
@@ -204,7 +204,7 @@ func (c *App) maybeCheckGithub(ctx context.Context, us *updateState) error {
 
 	// before we check for update, write update state file again, so if this fails
 	// we won't bother GitHub for a while
-	us.NextCheckTime = clock.Now().Add(c.updateCheckInterval)
+	us.NextCheckTime = clock.WallClockTime().Add(c.updateCheckInterval)
 	if err := c.writeUpdateState(us); err != nil {
 		return errors.Wrap(err, "unable to write update state")
 	}

--- a/fs/cachefs/cache.go
+++ b/fs/cachefs/cache.go
@@ -98,7 +98,7 @@ func (c *Cache) Readdir(ctx context.Context, d fs.Directory, w EntryWrapper) (fs
 
 func (c *Cache) getEntriesFromCacheLocked(ctx context.Context, id string) fs.Entries {
 	if v, ok := c.data[id]; id != "" && ok {
-		if clock.Now().Before(v.expireAfter) {
+		if clock.WallClockTime().Before(v.expireAfter) {
 			c.moveToHead(v)
 
 			if c.debug {
@@ -155,7 +155,7 @@ func (c *Cache) getEntries(ctx context.Context, id string, expirationTime time.D
 	entry := &cacheEntry{
 		id:          id,
 		entries:     wrapped,
-		expireAfter: clock.Now().Add(expirationTime),
+		expireAfter: clock.WallClockTime().Add(expirationTime),
 	}
 
 	c.addToHead(entry)

--- a/fs/localfs/local_fs_test.go
+++ b/fs/localfs/local_fs_test.go
@@ -27,7 +27,7 @@ func TestFiles(t *testing.T) {
 	var dir fs.Directory
 
 	// Try listing directory that does not exist.
-	_, err = Directory(fmt.Sprintf("/no-such-dir-%v", clock.Now().Nanosecond()))
+	_, err = Directory(fmt.Sprintf("/no-such-dir-%v", clock.WallClockTime().Nanosecond()))
 	if err == nil {
 		t.Errorf("expected error when dir directory that does not exist.")
 	}

--- a/fs/loggingfs/loggingfs.go
+++ b/fs/loggingfs/loggingfs.go
@@ -3,9 +3,9 @@ package loggingfs
 
 import (
 	"context"
+	"time"
 
 	"github.com/kopia/kopia/fs"
-	"github.com/kopia/kopia/internal/clock"
 )
 
 type loggingOptions struct {
@@ -20,9 +20,9 @@ type loggingDirectory struct {
 }
 
 func (ld *loggingDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 	entry, err := ld.Directory.Child(ctx, name)
-	dt := clock.Since(t0)
+	dt := time.Since(t0) // nolint:forbidigo
 	ld.options.printf(ld.options.prefix+"Child(%v) took %v and returned %v", ld.relativePath, dt, err)
 
 	if err != nil {
@@ -34,9 +34,9 @@ func (ld *loggingDirectory) Child(ctx context.Context, name string) (fs.Entry, e
 }
 
 func (ld *loggingDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 	entries, err := ld.Directory.Readdir(ctx)
-	dt := clock.Since(t0)
+	dt := time.Since(t0) // nolint:forbidigo
 	ld.options.printf(ld.options.prefix+"Readdir(%v) took %v and returned %v items", ld.relativePath, dt, len(entries))
 
 	loggingEntries := make(fs.Entries, len(entries))

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -8,10 +8,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"time"
 
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/tlsutil"
 	"github.com/kopia/kopia/repo/logging"
 )
@@ -191,15 +191,16 @@ type loggingTransport struct {
 }
 
 func (t loggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	t0 := clock.Now()
-
+	t0 := time.Now() //nolint:forbidigo
 	resp, err := t.base.RoundTrip(req)
+	dur := time.Since(t0) //nolint:forbidigo
+
 	if err != nil {
-		log(req.Context()).Debugf("%v %v took %v and failed with %v", req.Method, req.URL, clock.Since(t0), err)
+		log(req.Context()).Debugf("%v %v took %v and failed with %v", req.Method, req.URL, dur, err)
 		return nil, errors.Wrap(err, "round-trip error")
 	}
 
-	log(req.Context()).Debugf("%v %v took %v and returned %v", req.Method, req.URL, clock.Since(t0), resp.Status)
+	log(req.Context()).Debugf("%v %v took %v and returned %v", req.Method, req.URL, dur, resp.Status)
 
 	return resp, nil
 }

--- a/internal/auth/authn_repo.go
+++ b/internal/auth/authn_repo.go
@@ -35,8 +35,8 @@ func (ac *repositoryUserAuthenticator) IsValid(ctx context.Context, rep repo.Rep
 	}
 
 	// see if we're due for a refresh and refresh userProfiles map
-	if clock.Now().After(ac.nextRefreshTime) {
-		ac.nextRefreshTime = clock.Now().Add(ac.userProfileRefreshFrequency)
+	if clock.WallClockTime().After(ac.nextRefreshTime) {
+		ac.nextRefreshTime = clock.WallClockTime().Add(ac.userProfileRefreshFrequency)
 
 		newUsers, err := user.LoadProfileMap(ctx, rep, ac.userProfiles)
 		if err != nil {

--- a/internal/auth/authz_acl.go
+++ b/internal/auth/authz_acl.go
@@ -116,8 +116,8 @@ func (ac *aclCache) Authorize(ctx context.Context, rep repo.Repository, username
 	}
 
 	// see if we're due for a refresh and refresh aclEntries
-	if clock.Now().After(ac.nextRefreshTime) {
-		ac.nextRefreshTime = clock.Now().Add(ac.aclRefreshFrequency)
+	if clock.WallClockTime().After(ac.nextRefreshTime) {
+		ac.nextRefreshTime = clock.WallClockTime().Add(ac.aclRefreshFrequency)
 
 		newMap, err := acl.LoadEntries(ctx, rep, ac.aclEntries)
 		if err != nil {

--- a/internal/blobtesting/cleanup.go
+++ b/internal/blobtesting/cleanup.go
@@ -21,8 +21,10 @@ func CleanupOldData(ctx context.Context, tb testing.TB, st blob.Storage, cleanup
 
 	pq := parallelwork.NewQueue()
 
+	now := clock.WallClockTime()
+
 	_ = st.ListBlobs(ctx, "", func(it blob.Metadata) error {
-		age := clock.Since(it.Timestamp)
+		age := now.Sub(it.Timestamp)
 		if age > cleanupAge {
 			pq.EnqueueBack(ctx, func() error {
 				tb.Logf("deleting %v", it.BlobID)

--- a/internal/blobtesting/eventually_consistent.go
+++ b/internal/blobtesting/eventually_consistent.go
@@ -55,7 +55,7 @@ func (c *ecFrontendCache) put(id blob.ID, data []byte) {
 	}
 
 	c.cachedEntries[id] = &ecCacheEntry{
-		accessTime: clock.Now(),
+		accessTime: clock.WallClockTime(),
 		data:       data,
 	}
 }
@@ -75,7 +75,7 @@ type ecCacheEntry struct {
 }
 
 func (e *ecCacheEntry) isValid() bool {
-	return clock.Since(e.accessTime) < ecCacheDuration
+	return clock.WallClockTime().Sub(e.accessTime) < ecCacheDuration
 }
 
 type eventuallyConsistentStorage struct {

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -184,7 +184,7 @@ func NewMapStorage(data DataMap, keyTime map[blob.ID]time.Time, timeNow func() t
 	}
 
 	if timeNow == nil {
-		timeNow = clock.Now
+		timeNow = clock.WallClockTime
 	}
 
 	return &mapStorage{data: data, keyTime: keyTime, timeNow: timeNow}

--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/stats"
 
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/logging"
@@ -193,7 +192,7 @@ func (h *contentMetadataHeap) Pop() interface{} {
 }
 
 func (c *PersistentCache) sweepDirectory(ctx context.Context) (err error) {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 
 	var h contentMetadataHeap
 
@@ -217,7 +216,9 @@ func (c *PersistentCache) sweepDirectory(ctx context.Context) (err error) {
 		return errors.Wrapf(err, "error listing %v", c.description)
 	}
 
-	log(ctx).Debugf("finished sweeping %v in %v and retained %v/%v bytes (%v %%)", c.description, clock.Since(t0), totalRetainedSize, c.maxSizeBytes, 100*totalRetainedSize/c.maxSizeBytes)
+	dur := time.Since(t0) // nolint:forbidigo
+
+	log(ctx).Debugf("finished sweeping %v in %v and retained %v/%v bytes (%v %%)", c.description, dur, totalRetainedSize, c.maxSizeBytes, 100*totalRetainedSize/c.maxSizeBytes)
 
 	return nil
 }

--- a/internal/clock/now.go
+++ b/internal/clock/now.go
@@ -1,16 +1,14 @@
-// Package clock provides indirection for accessing current time.
+// Package clock provides indirection for accessing current wall clock time.
+// this is suitable for timestamps and long-term time operations, not short-term time measurements.
 package clock
 
-import (
-	"time"
-)
+import "time"
 
-// Since returns time since the given timestamp.
-func Since(t time.Time) time.Duration {
-	return Now().Sub(t)
-}
-
-// Until returns duration of time between now and a given time.
-func Until(t time.Time) time.Duration {
-	return t.Sub(Now())
+// discardMonotonicTime discards any monotonic time component of time,
+// which behaves incorrectly when the computer goes to sleep and we want to measure durations
+// between points in time.
+//
+// See https://go.googlesource.com/proposal/+/master/design/12914-monotonic.md
+func discardMonotonicTime(t time.Time) time.Time {
+	return time.Unix(0, t.UnixNano())
 }

--- a/internal/clock/now_prod.go
+++ b/internal/clock/now_prod.go
@@ -5,7 +5,7 @@ package clock
 
 import "time"
 
-// Now returns current wall clock time.
-func Now() time.Time {
-	return time.Now() // nolint:forbidigo
+// WallClockTime returns current wall clock time.
+func WallClockTime() time.Time {
+	return discardMonotonicTime(time.Now()) // nolint:forbidigo
 }

--- a/internal/clock/now_testing.go
+++ b/internal/clock/now_testing.go
@@ -14,8 +14,8 @@ import (
 
 const refreshServerTimeEvery = 3 * time.Second
 
-// Now is overridable function that returns current wall clock time.
-var Now = time.Now // nolint:forbidigo
+// WallClockTime is overridable function that returns current wall clock time.
+var WallClockTime = time.Now // nolint:forbidigo
 
 func init() {
 	fakeTimeServer := os.Getenv("KOPIA_FAKE_CLOCK_ENDPOINT")
@@ -23,7 +23,7 @@ func init() {
 		return
 	}
 
-	Now = getTimeFromServer(fakeTimeServer)
+	WallClockTime = getTimeFromServer(fakeTimeServer)
 }
 
 // getTimeFromServer returns a function that will return timestamp as returned by the server

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -145,7 +145,7 @@ func TestIndexEpochManager_Parallel(t *testing.T) {
 
 	// run for 30 seconds of real time or 60 days of fake time which advances much faster
 	endFakeTime := te.ft.NowFunc()().Add(60 * 24 * time.Hour)
-	endTimeReal := clock.Now().Add(30 * time.Second)
+	endTimeReal := clock.WallClockTime().Add(30 * time.Second)
 
 	for worker := 1; worker <= 5; worker++ {
 		worker := worker
@@ -162,7 +162,7 @@ func TestIndexEpochManager_Parallel(t *testing.T) {
 				successfulMergeCount int
 			)
 
-			for te2.ft.NowFunc()().Before(endFakeTime) && clock.Now().Before(endTimeReal) {
+			for te2.ft.NowFunc()().Before(endFakeTime) && clock.WallClockTime().Before(endTimeReal) {
 				if err := ctx.Err(); err != nil {
 					return err
 				}

--- a/internal/faketime/faketime.go
+++ b/internal/faketime/faketime.go
@@ -75,7 +75,7 @@ func (t *ClockTimeWithOffset) NowFunc() func() time.Time {
 		t.mu.Lock()
 		defer t.mu.Unlock()
 
-		return clock.Now().Add(t.offset)
+		return clock.WallClockTime().Add(t.offset)
 	}
 }
 
@@ -87,5 +87,5 @@ func (t *ClockTimeWithOffset) Advance(dt time.Duration) time.Time {
 
 	t.offset += dt
 
-	return clock.Now().Add(t.offset)
+	return clock.WallClockTime().Add(t.offset)
 }

--- a/internal/faketime/faketime_test.go
+++ b/internal/faketime/faketime_test.go
@@ -12,7 +12,7 @@ import (
 func TestFrozen(t *testing.T) {
 	times := []time.Time{
 		time.Date(2015, 1, 3, 0, 0, 0, 0, time.UTC),
-		clock.Now(),
+		clock.WallClockTime(),
 	}
 
 	for _, tm := range times {

--- a/internal/listcache/listcache.go
+++ b/internal/listcache/listcache.go
@@ -170,7 +170,7 @@ func NewWrapper(st, cacheStorage blob.Storage, prefixes []blob.ID, hmacSecret []
 		Storage:       st,
 		cacheStorage:  cacheStorage,
 		prefixes:      prefixes,
-		cacheTimeFunc: clock.Now,
+		cacheTimeFunc: clock.WallClockTime,
 		hmacSecret:    hmacSecret,
 		cacheDuration: duration,
 	}

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -87,7 +87,7 @@ func (c *loggingFlags) initialize(ctx *kingpin.ParseContext) error {
 		return nil
 	}
 
-	now := clock.Now()
+	now := clock.WallClockTime()
 	if c.fileLogLocalTimezone {
 		now = now.Local()
 	} else {
@@ -240,7 +240,7 @@ func shouldSweepLog(maxFiles int, maxAge time.Duration) bool {
 func sweepLogDir(ctx context.Context, dirname string, maxCount int, maxAge time.Duration) {
 	var timeCutoff time.Time
 	if maxAge > 0 {
-		timeCutoff = clock.Now().Add(-maxAge)
+		timeCutoff = clock.WallClockTime().Add(-maxAge)
 	}
 
 	if maxCount == 0 {

--- a/internal/logfile/logfile_test.go
+++ b/internal/logfile/logfile_test.go
@@ -111,7 +111,7 @@ func verifyFileLogFormat(t *testing.T, fname string, re *regexp.Regexp) {
 }
 
 func isUTC() bool {
-	_, offset := clock.Now().Zone()
+	_, offset := clock.WallClockTime().Zone()
 
 	return offset == 0
 }

--- a/internal/ownwrites/ownwrites.go
+++ b/internal/ownwrites/ownwrites.go
@@ -193,7 +193,7 @@ func NewWrapper(st, cacheStorage blob.Storage, prefixes []blob.ID, cacheDuration
 		Storage:       st,
 		cacheStorage:  cacheStorage,
 		prefixes:      prefixes,
-		cacheTimeFunc: clock.Now,
+		cacheTimeFunc: clock.WallClockTime,
 		cacheDuration: cacheDuration,
 	}
 }

--- a/internal/parallelwork/parallel_work_queue.go
+++ b/internal/parallelwork/parallel_work_queue.go
@@ -135,11 +135,11 @@ func (v *Queue) reportProgress(ctx context.Context) {
 }
 
 func (v *Queue) maybeReportProgress(ctx context.Context) {
-	if clock.Now().Before(v.nextReportTime) {
+	if clock.WallClockTime().Before(v.nextReportTime) {
 		return
 	}
 
-	v.nextReportTime = clock.Now().Add(1 * time.Second)
+	v.nextReportTime = clock.WallClockTime().Add(1 * time.Second)
 
 	v.reportProgress(ctx)
 }

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -155,7 +155,7 @@ func ValidateProvider(ctx context.Context, st blob.Storage, opt Options) error {
 		return errors.Errorf("invalid length returned by GetMetadata(): %v, wanted %v", got, want)
 	}
 
-	now := clock.Now()
+	now := clock.WallClockTime()
 
 	timeDiff := now.Sub(bm.Timestamp)
 	if timeDiff < 0 {
@@ -200,7 +200,7 @@ func newConcurrencyTest(st blob.Storage, prefix blob.ID, opt Options) *concurren
 		opt:      opt,
 		st:       st,
 		prefix:   prefix,
-		deadline: clock.Now().Add(opt.ConcurrencyTestDuration),
+		deadline: clock.WallClockTime().Add(opt.ConcurrencyTestDuration),
 
 		blobData:    make(map[blob.ID][]byte),
 		blobWritten: make(map[blob.ID]bool),
@@ -209,7 +209,7 @@ func newConcurrencyTest(st blob.Storage, prefix blob.ID, opt Options) *concurren
 
 func (c *concurrencyTest) putBlobWorker(ctx context.Context, worker int) func() error {
 	return func() error {
-		for clock.Now().Before(c.deadline) {
+		for clock.WallClockTime().Before(c.deadline) {
 			blobLen := blobIDLength + rand.Intn(c.opt.MaxBlobLength-blobIDLength) //nolint:gosec
 
 			data := make([]byte, blobLen)
@@ -267,7 +267,7 @@ func (c *concurrencyTest) getBlobWorker(ctx context.Context, worker int) func() 
 		var out gather.WriteBuffer
 		defer out.Close()
 
-		for clock.Now().Before(c.deadline) {
+		for clock.WallClockTime().Before(c.deadline) {
 			c.randomSleep()
 
 			blobID, blobData, fullyWritten := c.pickBlob()
@@ -301,7 +301,7 @@ func (c *concurrencyTest) getBlobWorker(ctx context.Context, worker int) func() 
 
 func (c *concurrencyTest) getMetadataWorker(ctx context.Context, worker int) func() error {
 	return func() error {
-		for clock.Now().Before(c.deadline) {
+		for clock.WallClockTime().Before(c.deadline) {
 			c.randomSleep()
 
 			blobID, blobData, fullyWritten := c.pickBlob()

--- a/internal/server/api_object_get.go
+++ b/internal/server/api_object_get.go
@@ -42,7 +42,7 @@ func (s *Server) handleObjectGet(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Disposition", "attachment; filename=\""+p+"\"")
 	}
 
-	mtime := clock.Now()
+	mtime := clock.WallClockTime()
 
 	if p := r.URL.Query().Get("mtime"); p != "" {
 		if m, err := time.Parse(time.RFC3339Nano, p); err == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -161,7 +161,7 @@ func (s *Server) isAuthenticated(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 
-	now := clock.Now()
+	now := clock.WallClockTime()
 
 	ac, err := s.generateShortTermAuthCookie(username, now)
 	if err != nil {

--- a/internal/testutil/tmpdir.go
+++ b/internal/testutil/tmpdir.go
@@ -81,7 +81,7 @@ func TempLogDirectory(t *testing.T) string {
 		logsBaseDir = filepath.Join(os.TempDir(), "kopia-logs")
 	}
 
-	logsDir := filepath.Join(logsBaseDir, cleanName+"."+clock.Now().Local().Format("20060102150405"))
+	logsDir := filepath.Join(logsBaseDir, cleanName+"."+clock.WallClockTime().Local().Format("20060102150405"))
 
 	require.NoError(t, os.MkdirAll(logsDir, logsDirPermissions))
 

--- a/internal/timetrack/estimator.go
+++ b/internal/timetrack/estimator.go
@@ -39,7 +39,7 @@ func (v Estimator) Estimate(completed, total float64) (Timings, bool) {
 		predictedSeconds := elapsed.Seconds() / completedRatio
 		predictedEndTime := v.startTime.Add(time.Duration(predictedSeconds) * time.Second)
 
-		dt := clock.Until(predictedEndTime).Truncate(time.Second)
+		dt := predictedEndTime.Sub(clock.WallClockTime()).Truncate(time.Second)
 		if dt < 0 {
 			dt = 0
 		}

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -40,7 +40,7 @@ func GenerateServerCertificate(ctx context.Context, keySize int, certValid time.
 		return nil, nil, errors.Wrap(err, "unable to generate RSA key")
 	}
 
-	notBefore := clock.Now()
+	notBefore := clock.WallClockTime()
 	notAfter := notBefore.Add(certValid)
 
 	// nolint:gomnd

--- a/internal/uitask/uitask.go
+++ b/internal/uitask/uitask.go
@@ -151,7 +151,7 @@ func (t *runningTaskInfo) addLogEntry(module string, level LogLevel, msg string,
 	defer t.mu.Unlock()
 
 	t.LogLines = append(t.LogLines, LogEntry{
-		Timestamp: float64(clock.Now().UnixNano()) / 1e9,
+		Timestamp: float64(clock.WallClockTime().UnixNano()) / 1e9,
 		Level:     level,
 		Module:    module,
 		Text:      fmt.Sprintf(msg, args...),

--- a/internal/uitask/uitask_manager.go
+++ b/internal/uitask/uitask_manager.go
@@ -150,7 +150,7 @@ func (m *Manager) startTask(r *runningTaskInfo) string {
 	m.nextTaskID++
 
 	taskID := fmt.Sprintf("%x", m.nextTaskID)
-	r.StartTime = clock.Now()
+	r.StartTime = clock.WallClockTime()
 	r.TaskID = taskID
 	r.sequenceNumber = m.nextTaskID
 	m.running[taskID] = r
@@ -181,7 +181,7 @@ func (m *Manager) completeTask(r *runningTaskInfo, err error) {
 
 	r.ProgressInfo = ""
 
-	now := clock.Now()
+	now := clock.WallClockTime()
 	r.EndTime = &now
 
 	delete(m.running, r.TaskID)

--- a/internal/zaplogutil/zaplogutil.go
+++ b/internal/zaplogutil/zaplogutil.go
@@ -14,10 +14,10 @@ var PreciseTimeEncoder = zapcore.TimeEncoderOfLayout("2006-01-02T15:04:05.000000
 
 type theClock struct{}
 
-func (c theClock) Now() time.Time                         { return clock.Now() }
+func (c theClock) Now() time.Time                         { return clock.WallClockTime() }
 func (c theClock) NewTicker(d time.Duration) *time.Ticker { return time.NewTicker(d) }
 
-// Clock isn aimplementation of zapcore.Clock that uses clock.Now().
+// Clock isn aimplementation of zapcore.Clock that uses clock.WallClockTime().
 var Clock zapcore.Clock = theClock{}
 
 // TimezoneAdjust returns zapcore.TimeEncoder that adjusts the time to either UTC or local time before logging.

--- a/repo/api_server_repository.go
+++ b/repo/api_server_repository.go
@@ -128,7 +128,7 @@ func (r *apiServerRepository) DeleteManifest(ctx context.Context, id manifest.ID
 }
 
 func (r *apiServerRepository) Time() time.Time {
-	return clock.Now()
+	return clock.WallClockTime()
 }
 
 func (r *apiServerRepository) Refresh(ctx context.Context) error {

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -268,7 +268,7 @@ func New(ctx context.Context, opt *Options) (blob.Storage, error) {
 
 	// verify Azure connection is functional by listing blobs in a bucket, which will fail if the container
 	// does not exist. We list with a prefix that will not exist, to avoid iterating through any objects.
-	nonExistentPrefix := fmt.Sprintf("kopia-azure-storage-initializing-%v", clock.Now().UnixNano())
+	nonExistentPrefix := fmt.Sprintf("kopia-azure-storage-initializing-%v", clock.WallClockTime().UnixNano())
 	err = az.ListBlobs(ctx, blob.ID(nonExistentPrefix), func(md blob.Metadata) error {
 		return nil
 	})

--- a/repo/blob/azure/azure_storage_test.go
+++ b/repo/blob/azure/azure_storage_test.go
@@ -113,7 +113,7 @@ func TestAzureStorage(t *testing.T) {
 		Container:      container,
 		StorageAccount: storageAccount,
 		StorageKey:     storageKey,
-		Prefix:         fmt.Sprintf("test-%v-%x-", clock.Now().Unix(), data),
+		Prefix:         fmt.Sprintf("test-%v-%x-", clock.WallClockTime().Unix(), data),
 	})
 	require.NoError(t, err)
 
@@ -141,7 +141,7 @@ func TestAzureStorageSASToken(t *testing.T) {
 		Container:      container,
 		StorageAccount: storageAccount,
 		SASToken:       sasToken,
-		Prefix:         fmt.Sprintf("sastest-%v-%x-", clock.Now().Unix(), data),
+		Prefix:         fmt.Sprintf("sastest-%v-%x-", clock.WallClockTime().Unix(), data),
 	})
 	require.NoError(t, err)
 
@@ -185,7 +185,7 @@ func TestAzureStorageInvalidBlob(t *testing.T) {
 func TestAzureStorageInvalidContainer(t *testing.T) {
 	testutil.ProviderTest(t)
 
-	container := fmt.Sprintf("invalid-container-%v", clock.Now().UnixNano())
+	container := fmt.Sprintf("invalid-container-%v", clock.WallClockTime().UnixNano())
 	storageAccount := getEnvOrSkip(t, testStorageAccountEnv)
 	storageKey := getEnvOrSkip(t, testStorageKeyEnv)
 

--- a/repo/blob/b2/b2_storage_test.go
+++ b/repo/blob/b2/b2_storage_test.go
@@ -106,7 +106,7 @@ func TestB2StorageInvalidBlob(t *testing.T) {
 	var tmp gather.WriteBuffer
 	defer tmp.Close()
 
-	err = st.GetBlob(ctx, blob.ID(fmt.Sprintf("invalid-blob-%v", clock.Now().UnixNano())), 0, 30, &tmp)
+	err = st.GetBlob(ctx, blob.ID(fmt.Sprintf("invalid-blob-%v", clock.WallClockTime().UnixNano())), 0, 30, &tmp)
 	if err == nil {
 		t.Errorf("unexpected success when requesting non-existing blob")
 	}
@@ -116,7 +116,7 @@ func TestB2StorageInvalidBucket(t *testing.T) {
 	t.Parallel()
 	testutil.ProviderTest(t)
 
-	bucket := fmt.Sprintf("invalid-bucket-%v", clock.Now().UnixNano())
+	bucket := fmt.Sprintf("invalid-bucket-%v", clock.WallClockTime().UnixNano())
 	keyID := getEnvOrSkip(t, testKeyIDEnv)
 	key := getEnvOrSkip(t, testKeyEnv)
 

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -255,7 +255,7 @@ func (fs *fsStorage) TouchBlob(ctx context.Context, blobID blob.ID, threshold ti
 		return err
 	}
 
-	n := clock.Now()
+	n := clock.WallClockTime()
 
 	age := n.Sub(st.ModTime())
 	if age < threshold {

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -268,7 +268,7 @@ func New(ctx context.Context, opt *Options) (blob.Storage, error) {
 
 	// verify GCS connection is functional by listing blobs in a bucket, which will fail if the bucket
 	// does not exist. We list with a prefix that will not exist, to avoid iterating through any objects.
-	nonExistentPrefix := fmt.Sprintf("kopia-gcs-storage-initializing-%v", clock.Now().UnixNano())
+	nonExistentPrefix := fmt.Sprintf("kopia-gcs-storage-initializing-%v", clock.WallClockTime().UnixNano())
 	err = gcs.ListBlobs(ctx, blob.ID(nonExistentPrefix), func(md blob.Metadata) error {
 		return nil
 	})

--- a/repo/blob/logging/logging_storage.go
+++ b/repo/blob/logging/logging_storage.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -19,9 +18,9 @@ type loggingStorage struct {
 }
 
 func (s *loggingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output *gather.WriteBuffer) error {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 	err := s.base.GetBlob(ctx, id, offset, length, output)
-	dt := clock.Since(t0)
+	dt := time.Since(t0) // nolint:forbidigo
 
 	if output.Length() < maxLoggedBlobLength {
 		s.printf(s.prefix+"GetBlob(%q,%v,%v)=(%v, %#v) took %v", id, offset, length, output, err, dt)
@@ -34,9 +33,9 @@ func (s *loggingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length
 }
 
 func (s *loggingStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata, error) {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 	result, err := s.base.GetMetadata(ctx, id)
-	dt := clock.Since(t0)
+	dt := time.Since(t0) // nolint:forbidigo
 
 	s.printf(s.prefix+"GetMetadata(%q)=(%v, %#v) took %v", id, result, err, dt)
 
@@ -45,9 +44,9 @@ func (s *loggingStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Meta
 }
 
 func (s *loggingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 	err := s.base.PutBlob(ctx, id, data)
-	dt := clock.Since(t0)
+	dt := time.Since(t0) // nolint:forbidigo
 	s.printf(s.prefix+"PutBlob(%q,len=%v)=%#v took %v", id, data.Length(), err, dt)
 
 	// nolint:wrapcheck
@@ -55,9 +54,9 @@ func (s *loggingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Byte
 }
 
 func (s *loggingStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) error {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 	err := s.base.SetTime(ctx, id, t)
-	dt := clock.Since(t0)
+	dt := time.Since(t0) // nolint:forbidigo
 	s.printf(s.prefix+"SetTime(%q,%v)=%#v took %v", id, t, err, dt)
 
 	// nolint:wrapcheck
@@ -65,9 +64,9 @@ func (s *loggingStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) e
 }
 
 func (s *loggingStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 	err := s.base.DeleteBlob(ctx, id)
-	dt := clock.Since(t0)
+	dt := time.Since(t0) // nolint:forbidigo
 	s.printf(s.prefix+"DeleteBlob(%q)=%#v took %v", id, err, dt)
 
 	// nolint:wrapcheck
@@ -75,22 +74,22 @@ func (s *loggingStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
 }
 
 func (s *loggingStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback func(blob.Metadata) error) error {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 	cnt := 0
 	err := s.base.ListBlobs(ctx, prefix, func(bi blob.Metadata) error {
 		cnt++
 		return callback(bi)
 	})
-	s.printf(s.prefix+"ListBlobs(%q)=%v returned %v items and took %v", prefix, err, cnt, clock.Since(t0))
+	s.printf(s.prefix+"ListBlobs(%q)=%v returned %v items and took %v", prefix, err, cnt, time.Since(t0)) // nolint:forbidigo
 
 	// nolint:wrapcheck
 	return err
 }
 
 func (s *loggingStorage) Close(ctx context.Context) error {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 	err := s.base.Close(ctx)
-	dt := clock.Since(t0)
+	dt := time.Since(t0) // nolint:forbidigo
 	s.printf(s.prefix+"Close()=%#v took %v", err, dt)
 
 	// nolint:wrapcheck
@@ -106,9 +105,9 @@ func (s *loggingStorage) DisplayName() string {
 }
 
 func (s *loggingStorage) FlushCaches(ctx context.Context) error {
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 	err := s.base.FlushCaches(ctx)
-	dt := clock.Since(t0)
+	dt := time.Since(t0) // nolint:forbidigo
 	s.printf(s.prefix+"FlushCaches()=%#v took %v", err, dt)
 
 	// nolint:wrapcheck

--- a/repo/blob/rclone/rclone_storage_test.go
+++ b/repo/blob/rclone/rclone_storage_test.go
@@ -257,9 +257,10 @@ func cleanupOldData(ctx context.Context, t *testing.T, opt *rclone.Options, clea
 func cleanupAllBlobs(ctx context.Context, t *testing.T, st blob.Storage, cleanupAge time.Duration) {
 	t.Helper()
 
+	now := clock.WallClockTime()
+
 	_ = st.ListBlobs(ctx, "", func(it blob.Metadata) error {
-		age := clock.Since(it.Timestamp)
-		if age > cleanupAge {
+		if age := now.Sub(it.Timestamp); age > cleanupAge {
 			if err := st.DeleteBlob(ctx, it.BlobID); err != nil {
 				t.Errorf("warning: unable to delete %q: %v", it.BlobID, err)
 			}

--- a/repo/blob/retrying/retrying_storage_test.go
+++ b/repo/blob/retrying/retrying_storage_test.go
@@ -50,7 +50,7 @@ func TestRetrying(t *testing.T) {
 
 	require.NoError(t, rs.PutBlob(ctx, blobID2, gather.FromSlice([]byte{1, 2, 3, 4})))
 
-	require.NoError(t, rs.SetTime(ctx, blobID, clock.Now()))
+	require.NoError(t, rs.SetTime(ctx, blobID, clock.WallClockTime()))
 
 	var tmp gather.WriteBuffer
 	defer tmp.Close()
@@ -81,7 +81,7 @@ func TestRetrying(t *testing.T) {
 		{Err: blob.ErrSetTimeUnsupported},
 	}
 
-	if err := rs.SetTime(ctx, blobID, clock.Now()); !errors.Is(err, blob.ErrSetTimeUnsupported) {
+	if err := rs.SetTime(ctx, blobID, clock.WallClockTime()); !errors.Is(err, blob.ErrSetTimeUnsupported) {
 		t.Fatalf("unexpected error from SetTime: %v", err)
 	}
 

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/blobtesting"
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/providervalidation"
 	"github.com/kopia/kopia/internal/testlogging"
@@ -205,7 +204,7 @@ func TestInvalidCredsFailsFast(t *testing.T) {
 
 	ctx := testlogging.Context(t)
 
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 
 	_, err := New(ctx, &Options{
 		Endpoint:        minioEndpoint,
@@ -218,7 +217,8 @@ func TestInvalidCredsFailsFast(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	if dt := clock.Since(t0); dt > 10*time.Second {
+	// nolint:forbidigo
+	if dt := time.Since(t0); dt > 10*time.Second {
 		t.Fatalf("opening storage took too long, probably due to retries")
 	}
 }

--- a/repo/blob/s3/s3_versioned_test.go
+++ b/repo/blob/s3/s3_versioned_test.go
@@ -373,7 +373,7 @@ func TestInfoToVersionMetadata(t *testing.T) {
 func TestGetOlderThan(t *testing.T) {
 	t.Parallel()
 
-	base := clock.Now().UTC().Truncate(time.Second)
+	base := clock.WallClockTime().UTC().Truncate(time.Second)
 	vs := makeVersionsMetadata(t, blob.ID("blobfux"), 11, base)
 	want := append([]versionMetadata(nil), vs...)
 
@@ -393,7 +393,7 @@ func TestGetOlderThan(t *testing.T) {
 func TestGetOlderThanSameTime(t *testing.T) {
 	t.Parallel()
 
-	base := clock.Now().UTC().Truncate(time.Second)
+	base := clock.WallClockTime().UTC().Truncate(time.Second)
 	vs := makeVersionsMetadata(t, blob.ID("foobarx"), 4, base)
 
 	// two consecutive versions with the same timestamp
@@ -419,7 +419,7 @@ func TestGetOlderThanSameTime(t *testing.T) {
 func TestNewestAtUnlessDeleted_NonDeleted(t *testing.T) {
 	t.Parallel()
 
-	base := clock.Now().UTC().Truncate(time.Second)
+	base := clock.WallClockTime().UTC().Truncate(time.Second)
 	vs := makeVersionsMetadata(t, blob.ID("blobfux"), 11, base)
 
 	for i, v := range vs {
@@ -448,7 +448,7 @@ func TestNewestAtUnlessDeleted_NonDeleted(t *testing.T) {
 func TestNewestAtUnlessDeleted_Deleted(t *testing.T) {
 	t.Parallel()
 
-	base := clock.Now().UTC().Truncate(time.Second)
+	base := clock.WallClockTime().UTC().Truncate(time.Second)
 	vs := makeVersionsMetadata(t, blob.ID("blobfux"), 5, base)
 
 	// insert a couple of deletion markers
@@ -486,7 +486,7 @@ func TestNewestAtUnlessDeleted_Deleted(t *testing.T) {
 func TestNewestAtUnlessDeleted_AllDeleted(t *testing.T) {
 	t.Parallel()
 
-	base := clock.Now().UTC().Truncate(time.Second)
+	base := clock.WallClockTime().UTC().Truncate(time.Second)
 	vs := makeVersionsMetadata(t, blob.ID("blobfux"), 5, base)
 
 	// make them all deletion markers

--- a/repo/blob/sftp/sftp_storage_test.go
+++ b/repo/blob/sftp/sftp_storage_test.go
@@ -108,8 +108,8 @@ func startDockerSFTPServerOrSkip(t *testing.T, idRSA string) (host string, port 
 	sftpEndpoint := testutil.GetContainerMappedPortAddress(t, shortContainerID, "22")
 
 	// wait for SFTP server to come up.
-	deadline := clock.Now().Add(dialTimeout)
-	for clock.Now().Before(deadline) {
+	deadline := clock.WallClockTime().Add(dialTimeout)
+	for clock.WallClockTime().Before(deadline) {
 		t.Logf("waiting for SFTP server to come up on '%v'...", sftpEndpoint)
 
 		conn, err := net.DialTimeout("tcp", sftpEndpoint, time.Second)
@@ -250,7 +250,7 @@ func TestInvalidServerFailsFast(t *testing.T) {
 	mustRunCommand(t, "ssh-keygen", "-t", "rsa", "-P", "", "-f", idRSA)
 	os.WriteFile(knownHostsFile, nil, 0o600)
 
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 
 	if _, err := createSFTPStorage(ctx, t, sftp.Options{
 		Path:           "/upload",
@@ -263,7 +263,8 @@ func TestInvalidServerFailsFast(t *testing.T) {
 		t.Fatalf("unexpected success with bad credentials")
 	}
 
-	if dt := clock.Since(t0); dt > 10*time.Second {
+	// nolint:forbidigo
+	if dt := time.Since(t0); dt > 10*time.Second {
 		t.Fatalf("opening storage took too long, probably due to retries")
 	}
 }

--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -330,7 +330,7 @@ func newCommittedContentIndex(caching *CachingOptions,
 
 	if caching.CacheDirectory != "" {
 		dirname := filepath.Join(caching.CacheDirectory, "indexes")
-		cache = &diskCommittedContentIndexCache{dirname, clock.Now, v1PerContentOverhead, log}
+		cache = &diskCommittedContentIndexCache{dirname, clock.WallClockTime, v1PerContentOverhead, log}
 	} else {
 		cache = &memoryCommittedContentIndexCache{
 			contents:             map[blob.ID]packIndex{},

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -507,7 +507,7 @@ func (sm *SharedManager) shouldRefreshIndexes() bool {
 func NewSharedManager(ctx context.Context, st blob.Storage, f *FormattingOptions, caching *CachingOptions, opts *ManagerOptions) (*SharedManager, error) {
 	opts = opts.CloneOrDefault()
 	if opts.TimeNow == nil {
-		opts.TimeNow = clock.Now
+		opts.TimeNow = clock.WallClockTime
 	}
 
 	if f.Version < minSupportedReadVersion || f.Version > currentWriteVersion {

--- a/repo/content/content_cache_test.go
+++ b/repo/content/content_cache_test.go
@@ -37,11 +37,11 @@ func newUnderlyingStorageForContentCacheTesting(t *testing.T) blob.Storage {
 func TestCacheExpiration(t *testing.T) {
 	cacheData := blobtesting.DataMap{}
 
-	// on Windows, the time does not always move forward (sometimes clock.Now() returns exactly the same value for consecutive invocations)
-	// this matters here so we return a fake clock.Now() function that always moves forward.
+	// on Windows, the time does not always move forward (sometimes clock.WallClockTime() returns exactly the same value for consecutive invocations)
+	// this matters here so we return a fake clock.WallClockTime() function that always moves forward.
 	var currentTimeMutex sync.Mutex
 
-	currentTime := clock.Now()
+	currentTime := clock.WallClockTime()
 
 	movingTimeFunc := func() time.Time {
 		currentTimeMutex.Lock()

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -836,7 +836,7 @@ func (o *ManagerOptions) CloneOrDefault() *ManagerOptions {
 func NewManagerForTesting(ctx context.Context, st blob.Storage, f *FormattingOptions, caching *CachingOptions, options *ManagerOptions) (*WriteManager, error) {
 	options = options.CloneOrDefault()
 	if options.TimeNow == nil {
-		options.TimeNow = clock.Now
+		options.TimeNow = clock.WallClockTime
 	}
 
 	sharedManager, err := NewSharedManager(ctx, st, f, caching, options)

--- a/repo/content/content_manager_indexes.go
+++ b/repo/content/content_manager_indexes.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -39,10 +38,10 @@ func (sm *SharedManager) Refresh(ctx context.Context) error {
 
 	sm.indexBlobManager.invalidate(ctx)
 
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 
 	err := sm.loadPackIndexesLocked(ctx)
-	sm.log.Debugf("Refresh completed in %v", clock.Since(t0))
+	sm.log.Debugf("Refresh completed in %v", time.Since(t0)) // nolint:forbidigo
 
 	return err
 }

--- a/repo/content/index_blob_manager_v0_test.go
+++ b/repo/content/index_blob_manager_v0_test.go
@@ -160,7 +160,7 @@ func pickRandomActionTestIndexBlobManagerStress() action {
 // nolint:gocyclo
 func TestIndexBlobManagerStress(t *testing.T) {
 	t.Parallel()
-	rand.Seed(clock.Now().UnixNano())
+	rand.Seed(clock.WallClockTime().UnixNano())
 
 	for i := range actionsTestIndexBlobManagerStress {
 		actionsTestIndexBlobManagerStress[i].weight = rand.Intn(100)
@@ -170,10 +170,10 @@ func TestIndexBlobManagerStress(t *testing.T) {
 	var (
 		fakeTimeFunc      = faketime.AutoAdvance(fakeLocalStartTime, 100*time.Millisecond)
 		deadline          time.Time // when (according to fakeTimeFunc should the test finish)
-		localTimeDeadline time.Time // when (according to clock.Now, the test should finish)
+		localTimeDeadline time.Time // when (according to clock.WallClockTime, the test should finish)
 	)
 
-	localTimeDeadline = clock.Now().Add(30 * time.Second)
+	localTimeDeadline = clock.WallClockTime().Add(30 * time.Second)
 
 	if os.Getenv("CI") != "" {
 		// when running on CI, simulate 4 hours, this takes about ~15-20 seconds.
@@ -207,7 +207,7 @@ func TestIndexBlobManagerStress(t *testing.T) {
 			m := newIndexBlobManagerForTesting(t, loggedSt, fakeTimeFunc)
 
 			// run stress test until the deadline, aborting early on any failure
-			for fakeTimeFunc().Before(deadline) && clock.Now().Before(localTimeDeadline) {
+			for fakeTimeFunc().Before(deadline) && clock.WallClockTime().Before(localTimeDeadline) {
 				switch pickRandomActionTestIndexBlobManagerStress() {
 				case actionRead:
 					if err := verifyFakeContentsWritten(ctx, t, m, numWritten, contentPrefix, deletedContents); err != nil {
@@ -261,7 +261,7 @@ func TestIndexBlobManagerStress(t *testing.T) {
 }
 
 func TestIndexBlobManagerPreventsResurrectOfDeletedContents(t *testing.T) {
-	rand.Seed(clock.Now().UnixNano())
+	rand.Seed(clock.WallClockTime().UnixNano())
 
 	// the test is randomized and runs very quickly, run it lots of times
 	failed := false
@@ -275,7 +275,7 @@ func TestIndexBlobManagerPreventsResurrectOfDeletedContents(t *testing.T) {
 }
 
 func TestCompactionCreatesPreviousIndex(t *testing.T) {
-	rand.Seed(clock.Now().UnixNano())
+	rand.Seed(clock.WallClockTime().UnixNano())
 
 	storageData := blobtesting.DataMap{}
 
@@ -326,7 +326,7 @@ func TestCompactionCreatesPreviousIndex(t *testing.T) {
 }
 
 func TestIndexBlobManagerPreventsResurrectOfDeletedContents_RandomizedTimings(t *testing.T) {
-	rand.Seed(clock.Now().UnixNano())
+	rand.Seed(clock.WallClockTime().UnixNano())
 
 	numAttempts := 1000
 	if testutil.ShouldReduceTestComplexity() {

--- a/repo/content/internal_logger.go
+++ b/repo/content/internal_logger.go
@@ -76,7 +76,7 @@ func (m *internalLogManager) NewLogger() *zap.SugaredLogger {
 
 	w := &internalLogger{
 		m:      m,
-		prefix: blob.ID(fmt.Sprintf("%v%v_%x", TextLogBlobPrefix, clock.Now().Local().Format("20060102150405"), rnd)),
+		prefix: blob.ID(fmt.Sprintf("%v%v_%x", TextLogBlobPrefix, clock.WallClockTime().Local().Format("20060102150405"), rnd)),
 	}
 
 	return zap.New(zapcore.NewCore(
@@ -203,6 +203,6 @@ func newInternalLogManager(ctx context.Context, st blob.Storage, bc *Crypter) *i
 		st:             st,
 		bc:             bc,
 		flushThreshold: blobLoggerFlushThreshold,
-		timeFunc:       clock.Now,
+		timeFunc:       clock.WallClockTime,
 	}
 }

--- a/repo/content/sessions_test.go
+++ b/repo/content/sessions_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGenerateSessionID(t *testing.T) {
-	n := clock.Now()
+	n := clock.WallClockTime()
 
 	s1, err := generateSessionID(n)
 	if err != nil {

--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -373,7 +373,7 @@ func (r *grpcInnerSession) DeleteManifest(ctx context.Context, id manifest.ID) e
 }
 
 func (r *grpcRepositoryClient) Time() time.Time {
-	return clock.Now()
+	return clock.WallClockTime()
 }
 
 func (r *grpcRepositoryClient) Refresh(ctx context.Context) error {

--- a/repo/maintenance/blob_gc_test.go
+++ b/repo/maintenance/blob_gc_test.go
@@ -107,7 +107,7 @@ func (s *formatSpecificTestSuite) TestDeleteUnreferencedBlobs(t *testing.T) {
 	mustPutDummyBlob(t, env.RepositoryWriter.BlobStorage(), extraBlobIDWithSession3)
 
 	session1Marker := mustPutDummySessionBlob(t, env.RepositoryWriter.BlobStorage(), "s01", &content.SessionInfo{
-		CheckpointTime: clock.Now(),
+		CheckpointTime: clock.WallClockTime(),
 	})
 	session2Marker := mustPutDummySessionBlob(t, env.RepositoryWriter.BlobStorage(), "s02", &content.SessionInfo{
 		CheckpointTime: ta.NowFunc()(),

--- a/repo/maintenance/cleanup_logs.go
+++ b/repo/maintenance/cleanup_logs.go
@@ -44,7 +44,7 @@ func defaultLogRetention() LogRetentionOptions {
 // CleanupLogs deletes old logs blobs beyond certain age, total size or count.
 func CleanupLogs(ctx context.Context, rep repo.DirectRepositoryWriter, opt LogRetentionOptions) ([]blob.Metadata, error) {
 	if opt.TimeFunc == nil {
-		opt.TimeFunc = clock.Now
+		opt.TimeFunc = clock.WallClockTime
 	}
 
 	allLogBlobs, err := blob.ListAllBlobs(ctx, rep.BlobStorage(), "_")

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -301,7 +301,7 @@ func notRewritingContents(ctx context.Context) {
 }
 
 func notDeletingOrphanedBlobs(ctx context.Context, s *Schedule, safety SafetyParameters) {
-	left := clock.Until(nextBlobDeleteTime(s, safety)).Truncate(time.Second)
+	left := nextBlobDeleteTime(s, safety).Sub(clock.WallClockTime()).Truncate(time.Second)
 
 	log(ctx).Infof("Skipping blob deletion because not enough time has passed yet (%v left).", left)
 }

--- a/repo/maintenance/maintenance_schedule_test.go
+++ b/repo/maintenance/maintenance_schedule_test.go
@@ -27,11 +27,11 @@ func (s *formatSpecificTestSuite) TestMaintenanceSchedule(t *testing.T) {
 		t.Errorf("unexpected NextQuickMaintenanceTime: %v", sch.NextQuickMaintenanceTime)
 	}
 
-	sch.NextFullMaintenanceTime = clock.Now()
-	sch.NextQuickMaintenanceTime = clock.Now()
+	sch.NextFullMaintenanceTime = clock.WallClockTime()
+	sch.NextQuickMaintenanceTime = clock.WallClockTime()
 	sch.ReportRun("foo", maintenance.RunInfo{
-		Start:   clock.Now(),
-		End:     clock.Now(),
+		Start:   clock.WallClockTime(),
+		End:     clock.WallClockTime(),
 		Success: true,
 	})
 

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -268,7 +268,7 @@ type ManagerOptions struct {
 func NewManager(ctx context.Context, b contentManager, options ManagerOptions) (*Manager, error) {
 	timeNow := options.TimeNow
 	if timeNow == nil {
-		timeNow = clock.Now
+		timeNow = clock.WallClockTime
 	}
 
 	m := &Manager{

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -254,7 +254,7 @@ func TestCheckpointing(t *testing.T) {
 }
 
 func TestObjectWriterRaceBetweenCheckpointAndResult(t *testing.T) {
-	rand.Seed(clock.Now().UnixNano())
+	rand.Seed(clock.WallClockTime().UnixNano())
 
 	ctx := testlogging.Context(t)
 	data := map[content.ID][]byte{}

--- a/repo/open.go
+++ b/repo/open.go
@@ -307,7 +307,7 @@ func readFormatBlobBytesFromCache(ctx context.Context, cachedFile string, validD
 		return nil, errors.Wrap(err, "unable to open cache file")
 	}
 
-	if clock.Since(cst.ModTime()) > validDuration {
+	if clock.WallClockTime().Sub(cst.ModTime()) > validDuration {
 		// got cached file, but it's too old, remove it
 		if err := os.Remove(cachedFile); err != nil {
 			log(ctx).Debugf("unable to remove cache file: %v", err)

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -355,7 +355,7 @@ func defaultTime(f func() time.Time) func() time.Time {
 		return f
 	}
 
-	return clock.Now
+	return clock.WallClockTime
 }
 
 var _ DirectRepositoryWriter = (*directRepository)(nil)

--- a/snapshot/snapshotfs/checkpoint_registry_test.go
+++ b/snapshot/snapshotfs/checkpoint_registry_test.go
@@ -63,7 +63,7 @@ func TestCheckpointRegistry(t *testing.T) {
 		t.Fatalf("error running checkpoints: %v", err)
 	}
 
-	dm := dmb.Build(clock.Now(), "checkpoint")
+	dm := dmb.Build(clock.WallClockTime(), "checkpoint")
 	if got, want := len(dm.Entries), 4; got != want {
 		t.Fatalf("got %v entries, wanted %v (%+#v)", got, want, dm.Entries)
 	}

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -251,7 +251,7 @@ func (u *Uploader) uploadStreamingFileInternal(ctx context.Context, relativePath
 
 	de.FileSize = written
 	streamSize = written
-	de.ModTime = clock.Now()
+	de.ModTime = clock.WallClockTime()
 
 	atomic.AddInt32(&u.stats.TotalFileCount, 1)
 	atomic.AddInt64(&u.stats.TotalFileSize, de.FileSize)

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -522,7 +522,7 @@ func TestUploadWithCheckpointing(t *testing.T) {
 	for _, d := range dirsToCheckpointAt {
 		d.OnReaddir(func() {
 			// trigger checkpoint
-			fakeTicker <- clock.Now()
+			fakeTicker <- clock.WallClockTime()
 			// wait for checkpoint
 			<-u.checkpointFinished
 		})

--- a/tests/end_to_end_test/api_server_repository_test.go
+++ b/tests/end_to_end_test/api_server_repository_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/apiclient"
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
@@ -264,7 +263,7 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 	logErrorAndIgnore(t, serverapi.Shutdown(ctx, uiUserCLI))
 
 	// open repository client to a dead server, this should fail quickly instead of retrying forever.
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 
 	repo.OpenAPIServer(ctx, &repo.APIServerInfo{
 		BaseURL:                             sp.baseURL,
@@ -275,7 +274,8 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 		Hostname: "bar",
 	}, nil, "baz")
 
-	if dur := clock.Since(t0); dur > 15*time.Second {
+	// nolint:forbidigo
+	if dur := time.Since(t0); dur > 15*time.Second {
 		t.Fatalf("failed connection took %v", dur)
 	}
 }

--- a/tests/end_to_end_test/auto_update_test.go
+++ b/tests/end_to_end_test/auto_update_test.go
@@ -84,7 +84,7 @@ func TestAutoUpdateEnableTest(t *testing.T) {
 				}
 
 				// verify that initial delay is approximately wantInitialDelay from now +/- 1 minute
-				if got, want := clock.Now().Add(tc.wantInitialDelay), state.NextCheckTime; absDuration(got.Sub(want)) > 1*time.Minute {
+				if got, want := clock.WallClockTime().Add(tc.wantInitialDelay), state.NextCheckTime; absDuration(got.Sub(want)) > 1*time.Minute {
 					t.Errorf("unexpected NextCheckTime: %v, want approx %v", got, want)
 				}
 			}

--- a/tests/end_to_end_test/snapshot_actions_test.go
+++ b/tests/end_to_end_test/snapshot_actions_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/tests/clitestutil"
@@ -94,13 +93,14 @@ func TestSnapshotActionsBeforeSnapshotRoot(t *testing.T) {
 		th+" --exit-code=3 --sleep=30s",
 		"--action-command-mode=async")
 
-	t0 := clock.Now()
+	t0 := time.Now() // nolint:forbidigo
 
 	// at this point the data is all cached so this will be quick, definitely less than 30s,
 	// async action failure will not prevent snapshot success.
 	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
 
-	if dur := clock.Since(t0); dur > 30*time.Second {
+	// nolint:forbidigo
+	if dur := time.Since(t0); dur > 30*time.Second {
 		t.Errorf("command did not execute asynchronously (took %v)", dur)
 	}
 
@@ -111,12 +111,13 @@ func TestSnapshotActionsBeforeSnapshotRoot(t *testing.T) {
 		th+" --sleep=30s",
 		"--action-command-timeout=3s")
 
-	t0 = clock.Now()
+	t0 = time.Now() // nolint:forbidigo
 
 	// the action will be killed after 3s and cause a failure.
 	e.RunAndExpectFailure(t, "snapshot", "create", sharedTestDataDir1)
 
-	if dur := clock.Since(t0); dur > 30*time.Second {
+	// nolint:forbidigo
+	if dur := time.Since(t0); dur > 30*time.Second {
 		t.Errorf("command did not apply timeout (took %v)", dur)
 	}
 

--- a/tests/endurance_test/endurance_test.go
+++ b/tests/endurance_test/endurance_test.go
@@ -71,7 +71,7 @@ func TestEndurance(t *testing.T) {
 
 	defer os.RemoveAll(tmpDir)
 
-	testTime := faketime.NewClockTimeWithOffset(startTime.Sub(clock.Now()))
+	testTime := faketime.NewClockTimeWithOffset(startTime.Sub(clock.WallClockTime()))
 	fts := testenv.NewFakeTimeServer(testTime.NowFunc())
 
 	ft := httptest.NewServer(fts)

--- a/tests/repository_stress_test/repository_stress_test.go
+++ b/tests/repository_stress_test/repository_stress_test.go
@@ -78,7 +78,7 @@ var errSkipped = errors.Errorf("skipped")
 const masterPassword = "foo-bar-baz-1234"
 
 func init() {
-	rand.Seed(clock.Now().UnixNano())
+	rand.Seed(clock.WallClockTime().UnixNano())
 }
 
 func TestStressRepositoryMixAll(t *testing.T) {
@@ -265,7 +265,7 @@ func runStress(t *testing.T, opt *StressOptions) {
 			eg.Go(func() error {
 				log := logging.WithPrefix(fmt.Sprintf("%v::o%v", filepath.Base(configFile), i), logging.Broadcast{
 					logging.Printf(func(msg string, args ...interface{}) {
-						fmt.Fprintf(logFile, clock.Now().Format("2006-01-02T15:04:05.000000Z07:00")+" "+msg+"\n", args...)
+						fmt.Fprintf(logFile, clock.WallClockTime().Format("2006-01-02T15:04:05.000000Z07:00")+" "+msg+"\n", args...)
 					})("test"),
 				})
 

--- a/tests/robustness/checker/checker.go
+++ b/tests/robustness/checker/checker.go
@@ -343,7 +343,7 @@ func (chk *Checker) DeleteSnapshot(ctx context.Context, snapID string, opts map[
 		return err
 	}
 
-	ssMeta.DeletionTime = clock.Now()
+	ssMeta.DeletionTime = clock.WallClockTime()
 	ssMeta.ValidationData = nil
 
 	return chk.safeDeleteFinish(ctx, ssMeta)

--- a/tests/robustness/engine/action.go
+++ b/tests/robustness/engine/action.go
@@ -26,7 +26,7 @@ func (e *Engine) ExecAction(ctx context.Context, actionKey ActionKey, opts map[s
 	e.statsIncrActionCountAndLog(actionKey)
 
 	action := actions[actionKey]
-	st := clock.Now()
+	st := clock.WallClockTime()
 
 	logEntry := &LogEntry{
 		StartTime:       st,

--- a/tests/robustness/engine/engine.go
+++ b/tests/robustness/engine/engine.go
@@ -13,8 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/tests/robustness"
 	"github.com/kopia/kopia/tests/robustness/checker"
 )
@@ -63,7 +63,7 @@ func New(args *Args) (*Engine, error) {
 			baseDirPath: args.WorkingDir,
 			RunStats: Stats{
 				RunCounter:     1,
-				CreationTime:   clock.Now(),
+				CreationTime:   time.Now(), // nolint:forbidigo
 				PerActionStats: make(map[ActionKey]*ActionStats),
 			},
 		}
@@ -129,7 +129,7 @@ func (e *Engine) Shutdown(ctx context.Context) error {
 
 	log.Print(cleanupSummaryBuilder.String())
 
-	e.RunStats.RunTime = clock.Since(e.RunStats.CreationTime)
+	e.RunStats.RunTime = time.Since(e.RunStats.CreationTime) // nolint:forbidigo
 	e.CumulativeStats.RunTime += e.RunStats.RunTime
 
 	defer e.cleanComponents()

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -717,7 +717,7 @@ func TestStatsPersist(t *testing.T) {
 		MaxRuntime:   35 * time.Minute,
 	}
 
-	creationTime := clock.Now().Add(-time.Hour)
+	creationTime := clock.WallClockTime().Add(-time.Hour)
 
 	eng := &Engine{
 		MetaStore: snapStore,
@@ -783,8 +783,8 @@ func TestLogsPersist(t *testing.T) {
 	logData := Log{
 		Log: []*LogEntry{
 			{
-				StartTime: clock.Now().Add(-time.Hour),
-				EndTime:   clock.Now(),
+				StartTime: clock.WallClockTime().Add(-time.Hour),
+				EndTime:   clock.WallClockTime(),
 				Action:    ActionKey("some action"),
 				Error:     "some error",
 				Idx:       11235,

--- a/tests/robustness/engine/log.go
+++ b/tests/robustness/engine/log.go
@@ -86,7 +86,7 @@ func (elog *Log) AddEntry(l *LogEntry) {
 // AddCompleted finalizes a log entry at the time it is called
 // and with the provided error, before adding it to the Log.
 func (elog *Log) AddCompleted(logEntry *LogEntry, err error) {
-	logEntry.EndTime = clock.Now()
+	logEntry.EndTime = clock.WallClockTime()
 	if err != nil {
 		logEntry.Error = err.Error()
 	}

--- a/tests/robustness/engine/metadata.go
+++ b/tests/robustness/engine/metadata.go
@@ -68,7 +68,7 @@ func (e *Engine) loadStats(ctx context.Context) error {
 			// Swallow key-not-found error. We may not have historical
 			// stats data. Initialize the action map for the cumulative stats
 			e.CumulativeStats.PerActionStats = make(map[ActionKey]*ActionStats)
-			e.CumulativeStats.CreationTime = clock.Now()
+			e.CumulativeStats.CreationTime = clock.WallClockTime()
 
 			return nil
 		}

--- a/tests/robustness/engine/stats.go
+++ b/tests/robustness/engine/stats.go
@@ -8,8 +8,6 @@ import (
 	"log"
 	"strings"
 	"time"
-
-	"github.com/kopia/kopia/internal/clock"
 )
 
 var (
@@ -116,7 +114,7 @@ func (s *ActionStats) AverageRuntime() time.Duration {
 // Record records the current time against the provided start time
 // and updates the stats accordingly.
 func (s *ActionStats) Record(st time.Time, err error) {
-	thisRuntime := clock.Since(st)
+	thisRuntime := time.Since(st) // nolint:forbidigo
 	s.TotalRuntime += thisRuntime
 
 	if thisRuntime > s.MaxRuntime {
@@ -135,7 +133,8 @@ func (s *ActionStats) Record(st time.Time, err error) {
 }
 
 func (stats *Stats) getLifetimeSeconds() int64 {
-	return durationToSec(clock.Since(stats.CreationTime))
+	// nolint:forbidigo
+	return durationToSec(time.Since(stats.CreationTime))
 }
 
 func durationToSec(dur time.Duration) int64 {
@@ -155,7 +154,8 @@ func (e *Engine) getTimestampS() int64 {
 }
 
 func (e *Engine) getRuntimeSeconds() int64 {
-	return durationToSec(e.CumulativeStats.RunTime + clock.Since(e.RunStats.CreationTime))
+	// nolint:forbidigo
+	return durationToSec(e.CumulativeStats.RunTime + time.Since(e.RunStats.CreationTime))
 }
 
 type statsUpdatetype int

--- a/tests/robustness/multiclient_test/multiclient_test.go
+++ b/tests/robustness/multiclient_test/multiclient_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/tests/robustness"
 	"github.com/kopia/kopia/tests/robustness/engine"
@@ -124,7 +123,7 @@ func TestManySmallFilesAcrossDirecoryTree(t *testing.T) {
 
 func TestRandomizedSmall(t *testing.T) {
 	numClients := 4
-	st := clock.Now()
+	st := time.Now() // nolint:forbidigo
 
 	opts := engine.ActionOpts{
 		engine.ActionControlActionKey: map[string]string{
@@ -146,7 +145,8 @@ func TestRandomizedSmall(t *testing.T) {
 		err := tryRestoreIntoDataDirectory(ctx, t)
 		require.NoError(t, err)
 
-		for clock.Since(st) <= *randomizedTestDur {
+		// nolint:forbidigo
+		for time.Since(st) <= *randomizedTestDur {
 			err := tryRandomAction(ctx, t, opts)
 			require.NoError(t, err)
 		}

--- a/tests/robustness/robustness_test/robustness_test.go
+++ b/tests/robustness/robustness_test/robustness_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -95,7 +96,7 @@ func TestManySmallFilesAcrossDirecoryTree(t *testing.T) {
 }
 
 func TestRandomizedSmall(t *testing.T) {
-	st := clock.Now()
+	st := clock.WallClockTime()
 
 	opts := engine.ActionOpts{
 		engine.ActionControlActionKey: map[string]string{
@@ -114,7 +115,9 @@ func TestRandomizedSmall(t *testing.T) {
 	}
 
 	ctx := testlogging.ContextWithLevel(t, testlogging.LevelInfo)
-	for clock.Since(st) <= *randomizedTestDur {
+
+	// nolint:forbidigo
+	for time.Since(st) <= *randomizedTestDur {
 		err := eng.RandomAction(ctx, opts)
 		if errors.Is(err, robustness.ErrNoOp) {
 			t.Log("Random action resulted in no-op")

--- a/tests/robustness/snapmeta/kopia_snapshotter.go
+++ b/tests/robustness/snapmeta/kopia_snapshotter.go
@@ -93,14 +93,14 @@ func (ks *KopiaSnapshotter) CreateSnapshot(ctx context.Context, sourceDir string
 		return
 	}
 
-	ssStart := clock.Now()
+	ssStart := clock.WallClockTime()
 
 	snapID, err = ks.snap.CreateSnapshot(sourceDir)
 	if err != nil {
 		return
 	}
 
-	ssEnd := clock.Now()
+	ssEnd := clock.WallClockTime()
 
 	snapStats = &robustness.CreateSnapshotStats{
 		SnapStartTime: ssStart,

--- a/tests/stress_test/stress_test.go
+++ b/tests/stress_test/stress_test.go
@@ -27,7 +27,7 @@ func TestStressBlockManager(t *testing.T) {
 
 	data := blobtesting.DataMap{}
 	keyTimes := map[blob.ID]time.Time{}
-	memst := blobtesting.NewMapStorage(data, keyTimes, clock.Now)
+	memst := blobtesting.NewMapStorage(data, keyTimes, clock.WallClockTime)
 
 	duration := 3 * time.Second
 	if os.Getenv("CI") != "" {
@@ -53,11 +53,11 @@ func stressTestWithStorage(t *testing.T, st blob.Storage, duration time.Duration
 		}, nil, nil)
 	}
 
-	seed0 := clock.Now().Nanosecond()
+	seed0 := clock.WallClockTime().Nanosecond()
 
 	t.Logf("running with seed %v", seed0)
 
-	deadline := clock.Now().Add(duration)
+	deadline := clock.WallClockTime().Add(duration)
 
 	t.Run("workers", func(t *testing.T) {
 		for i := 0; i < goroutineCount; i++ {
@@ -87,7 +87,7 @@ func stressWorker(ctx context.Context, t *testing.T, deadline time.Time, openMgr
 
 	var workerBlocks []writtenBlock
 
-	for clock.Now().Before(deadline) {
+	for clock.WallClockTime().Before(deadline) {
 		l := rnd.Intn(30000)
 		data := make([]byte, l)
 

--- a/tests/testdirtree/testdirtree.go
+++ b/tests/testdirtree/testdirtree.go
@@ -259,7 +259,7 @@ func createRandomFile(filename string, options DirectoryTreeOptions, counters *D
 		length = mfs
 	}
 
-	if err := iocopy.JustCopy(f, io.LimitReader(rand.New(rand.NewSource(clock.Now().UnixNano())), length)); err != nil {
+	if err := iocopy.JustCopy(f, io.LimitReader(rand.New(rand.NewSource(clock.WallClockTime().UnixNano())), length)); err != nil {
 		return errors.Wrap(err, "file create error")
 	}
 

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -77,7 +77,7 @@ func NewCLITest(t *testing.T, repoCreateFlags []string, runner CLIRunner) *CLITe
 	}
 
 	return &CLITest{
-		startTime:                    clock.Now(),
+		startTime:                    clock.WallClockTime(),
 		RepoDir:                      testutil.TempDirectory(t),
 		ConfigDir:                    configDir,
 		fixedArgs:                    fixedArgs,
@@ -177,7 +177,7 @@ func (e *CLITest) Run(t *testing.T, expectedError bool, args ...string) (stdout,
 	args = e.cmdArgs(args)
 	t.Logf("running 'kopia %v'", strings.Join(args, " "))
 
-	t0 := clock.Now()
+	t0 := clock.WallClockTime()
 
 	stdoutReader, stderrReader, wait, _ := e.Runner.Start(t, args)
 
@@ -223,7 +223,8 @@ func (e *CLITest) Run(t *testing.T, expectedError bool, args ...string) (stdout,
 		require.NoError(t, gotErr, "unexpected error when running 'kopia %v' (stdout:\n%v\nstderr:\n%v", strings.Join(args, " "), strings.Join(stdout, "\n"), strings.Join(stderr, "\n"))
 	}
 
-	t.Logf("finished in %v: 'kopia %v'", clock.Since(t0).Milliseconds(), strings.Join(args, " "))
+	// nolint:forbidigo
+	t.Logf("finished in %v: 'kopia %v'", time.Since(t0).Milliseconds(), strings.Join(args, " "))
 
 	return stdout, stderr, gotErr
 }


### PR DESCRIPTION
The dual time measurement is described in
https://go.googlesource.com/proposal/+/master/design/12914-monotonic.md

The problem in #1402 was that passage of time was measured using
the monotonic time and not wall clock time. When the computer goes
to sleep, monotonic time is still monotonic while wall clock time makes
a leap when the computer wakes up. This is the behavior that
epoch manager (and most other compontents in Kopia) rely upon.

The fix is to discard hidden monotonic time component of time.Time
by converting to unix time and back.

Reviewed usage of clock.Now() and replaced with clock.WallClockTime()
or time.Now() as appropriate.

Fixes #1402