### PR TITLE
Use blob.OutputBuffer in blob.Reader interface instead of internal gather.WriteBuffer

### DIFF
--- a/internal/blobtesting/eventually_consistent.go
+++ b/internal/blobtesting/eventually_consistent.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/clock"
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -102,7 +101,7 @@ func (s *eventuallyConsistentStorage) randomFrontendCache() *ecFrontendCache {
 	return s.caches[n]
 }
 
-func (s *eventuallyConsistentStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (s *eventuallyConsistentStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	// don't bother caching partial reads
 	if length >= 0 {
 		return s.realStorage.GetBlob(ctx, id, offset, length, output)

--- a/internal/blobtesting/eventually_consistent.go
+++ b/internal/blobtesting/eventually_consistent.go
@@ -12,6 +12,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -116,13 +118,17 @@ func (s *eventuallyConsistentStorage) GetBlob(ctx context.Context, id blob.ID, o
 			return blob.ErrBlobNotFound
 		}
 
-		output.Append(e.data)
+		if _, err := output.Write(e.data); err != nil {
+			return errors.Wrap(err, "error appending to output")
+		}
 
 		return nil
 	}
 
+	var buf gather.WriteBuffer
+
 	// fetch from the underlying storage.
-	err := s.realStorage.GetBlob(ctx, id, offset, length, output)
+	err := s.realStorage.GetBlob(ctx, id, offset, length, &buf)
 	if err != nil {
 		if errors.Is(err, blob.ErrBlobNotFound) {
 			c.put(id, nil)
@@ -131,9 +137,9 @@ func (s *eventuallyConsistentStorage) GetBlob(ctx context.Context, id blob.ID, o
 		return err
 	}
 
-	c.put(id, output.ToByteSlice())
+	c.put(id, buf.ToByteSlice())
 
-	return nil
+	return iocopy.JustCopy(output, buf.Bytes().Reader())
 }
 
 func (s *eventuallyConsistentStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata, error) {

--- a/internal/blobtesting/faulty.go
+++ b/internal/blobtesting/faulty.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/logging"
 )
@@ -31,7 +30,7 @@ type FaultyStorage struct {
 }
 
 // GetBlob implements blob.Storage.
-func (s *FaultyStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (s *FaultyStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	if err := s.getNextFault(ctx, "GetBlob", id, offset, length); err != nil {
 		return err
 	}

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -31,28 +31,32 @@ func (s *mapStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int
 	output.Reset()
 
 	data, ok := s.data[id]
-	if ok {
-		if length < 0 {
-			output.Append(data)
+	if !ok {
+		return blob.ErrBlobNotFound
+	}
 
-			return nil
+	if length < 0 {
+		if _, err := output.Write(data); err != nil {
+			return errors.Wrap(err, "error writing data to output")
 		}
-
-		if int(offset) > len(data) || offset < 0 {
-			return errors.Wrapf(blob.ErrInvalidRange, "invalid offset: %v", offset)
-		}
-
-		data = data[offset:]
-		if int(length) > len(data) {
-			return errors.Wrapf(blob.ErrInvalidRange, "invalid length: %v", length)
-		}
-
-		output.Append(data[0:length])
 
 		return nil
 	}
 
-	return blob.ErrBlobNotFound
+	if int(offset) > len(data) || offset < 0 {
+		return errors.Wrapf(blob.ErrInvalidRange, "invalid offset: %v", offset)
+	}
+
+	data = data[offset:]
+	if int(length) > len(data) {
+		return errors.Wrapf(blob.ErrInvalidRange, "invalid length: %v", length)
+	}
+
+	if _, err := output.Write(data[0:length]); err != nil {
+		return errors.Wrap(err, "error writing data to output")
+	}
+
+	return nil
 }
 
 func (s *mapStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata, error) {

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/clock"
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -25,7 +24,7 @@ type mapStorage struct {
 	mutex   sync.RWMutex
 }
 
-func (s *mapStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (s *mapStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -17,7 +17,6 @@ import (
 	"gocloud.dev/gcerrors"
 
 	"github.com/kopia/kopia/internal/clock"
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/retrying"
@@ -38,7 +37,7 @@ type azStorage struct {
 	uploadThrottler   *iothrottler.IOThrottlerPool
 }
 
-func (az *azStorage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (az *azStorage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	if offset < 0 {
 		return errors.Wrap(blob.ErrInvalidRange, "invalid offset")
 	}

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/kothar/go-backblaze.v0"
 
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/retrying"
@@ -35,7 +34,7 @@ type b2Storage struct {
 	uploadThrottler   *iothrottler.IOThrottlerPool
 }
 
-func (s *b2Storage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (s *b2Storage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	fileName := s.getObjectNameString(id)
 
 	if offset < 0 {

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/clock"
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/repo/blob"
@@ -75,7 +74,7 @@ func isRetriable(err error) bool {
 	return errors.Is(err, errRetriableInvalidLength)
 }
 
-func (fs *fsImpl) GetBlobFromPath(ctx context.Context, dirPath, path string, offset, length int64, output *gather.WriteBuffer) error {
+func (fs *fsImpl) GetBlobFromPath(ctx context.Context, dirPath, path string, offset, length int64, output blob.OutputBuffer) error {
 	err := retry.WithExponentialBackoffNoValue(ctx, "GetBlobFromPath:"+path, func() error {
 		output.Reset()
 

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -19,7 +19,6 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/kopia/kopia/internal/clock"
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/throttle"
 	"github.com/kopia/kopia/repo/blob"
@@ -42,7 +41,7 @@ type gcsStorage struct {
 	uploadThrottler   *iothrottler.IOThrottlerPool
 }
 
-func (gcs *gcsStorage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (gcs *gcsStorage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	if offset < 0 {
 		return blob.ErrInvalidRange
 	}

--- a/repo/blob/logging/logging_storage.go
+++ b/repo/blob/logging/logging_storage.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -18,7 +17,7 @@ type loggingStorage struct {
 	prefix string
 }
 
-func (s *loggingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (s *loggingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	timer := timetrack.StartTimer()
 	err := s.base.GetBlob(ctx, id, offset, length, output)
 	dt := timer.Elapsed()

--- a/repo/blob/readonly/readonly_storage.go
+++ b/repo/blob/readonly/readonly_storage.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -19,7 +18,7 @@ type readonlyStorage struct {
 	base blob.Storage
 }
 
-func (s readonlyStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (s readonlyStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	// nolint:wrapcheck
 	return s.base.GetBlob(ctx, id, offset, length, output)
 }

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -17,7 +16,7 @@ type retryingStorage struct {
 	blob.Storage
 }
 
-func (s retryingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (s retryingStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	// nolint:wrapcheck
 	return retry.WithExponentialBackoffNoValue(ctx, fmt.Sprintf("GetBlob(%v,%v,%v)", id, offset, length), func() error {
 		output.Reset()

--- a/repo/blob/s3/s3_pit.go
+++ b/repo/blob/s3/s3_pit.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/readonly"
 )
@@ -54,7 +53,7 @@ func (s *s3PointInTimeStorage) ListBlobs(ctx context.Context, blobIDPrefix blob.
 	return nil
 }
 
-func (s *s3PointInTimeStorage) GetBlob(ctx context.Context, blobID blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (s *s3PointInTimeStorage) GetBlob(ctx context.Context, blobID blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	// getMetadata returns the specific blob version at time t
 	m, err := s.getMetadata(ctx, blobID)
 	if err != nil {

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -39,12 +39,12 @@ type s3Storage struct {
 	storageConfig     *StorageConfig
 }
 
-func (s *s3Storage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (s *s3Storage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	return s.getBlobWithVersion(ctx, b, latestVersionID, offset, length, output)
 }
 
 // getBlobWithVersion returns full or partial contents of a blob with given ID and version.
-func (s *s3Storage) getBlobWithVersion(ctx context.Context, b blob.ID, version string, offset, length int64, output *gather.WriteBuffer) error {
+func (s *s3Storage) getBlobWithVersion(ctx context.Context, b blob.ID, version string, offset, length int64, output blob.OutputBuffer) error {
 	output.Reset()
 
 	attempt := func() error {

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -19,7 +19,6 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 
 	"github.com/kopia/kopia/internal/connection"
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/ospath"
 	"github.com/kopia/kopia/repo/blob"
@@ -104,7 +103,7 @@ func (s *sftpImpl) IsConnectionClosedError(err error) bool {
 	return false
 }
 
-func (s *sftpImpl) GetBlobFromPath(ctx context.Context, dirPath, fullPath string, offset, length int64, output *gather.WriteBuffer) error {
+func (s *sftpImpl) GetBlobFromPath(ctx context.Context, dirPath, fullPath string, offset, length int64, output blob.OutputBuffer) error {
 	// nolint:wrapcheck
 	return s.rec.UsingConnectionNoResult(ctx, "GetBlobFromPath", func(conn connection.Connection) error {
 		r, err := sftpClientFromConnection(conn).Open(fullPath)

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -25,7 +25,7 @@ var log = logging.Module("sharded")
 
 // Impl must be implemented by underlying provided.
 type Impl interface {
-	GetBlobFromPath(ctx context.Context, dirPath, filePath string, offset, length int64, output *gather.WriteBuffer) error
+	GetBlobFromPath(ctx context.Context, dirPath, filePath string, offset, length int64, output blob.OutputBuffer) error
 	GetMetadataFromPath(ctx context.Context, dirPath, filePath string) (blob.Metadata, error)
 	PutBlobInPath(ctx context.Context, dirPath, filePath string, dataSlices blob.Bytes) error
 	SetTimeInPath(ctx context.Context, dirPath, filePath string, t time.Time) error
@@ -46,7 +46,7 @@ type Storage struct {
 }
 
 // GetBlob implements blob.Storage.
-func (s *Storage) GetBlob(ctx context.Context, blobID blob.ID, offset, length int64, output *gather.WriteBuffer) error {
+func (s *Storage) GetBlob(ctx context.Context, blobID blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	dirPath, filePath, err := s.GetShardedPathAndFilePath(ctx, blobID)
 	if err != nil {
 		return errors.Wrap(err, "error determining sharded path")

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/kopia/kopia/internal/gather"
 )
 
 // ErrSetTimeUnsupported is returned by implementations of Storage that don't support SetTime.
@@ -28,13 +26,23 @@ type Bytes interface {
 	Reader() io.Reader
 }
 
+// OutputBuffer is implemented by *gather.WriteBuffer.
+type OutputBuffer interface {
+	io.Writer
+
+	Reset()
+	Length() int
+	ToByteSlice() []byte
+	Append(data []byte)
+}
+
 // Reader defines read access API to blob storage.
 type Reader interface {
 	// GetBlob returns full or partial contents of a blob with given ID.
 	// If length>0, the the function retrieves a range of bytes [offset,offset+length)
 	// If length<0, the entire blob must be fetched.
 	// Returns ErrInvalidRange if the fetched blob length is invalid.
-	GetBlob(ctx context.Context, blobID ID, offset, length int64, output *gather.WriteBuffer) error
+	GetBlob(ctx context.Context, blobID ID, offset, length int64, output OutputBuffer) error
 
 	// GetMetadata returns Metadata about single blob.
 	GetMetadata(ctx context.Context, blobID ID) (Metadata, error)

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -32,8 +32,6 @@ type OutputBuffer interface {
 
 	Reset()
 	Length() int
-	ToByteSlice() []byte
-	Append(data []byte)
 }
 
 // Reader defines read access API to blob storage.

--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/studio-b12/gowebdav"
 
-	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/internal/tlsutil"
@@ -48,7 +47,7 @@ type davStorageImpl struct {
 	cli *gowebdav.Client
 }
 
-func (d *davStorageImpl) GetBlobFromPath(ctx context.Context, dirPath, path string, offset, length int64, output *gather.WriteBuffer) error {
+func (d *davStorageImpl) GetBlobFromPath(ctx context.Context, dirPath, path string, offset, length int64, output blob.OutputBuffer) error {
 	output.Reset()
 
 	if offset < 0 {


### PR DESCRIPTION
Exported blob.Storage interface can't be implemented as GetBlob() is using internal gather.WriteBuffer as an output argument type.

My use case is to intercept all Kopia calls to blob.Storage so I can recreate new underlying blob.Storage on the fly if AWS session expires in the middle of a long operation like creating the snapshot.

I am also using this blob.Storage wrapper to log and keep statistics of all calls to blob.Storage.

Proposed changes change the GetBlob() argument type to blob.OutputBuffer.

make command ran all tests successfully

Forum discussion reference:
https://kopia.discourse.group/t/implementing-repo-blob-reader-interface/706/4
