### PR TITLE
fixed directory read race condition

### DIFF
--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -127,6 +127,11 @@ func scanCacheDir(dirname string) (fileCount int, totalFileLength int64, err err
 
 	for _, e := range entries {
 		fi, err := e.Info()
+		if os.IsNotExist(err) {
+			// we lost the race, the file was deleted since it was listed.
+			continue
+		}
+
 		if err != nil {
 			return 0, 0, errors.Wrap(err, "unable to read file info")
 		}

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -278,6 +278,11 @@ func sweepLogDir(ctx context.Context, dirname string, maxCount int, maxAge time.
 
 	for _, e := range entries {
 		info, err2 := e.Info()
+		if os.IsNotExist(err2) {
+			// we lost the race, the file was deleted since it was listed.
+			continue
+		}
+
 		if err2 != nil {
 			log(ctx).Errorf("unable to read file info: %v", err2)
 			return

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -233,6 +233,12 @@ func (fs *fsImpl) ReadDir(ctx context.Context, dirname string) ([]os.FileInfo, e
 
 	for _, e := range v.([]os.DirEntry) {
 		fi, err := e.Info()
+
+		if os.IsNotExist(err) {
+			// we lost the race, the file was deleted since it was listed.
+			continue
+		}
+
 		if err != nil {
 			// nolint:wrapcheck
 			return nil, err

--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -148,6 +148,11 @@ func (c *diskCommittedContentIndexCache) expireUnused(ctx context.Context, used 
 
 	for _, ent := range entries {
 		fi, err := ent.Info()
+		if os.IsNotExist(err) {
+			// we lost the race, the file was deleted since it was listed.
+			continue
+		}
+
 		if err != nil {
 			return errors.Wrap(err, "failed to read file info")
 		}


### PR DESCRIPTION
This was introduced by a refactoring in #1361 - unlike
ioutil.ReadDir() which internally handles list/delete race and always
returns os.FileInfo, Info() on os.DirEntry can fail if a file
is deleted right after listing it.

Fixes #1486