### PR TITLE
server: add API endpoints for source, snapshot, batch deletion

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -76,11 +76,14 @@ func (s *Server) APIHandlers(legacyAPI bool) http.Handler {
 	// sources
 	m.HandleFunc("/api/v1/sources", s.handleAPI(requireUIUser, s.handleSourcesList)).Methods(http.MethodGet)
 	m.HandleFunc("/api/v1/sources", s.handleAPI(requireUIUser, s.handleSourcesCreate)).Methods(http.MethodPost)
+	m.HandleFunc("/api/v1/sources/delete", s.handleAPI(requireUIUser, s.handleDelete)).Methods(http.MethodDelete)
 	m.HandleFunc("/api/v1/sources/upload", s.handleAPI(requireUIUser, s.handleUpload)).Methods(http.MethodPost)
 	m.HandleFunc("/api/v1/sources/cancel", s.handleAPI(requireUIUser, s.handleCancel)).Methods(http.MethodPost)
 
 	// snapshots
 	m.HandleFunc("/api/v1/snapshots", s.handleAPI(requireUIUser, s.handleSnapshotList)).Methods(http.MethodGet)
+	m.HandleFunc("/api/v1/snapshots/{snapshotID}", s.handleAPI(requireUIUser, s.handleSnapshotDelete)).Methods(http.MethodDelete)
+	m.HandleFunc("/api/v1/snapshots:batchDelete", s.handleAPI(requireUIUser, s.handleSnapshotDeleteBatch)).Methods(http.MethodPost)
 
 	m.HandleFunc("/api/v1/policy", s.handleAPI(requireUIUser, s.handlePolicyGet)).Methods(http.MethodGet)
 	m.HandleFunc("/api/v1/policy", s.handleAPI(requireUIUser, s.handlePolicyPut)).Methods(http.MethodPut)
@@ -415,6 +418,10 @@ func (s *Server) handleUpload(ctx context.Context, r *http.Request, body []byte)
 
 func (s *Server) handleCancel(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
 	return s.forAllSourceManagersMatchingURLFilter(ctx, (*sourceManager).cancel, r.URL.Query())
+}
+
+func (s *Server) handleDelete(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
+	return s.forAllSourceManagersMatchingURLFilter(ctx, (*sourceManager).delete, r.URL.Query())
 }
 
 func (s *Server) beginUpload(ctx context.Context, src snapshot.SourceInfo) {

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -196,6 +196,12 @@ func (s *sourceManager) upload(ctx context.Context) serverapi.SourceActionRespon
 	return serverapi.SourceActionResponse{Success: true}
 }
 
+func (s *sourceManager) delete(ctx context.Context) serverapi.SourceActionResponse {
+	log(ctx).Infof("deletion triggered via API: %v", s.src)
+
+	return serverapi.SourceActionResponse{Success: false}
+}
+
 func (s *sourceManager) cancel(ctx context.Context) serverapi.SourceActionResponse {
 	log(ctx).Infof("cancel triggered via API: %v", s.src)
 

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -147,6 +147,11 @@ type CreateSnapshotSourceResponse struct {
 	SnapshotStarted bool `json:"snapshotted"` // whether snapshotting has been started
 }
 
+// BatchSnapshotDeleteRequest contains a list of snapshot IDs to be deleted.
+type BatchSnapshotDeleteRequest struct {
+	SnapshotManifestIds []string `json:"snapshotManifestIDs"`
+}
+
 // Snapshot describes single snapshot entry.
 type Snapshot struct {
 	ID               manifest.ID          `json:"id"`


### PR DESCRIPTION
as per our slack discussions, i just set up the endpoints and added some base logic. i probably could have made it a bit simpler for step 1 but it got away from me a bit, haha.

tested everything with `curl` on a server started with `--insecure --without-password` and had the expected results

let me know what you think 😄 