### PR TITLE
storage api put-blob retention options

### DIFF
--- a/cli/command_repository_repair.go
+++ b/cli/command_repository_repair.go
@@ -84,7 +84,7 @@ func (c *commandRepositoryRepair) recoverFormatBlob(ctx context.Context, st blob
 			log(ctx).Infof("looking for replica of format blob in %v...", bi.BlobID)
 			if b, err := repo.RecoverFormatBlob(ctx, st, bi.BlobID, bi.Length); err == nil {
 				if !c.repairDryRun {
-					if puterr := st.PutBlob(ctx, repo.FormatBlobID, gather.FromSlice(b)); puterr != nil {
+					if puterr := st.PutBlob(ctx, repo.FormatBlobID, gather.FromSlice(b), blob.StoragePutBlobOptions{}); puterr != nil {
 						return errors.Wrap(puterr, "error writing format blob")
 					}
 				}

--- a/cli/command_repository_repair.go
+++ b/cli/command_repository_repair.go
@@ -84,7 +84,7 @@ func (c *commandRepositoryRepair) recoverFormatBlob(ctx context.Context, st blob
 			log(ctx).Infof("looking for replica of format blob in %v...", bi.BlobID)
 			if b, err := repo.RecoverFormatBlob(ctx, st, bi.BlobID, bi.Length); err == nil {
 				if !c.repairDryRun {
-					if puterr := st.PutBlob(ctx, repo.FormatBlobID, gather.FromSlice(b), blob.StoragePutBlobOptions{}); puterr != nil {
+					if puterr := st.PutBlob(ctx, repo.FormatBlobID, gather.FromSlice(b), blob.PutOptions{}); puterr != nil {
 						return errors.Wrap(puterr, "error writing format blob")
 					}
 				}

--- a/cli/command_repository_sync.go
+++ b/cli/command_repository_sync.go
@@ -303,7 +303,7 @@ func (c *commandRepositorySyncTo) syncCopyBlob(ctx context.Context, m blob.Metad
 		return errors.Wrapf(err, "error reading blob '%v' from source", m.BlobID)
 	}
 
-	if err := dst.PutBlob(ctx, m.BlobID, data.Bytes()); err != nil {
+	if err := dst.PutBlob(ctx, m.BlobID, data.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
 		return errors.Wrapf(err, "error writing blob '%v' to destination", m.BlobID)
 	}
 
@@ -350,7 +350,7 @@ func (c *commandRepositorySyncTo) ensureRepositoriesHaveSameFormatBlob(ctx conte
 				return errors.Errorf("destination repository does not have a format blob")
 			}
 
-			return errors.Wrap(dst.PutBlob(ctx, repo.FormatBlobID, srcData.Bytes()), "error saving format blob")
+			return errors.Wrap(dst.PutBlob(ctx, repo.FormatBlobID, srcData.Bytes(), blob.StoragePutBlobOptions{}), "error saving format blob")
 		}
 
 		return errors.Wrap(err, "error reading destination repository format blob")

--- a/cli/command_repository_sync.go
+++ b/cli/command_repository_sync.go
@@ -303,7 +303,7 @@ func (c *commandRepositorySyncTo) syncCopyBlob(ctx context.Context, m blob.Metad
 		return errors.Wrapf(err, "error reading blob '%v' from source", m.BlobID)
 	}
 
-	if err := dst.PutBlob(ctx, m.BlobID, data.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
+	if err := dst.PutBlob(ctx, m.BlobID, data.Bytes(), blob.PutOptions{}); err != nil {
 		return errors.Wrapf(err, "error writing blob '%v' to destination", m.BlobID)
 	}
 
@@ -350,7 +350,7 @@ func (c *commandRepositorySyncTo) ensureRepositoriesHaveSameFormatBlob(ctx conte
 				return errors.Errorf("destination repository does not have a format blob")
 			}
 
-			return errors.Wrap(dst.PutBlob(ctx, repo.FormatBlobID, srcData.Bytes(), blob.StoragePutBlobOptions{}), "error saving format blob")
+			return errors.Wrap(dst.PutBlob(ctx, repo.FormatBlobID, srcData.Bytes(), blob.PutOptions{}), "error saving format blob")
 		}
 
 		return errors.Wrap(err, "error reading destination repository format blob")

--- a/internal/blobtesting/concurrent.go
+++ b/internal/blobtesting/concurrent.go
@@ -92,7 +92,7 @@ func VerifyConcurrentAccess(t *testing.T, st blob.Storage, options ConcurrentAcc
 			for i := 0; i < options.Iterations; i++ {
 				blobID := randomBlobID()
 				data := fmt.Sprintf("%v-%v", blobID, rand.Int63())
-				err := st.PutBlob(ctx, blobID, gather.FromSlice([]byte(data)))
+				err := st.PutBlob(ctx, blobID, gather.FromSlice([]byte(data)), blob.StoragePutBlobOptions{})
 				if err != nil {
 					return errors.Wrapf(err, "PutBlob %v returned unexpected error", blobID)
 				}

--- a/internal/blobtesting/concurrent.go
+++ b/internal/blobtesting/concurrent.go
@@ -92,7 +92,7 @@ func VerifyConcurrentAccess(t *testing.T, st blob.Storage, options ConcurrentAcc
 			for i := 0; i < options.Iterations; i++ {
 				blobID := randomBlobID()
 				data := fmt.Sprintf("%v-%v", blobID, rand.Int63())
-				err := st.PutBlob(ctx, blobID, gather.FromSlice([]byte(data)), blob.StoragePutBlobOptions{})
+				err := st.PutBlob(ctx, blobID, gather.FromSlice([]byte(data)), blob.PutOptions{})
 				if err != nil {
 					return errors.Wrapf(err, "PutBlob %v returned unexpected error", blobID)
 				}

--- a/internal/blobtesting/eventually_consistent.go
+++ b/internal/blobtesting/eventually_consistent.go
@@ -157,8 +157,8 @@ func (s *eventuallyConsistentStorage) GetMetadata(ctx context.Context, id blob.I
 	return s.realStorage.GetMetadata(ctx, id)
 }
 
-func (s *eventuallyConsistentStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
-	if err := s.realStorage.PutBlob(ctx, id, data); err != nil {
+func (s *eventuallyConsistentStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+	if err := s.realStorage.PutBlob(ctx, id, data, opts); err != nil {
 		return err
 	}
 

--- a/internal/blobtesting/eventually_consistent.go
+++ b/internal/blobtesting/eventually_consistent.go
@@ -157,7 +157,7 @@ func (s *eventuallyConsistentStorage) GetMetadata(ctx context.Context, id blob.I
 	return s.realStorage.GetMetadata(ctx, id)
 }
 
-func (s *eventuallyConsistentStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s *eventuallyConsistentStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	if err := s.realStorage.PutBlob(ctx, id, data, opts); err != nil {
 		return err
 	}

--- a/internal/blobtesting/faulty.go
+++ b/internal/blobtesting/faulty.go
@@ -48,7 +48,7 @@ func (s *FaultyStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metad
 }
 
 // PutBlob implements blob.Storage.
-func (s *FaultyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s *FaultyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	if err := s.getNextFault(ctx, "PutBlob", id); err != nil {
 		return err
 	}

--- a/internal/blobtesting/faulty.go
+++ b/internal/blobtesting/faulty.go
@@ -48,12 +48,12 @@ func (s *FaultyStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metad
 }
 
 // PutBlob implements blob.Storage.
-func (s *FaultyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
+func (s *FaultyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
 	if err := s.getNextFault(ctx, "PutBlob", id); err != nil {
 		return err
 	}
 
-	return s.Base.PutBlob(ctx, id, data)
+	return s.Base.PutBlob(ctx, id, data, opts)
 }
 
 // SetTime implements blob.Storage.

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -75,7 +75,11 @@ func (s *mapStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata
 	return blob.Metadata{}, blob.ErrBlobNotFound
 }
 
-func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
+func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+	if opts.RetentionPeriod != 0 || opts.RetentionMode != "" {
+		return blob.ErrBlobRetentionUnsupported
+	}
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -77,7 +77,7 @@ func (s *mapStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata
 
 func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	if opts.HasRetentionOptions() {
-		return blob.ErrBlobRetentionUnsupported
+		return errors.New("setting blob-retention is not supported")
 	}
 
 	s.mutex.Lock()

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -76,7 +76,7 @@ func (s *mapStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata
 }
 
 func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
-	if opts.RetentionPeriod != 0 || opts.RetentionMode != "" {
+	if opts.HasRetentionOptions() {
 		return blob.ErrBlobRetentionUnsupported
 	}
 

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -75,7 +75,7 @@ func (s *mapStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata
 	return blob.Metadata{}, blob.ErrBlobNotFound
 }
 
-func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	if opts.HasRetentionOptions() {
 		return blob.ErrBlobRetentionUnsupported
 	}

--- a/internal/blobtesting/map_test.go
+++ b/internal/blobtesting/map_test.go
@@ -15,5 +15,5 @@ func TestMapStorage(t *testing.T) {
 		t.Errorf("unexpected result: %v", r)
 	}
 
-	VerifyStorage(testlogging.Context(t), t, r, blob.StoragePutBlobOptions{})
+	VerifyStorage(testlogging.Context(t), t, r, blob.PutOptions{})
 }

--- a/internal/blobtesting/map_test.go
+++ b/internal/blobtesting/map_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/repo/blob"
 )
 
 func TestMapStorage(t *testing.T) {
@@ -14,5 +15,5 @@ func TestMapStorage(t *testing.T) {
 		t.Errorf("unexpected result: %v", r)
 	}
 
-	VerifyStorage(testlogging.Context(t), t, r)
+	VerifyStorage(testlogging.Context(t), t, r, blob.StoragePutBlobOptions{})
 }

--- a/internal/blobtesting/verify.go
+++ b/internal/blobtesting/verify.go
@@ -62,7 +62,7 @@ func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage) {
 				t.Run(fmt.Sprintf("%v-%v", b.blk, i), func(t *testing.T) {
 					t.Parallel()
 
-					if err := r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents)); err != nil {
+					if err := r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents), blob.StoragePutBlobOptions{}); err != nil {
 						t.Fatalf("can't put blob: %v", err)
 					}
 				})
@@ -114,7 +114,7 @@ func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage) {
 			t.Run(string(b.blk), func(t *testing.T) {
 				t.Parallel()
 
-				require.NoErrorf(t, r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents)), "can't put blob: %v", b)
+				require.NoErrorf(t, r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents), blob.StoragePutBlobOptions{}), "can't put blob: %v", b)
 				AssertGetBlob(ctx, t, r, b.blk, b.contents)
 			})
 		}

--- a/internal/blobtesting/verify.go
+++ b/internal/blobtesting/verify.go
@@ -18,7 +18,7 @@ import (
 
 // VerifyStorage verifies the behavior of the specified storage.
 // nolint:gocyclo,thelper
-func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage) {
+func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage, opts blob.StoragePutBlobOptions) {
 	blocks := []struct {
 		blk      blob.ID
 		contents []byte
@@ -62,7 +62,7 @@ func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage) {
 				t.Run(fmt.Sprintf("%v-%v", b.blk, i), func(t *testing.T) {
 					t.Parallel()
 
-					if err := r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents), blob.StoragePutBlobOptions{}); err != nil {
+					if err := r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents), opts); err != nil {
 						t.Fatalf("can't put blob: %v", err)
 					}
 				})

--- a/internal/blobtesting/verify.go
+++ b/internal/blobtesting/verify.go
@@ -18,7 +18,7 @@ import (
 
 // VerifyStorage verifies the behavior of the specified storage.
 // nolint:gocyclo,thelper
-func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage, opts blob.StoragePutBlobOptions) {
+func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage, opts blob.PutOptions) {
 	blocks := []struct {
 		blk      blob.ID
 		contents []byte
@@ -114,7 +114,7 @@ func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage, opts blob.
 			t.Run(string(b.blk), func(t *testing.T) {
 				t.Parallel()
 
-				require.NoErrorf(t, r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents), blob.StoragePutBlobOptions{}), "can't put blob: %v", b)
+				require.NoErrorf(t, r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents), blob.PutOptions{}), "can't put blob: %v", b)
 				AssertGetBlob(ctx, t, r, b.blk, b.contents)
 			})
 		}

--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -126,7 +126,7 @@ func (c *PersistentCache) Put(ctx context.Context, key string, data gather.Bytes
 
 	c.storageProtection.Protect(key, data, &protected)
 
-	if err := c.cacheStorage.PutBlob(ctx, blob.ID(key), protected.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
+	if err := c.cacheStorage.PutBlob(ctx, blob.ID(key), protected.Bytes(), blob.PutOptions{}); err != nil {
 		stats.Record(ctx, MetricStoreErrors.M(1))
 
 		log(ctx).Errorf("unable to add %v to %v: %v", key, c.description, err)

--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -126,7 +126,7 @@ func (c *PersistentCache) Put(ctx context.Context, key string, data gather.Bytes
 
 	c.storageProtection.Protect(key, data, &protected)
 
-	if err := c.cacheStorage.PutBlob(ctx, blob.ID(key), protected.Bytes()); err != nil {
+	if err := c.cacheStorage.PutBlob(ctx, blob.ID(key), protected.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
 		stats.Record(ctx, MetricStoreErrors.M(1))
 
 		log(ctx).Errorf("unable to add %v to %v: %v", key, c.description, err)

--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -191,7 +191,7 @@ func (e *Manager) AdvanceDeletionWatermark(ctx context.Context, ts time.Time) er
 
 	blobID := blob.ID(fmt.Sprintf("%v%v", string(DeletionWatermarkBlobPrefix), ts.Unix()))
 
-	if err := e.st.PutBlob(ctx, blobID, gather.FromSlice([]byte("deletion-watermark"))); err != nil {
+	if err := e.st.PutBlob(ctx, blobID, gather.FromSlice([]byte("deletion-watermark")), blob.StoragePutBlobOptions{}); err != nil {
 		return errors.Wrap(err, "error writing deletion watermark")
 	}
 
@@ -620,7 +620,7 @@ func (e *Manager) refreshAttemptLocked(ctx context.Context) error {
 func (e *Manager) advanceEpoch(ctx context.Context, cs CurrentSnapshot) error {
 	blobID := blob.ID(fmt.Sprintf("%v%v", string(EpochMarkerIndexBlobPrefix), cs.WriteEpoch+1))
 
-	if err := e.st.PutBlob(ctx, blobID, gather.FromSlice([]byte("epoch-marker"))); err != nil {
+	if err := e.st.PutBlob(ctx, blobID, gather.FromSlice([]byte("epoch-marker")), blob.StoragePutBlobOptions{}); err != nil {
 		return errors.Wrap(err, "error writing epoch marker")
 	}
 
@@ -688,7 +688,7 @@ func (e *Manager) WriteIndex(ctx context.Context, dataShards map[blob.ID]blob.By
 		for unprefixedBlobID, data := range dataShards {
 			blobID := UncompactedEpochBlobPrefix(cs.WriteEpoch) + unprefixedBlobID
 
-			if err := e.st.PutBlob(ctx, blobID, data); err != nil {
+			if err := e.st.PutBlob(ctx, blobID, data, blob.StoragePutBlobOptions{}); err != nil {
 				return nil, errors.Wrap(err, "error writing index blob")
 			}
 

--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -191,7 +191,7 @@ func (e *Manager) AdvanceDeletionWatermark(ctx context.Context, ts time.Time) er
 
 	blobID := blob.ID(fmt.Sprintf("%v%v", string(DeletionWatermarkBlobPrefix), ts.Unix()))
 
-	if err := e.st.PutBlob(ctx, blobID, gather.FromSlice([]byte("deletion-watermark")), blob.StoragePutBlobOptions{}); err != nil {
+	if err := e.st.PutBlob(ctx, blobID, gather.FromSlice([]byte("deletion-watermark")), blob.PutOptions{}); err != nil {
 		return errors.Wrap(err, "error writing deletion watermark")
 	}
 
@@ -620,7 +620,7 @@ func (e *Manager) refreshAttemptLocked(ctx context.Context) error {
 func (e *Manager) advanceEpoch(ctx context.Context, cs CurrentSnapshot) error {
 	blobID := blob.ID(fmt.Sprintf("%v%v", string(EpochMarkerIndexBlobPrefix), cs.WriteEpoch+1))
 
-	if err := e.st.PutBlob(ctx, blobID, gather.FromSlice([]byte("epoch-marker")), blob.StoragePutBlobOptions{}); err != nil {
+	if err := e.st.PutBlob(ctx, blobID, gather.FromSlice([]byte("epoch-marker")), blob.PutOptions{}); err != nil {
 		return errors.Wrap(err, "error writing epoch marker")
 	}
 
@@ -688,7 +688,7 @@ func (e *Manager) WriteIndex(ctx context.Context, dataShards map[blob.ID]blob.By
 		for unprefixedBlobID, data := range dataShards {
 			blobID := UncompactedEpochBlobPrefix(cs.WriteEpoch) + unprefixedBlobID
 
-			if err := e.st.PutBlob(ctx, blobID, data, blob.StoragePutBlobOptions{}); err != nil {
+			if err := e.st.PutBlob(ctx, blobID, data, blob.PutOptions{}); err != nil {
 				return nil, errors.Wrap(err, "error writing index blob")
 			}
 

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -66,7 +66,7 @@ func (te *epochManagerTestEnv) compact(ctx context.Context, blobs []blob.ID, pre
 	}
 
 	return errors.Wrap(
-		te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s0-c1", prefix, rand.Int63())), gather.FromSlice(merged.Bytes())),
+		te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s0-c1", prefix, rand.Int63())), gather.FromSlice(merged.Bytes()), blob.StoragePutBlobOptions{}),
 		"PutBlob error")
 }
 
@@ -74,8 +74,8 @@ func (te *epochManagerTestEnv) compact(ctx context.Context, blobs []blob.ID, pre
 func (te *epochManagerTestEnv) interruptedCompaction(ctx context.Context, _ []blob.ID, prefix blob.ID) error {
 	sess := rand.Int63()
 
-	te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s%v-c3", prefix, sess, rand.Int63())), gather.FromSlice([]byte("dummy")))
-	te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s%v-c3", prefix, sess, rand.Int63())), gather.FromSlice([]byte("dummy")))
+	te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s%v-c3", prefix, sess, rand.Int63())), gather.FromSlice([]byte("dummy")), blob.StoragePutBlobOptions{})
+	te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s%v-c3", prefix, sess, rand.Int63())), gather.FromSlice([]byte("dummy")), blob.StoragePutBlobOptions{})
 
 	return errors.Errorf("failed for some reason")
 }

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -66,7 +66,7 @@ func (te *epochManagerTestEnv) compact(ctx context.Context, blobs []blob.ID, pre
 	}
 
 	return errors.Wrap(
-		te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s0-c1", prefix, rand.Int63())), gather.FromSlice(merged.Bytes()), blob.StoragePutBlobOptions{}),
+		te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s0-c1", prefix, rand.Int63())), gather.FromSlice(merged.Bytes()), blob.PutOptions{}),
 		"PutBlob error")
 }
 
@@ -74,8 +74,8 @@ func (te *epochManagerTestEnv) compact(ctx context.Context, blobs []blob.ID, pre
 func (te *epochManagerTestEnv) interruptedCompaction(ctx context.Context, _ []blob.ID, prefix blob.ID) error {
 	sess := rand.Int63()
 
-	te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s%v-c3", prefix, sess, rand.Int63())), gather.FromSlice([]byte("dummy")), blob.StoragePutBlobOptions{})
-	te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s%v-c3", prefix, sess, rand.Int63())), gather.FromSlice([]byte("dummy")), blob.StoragePutBlobOptions{})
+	te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s%v-c3", prefix, sess, rand.Int63())), gather.FromSlice([]byte("dummy")), blob.PutOptions{})
+	te.st.PutBlob(ctx, blob.ID(fmt.Sprintf("%v%016x-s%v-c3", prefix, sess, rand.Int63())), gather.FromSlice([]byte("dummy")), blob.PutOptions{})
 
 	return errors.Errorf("failed for some reason")
 }

--- a/internal/listcache/listcache.go
+++ b/internal/listcache/listcache.go
@@ -45,7 +45,7 @@ func (s *listCacheStorage) saveListToCache(ctx context.Context, prefix blob.ID, 
 
 	hmac.Append(gather.FromSlice(data), s.hmacSecret, &b)
 
-	if err := s.cacheStorage.PutBlob(ctx, prefix, b.Bytes()); err != nil {
+	if err := s.cacheStorage.PutBlob(ctx, prefix, b.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
 		log(ctx).Debugf("unable to persist list cache entry: %v", err)
 	}
 }
@@ -114,8 +114,8 @@ func (s *listCacheStorage) ListBlobs(ctx context.Context, prefix blob.ID, cb fun
 }
 
 // PutBlob implements blob.Storage and writes markers into local cache for all successful writes.
-func (s *listCacheStorage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes) error {
-	err := s.Storage.PutBlob(ctx, blobID, data)
+func (s *listCacheStorage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+	err := s.Storage.PutBlob(ctx, blobID, data, opts)
 	s.invalidateAfterUpdate(ctx, blobID)
 
 	// nolint:wrapcheck

--- a/internal/listcache/listcache.go
+++ b/internal/listcache/listcache.go
@@ -45,7 +45,7 @@ func (s *listCacheStorage) saveListToCache(ctx context.Context, prefix blob.ID, 
 
 	hmac.Append(gather.FromSlice(data), s.hmacSecret, &b)
 
-	if err := s.cacheStorage.PutBlob(ctx, prefix, b.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
+	if err := s.cacheStorage.PutBlob(ctx, prefix, b.Bytes(), blob.PutOptions{}); err != nil {
 		log(ctx).Debugf("unable to persist list cache entry: %v", err)
 	}
 }
@@ -114,7 +114,7 @@ func (s *listCacheStorage) ListBlobs(ctx context.Context, prefix blob.ID, cb fun
 }
 
 // PutBlob implements blob.Storage and writes markers into local cache for all successful writes.
-func (s *listCacheStorage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s *listCacheStorage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	err := s.Storage.PutBlob(ctx, blobID, data, opts)
 	s.invalidateAfterUpdate(ctx, blobID)
 

--- a/internal/listcache/listcache_test.go
+++ b/internal/listcache/listcache_test.go
@@ -34,7 +34,7 @@ func TestListCache(t *testing.T) {
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n")
 
 	// modify underlying storage without going through cache layer
-	require.NoError(t, realStorage.PutBlob(ctx, "n1", gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, realStorage.PutBlob(ctx, "n1", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 
 	// still getting empty cached results.
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n")
@@ -42,13 +42,13 @@ func TestListCache(t *testing.T) {
 	// cache expires, real data is read
 	cacheTime.Advance(1 * time.Hour)
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1")
-	require.NoError(t, realStorage.PutBlob(ctx, "n2", gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, realStorage.PutBlob(ctx, "n2", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 
 	// n2 still invisible, "n" is cached.
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1")
 
 	// writing "n3" through the cache storage invalidates "n".
-	require.NoError(t, lc.PutBlob(ctx, "n3", gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, lc.PutBlob(ctx, "n3", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n2", "n3")
 
 	// deleting "n2" through the cache storage invalidates "n".
@@ -56,10 +56,10 @@ func TestListCache(t *testing.T) {
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3")
 
 	// add one more blob.
-	require.NoError(t, realStorage.PutBlob(ctx, "n4", gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, realStorage.PutBlob(ctx, "n4", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 
 	// replace "n" in cache storage with invalid data.
-	require.NoError(t, cachest.PutBlob(ctx, "n", gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, cachest.PutBlob(ctx, "n", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 
 	// on next read, "n" will be discarded and "n4" will be immediately visible.
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4")
@@ -68,7 +68,7 @@ func TestListCache(t *testing.T) {
 
 	// add one more blob.
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4")
-	require.NoError(t, realStorage.PutBlob(ctx, "n5", gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, realStorage.PutBlob(ctx, "n5", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4")
 	cacheTime.Advance(lc.cacheDuration - 1)
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4")
@@ -76,14 +76,14 @@ func TestListCache(t *testing.T) {
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4", "n5")
 
 	// explicit flush
-	require.NoError(t, realStorage.PutBlob(ctx, "n6", gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, realStorage.PutBlob(ctx, "n6", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4", "n5")
 	require.NoError(t, lc.FlushCaches(ctx))
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4", "n5", "n6")
 
 	// non-cached results
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "nc")
-	require.NoError(t, realStorage.PutBlob(ctx, "nc1", gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, realStorage.PutBlob(ctx, "nc1", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "nc", "nc1")
 
 	require.ErrorIs(t, lc.ListBlobs(ctx, "n", func(m blob.Metadata) error {

--- a/internal/listcache/listcache_test.go
+++ b/internal/listcache/listcache_test.go
@@ -34,7 +34,7 @@ func TestListCache(t *testing.T) {
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n")
 
 	// modify underlying storage without going through cache layer
-	require.NoError(t, realStorage.PutBlob(ctx, "n1", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, realStorage.PutBlob(ctx, "n1", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 
 	// still getting empty cached results.
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n")
@@ -42,13 +42,13 @@ func TestListCache(t *testing.T) {
 	// cache expires, real data is read
 	cacheTime.Advance(1 * time.Hour)
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1")
-	require.NoError(t, realStorage.PutBlob(ctx, "n2", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, realStorage.PutBlob(ctx, "n2", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 
 	// n2 still invisible, "n" is cached.
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1")
 
 	// writing "n3" through the cache storage invalidates "n".
-	require.NoError(t, lc.PutBlob(ctx, "n3", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, lc.PutBlob(ctx, "n3", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n2", "n3")
 
 	// deleting "n2" through the cache storage invalidates "n".
@@ -56,10 +56,10 @@ func TestListCache(t *testing.T) {
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3")
 
 	// add one more blob.
-	require.NoError(t, realStorage.PutBlob(ctx, "n4", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, realStorage.PutBlob(ctx, "n4", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 
 	// replace "n" in cache storage with invalid data.
-	require.NoError(t, cachest.PutBlob(ctx, "n", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, cachest.PutBlob(ctx, "n", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 
 	// on next read, "n" will be discarded and "n4" will be immediately visible.
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4")
@@ -68,7 +68,7 @@ func TestListCache(t *testing.T) {
 
 	// add one more blob.
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4")
-	require.NoError(t, realStorage.PutBlob(ctx, "n5", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, realStorage.PutBlob(ctx, "n5", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4")
 	cacheTime.Advance(lc.cacheDuration - 1)
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4")
@@ -76,14 +76,14 @@ func TestListCache(t *testing.T) {
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4", "n5")
 
 	// explicit flush
-	require.NoError(t, realStorage.PutBlob(ctx, "n6", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, realStorage.PutBlob(ctx, "n6", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4", "n5")
 	require.NoError(t, lc.FlushCaches(ctx))
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "n", "n1", "n3", "n4", "n5", "n6")
 
 	// non-cached results
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "nc")
-	require.NoError(t, realStorage.PutBlob(ctx, "nc1", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, realStorage.PutBlob(ctx, "nc1", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 	blobtesting.AssertListResultsIDs(ctx, t, lc, "nc", "nc1")
 
 	require.ErrorIs(t, lc.ListBlobs(ctx, "n", func(m blob.Metadata) error {

--- a/internal/ownwrites/ownwrites.go
+++ b/internal/ownwrites/ownwrites.go
@@ -122,11 +122,11 @@ func (s *CacheStorage) ListBlobs(ctx context.Context, prefix blob.ID, cb func(bl
 }
 
 // PutBlob implements blob.Storage and writes markers into local cache for all successful writes.
-func (s *CacheStorage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes) error {
-	err := s.Storage.PutBlob(ctx, blobID, data)
+func (s *CacheStorage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+	err := s.Storage.PutBlob(ctx, blobID, data, opts)
 	if err == nil && s.isCachedPrefix(blobID) {
 		// nolint:errcheck
-		s.cacheStorage.PutBlob(ctx, prefixAdd+blobID, markerData)
+		s.cacheStorage.PutBlob(ctx, prefixAdd+blobID, markerData, opts)
 	}
 
 	// nolint:wrapcheck
@@ -138,7 +138,7 @@ func (s *CacheStorage) DeleteBlob(ctx context.Context, blobID blob.ID) error {
 	err := s.Storage.DeleteBlob(ctx, blobID)
 	if err == nil && s.isCachedPrefix(blobID) {
 		// nolint:errcheck
-		s.cacheStorage.PutBlob(ctx, prefixDelete+blobID, markerData)
+		s.cacheStorage.PutBlob(ctx, prefixDelete+blobID, markerData, blob.StoragePutBlobOptions{})
 	}
 
 	// nolint:wrapcheck

--- a/internal/ownwrites/ownwrites.go
+++ b/internal/ownwrites/ownwrites.go
@@ -122,7 +122,7 @@ func (s *CacheStorage) ListBlobs(ctx context.Context, prefix blob.ID, cb func(bl
 }
 
 // PutBlob implements blob.Storage and writes markers into local cache for all successful writes.
-func (s *CacheStorage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s *CacheStorage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	err := s.Storage.PutBlob(ctx, blobID, data, opts)
 	if err == nil && s.isCachedPrefix(blobID) {
 		// nolint:errcheck
@@ -138,7 +138,7 @@ func (s *CacheStorage) DeleteBlob(ctx context.Context, blobID blob.ID) error {
 	err := s.Storage.DeleteBlob(ctx, blobID)
 	if err == nil && s.isCachedPrefix(blobID) {
 		// nolint:errcheck
-		s.cacheStorage.PutBlob(ctx, prefixDelete+blobID, markerData, blob.StoragePutBlobOptions{})
+		s.cacheStorage.PutBlob(ctx, prefixDelete+blobID, markerData, blob.PutOptions{})
 	}
 
 	// nolint:wrapcheck

--- a/internal/ownwrites/ownwrites_test.go
+++ b/internal/ownwrites/ownwrites_test.go
@@ -28,14 +28,14 @@ func TestOwnWrites(t *testing.T) {
 	ctx := testlogging.Context(t)
 
 	// seed some blobs into storage and advance time so they are reliably settled.
-	require.NoError(t, ec.PutBlob(ctx, "npreexisting", gather.FromSlice([]byte("pre-existing")), blob.StoragePutBlobOptions{}))
+	require.NoError(t, ec.PutBlob(ctx, "npreexisting", gather.FromSlice([]byte("pre-existing")), blob.PutOptions{}))
 	realStorageTime.Advance(1 * time.Hour)
 
-	require.NoError(t, ow.PutBlob(ctx, "n123", gather.FromSlice([]byte("not-important")), blob.StoragePutBlobOptions{}))
+	require.NoError(t, ow.PutBlob(ctx, "n123", gather.FromSlice([]byte("not-important")), blob.PutOptions{}))
 	// verify we wrote the marker into cache.
 	blobtesting.AssertGetBlob(ctx, t, cachest, "addn123", []byte("marker"))
 
-	require.NoError(t, ow.PutBlob(ctx, "x123", gather.FromSlice([]byte("not-important")), blob.StoragePutBlobOptions{}))
+	require.NoError(t, ow.PutBlob(ctx, "x123", gather.FromSlice([]byte("not-important")), blob.PutOptions{}))
 	blobtesting.AssertGetBlobNotFound(ctx, t, cachest, "addx123")
 
 	// make sure eventual consistency wrapper won't return the item yet.

--- a/internal/ownwrites/ownwrites_test.go
+++ b/internal/ownwrites/ownwrites_test.go
@@ -28,14 +28,14 @@ func TestOwnWrites(t *testing.T) {
 	ctx := testlogging.Context(t)
 
 	// seed some blobs into storage and advance time so they are reliably settled.
-	require.NoError(t, ec.PutBlob(ctx, "npreexisting", gather.FromSlice([]byte("pre-existing"))))
+	require.NoError(t, ec.PutBlob(ctx, "npreexisting", gather.FromSlice([]byte("pre-existing")), blob.StoragePutBlobOptions{}))
 	realStorageTime.Advance(1 * time.Hour)
 
-	require.NoError(t, ow.PutBlob(ctx, "n123", gather.FromSlice([]byte("not-important"))))
+	require.NoError(t, ow.PutBlob(ctx, "n123", gather.FromSlice([]byte("not-important")), blob.StoragePutBlobOptions{}))
 	// verify we wrote the marker into cache.
 	blobtesting.AssertGetBlob(ctx, t, cachest, "addn123", []byte("marker"))
 
-	require.NoError(t, ow.PutBlob(ctx, "x123", gather.FromSlice([]byte("not-important"))))
+	require.NoError(t, ow.PutBlob(ctx, "x123", gather.FromSlice([]byte("not-important")), blob.StoragePutBlobOptions{}))
 	blobtesting.AssertGetBlobNotFound(ctx, t, cachest, "addx123")
 
 	// make sure eventual consistency wrapper won't return the item yet.

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -89,7 +89,7 @@ func ValidateProvider(ctx context.Context, st blob.Storage, opt Options) error {
 	log(ctx).Infof("Writing blob (%v bytes)", len(blobData))
 
 	// write blob
-	if err := st.PutBlob(ctx, prefix1+"1", gather.FromSlice(blobData), blob.StoragePutBlobOptions{}); err != nil {
+	if err := st.PutBlob(ctx, prefix1+"1", gather.FromSlice(blobData), blob.PutOptions{}); err != nil {
 		return errors.Wrap(err, "error writing blob #1")
 	}
 
@@ -230,7 +230,7 @@ func (c *concurrencyTest) putBlobWorker(ctx context.Context, worker int) func() 
 
 			log(ctx).Debugf("PutBlob worker %v writing %v (%v bytes)", worker, id, len(data))
 
-			if err := c.st.PutBlob(ctx, id, gather.FromSlice(data), blob.StoragePutBlobOptions{}); err != nil {
+			if err := c.st.PutBlob(ctx, id, gather.FromSlice(data), blob.PutOptions{}); err != nil {
 				return errors.Wrap(err, "error writing blob")
 			}
 

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -89,7 +89,7 @@ func ValidateProvider(ctx context.Context, st blob.Storage, opt Options) error {
 	log(ctx).Infof("Writing blob (%v bytes)", len(blobData))
 
 	// write blob
-	if err := st.PutBlob(ctx, prefix1+"1", gather.FromSlice(blobData)); err != nil {
+	if err := st.PutBlob(ctx, prefix1+"1", gather.FromSlice(blobData), blob.StoragePutBlobOptions{}); err != nil {
 		return errors.Wrap(err, "error writing blob #1")
 	}
 
@@ -230,7 +230,7 @@ func (c *concurrencyTest) putBlobWorker(ctx context.Context, worker int) func() 
 
 			log(ctx).Debugf("PutBlob worker %v writing %v (%v bytes)", worker, id, len(data))
 
-			if err := c.st.PutBlob(ctx, id, gather.FromSlice(data)); err != nil {
+			if err := c.st.PutBlob(ctx, id, gather.FromSlice(data), blob.StoragePutBlobOptions{}); err != nil {
 				return errors.Wrap(err, "error writing blob")
 			}
 

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -106,7 +106,7 @@ func translateError(err error) error {
 
 func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	if opts.HasRetentionOptions() {
-		return blob.ErrBlobRetentionUnsupported
+		return errors.New("setting blob-retention is not supported")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -105,7 +105,7 @@ func translateError(err error) error {
 }
 
 func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
-	if opts.RetentionPeriod != 0 || opts.RetentionMode != "" {
+	if opts.HasRetentionOptions() {
 		return blob.ErrBlobRetentionUnsupported
 	}
 

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -104,7 +104,7 @@ func translateError(err error) error {
 	}
 }
 
-func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	if opts.HasRetentionOptions() {
 		return blob.ErrBlobRetentionUnsupported
 	}

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -104,7 +104,11 @@ func translateError(err error) error {
 	}
 }
 
-func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes) error {
+func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+	if opts.RetentionPeriod != 0 || opts.RetentionMode != "" {
+		return blob.ErrBlobRetentionUnsupported
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/repo/blob/azure/azure_storage_test.go
+++ b/repo/blob/azure/azure_storage_test.go
@@ -120,7 +120,7 @@ func TestAzureStorage(t *testing.T) {
 
 	defer st.Close(ctx)
 
-	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
+	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 }
@@ -149,7 +149,7 @@ func TestAzureStorageSASToken(t *testing.T) {
 	defer st.Close(ctx)
 	defer blobtesting.CleanupOldData(ctx, t, st, 0)
 
-	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
+	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 }

--- a/repo/blob/azure/azure_storage_test.go
+++ b/repo/blob/azure/azure_storage_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kopia/kopia/internal/providervalidation"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/azure"
 )
 
@@ -119,7 +120,7 @@ func TestAzureStorage(t *testing.T) {
 
 	defer st.Close(ctx)
 
-	blobtesting.VerifyStorage(ctx, t, st)
+	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 }
@@ -148,7 +149,7 @@ func TestAzureStorageSASToken(t *testing.T) {
 	defer st.Close(ctx)
 	defer blobtesting.CleanupOldData(ctx, t, st, 0)
 
-	blobtesting.VerifyStorage(ctx, t, st)
+	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 }

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -147,7 +147,7 @@ func translateError(err error) error {
 	return err
 }
 
-func (s *b2Storage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s *b2Storage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	throttled, err := s.uploadThrottler.AddReader(io.NopCloser(data.Reader()))
 	if err != nil {
 		return translateError(err)

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -147,7 +147,7 @@ func translateError(err error) error {
 	return err
 }
 
-func (s *b2Storage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
+func (s *b2Storage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
 	throttled, err := s.uploadThrottler.AddReader(io.NopCloser(data.Reader()))
 	if err != nil {
 		return translateError(err)

--- a/repo/blob/b2/b2_storage_test.go
+++ b/repo/blob/b2/b2_storage_test.go
@@ -79,7 +79,7 @@ func TestB2Storage(t *testing.T) {
 	defer st.Close(ctx)
 	defer blobtesting.CleanupOldData(ctx, t, st, 0)
 
-	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
+	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 }

--- a/repo/blob/b2/b2_storage_test.go
+++ b/repo/blob/b2/b2_storage_test.go
@@ -79,7 +79,7 @@ func TestB2Storage(t *testing.T) {
 	defer st.Close(ctx)
 	defer blobtesting.CleanupOldData(ctx, t, st, 0)
 
-	blobtesting.VerifyStorage(ctx, t, st)
+	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 }

--- a/repo/blob/filesystem/filesystem_storage_test.go
+++ b/repo/blob/filesystem/filesystem_storage_test.go
@@ -77,11 +77,11 @@ func TestFileStorageTouch(t *testing.T) {
 	}
 
 	fs := r.(*fsStorage)
-	assertNoError(t, fs.PutBlob(ctx, t1, gather.FromSlice([]byte{1})))
+	assertNoError(t, fs.PutBlob(ctx, t1, gather.FromSlice([]byte{1}), blob.StoragePutBlobOptions{}))
 	time.Sleep(2 * time.Second) // sleep a bit to accommodate Apple filesystems with low timestamp resolution
-	assertNoError(t, fs.PutBlob(ctx, t2, gather.FromSlice([]byte{1})))
+	assertNoError(t, fs.PutBlob(ctx, t2, gather.FromSlice([]byte{1}), blob.StoragePutBlobOptions{}))
 	time.Sleep(2 * time.Second)
-	assertNoError(t, fs.PutBlob(ctx, t3, gather.FromSlice([]byte{1})))
+	assertNoError(t, fs.PutBlob(ctx, t3, gather.FromSlice([]byte{1}), blob.StoragePutBlobOptions{}))
 	time.Sleep(2 * time.Second) // sleep a bit to accommodate Apple filesystems with low timestamp resolution
 
 	verifyBlobTimestampOrder(t, fs, t1, t2, t3)
@@ -146,7 +146,7 @@ func TestFilesystemStorageDirectoryShards(t *testing.T) {
 
 	defer st.Close(ctx)
 
-	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 	require.FileExists(t, filepath.Join(dataDir, "someb", "lo", "b1234567812345678.f"))
 }
 

--- a/repo/blob/filesystem/filesystem_storage_test.go
+++ b/repo/blob/filesystem/filesystem_storage_test.go
@@ -44,7 +44,7 @@ func TestFileStorage(t *testing.T) {
 			t.Errorf("unexpected result: %v %v", r, err)
 		}
 
-		blobtesting.VerifyStorage(ctx, t, r)
+		blobtesting.VerifyStorage(ctx, t, r, blob.StoragePutBlobOptions{})
 		blobtesting.AssertConnectionInfoRoundTrips(ctx, t, r)
 		require.NoError(t, providervalidation.ValidateProvider(ctx, r, blobtesting.TestValidationOptions))
 

--- a/repo/blob/filesystem/filesystem_storage_test.go
+++ b/repo/blob/filesystem/filesystem_storage_test.go
@@ -44,7 +44,7 @@ func TestFileStorage(t *testing.T) {
 			t.Errorf("unexpected result: %v %v", r, err)
 		}
 
-		blobtesting.VerifyStorage(ctx, t, r, blob.StoragePutBlobOptions{})
+		blobtesting.VerifyStorage(ctx, t, r, blob.PutOptions{})
 		blobtesting.AssertConnectionInfoRoundTrips(ctx, t, r)
 		require.NoError(t, providervalidation.ValidateProvider(ctx, r, blobtesting.TestValidationOptions))
 
@@ -77,11 +77,11 @@ func TestFileStorageTouch(t *testing.T) {
 	}
 
 	fs := r.(*fsStorage)
-	assertNoError(t, fs.PutBlob(ctx, t1, gather.FromSlice([]byte{1}), blob.StoragePutBlobOptions{}))
+	assertNoError(t, fs.PutBlob(ctx, t1, gather.FromSlice([]byte{1}), blob.PutOptions{}))
 	time.Sleep(2 * time.Second) // sleep a bit to accommodate Apple filesystems with low timestamp resolution
-	assertNoError(t, fs.PutBlob(ctx, t2, gather.FromSlice([]byte{1}), blob.StoragePutBlobOptions{}))
+	assertNoError(t, fs.PutBlob(ctx, t2, gather.FromSlice([]byte{1}), blob.PutOptions{}))
 	time.Sleep(2 * time.Second)
-	assertNoError(t, fs.PutBlob(ctx, t3, gather.FromSlice([]byte{1}), blob.StoragePutBlobOptions{}))
+	assertNoError(t, fs.PutBlob(ctx, t3, gather.FromSlice([]byte{1}), blob.PutOptions{}))
 	time.Sleep(2 * time.Second) // sleep a bit to accommodate Apple filesystems with low timestamp resolution
 
 	verifyBlobTimestampOrder(t, fs, t1, t2, t3)
@@ -146,7 +146,7 @@ func TestFilesystemStorageDirectoryShards(t *testing.T) {
 
 	defer st.Close(ctx)
 
-	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 	require.FileExists(t, filepath.Join(dataDir, "someb", "lo", "b1234567812345678.f"))
 }
 

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -97,7 +97,7 @@ func translateError(err error) error {
 }
 
 func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
-	if opts.RetentionPeriod != 0 || opts.RetentionMode != "" {
+	if opts.HasRetentionOptions() {
 		return blob.ErrBlobRetentionUnsupported
 	}
 

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -96,7 +96,7 @@ func translateError(err error) error {
 	}
 }
 
-func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	if opts.HasRetentionOptions() {
 		return blob.ErrBlobRetentionUnsupported
 	}

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -96,7 +96,11 @@ func translateError(err error) error {
 	}
 }
 
-func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes) error {
+func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+	if opts.RetentionPeriod != 0 || opts.RetentionMode != "" {
+		return blob.ErrBlobRetentionUnsupported
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 
 	obj := gcs.bucket.Object(gcs.getObjectNameString(b))

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -98,7 +98,7 @@ func translateError(err error) error {
 
 func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	if opts.HasRetentionOptions() {
-		return blob.ErrBlobRetentionUnsupported
+		return errors.New("setting blob-retention is not supported")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kopia/kopia/internal/providervalidation"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/gcs"
 )
 
@@ -43,7 +44,7 @@ func TestGCSStorage(t *testing.T) {
 	defer st.Close(ctx)
 	defer blobtesting.CleanupOldData(ctx, t, st, 0)
 
-	blobtesting.VerifyStorage(ctx, t, st)
+	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 }

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -44,7 +44,7 @@ func TestGCSStorage(t *testing.T) {
 	defer st.Close(ctx)
 	defer blobtesting.CleanupOldData(ctx, t, st, 0)
 
-	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
+	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 }

--- a/repo/blob/logging/logging_storage.go
+++ b/repo/blob/logging/logging_storage.go
@@ -50,9 +50,9 @@ func (s *loggingStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Meta
 	return result, err
 }
 
-func (s *loggingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
+func (s *loggingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
 	timer := timetrack.StartTimer()
-	err := s.base.PutBlob(ctx, id, data)
+	err := s.base.PutBlob(ctx, id, data, opts)
 	dt := timer.Elapsed()
 
 	s.logger.Debugw(s.prefix+"PutBlob",

--- a/repo/blob/logging/logging_storage.go
+++ b/repo/blob/logging/logging_storage.go
@@ -50,7 +50,7 @@ func (s *loggingStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Meta
 	return result, err
 }
 
-func (s *loggingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s *loggingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	timer := timetrack.StartTimer()
 	err := s.base.PutBlob(ctx, id, data, opts)
 	dt := timer.Elapsed()

--- a/repo/blob/logging/logging_storage_test.go
+++ b/repo/blob/logging/logging_storage_test.go
@@ -34,7 +34,7 @@ func TestLoggingStorage(t *testing.T) {
 	}
 
 	ctx := testlogging.Context(t)
-	blobtesting.VerifyStorage(ctx, t, st)
+	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
 
 	if err := st.Close(ctx); err != nil {
 		t.Fatalf("err: %v", err)

--- a/repo/blob/logging/logging_storage_test.go
+++ b/repo/blob/logging/logging_storage_test.go
@@ -34,7 +34,7 @@ func TestLoggingStorage(t *testing.T) {
 	}
 
 	ctx := testlogging.Context(t)
-	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
+	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 
 	if err := st.Close(ctx); err != nil {
 		t.Fatalf("err: %v", err)

--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -46,7 +46,7 @@ type rcloneStorage struct {
 	changeCount          *int32 // set to 1 when we had any writes
 }
 
-func (r *rcloneStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (r *rcloneStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	err := r.Storage.PutBlob(ctx, b, data, opts)
 	if err == nil {
 		atomic.StoreInt32(r.changeCount, 1)

--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -46,8 +46,8 @@ type rcloneStorage struct {
 	changeCount          *int32 // set to 1 when we had any writes
 }
 
-func (r *rcloneStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes) error {
-	err := r.Storage.PutBlob(ctx, b, data)
+func (r *rcloneStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+	err := r.Storage.PutBlob(ctx, b, data, opts)
 	if err == nil {
 		atomic.StoreInt32(r.changeCount, 1)
 		return nil

--- a/repo/blob/rclone/rclone_storage_test.go
+++ b/repo/blob/rclone/rclone_storage_test.go
@@ -95,7 +95,7 @@ func TestRCloneStorage(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	blobtesting.VerifyStorage(ctx, t, st)
+	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 }
 
@@ -226,7 +226,8 @@ func TestRCloneProviders(t *testing.T) {
 
 			defer st.Close(ctx)
 
-			blobtesting.VerifyStorage(ctx, t, logging.NewWrapper(st, testlogging.NewTestLogger(t), "[RCLONE-STORAGE] "))
+			blobtesting.VerifyStorage(ctx, t, logging.NewWrapper(st, testlogging.NewTestLogger(t), "[RCLONE-STORAGE] "),
+				blob.StoragePutBlobOptions{})
 			blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 		})
 	}

--- a/repo/blob/rclone/rclone_storage_test.go
+++ b/repo/blob/rclone/rclone_storage_test.go
@@ -121,7 +121,7 @@ func TestRCloneStorageDirectoryShards(t *testing.T) {
 
 	defer st.Close(ctx)
 
-	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 	require.FileExists(t, filepath.Join(dataDir, "someb", "lo", "b1234567812345678.f"))
 }
 

--- a/repo/blob/rclone/rclone_storage_test.go
+++ b/repo/blob/rclone/rclone_storage_test.go
@@ -95,7 +95,7 @@ func TestRCloneStorage(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
+	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 }
 
@@ -121,7 +121,7 @@ func TestRCloneStorageDirectoryShards(t *testing.T) {
 
 	defer st.Close(ctx)
 
-	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 	require.FileExists(t, filepath.Join(dataDir, "someb", "lo", "b1234567812345678.f"))
 }
 
@@ -227,7 +227,7 @@ func TestRCloneProviders(t *testing.T) {
 			defer st.Close(ctx)
 
 			blobtesting.VerifyStorage(ctx, t, logging.NewWrapper(st, testlogging.NewTestLogger(t), "[RCLONE-STORAGE] "),
-				blob.StoragePutBlobOptions{})
+				blob.PutOptions{})
 			blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 		})
 	}

--- a/repo/blob/readonly/readonly_storage.go
+++ b/repo/blob/readonly/readonly_storage.go
@@ -32,7 +32,7 @@ func (s readonlyStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) e
 	return ErrReadonly
 }
 
-func (s readonlyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
+func (s readonlyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
 	return ErrReadonly
 }
 

--- a/repo/blob/readonly/readonly_storage.go
+++ b/repo/blob/readonly/readonly_storage.go
@@ -32,7 +32,7 @@ func (s readonlyStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) e
 	return ErrReadonly
 }
 
-func (s readonlyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s readonlyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	return ErrReadonly
 }
 

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -47,10 +47,10 @@ func (s retryingStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) e
 	return err // nolint:wrapcheck
 }
 
-func (s retryingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
+func (s retryingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
 	_, err := retry.WithExponentialBackoff(ctx, "PutBlob("+string(id)+")", func() (interface{}, error) {
 		// nolint:wrapcheck
-		return true, s.Storage.PutBlob(ctx, id, data)
+		return true, s.Storage.PutBlob(ctx, id, data, opts)
 	}, isRetriable)
 
 	return err // nolint:wrapcheck

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -47,7 +47,7 @@ func (s retryingStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) e
 	return err // nolint:wrapcheck
 }
 
-func (s retryingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s retryingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	_, err := retry.WithExponentialBackoff(ctx, "PutBlob("+string(id)+")", func() (interface{}, error) {
 		// nolint:wrapcheck
 		return true, s.Storage.PutBlob(ctx, id, data, opts)

--- a/repo/blob/retrying/retrying_storage_test.go
+++ b/repo/blob/retrying/retrying_storage_test.go
@@ -46,9 +46,9 @@ func TestRetrying(t *testing.T) {
 	blobID := blob.ID("deadcafe")
 	blobID2 := blob.ID("deadcafe2")
 
-	require.NoError(t, rs.PutBlob(ctx, blobID, gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, rs.PutBlob(ctx, blobID, gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 
-	require.NoError(t, rs.PutBlob(ctx, blobID2, gather.FromSlice([]byte{1, 2, 3, 4}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, rs.PutBlob(ctx, blobID2, gather.FromSlice([]byte{1, 2, 3, 4}), blob.PutOptions{}))
 
 	require.NoError(t, rs.SetTime(ctx, blobID, clock.Now()))
 

--- a/repo/blob/retrying/retrying_storage_test.go
+++ b/repo/blob/retrying/retrying_storage_test.go
@@ -46,9 +46,9 @@ func TestRetrying(t *testing.T) {
 	blobID := blob.ID("deadcafe")
 	blobID2 := blob.ID("deadcafe2")
 
-	require.NoError(t, rs.PutBlob(ctx, blobID, gather.FromSlice([]byte{1, 2, 3})))
+	require.NoError(t, rs.PutBlob(ctx, blobID, gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
 
-	require.NoError(t, rs.PutBlob(ctx, blobID2, gather.FromSlice([]byte{1, 2, 3, 4})))
+	require.NoError(t, rs.PutBlob(ctx, blobID2, gather.FromSlice([]byte{1, 2, 3, 4}), blob.StoragePutBlobOptions{}))
 
 	require.NoError(t, rs.SetTime(ctx, blobID, clock.Now()))
 

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -131,13 +131,13 @@ func (s *s3Storage) getVersionMetadata(ctx context.Context, b blob.ID, version s
 	return infoToVersionMetadata(s.Prefix, &oi), nil
 }
 
-func (s *s3Storage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s *s3Storage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	_, err := s.putBlob(ctx, b, data, opts)
 
 	return err
 }
 
-func (s *s3Storage) putBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) (versionMetadata, error) {
+func (s *s3Storage) putBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) (versionMetadata, error) {
 	throttled, err := s.uploadThrottler.AddReader(io.NopCloser(data.Reader()))
 	if err != nil {
 		return versionMetadata{}, errors.Wrap(err, "AddReader")

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -194,7 +194,7 @@ func TestS3StorageAWSRetentionUnversionedBucket(t *testing.T) {
 	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
 		RetentionMode:   minio.Governance.String(),
 		RetentionPeriod: time.Hour * 24,
-	}, blob.ErrBlobRetentionDisabled)
+	})
 }
 
 func TestS3StorageAWSRetentionLockedBucket(t *testing.T) {
@@ -232,7 +232,7 @@ func TestS3StorageAWSRetentionInvalidPeriod(t *testing.T) {
 	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
 		RetentionMode:   minio.Governance.String(),
 		RetentionPeriod: time.Nanosecond,
-	}, blob.ErrBlobRetentionInvalid)
+	})
 }
 
 func TestS3StorageAWSRetentionInvalidPeriodLockedBucket(t *testing.T) {
@@ -251,7 +251,7 @@ func TestS3StorageAWSRetentionInvalidPeriodLockedBucket(t *testing.T) {
 	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
 		RetentionMode:   minio.Governance.String(),
 		RetentionPeriod: time.Nanosecond,
-	}, blob.ErrBlobRetentionInvalid)
+	})
 }
 
 func TestS3StorageMinio(t *testing.T) {
@@ -407,7 +407,7 @@ func testStorage(t *testing.T, options *Options, runValidationTest bool, opts bl
 }
 
 // nolint:thelper
-func testPutBlobWithInvalidRetention(t *testing.T, options *Options, opts blob.PutOptions, expectedError error) {
+func testPutBlobWithInvalidRetention(t *testing.T, options *Options, opts blob.PutOptions) {
 	ctx := testlogging.Context(t)
 
 	require.Equal(t, "", options.Prefix)
@@ -421,9 +421,8 @@ func testPutBlobWithInvalidRetention(t *testing.T, options *Options, opts blob.P
 	defer blobtesting.CleanupOldData(ctx, t, st, 0)
 
 	// Now attempt to add a block and expect to fail
-	require.ErrorAs(t,
-		st.PutBlob(ctx, blob.ID("abcdbbf4f0507d054ed5a80a5b65086f602b"), gather.FromSlice([]byte{}), opts),
-		&expectedError)
+	require.Error(t,
+		st.PutBlob(ctx, blob.ID("abcdbbf4f0507d054ed5a80a5b65086f602b"), gather.FromSlice([]byte{}), opts))
 
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 }

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -178,6 +178,70 @@ func TestS3StorageAWSSTS(t *testing.T) {
 	testStorage(t, options, false)
 }
 
+func TestS3StorageAWSRetention(t *testing.T) {
+	t.Parallel()
+
+	// skip the test if AWS creds are not provided
+	options := &Options{
+		Endpoint:        getEnv(testEndpointEnv, awsEndpoint),
+		AccessKeyID:     getEnvOrSkip(t, testAccessKeyIDEnv),
+		SecretAccessKey: getEnvOrSkip(t, testSecretAccessKeyEnv),
+		BucketName:      getEnvOrSkip(t, testBucketEnv),
+		Region:          getEnvOrSkip(t, testRegionEnv),
+	}
+
+	createBucket(t, options)
+	testStorage(t, options, false)
+}
+
+func TestS3StorageAWSRetentionLockedBucket(t *testing.T) {
+	t.Parallel()
+
+	// skip the test if AWS creds are not provided
+	options := &Options{
+		Endpoint:        getEnv(testEndpointEnv, awsEndpoint),
+		AccessKeyID:     getEnvOrSkip(t, testAccessKeyIDEnv),
+		SecretAccessKey: getEnvOrSkip(t, testSecretAccessKeyEnv),
+		BucketName:      getEnvOrSkip(t, testLockedBucketEnv),
+		Region:          getEnvOrSkip(t, testRegionEnv),
+	}
+
+	createBucket(t, options)
+	testStorage(t, options, false)
+}
+
+func TestS3StorageAWSInvalidRetention(t *testing.T) {
+	t.Parallel()
+
+	// skip the test if AWS creds are not provided
+	options := &Options{
+		Endpoint:        getEnv(testEndpointEnv, awsEndpoint),
+		AccessKeyID:     getEnvOrSkip(t, testAccessKeyIDEnv),
+		SecretAccessKey: getEnvOrSkip(t, testSecretAccessKeyEnv),
+		BucketName:      getEnvOrSkip(t, testBucketEnv),
+		Region:          getEnvOrSkip(t, testRegionEnv),
+	}
+
+	createBucket(t, options)
+	testStorage(t, options, false)
+}
+
+func TestS3StorageAWSInvalidRetentionLockedBucket(t *testing.T) {
+	t.Parallel()
+
+	// skip the test if AWS creds are not provided
+	options := &Options{
+		Endpoint:        getEnv(testEndpointEnv, awsEndpoint),
+		AccessKeyID:     getEnvOrSkip(t, testAccessKeyIDEnv),
+		SecretAccessKey: getEnvOrSkip(t, testSecretAccessKeyEnv),
+		BucketName:      getEnvOrSkip(t, testLockedBucketEnv),
+		Region:          getEnvOrSkip(t, testRegionEnv),
+	}
+
+	createBucket(t, options)
+	testStorage(t, options, false)
+}
+
 func TestS3StorageMinio(t *testing.T) {
 	t.Parallel()
 	testutil.ProviderTest(t)
@@ -296,7 +360,7 @@ func TestNeedMD5AWS(t *testing.T) {
 		blobtesting.CleanupOldData(context.Background(), t, s, 0)
 	})
 
-	err = s.PutBlob(ctx, blob.ID("test-put-blob-0"), gather.FromSlice([]byte("xxyasdf243z")))
+	err = s.PutBlob(ctx, blob.ID("test-put-blob-0"), gather.FromSlice([]byte("xxyasdf243z")), blob.StoragePutBlobOptions{})
 
 	require.NoError(t, err, "could not put test blob")
 }

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -131,7 +131,7 @@ func TestS3StorageProviders(t *testing.T) {
 		t.Run(k, func(t *testing.T) {
 			opt := getProviderOptions(t, env)
 
-			testStorage(t, opt, false, blob.StoragePutBlobOptions{})
+			testStorage(t, opt, false, blob.PutOptions{})
 		})
 	}
 }
@@ -149,7 +149,7 @@ func TestS3StorageAWS(t *testing.T) {
 	}
 
 	createBucket(t, options)
-	testStorage(t, options, false, blob.StoragePutBlobOptions{})
+	testStorage(t, options, false, blob.PutOptions{})
 }
 
 func TestS3StorageAWSSTS(t *testing.T) {
@@ -175,7 +175,7 @@ func TestS3StorageAWSSTS(t *testing.T) {
 		BucketName:      options.BucketName,
 		Region:          options.Region,
 	})
-	testStorage(t, options, false, blob.StoragePutBlobOptions{})
+	testStorage(t, options, false, blob.PutOptions{})
 }
 
 func TestS3StorageAWSRetentionUnversionedBucket(t *testing.T) {
@@ -191,7 +191,7 @@ func TestS3StorageAWSRetentionUnversionedBucket(t *testing.T) {
 	}
 
 	createBucket(t, options)
-	testPutBlobWithInvalidRetention(t, options, blob.StoragePutBlobOptions{
+	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
 		RetentionMode:   minio.Governance.String(),
 		RetentionPeriod: time.Hour * 24,
 	}, blob.ErrBlobRetentionDisabled)
@@ -210,7 +210,7 @@ func TestS3StorageAWSRetentionLockedBucket(t *testing.T) {
 	}
 
 	createBucket(t, options)
-	testStorage(t, options, false, blob.StoragePutBlobOptions{
+	testStorage(t, options, false, blob.PutOptions{
 		RetentionMode:   minio.Governance.String(),
 		RetentionPeriod: time.Hour * 24,
 	})
@@ -229,7 +229,7 @@ func TestS3StorageAWSRetentionInvalidPeriod(t *testing.T) {
 	}
 
 	createBucket(t, options)
-	testPutBlobWithInvalidRetention(t, options, blob.StoragePutBlobOptions{
+	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
 		RetentionMode:   minio.Governance.String(),
 		RetentionPeriod: time.Nanosecond,
 	}, blob.ErrBlobRetentionInvalid)
@@ -248,7 +248,7 @@ func TestS3StorageAWSRetentionInvalidPeriodLockedBucket(t *testing.T) {
 	}
 
 	createBucket(t, options)
-	testPutBlobWithInvalidRetention(t, options, blob.StoragePutBlobOptions{
+	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
 		RetentionMode:   minio.Governance.String(),
 		RetentionPeriod: time.Nanosecond,
 	}, blob.ErrBlobRetentionInvalid)
@@ -270,7 +270,7 @@ func TestS3StorageMinio(t *testing.T) {
 	}
 
 	createBucket(t, options)
-	testStorage(t, options, true, blob.StoragePutBlobOptions{})
+	testStorage(t, options, true, blob.PutOptions{})
 }
 
 func TestInvalidCredsFailsFast(t *testing.T) {
@@ -330,7 +330,7 @@ func TestS3StorageMinioSTS(t *testing.T) {
 		BucketName:      minioBucketName,
 		Region:          minioRegion,
 		DoNotUseTLS:     true,
-	}, true, blob.StoragePutBlobOptions{})
+	}, true, blob.PutOptions{})
 }
 
 func TestNeedMD5AWS(t *testing.T) {
@@ -372,13 +372,13 @@ func TestNeedMD5AWS(t *testing.T) {
 		blobtesting.CleanupOldData(context.Background(), t, s, 0)
 	})
 
-	err = s.PutBlob(ctx, blob.ID("test-put-blob-0"), gather.FromSlice([]byte("xxyasdf243z")), blob.StoragePutBlobOptions{})
+	err = s.PutBlob(ctx, blob.ID("test-put-blob-0"), gather.FromSlice([]byte("xxyasdf243z")), blob.PutOptions{})
 
 	require.NoError(t, err, "could not put test blob")
 }
 
 // nolint:thelper
-func testStorage(t *testing.T, options *Options, runValidationTest bool, opts blob.StoragePutBlobOptions) {
+func testStorage(t *testing.T, options *Options, runValidationTest bool, opts blob.PutOptions) {
 	ctx := testlogging.Context(t)
 
 	require.Equal(t, "", options.Prefix)
@@ -407,7 +407,7 @@ func testStorage(t *testing.T, options *Options, runValidationTest bool, opts bl
 }
 
 // nolint:thelper
-func testPutBlobWithInvalidRetention(t *testing.T, options *Options, opts blob.StoragePutBlobOptions, expectedError error) {
+func testPutBlobWithInvalidRetention(t *testing.T, options *Options, opts blob.PutOptions, expectedError error) {
 	ctx := testlogging.Context(t)
 
 	require.Equal(t, "", options.Prefix)

--- a/repo/blob/s3/s3_versioned_test.go
+++ b/repo/blob/s3/s3_versioned_test.go
@@ -719,7 +719,7 @@ func putBlobs(ctx context.Context, tb testing.TB, s *s3Storage, blobs []blobCont
 	vm := make([]versionMetadata, len(blobs))
 
 	for i, b := range blobs {
-		m, err := s.putBlobVersion(ctx, b.id, b.contents(tb))
+		m, err := s.putBlobVersion(ctx, b.id, b.contents(tb), blob.StoragePutBlobOptions{})
 		if err != nil {
 			tb.Fatalf("can't put blob: %v", err)
 			continue
@@ -732,11 +732,11 @@ func putBlobs(ctx context.Context, tb testing.TB, s *s3Storage, blobs []blobCont
 }
 
 // only available for tests.
-func (s *s3Storage) putBlobVersion(ctx context.Context, id blob.ID, data blob.Bytes) (versionMetadata, error) {
+func (s *s3Storage) putBlobVersion(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) (versionMetadata, error) {
 	var vm versionMetadata
 
 	_, err := retry.WithExponentialBackoff(ctx, "putBlobVersion("+string(id)+")", func() (interface{}, error) {
-		v, err := s.putBlob(ctx, id, data)
+		v, err := s.putBlob(ctx, id, data, opts)
 		vm = v
 
 		return true, err // nolint:wrapcheck

--- a/repo/blob/s3/s3_versioned_test.go
+++ b/repo/blob/s3/s3_versioned_test.go
@@ -719,7 +719,7 @@ func putBlobs(ctx context.Context, tb testing.TB, s *s3Storage, blobs []blobCont
 	vm := make([]versionMetadata, len(blobs))
 
 	for i, b := range blobs {
-		m, err := s.putBlobVersion(ctx, b.id, b.contents(tb), blob.StoragePutBlobOptions{})
+		m, err := s.putBlobVersion(ctx, b.id, b.contents(tb), blob.PutOptions{})
 		if err != nil {
 			tb.Fatalf("can't put blob: %v", err)
 			continue
@@ -732,7 +732,7 @@ func putBlobs(ctx context.Context, tb testing.TB, s *s3Storage, blobs []blobCont
 }
 
 // only available for tests.
-func (s *s3Storage) putBlobVersion(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) (versionMetadata, error) {
+func (s *s3Storage) putBlobVersion(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) (versionMetadata, error) {
 	var vm versionMetadata
 
 	_, err := retry.WithExponentialBackoff(ctx, "putBlobVersion("+string(id)+")", func() (interface{}, error) {

--- a/repo/blob/sftp/sftp_storage_test.go
+++ b/repo/blob/sftp/sftp_storage_test.go
@@ -196,7 +196,7 @@ func TestSFTPStorageValid(t *testing.T) {
 
 			deleteBlobs(ctx, t, st)
 
-			blobtesting.VerifyStorage(ctx, t, st)
+			blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
 			blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 			require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 
@@ -227,7 +227,7 @@ func TestSFTPStorageValid(t *testing.T) {
 
 		deleteBlobs(ctx, t, st)
 
-		blobtesting.VerifyStorage(ctx, t, st)
+		blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
 		blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 
 		// delete everything again

--- a/repo/blob/sftp/sftp_storage_test.go
+++ b/repo/blob/sftp/sftp_storage_test.go
@@ -196,7 +196,7 @@ func TestSFTPStorageValid(t *testing.T) {
 
 			deleteBlobs(ctx, t, st)
 
-			blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
+			blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 			blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 			require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 
@@ -227,7 +227,7 @@ func TestSFTPStorageValid(t *testing.T) {
 
 		deleteBlobs(ctx, t, st)
 
-		blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
+		blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 		blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 
 		// delete everything again

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -181,7 +181,7 @@ func (s *Storage) GetMetadata(ctx context.Context, blobID blob.ID) (blob.Metadat
 
 // PutBlob implements blob.Storage.
 func (s *Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
-	if opts.RetentionPeriod != 0 || opts.RetentionMode != "" {
+	if opts.HasRetentionOptions() {
 		return blob.ErrBlobRetentionUnsupported
 	}
 

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -182,7 +182,7 @@ func (s *Storage) GetMetadata(ctx context.Context, blobID blob.ID) (blob.Metadat
 // PutBlob implements blob.Storage.
 func (s *Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	if opts.HasRetentionOptions() {
-		return blob.ErrBlobRetentionUnsupported
+		return errors.New("setting blob-retention is not supported")
 	}
 
 	dirPath, filePath, err := s.GetShardedPathAndFilePath(ctx, blobID)

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -180,7 +180,7 @@ func (s *Storage) GetMetadata(ctx context.Context, blobID blob.ID) (blob.Metadat
 }
 
 // PutBlob implements blob.Storage.
-func (s *Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+func (s *Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	if opts.HasRetentionOptions() {
 		return blob.ErrBlobRetentionUnsupported
 	}

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -180,7 +180,11 @@ func (s *Storage) GetMetadata(ctx context.Context, blobID blob.ID) (blob.Metadat
 }
 
 // PutBlob implements blob.Storage.
-func (s *Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes) error {
+func (s *Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.StoragePutBlobOptions) error {
+	if opts.RetentionPeriod != 0 || opts.RetentionMode != "" {
+		return blob.ErrBlobRetentionUnsupported
+	}
+
 	dirPath, filePath, err := s.GetShardedPathAndFilePath(ctx, blobID)
 	if err != nil {
 		return errors.Wrap(err, "error determining sharded path")

--- a/repo/blob/sharded/sharded_test.go
+++ b/repo/blob/sharded/sharded_test.go
@@ -144,7 +144,7 @@ func TestShardedFileStorageShardingMap(t *testing.T) {
 			var allBlobIDs []blob.ID
 
 			for blobID, wantFilename := range tc.blobFilePathMap {
-				require.NoError(t, r.PutBlob(ctx, blobID, gather.FromSlice([]byte("foo"))))
+				require.NoError(t, r.PutBlob(ctx, blobID, gather.FromSlice([]byte("foo")), blob.StoragePutBlobOptions{}))
 				require.FileExists(t, filepath.Join(path, wantFilename))
 
 				allBlobIDs = append(allBlobIDs, blobID)
@@ -189,19 +189,19 @@ func TestShardedFileStorageShardingMap_Invalid(t *testing.T) {
 	var tmp gather.WriteBuffer
 	defer tmp.Close()
 
-	require.Error(t, r.PutBlob(ctx, "someblob", gather.FromSlice([]byte("foo"))))
+	require.Error(t, r.PutBlob(ctx, "someblob", gather.FromSlice([]byte("foo")), blob.StoragePutBlobOptions{}))
 
 	// delete invalid .shards file
 	require.NoError(t, os.Remove(dotShardsFile))
 
 	// now putting the blob will succeed
-	require.NoError(t, r.PutBlob(ctx, "someblob", gather.FromSlice([]byte("foo"))))
+	require.NoError(t, r.PutBlob(ctx, "someblob", gather.FromSlice([]byte("foo")), blob.StoragePutBlobOptions{}))
 
 	// write malformed file again, but will be ignored since it was successfully loaded
 	// in this session.
 	require.NoError(t, os.WriteFile(dotShardsFile, []byte{1, 2, 3}, 0o600))
 
-	require.NoError(t, r.PutBlob(ctx, "someblob2", gather.FromSlice([]byte("foo"))))
+	require.NoError(t, r.PutBlob(ctx, "someblob2", gather.FromSlice([]byte("foo")), blob.StoragePutBlobOptions{}))
 }
 
 func TestClone(t *testing.T) {

--- a/repo/blob/sharded/sharded_test.go
+++ b/repo/blob/sharded/sharded_test.go
@@ -48,7 +48,7 @@ func TestShardedFileStorage(t *testing.T) {
 					t.Errorf("unexpected result: %v %v", r, err)
 				}
 
-				blobtesting.VerifyStorage(ctx, t, r)
+				blobtesting.VerifyStorage(ctx, t, r, blob.StoragePutBlobOptions{})
 				blobtesting.AssertConnectionInfoRoundTrips(ctx, t, r)
 
 				if err := r.Close(ctx); err != nil {

--- a/repo/blob/sharded/sharded_test.go
+++ b/repo/blob/sharded/sharded_test.go
@@ -48,7 +48,7 @@ func TestShardedFileStorage(t *testing.T) {
 					t.Errorf("unexpected result: %v %v", r, err)
 				}
 
-				blobtesting.VerifyStorage(ctx, t, r, blob.StoragePutBlobOptions{})
+				blobtesting.VerifyStorage(ctx, t, r, blob.PutOptions{})
 				blobtesting.AssertConnectionInfoRoundTrips(ctx, t, r)
 
 				if err := r.Close(ctx); err != nil {
@@ -144,7 +144,7 @@ func TestShardedFileStorageShardingMap(t *testing.T) {
 			var allBlobIDs []blob.ID
 
 			for blobID, wantFilename := range tc.blobFilePathMap {
-				require.NoError(t, r.PutBlob(ctx, blobID, gather.FromSlice([]byte("foo")), blob.StoragePutBlobOptions{}))
+				require.NoError(t, r.PutBlob(ctx, blobID, gather.FromSlice([]byte("foo")), blob.PutOptions{}))
 				require.FileExists(t, filepath.Join(path, wantFilename))
 
 				allBlobIDs = append(allBlobIDs, blobID)
@@ -189,19 +189,19 @@ func TestShardedFileStorageShardingMap_Invalid(t *testing.T) {
 	var tmp gather.WriteBuffer
 	defer tmp.Close()
 
-	require.Error(t, r.PutBlob(ctx, "someblob", gather.FromSlice([]byte("foo")), blob.StoragePutBlobOptions{}))
+	require.Error(t, r.PutBlob(ctx, "someblob", gather.FromSlice([]byte("foo")), blob.PutOptions{}))
 
 	// delete invalid .shards file
 	require.NoError(t, os.Remove(dotShardsFile))
 
 	// now putting the blob will succeed
-	require.NoError(t, r.PutBlob(ctx, "someblob", gather.FromSlice([]byte("foo")), blob.StoragePutBlobOptions{}))
+	require.NoError(t, r.PutBlob(ctx, "someblob", gather.FromSlice([]byte("foo")), blob.PutOptions{}))
 
 	// write malformed file again, but will be ignored since it was successfully loaded
 	// in this session.
 	require.NoError(t, os.WriteFile(dotShardsFile, []byte{1, 2, 3}, 0o600))
 
-	require.NoError(t, r.PutBlob(ctx, "someblob2", gather.FromSlice([]byte("foo")), blob.StoragePutBlobOptions{}))
+	require.NoError(t, r.PutBlob(ctx, "someblob2", gather.FromSlice([]byte("foo")), blob.PutOptions{}))
 }
 
 func TestClone(t *testing.T) {

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -75,6 +75,12 @@ type StoragePutBlobOptions struct {
 	RetentionPeriod time.Duration
 }
 
+// HasRetentionOptions returns true when blob-retention settings have been
+// specified, otherwise retruns false.
+func (o StoragePutBlobOptions) HasRetentionOptions() bool {
+	return o.RetentionPeriod != 0 || o.RetentionMode != ""
+}
+
 // Storage encapsulates API for connecting to blob storage.
 //
 // The underlying storage system must provide:

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -17,6 +17,18 @@ var ErrSetTimeUnsupported = errors.Errorf("SetTime is not supported")
 // ErrInvalidRange is returned when the requested blob offset or length is invalid.
 var ErrInvalidRange = errors.Errorf("invalid blob offset or length")
 
+// ErrBlobRetentionUnsupported is returned by implementations of Storage that
+// don't support setting blob-retention times.
+var ErrBlobRetentionUnsupported = errors.Errorf("setting blob-retention is not supported")
+
+// ErrBlobRetentionDisabled is returned by storage where the retention policies
+// are disabled.
+var ErrBlobRetentionDisabled = errors.Errorf("setting blob-retention is disabled")
+
+// ErrBlobRetentionInvalid is returned by storage where the retention settings
+// are invalid.
+var ErrBlobRetentionInvalid = errors.Errorf("invalid blob-retention settings")
+
 // Bytes encapsulates a sequence of bytes, possibly stored in a non-contiguous buffers,
 // which can be written sequentially or treated as a io.Reader.
 type Bytes interface {
@@ -57,6 +69,12 @@ type Reader interface {
 	DisplayName() string
 }
 
+// StoragePutBlobOptions represents put-options for a single BLOB in a storage.
+type StoragePutBlobOptions struct {
+	RetentionMode   string
+	RetentionPeriod time.Duration
+}
+
 // Storage encapsulates API for connecting to blob storage.
 //
 // The underlying storage system must provide:
@@ -73,7 +91,7 @@ type Storage interface {
 
 	// PutBlob uploads the blob with given data to the repository or replaces existing blob with the provided
 	// id with contents gathered from the specified list of slices.
-	PutBlob(ctx context.Context, blobID ID, data Bytes) error
+	PutBlob(ctx context.Context, blobID ID, data Bytes, opts StoragePutBlobOptions) error
 
 	// SetTime changes last modification time of a given blob, if supported, returns ErrSetTimeUnsupported otherwise.
 	SetTime(ctx context.Context, blobID ID, t time.Time) error

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -69,15 +69,15 @@ type Reader interface {
 	DisplayName() string
 }
 
-// StoragePutBlobOptions represents put-options for a single BLOB in a storage.
-type StoragePutBlobOptions struct {
+// PutOptions represents put-options for a single BLOB in a storage.
+type PutOptions struct {
 	RetentionMode   string
 	RetentionPeriod time.Duration
 }
 
 // HasRetentionOptions returns true when blob-retention settings have been
 // specified, otherwise retruns false.
-func (o StoragePutBlobOptions) HasRetentionOptions() bool {
+func (o PutOptions) HasRetentionOptions() bool {
 	return o.RetentionPeriod != 0 || o.RetentionMode != ""
 }
 
@@ -97,7 +97,7 @@ type Storage interface {
 
 	// PutBlob uploads the blob with given data to the repository or replaces existing blob with the provided
 	// id with contents gathered from the specified list of slices.
-	PutBlob(ctx context.Context, blobID ID, data Bytes, opts StoragePutBlobOptions) error
+	PutBlob(ctx context.Context, blobID ID, data Bytes, opts PutOptions) error
 
 	// SetTime changes last modification time of a given blob, if supported, returns ErrSetTimeUnsupported otherwise.
 	SetTime(ctx context.Context, blobID ID, t time.Time) error

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -17,18 +17,6 @@ var ErrSetTimeUnsupported = errors.Errorf("SetTime is not supported")
 // ErrInvalidRange is returned when the requested blob offset or length is invalid.
 var ErrInvalidRange = errors.Errorf("invalid blob offset or length")
 
-// ErrBlobRetentionUnsupported is returned by implementations of Storage that
-// don't support setting blob-retention times.
-var ErrBlobRetentionUnsupported = errors.Errorf("setting blob-retention is not supported")
-
-// ErrBlobRetentionDisabled is returned by storage where the retention policies
-// are disabled.
-var ErrBlobRetentionDisabled = errors.Errorf("setting blob-retention is disabled")
-
-// ErrBlobRetentionInvalid is returned by storage where the retention settings
-// are invalid.
-var ErrBlobRetentionInvalid = errors.Errorf("invalid blob-retention settings")
-
 // Bytes encapsulates a sequence of bytes, possibly stored in a non-contiguous buffers,
 // which can be written sequentially or treated as a io.Reader.
 type Bytes interface {

--- a/repo/blob/storage_test.go
+++ b/repo/blob/storage_test.go
@@ -18,9 +18,9 @@ func TestListAllBlobs(t *testing.T) {
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, nil)
 	ctx := context.Background()
-	st.PutBlob(ctx, "foo", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{})
-	st.PutBlob(ctx, "boo", gather.FromSlice([]byte{2, 3, 4}), blob.StoragePutBlobOptions{})
-	st.PutBlob(ctx, "bar", gather.FromSlice([]byte{3, 4, 5}), blob.StoragePutBlobOptions{})
+	st.PutBlob(ctx, "foo", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{})
+	st.PutBlob(ctx, "boo", gather.FromSlice([]byte{2, 3, 4}), blob.PutOptions{})
+	st.PutBlob(ctx, "bar", gather.FromSlice([]byte{3, 4, 5}), blob.PutOptions{})
 
 	result1, err := blob.ListAllBlobs(ctx, st, "")
 	require.NoError(t, err)
@@ -39,9 +39,9 @@ func TestIterateAllPrefixesInParallel(t *testing.T) {
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, nil)
 	ctx := context.Background()
-	st.PutBlob(ctx, "foo", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{})
-	st.PutBlob(ctx, "boo", gather.FromSlice([]byte{2, 3, 4}), blob.StoragePutBlobOptions{})
-	st.PutBlob(ctx, "bar", gather.FromSlice([]byte{3, 4, 5}), blob.StoragePutBlobOptions{})
+	st.PutBlob(ctx, "foo", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{})
+	st.PutBlob(ctx, "boo", gather.FromSlice([]byte{2, 3, 4}), blob.PutOptions{})
+	st.PutBlob(ctx, "bar", gather.FromSlice([]byte{3, 4, 5}), blob.PutOptions{})
 
 	var (
 		mu  sync.Mutex

--- a/repo/blob/storage_test.go
+++ b/repo/blob/storage_test.go
@@ -18,9 +18,9 @@ func TestListAllBlobs(t *testing.T) {
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, nil)
 	ctx := context.Background()
-	st.PutBlob(ctx, "foo", gather.FromSlice([]byte{1, 2, 3}))
-	st.PutBlob(ctx, "boo", gather.FromSlice([]byte{2, 3, 4}))
-	st.PutBlob(ctx, "bar", gather.FromSlice([]byte{3, 4, 5}))
+	st.PutBlob(ctx, "foo", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{})
+	st.PutBlob(ctx, "boo", gather.FromSlice([]byte{2, 3, 4}), blob.StoragePutBlobOptions{})
+	st.PutBlob(ctx, "bar", gather.FromSlice([]byte{3, 4, 5}), blob.StoragePutBlobOptions{})
 
 	result1, err := blob.ListAllBlobs(ctx, st, "")
 	require.NoError(t, err)
@@ -39,9 +39,9 @@ func TestIterateAllPrefixesInParallel(t *testing.T) {
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, nil)
 	ctx := context.Background()
-	st.PutBlob(ctx, "foo", gather.FromSlice([]byte{1, 2, 3}))
-	st.PutBlob(ctx, "boo", gather.FromSlice([]byte{2, 3, 4}))
-	st.PutBlob(ctx, "bar", gather.FromSlice([]byte{3, 4, 5}))
+	st.PutBlob(ctx, "foo", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{})
+	st.PutBlob(ctx, "boo", gather.FromSlice([]byte{2, 3, 4}), blob.StoragePutBlobOptions{})
+	st.PutBlob(ctx, "bar", gather.FromSlice([]byte{3, 4, 5}), blob.StoragePutBlobOptions{})
 
 	var (
 		mu  sync.Mutex

--- a/repo/blob/throttling/throttling_storage.go
+++ b/repo/blob/throttling/throttling_storage.go
@@ -79,11 +79,11 @@ func (s *throttlingStorage) SetTime(ctx context.Context, id blob.ID, t time.Time
 	return s.Storage.SetTime(ctx, id, t) // nolint:wrapcheck
 }
 
-func (s *throttlingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes) error {
+func (s *throttlingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	s.throttler.BeforeOperation(ctx, "PutBlob")
 	s.throttler.BeforeUpload(ctx, int64(data.Length()))
 
-	return s.Storage.PutBlob(ctx, id, data) // nolint:wrapcheck
+	return s.Storage.PutBlob(ctx, id, data, opts) // nolint:wrapcheck
 }
 
 func (s *throttlingStorage) DeleteBlob(ctx context.Context, id blob.ID) error {

--- a/repo/blob/throttling/throttling_storage_test.go
+++ b/repo/blob/throttling/throttling_storage_test.go
@@ -70,7 +70,7 @@ func TestThrottling(t *testing.T) {
 
 	// upload blob of 7 bytes
 	m.Reset()
-	require.NoError(t, wrapped.PutBlob(ctx, "blob1", gather.FromSlice([]byte{1, 2, 3, 4, 5, 6, 7})))
+	require.NoError(t, wrapped.PutBlob(ctx, "blob1", gather.FromSlice([]byte{1, 2, 3, 4, 5, 6, 7}), blob.PutOptions{}))
 	require.Equal(t, []string{
 		"BeforeOperation(PutBlob)",
 		"BeforeUpload(7)",
@@ -79,7 +79,7 @@ func TestThrottling(t *testing.T) {
 
 	// upload another blob of 30MB
 	m.Reset()
-	require.NoError(t, wrapped.PutBlob(ctx, "blob2", gather.FromSlice(bytes.Repeat([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 3000000))))
+	require.NoError(t, wrapped.PutBlob(ctx, "blob2", gather.FromSlice(bytes.Repeat([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 3000000)), blob.PutOptions{}))
 	require.Equal(t, []string{
 		"BeforeOperation(PutBlob)",
 		"BeforeUpload(30000000)",

--- a/repo/blob/webdav/webdav_storage_test.go
+++ b/repo/blob/webdav/webdav_storage_test.go
@@ -164,7 +164,7 @@ func verifyWebDAVStorage(t *testing.T, url, username, password string, shardSpec
 		t.Fatalf("unable to clear webdav storage: %v", err)
 	}
 
-	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
+	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 

--- a/repo/blob/webdav/webdav_storage_test.go
+++ b/repo/blob/webdav/webdav_storage_test.go
@@ -164,7 +164,7 @@ func verifyWebDAVStorage(t *testing.T, url, username, password string, shardSpec
 		t.Fatalf("unable to clear webdav storage: %v", err)
 	}
 
-	blobtesting.VerifyStorage(ctx, t, st)
+	blobtesting.VerifyStorage(ctx, t, st, blob.StoragePutBlobOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 

--- a/repo/content/content_cache_test.go
+++ b/repo/content/content_cache_test.go
@@ -28,8 +28,8 @@ func newUnderlyingStorageForContentCacheTesting(t *testing.T) blob.Storage {
 	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, nil)
-	require.NoError(t, st.PutBlob(ctx, "content-1", gather.FromSlice([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), blob.StoragePutBlobOptions{}))
-	require.NoError(t, st.PutBlob(ctx, "content-4k", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3, 4}, 1000)), blob.StoragePutBlobOptions{})) // 4000 bytes
+	require.NoError(t, st.PutBlob(ctx, "content-1", gather.FromSlice([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), blob.PutOptions{}))
+	require.NoError(t, st.PutBlob(ctx, "content-4k", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3, 4}, 1000)), blob.PutOptions{})) // 4000 bytes
 
 	return st
 }
@@ -187,7 +187,7 @@ func verifyContentCache(t *testing.T, cc contentCache, cacheStorage blob.Storage
 		b := tmp.Bytes()
 		b.Slices[0][0] ^= 1
 
-		require.NoError(t, cacheStorage.PutBlob(ctx, cacheKey, b, blob.StoragePutBlobOptions{}))
+		require.NoError(t, cacheStorage.PutBlob(ctx, cacheKey, b, blob.PutOptions{}))
 
 		err := cc.getContent(ctx, "xf0f0f1", "content-1", 1, 5, &tmp)
 		if err != nil {

--- a/repo/content/content_cache_test.go
+++ b/repo/content/content_cache_test.go
@@ -28,8 +28,8 @@ func newUnderlyingStorageForContentCacheTesting(t *testing.T) blob.Storage {
 	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, nil)
-	require.NoError(t, st.PutBlob(ctx, "content-1", gather.FromSlice([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})))
-	require.NoError(t, st.PutBlob(ctx, "content-4k", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3, 4}, 1000)))) // 4000 bytes
+	require.NoError(t, st.PutBlob(ctx, "content-1", gather.FromSlice([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), blob.StoragePutBlobOptions{}))
+	require.NoError(t, st.PutBlob(ctx, "content-4k", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3, 4}, 1000)), blob.StoragePutBlobOptions{})) // 4000 bytes
 
 	return st
 }
@@ -187,7 +187,7 @@ func verifyContentCache(t *testing.T, cc contentCache, cacheStorage blob.Storage
 		b := tmp.Bytes()
 		b.Slices[0][0] ^= 1
 
-		require.NoError(t, cacheStorage.PutBlob(ctx, cacheKey, b))
+		require.NoError(t, cacheStorage.PutBlob(ctx, cacheKey, b, blob.StoragePutBlobOptions{}))
 
 		err := cc.getContent(ctx, "xf0f0f1", "content-1", 1, 5, &tmp)
 		if err != nil {

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -161,7 +161,7 @@ func (bm *WriteManager) writePackFileNotLocked(ctx context.Context, packFile blo
 	bm.Stats.wroteContent(data.Length())
 	bm.onUpload(int64(data.Length()))
 
-	return errors.Wrap(bm.st.PutBlob(ctx, packFile, data, blob.StoragePutBlobOptions{}), "error writing pack file")
+	return errors.Wrap(bm.st.PutBlob(ctx, packFile, data, blob.PutOptions{}), "error writing pack file")
 }
 
 func (sm *SharedManager) hashData(output []byte, data gather.Bytes) []byte {

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -161,7 +161,7 @@ func (bm *WriteManager) writePackFileNotLocked(ctx context.Context, packFile blo
 	bm.Stats.wroteContent(data.Length())
 	bm.onUpload(int64(data.Length()))
 
-	return errors.Wrap(bm.st.PutBlob(ctx, packFile, data), "error writing pack file")
+	return errors.Wrap(bm.st.PutBlob(ctx, packFile, data, blob.StoragePutBlobOptions{}), "error writing pack file")
 }
 
 func (sm *SharedManager) hashData(output []byte, data gather.Bytes) []byte {

--- a/repo/content/encrypted_blob_mgr.go
+++ b/repo/content/encrypted_blob_mgr.go
@@ -37,7 +37,7 @@ func (m *encryptedBlobMgr) encryptAndWriteBlob(ctx context.Context, data gather.
 		return blob.Metadata{}, errors.Wrap(err, "error encrypting")
 	}
 
-	err = m.st.PutBlob(ctx, blobID, data2.Bytes())
+	err = m.st.PutBlob(ctx, blobID, data2.Bytes(), blob.StoragePutBlobOptions{})
 	if err != nil {
 		m.log.Debugf("write-index-blob %v failed %v", blobID, err)
 		return blob.Metadata{}, errors.Wrapf(err, "error writing blob %v", blobID)

--- a/repo/content/encrypted_blob_mgr.go
+++ b/repo/content/encrypted_blob_mgr.go
@@ -37,7 +37,7 @@ func (m *encryptedBlobMgr) encryptAndWriteBlob(ctx context.Context, data gather.
 		return blob.Metadata{}, errors.Wrap(err, "error encrypting")
 	}
 
-	err = m.st.PutBlob(ctx, blobID, data2.Bytes(), blob.StoragePutBlobOptions{})
+	err = m.st.PutBlob(ctx, blobID, data2.Bytes(), blob.PutOptions{})
 	if err != nil {
 		m.log.Debugf("write-index-blob %v failed %v", blobID, err)
 		return blob.Metadata{}, errors.Wrapf(err, "error writing blob %v", blobID)

--- a/repo/content/index_blob_manager_v1.go
+++ b/repo/content/index_blob_manager_v1.go
@@ -95,7 +95,7 @@ func (m *indexBlobManagerV1) compactEpoch(ctx context.Context, blobIDs []blob.ID
 			return errors.Wrap(err, "error encrypting")
 		}
 
-		if err := m.st.PutBlob(ctx, blobID, data2.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
+		if err := m.st.PutBlob(ctx, blobID, data2.Bytes(), blob.PutOptions{}); err != nil {
 			return errors.Wrap(err, "error writing index blob")
 		}
 	}

--- a/repo/content/index_blob_manager_v1.go
+++ b/repo/content/index_blob_manager_v1.go
@@ -95,7 +95,7 @@ func (m *indexBlobManagerV1) compactEpoch(ctx context.Context, blobIDs []blob.ID
 			return errors.Wrap(err, "error encrypting")
 		}
 
-		if err := m.st.PutBlob(ctx, blobID, data2.Bytes()); err != nil {
+		if err := m.st.PutBlob(ctx, blobID, data2.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
 			return errors.Wrap(err, "error writing index blob")
 		}
 	}

--- a/repo/content/internal_logger.go
+++ b/repo/content/internal_logger.go
@@ -61,7 +61,7 @@ func (m *internalLogManager) encryptAndWriteLogBlob(prefix blob.ID, data gather.
 		defer encrypted.Close()
 		defer closeFunc()
 
-		if err := m.st.PutBlob(m.ctx, blobID, b); err != nil {
+		if err := m.st.PutBlob(m.ctx, blobID, b, blob.StoragePutBlobOptions{}); err != nil {
 			// nothing can be done about this, we're not in a place where we can return error, log it.
 			return
 		}

--- a/repo/content/internal_logger.go
+++ b/repo/content/internal_logger.go
@@ -61,7 +61,7 @@ func (m *internalLogManager) encryptAndWriteLogBlob(prefix blob.ID, data gather.
 		defer encrypted.Close()
 		defer closeFunc()
 
-		if err := m.st.PutBlob(m.ctx, blobID, b, blob.StoragePutBlobOptions{}); err != nil {
+		if err := m.st.PutBlob(m.ctx, blobID, b, blob.PutOptions{}); err != nil {
 			// nothing can be done about this, we're not in a place where we can return error, log it.
 			return
 		}

--- a/repo/content/sessions.go
+++ b/repo/content/sessions.go
@@ -117,7 +117,7 @@ func (bm *WriteManager) writeSessionMarkerLocked(ctx context.Context) error {
 
 	bm.onUpload(int64(encrypted.Length()))
 
-	if err := bm.st.PutBlob(ctx, sessionBlobID, encrypted.Bytes()); err != nil {
+	if err := bm.st.PutBlob(ctx, sessionBlobID, encrypted.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
 		return errors.Wrapf(err, "unable to write session marker: %v", string(sessionBlobID))
 	}
 

--- a/repo/content/sessions.go
+++ b/repo/content/sessions.go
@@ -117,7 +117,7 @@ func (bm *WriteManager) writeSessionMarkerLocked(ctx context.Context) error {
 
 	bm.onUpload(int64(encrypted.Length()))
 
-	if err := bm.st.PutBlob(ctx, sessionBlobID, encrypted.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
+	if err := bm.st.PutBlob(ctx, sessionBlobID, encrypted.Bytes(), blob.PutOptions{}); err != nil {
 		return errors.Wrapf(err, "unable to write session marker: %v", string(sessionBlobID))
 	}
 

--- a/repo/format_block.go
+++ b/repo/format_block.go
@@ -170,7 +170,7 @@ func writeFormatBlob(ctx context.Context, st blob.Storage, f *formatBlob) error 
 		return errors.Wrap(err, "unable to marshal format blob")
 	}
 
-	if err := st.PutBlob(ctx, FormatBlobID, buf.Bytes()); err != nil {
+	if err := st.PutBlob(ctx, FormatBlobID, buf.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
 		return errors.Wrap(err, "unable to write format blob")
 	}
 

--- a/repo/format_block.go
+++ b/repo/format_block.go
@@ -170,7 +170,7 @@ func writeFormatBlob(ctx context.Context, st blob.Storage, f *formatBlob) error 
 		return errors.Wrap(err, "unable to marshal format blob")
 	}
 
-	if err := st.PutBlob(ctx, FormatBlobID, buf.Bytes(), blob.StoragePutBlobOptions{}); err != nil {
+	if err := st.PutBlob(ctx, FormatBlobID, buf.Bytes(), blob.PutOptions{}); err != nil {
 		return errors.Wrap(err, "unable to write format blob")
 	}
 

--- a/repo/format_block_test.go
+++ b/repo/format_block_test.go
@@ -29,19 +29,19 @@ func TestFormatBlobRecovery(t *testing.T) {
 		t.Errorf("unexpected checksummed length: %v, want %v", got, want)
 	}
 
-	assertNoError(t, st.PutBlob(ctx, "some-blob-by-itself", gather.FromSlice(checksummed), blob.StoragePutBlobOptions{}))
-	assertNoError(t, st.PutBlob(ctx, "some-blob-suffix", gather.FromSlice(append(append([]byte(nil), 1, 2, 3), checksummed...)), blob.StoragePutBlobOptions{}))
-	assertNoError(t, st.PutBlob(ctx, "some-blob-prefix", gather.FromSlice(append(append([]byte(nil), checksummed...), 1, 2, 3)), blob.StoragePutBlobOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "some-blob-by-itself", gather.FromSlice(checksummed), blob.PutOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "some-blob-suffix", gather.FromSlice(append(append([]byte(nil), 1, 2, 3), checksummed...)), blob.PutOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "some-blob-prefix", gather.FromSlice(append(append([]byte(nil), checksummed...), 1, 2, 3)), blob.PutOptions{}))
 
 	// mess up checksum
 	checksummed[len(checksummed)-3] ^= 1
-	assertNoError(t, st.PutBlob(ctx, "bad-checksum", gather.FromSlice(checksummed), blob.StoragePutBlobOptions{}))
-	assertNoError(t, st.PutBlob(ctx, "zero-len", gather.FromSlice([]byte{}), blob.StoragePutBlobOptions{}))
-	assertNoError(t, st.PutBlob(ctx, "one-len", gather.FromSlice([]byte{1}), blob.StoragePutBlobOptions{}))
-	assertNoError(t, st.PutBlob(ctx, "two-len", gather.FromSlice([]byte{1, 2}), blob.StoragePutBlobOptions{}))
-	assertNoError(t, st.PutBlob(ctx, "three-len", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
-	assertNoError(t, st.PutBlob(ctx, "four-len", gather.FromSlice([]byte{1, 2, 3, 4}), blob.StoragePutBlobOptions{}))
-	assertNoError(t, st.PutBlob(ctx, "five-len", gather.FromSlice([]byte{1, 2, 3, 4, 5}), blob.StoragePutBlobOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "bad-checksum", gather.FromSlice(checksummed), blob.PutOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "zero-len", gather.FromSlice([]byte{}), blob.PutOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "one-len", gather.FromSlice([]byte{1}), blob.PutOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "two-len", gather.FromSlice([]byte{1, 2}), blob.PutOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "three-len", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "four-len", gather.FromSlice([]byte{1, 2, 3, 4}), blob.PutOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "five-len", gather.FromSlice([]byte{1, 2, 3, 4, 5}), blob.PutOptions{}))
 
 	cases := []struct {
 		blobID blob.ID

--- a/repo/format_block_test.go
+++ b/repo/format_block_test.go
@@ -29,19 +29,19 @@ func TestFormatBlobRecovery(t *testing.T) {
 		t.Errorf("unexpected checksummed length: %v, want %v", got, want)
 	}
 
-	assertNoError(t, st.PutBlob(ctx, "some-blob-by-itself", gather.FromSlice(checksummed)))
-	assertNoError(t, st.PutBlob(ctx, "some-blob-suffix", gather.FromSlice(append(append([]byte(nil), 1, 2, 3), checksummed...))))
-	assertNoError(t, st.PutBlob(ctx, "some-blob-prefix", gather.FromSlice(append(append([]byte(nil), checksummed...), 1, 2, 3))))
+	assertNoError(t, st.PutBlob(ctx, "some-blob-by-itself", gather.FromSlice(checksummed), blob.StoragePutBlobOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "some-blob-suffix", gather.FromSlice(append(append([]byte(nil), 1, 2, 3), checksummed...)), blob.StoragePutBlobOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "some-blob-prefix", gather.FromSlice(append(append([]byte(nil), checksummed...), 1, 2, 3)), blob.StoragePutBlobOptions{}))
 
 	// mess up checksum
 	checksummed[len(checksummed)-3] ^= 1
-	assertNoError(t, st.PutBlob(ctx, "bad-checksum", gather.FromSlice(checksummed)))
-	assertNoError(t, st.PutBlob(ctx, "zero-len", gather.FromSlice([]byte{})))
-	assertNoError(t, st.PutBlob(ctx, "one-len", gather.FromSlice([]byte{1})))
-	assertNoError(t, st.PutBlob(ctx, "two-len", gather.FromSlice([]byte{1, 2})))
-	assertNoError(t, st.PutBlob(ctx, "three-len", gather.FromSlice([]byte{1, 2, 3})))
-	assertNoError(t, st.PutBlob(ctx, "four-len", gather.FromSlice([]byte{1, 2, 3, 4})))
-	assertNoError(t, st.PutBlob(ctx, "five-len", gather.FromSlice([]byte{1, 2, 3, 4, 5})))
+	assertNoError(t, st.PutBlob(ctx, "bad-checksum", gather.FromSlice(checksummed), blob.StoragePutBlobOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "zero-len", gather.FromSlice([]byte{}), blob.StoragePutBlobOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "one-len", gather.FromSlice([]byte{1}), blob.StoragePutBlobOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "two-len", gather.FromSlice([]byte{1, 2}), blob.StoragePutBlobOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "three-len", gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "four-len", gather.FromSlice([]byte{1, 2, 3, 4}), blob.StoragePutBlobOptions{}))
+	assertNoError(t, st.PutBlob(ctx, "five-len", gather.FromSlice([]byte{1, 2, 3, 4, 5}), blob.StoragePutBlobOptions{}))
 
 	cases := []struct {
 		blobID blob.ID

--- a/repo/maintenance/blob_gc_test.go
+++ b/repo/maintenance/blob_gc_test.go
@@ -180,7 +180,7 @@ func verifyBlobNotFound(t *testing.T, st blob.Storage, blobID blob.ID) {
 func mustPutDummyBlob(t *testing.T, st blob.Storage, blobID blob.ID) {
 	t.Helper()
 
-	if err := st.PutBlob(testlogging.Context(t), blobID, gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}); err != nil {
+	if err := st.PutBlob(testlogging.Context(t), blobID, gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -212,7 +212,7 @@ func mustPutDummySessionBlob(t *testing.T, st blob.Storage, sessionIDSuffix blob
 	defer enc.Close()
 
 	require.NoError(t, e.Encrypt(gather.FromSlice(j), iv, &enc))
-	require.NoError(t, st.PutBlob(testlogging.Context(t), blobID, enc.Bytes(), blob.StoragePutBlobOptions{}))
+	require.NoError(t, st.PutBlob(testlogging.Context(t), blobID, enc.Bytes(), blob.PutOptions{}))
 
 	return blobID
 }

--- a/repo/maintenance/blob_gc_test.go
+++ b/repo/maintenance/blob_gc_test.go
@@ -180,7 +180,7 @@ func verifyBlobNotFound(t *testing.T, st blob.Storage, blobID blob.ID) {
 func mustPutDummyBlob(t *testing.T, st blob.Storage, blobID blob.ID) {
 	t.Helper()
 
-	if err := st.PutBlob(testlogging.Context(t), blobID, gather.FromSlice([]byte{1, 2, 3})); err != nil {
+	if err := st.PutBlob(testlogging.Context(t), blobID, gather.FromSlice([]byte{1, 2, 3}), blob.StoragePutBlobOptions{}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -212,7 +212,7 @@ func mustPutDummySessionBlob(t *testing.T, st blob.Storage, sessionIDSuffix blob
 	defer enc.Close()
 
 	require.NoError(t, e.Encrypt(gather.FromSlice(j), iv, &enc))
-	require.NoError(t, st.PutBlob(testlogging.Context(t), blobID, enc.Bytes()))
+	require.NoError(t, st.PutBlob(testlogging.Context(t), blobID, enc.Bytes(), blob.StoragePutBlobOptions{}))
 
 	return blobID
 }

--- a/repo/maintenance/maintenance_schedule.go
+++ b/repo/maintenance/maintenance_schedule.go
@@ -170,7 +170,7 @@ func SetSchedule(ctx context.Context, rep repo.DirectRepositoryWriter, s *Schedu
 	ciphertext := c.Seal(result, nonce, v, maintenanceScheduleAEADExtraData)
 
 	// nolint:wrapcheck
-	return rep.BlobStorage().PutBlob(ctx, maintenanceScheduleBlobID, gather.FromSlice(ciphertext))
+	return rep.BlobStorage().PutBlob(ctx, maintenanceScheduleBlobID, gather.FromSlice(ciphertext), blob.StoragePutBlobOptions{})
 }
 
 // ReportRun reports timing of a maintenance run and persists it in repository.

--- a/repo/maintenance/maintenance_schedule.go
+++ b/repo/maintenance/maintenance_schedule.go
@@ -170,7 +170,7 @@ func SetSchedule(ctx context.Context, rep repo.DirectRepositoryWriter, s *Schedu
 	ciphertext := c.Seal(result, nonce, v, maintenanceScheduleAEADExtraData)
 
 	// nolint:wrapcheck
-	return rep.BlobStorage().PutBlob(ctx, maintenanceScheduleBlobID, gather.FromSlice(ciphertext), blob.StoragePutBlobOptions{})
+	return rep.BlobStorage().PutBlob(ctx, maintenanceScheduleBlobID, gather.FromSlice(ciphertext), blob.PutOptions{})
 }
 
 // ReportRun reports timing of a maintenance run and persists it in repository.

--- a/site/content/docs/Getting started/_index.md
+++ b/site/content/docs/Getting started/_index.md
@@ -339,7 +339,7 @@ Kopia provides low-level commands to examine the contents of repository, perform
 
 ### BLOBs
 
-We can list the files in the repository using `kopia blob ls`, which shows how kopia manages snapshots. We can see that repository contents are groupped into Pack files (starting with `p`) and indexed using Index files (starting with `n`). Both index and pack files are encrypted, which makes it impossible to get data and metadata about snapshotted files without knowing the password.
+We can list the files in the repository using `kopia blob ls`, which shows how kopia manages snapshots. We can see that repository contents are grouped into Pack files (starting with `p`) and indexed using Index files (starting with `n`). Both index and pack files are encrypted, which makes it impossible to get data and metadata about snapshotted files without knowing the password.
 
 ```
 $ kopia blob ls


### PR DESCRIPTION
In order to provide blob-retention setting on each blob put operation we introduce put-blob API changes at the storage interface level. These settings allow us to supply retention configuration. For now, just AWS S3 storage support has been added that respects these options but the same concept can be extended to other supported storage vendors in the future.