### PR TITLE
blob: changed default shards from {3,3} to {1,3}

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -96,7 +96,7 @@ type advancedAppServices interface {
 	maybeInitializeUpdateCheck(ctx context.Context, co *connectOptions)
 	removeUpdateState()
 	passwordPersistenceStrategy() passwordpersist.Strategy
-	getPasswordFromFlags(ctx context.Context, isNew, allowPersistent bool) (string, error)
+	getPasswordFromFlags(ctx context.Context, isCreate, allowPersistent bool) (string, error)
 	optionsFromFlags(ctx context.Context) *repo.Options
 
 	rootContext() context.Context

--- a/cli/command_blob_shards_modify_test.go
+++ b/cli/command_blob_shards_modify_test.go
@@ -18,8 +18,8 @@ func TestBlobShardsModify(t *testing.T) {
 
 	someQBlob := strings.Split(env.RunAndExpectSuccess(t, "blob", "list", "--prefix=q")[0], " ")[0]
 
-	// verify default sharding is 3,3
-	require.FileExists(t, filepath.Join(env.RepoDir, someQBlob[0:3], someQBlob[3:6], someQBlob[6:]+sharded.CompleteBlobSuffix))
+	// verify default sharding is 1,3
+	require.FileExists(t, filepath.Join(env.RepoDir, someQBlob[0:1], someQBlob[1:4], someQBlob[4:]+sharded.CompleteBlobSuffix))
 	require.FileExists(t, filepath.Join(env.RepoDir, "kopia.repository.f"))
 
 	env.RunAndExpectSuccess(t, "blob", "shards", "modify", "--path", env.RepoDir, "--default-shards=5,5", "--i-am-sure-kopia-is-not-running")

--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -32,7 +32,7 @@ func (c *commandRepositoryConnect) setup(svc advancedAppServices, parent command
 		f.setup(svc, cc)
 		cc.Action(func(_ *kingpin.ParseContext) error {
 			ctx := svc.rootContext()
-			st, err := f.connect(ctx, false)
+			st, err := f.connect(ctx, false, 0)
 			if err != nil {
 				return errors.Wrap(err, "can't connect to storage")
 			}

--- a/cli/command_repository_connect_from_config.go
+++ b/cli/command_repository_connect_from_config.go
@@ -24,8 +24,8 @@ func (c *storageFromConfigFlags) setup(sps storageProviderServices, cmd *kingpin
 	c.sps = sps
 }
 
-func (c *storageFromConfigFlags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {
-	if isNew {
+func (c *storageFromConfigFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
+	if isCreate {
 		return nil, errors.New("not supported")
 	}
 
@@ -51,7 +51,7 @@ func (c *storageFromConfigFlags) connectToStorageFromConfigFile(ctx context.Cont
 	}
 
 	// nolint:wrapcheck
-	return blob.NewStorage(ctx, *cfg.Storage)
+	return blob.NewStorage(ctx, *cfg.Storage, false)
 }
 
 func (c *storageFromConfigFlags) connectToStorageFromConfigToken(ctx context.Context) (blob.Storage, error) {
@@ -65,5 +65,5 @@ func (c *storageFromConfigFlags) connectToStorageFromConfigToken(ctx context.Con
 	}
 
 	// nolint:wrapcheck
-	return blob.NewStorage(ctx, ci)
+	return blob.NewStorage(ctx, ci, false)
 }

--- a/cli/command_repository_connect_from_config.go
+++ b/cli/command_repository_connect_from_config.go
@@ -24,7 +24,7 @@ func (c *storageFromConfigFlags) setup(sps storageProviderServices, cmd *kingpin
 	c.sps = sps
 }
 
-func (c *storageFromConfigFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
+func (c *storageFromConfigFlags) connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error) {
 	if isCreate {
 		return nil, errors.New("not supported")
 	}

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -58,7 +58,7 @@ func (c *commandRepositoryCreate) setup(svc advancedAppServices, parent commandP
 		f.setup(svc, cc)
 		cc.Action(func(_ *kingpin.ParseContext) error {
 			ctx := svc.rootContext()
-			st, err := f.connect(ctx, true)
+			st, err := f.connect(ctx, true, c.createFormatVersion)
 			if err != nil {
 				return errors.Wrap(err, "can't connect to storage")
 			}

--- a/cli/command_repository_repair.go
+++ b/cli/command_repository_repair.go
@@ -31,7 +31,7 @@ func (c *commandRepositoryRepair) setup(svc advancedAppServices, parent commandP
 		f.setup(svc, cc)
 		cc.Action(func(_ *kingpin.ParseContext) error {
 			ctx := svc.rootContext()
-			st, err := f.connect(ctx, false)
+			st, err := f.connect(ctx, false, 0)
 			if err != nil {
 				return errors.Wrap(err, "can't connect to storage")
 			}

--- a/cli/command_repository_sync.go
+++ b/cli/command_repository_sync.go
@@ -58,7 +58,7 @@ func (c *commandRepositorySyncTo) setup(svc advancedAppServices, parent commandP
 		f.setup(svc, cc)
 		cc.Action(func(_ *kingpin.ParseContext) error {
 			ctx := svc.rootContext()
-			st, err := f.connect(ctx, false)
+			st, err := f.connect(ctx, false, 0)
 			if err != nil {
 				return errors.Wrap(err, "can't connect to storage")
 			}

--- a/cli/password.go
+++ b/cli/password.go
@@ -68,12 +68,12 @@ func (c *App) setPasswordFromToken(pwd string) {
 	c.password = pwd
 }
 
-func (c *App) getPasswordFromFlags(ctx context.Context, isNew, allowPersistent bool) (string, error) {
+func (c *App) getPasswordFromFlags(ctx context.Context, isCreate, allowPersistent bool) (string, error) {
 	switch {
 	case c.password != "":
 		// password provided via --password flag or KOPIA_PASSWORD environment variable
 		return strings.TrimSpace(c.password), nil
-	case isNew:
+	case isCreate:
 		// this is a new repository, ask for password
 		return askForNewRepositoryPassword(c.stdoutWriter)
 	case allowPersistent:

--- a/cli/storage_azure.go
+++ b/cli/storage_azure.go
@@ -24,7 +24,7 @@ func (c *storageAzureFlags) setup(_ storageProviderServices, cmd *kingpin.CmdCla
 	cmd.Flag("max-upload-speed", "Limit the upload speed.").PlaceHolder("BYTES_PER_SEC").IntVar(&c.azOptions.MaxUploadSpeedBytesPerSecond)
 }
 
-func (c *storageAzureFlags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {
+func (c *storageAzureFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
 	// nolint:wrapcheck
 	return azure.New(ctx, &c.azOptions)
 }

--- a/cli/storage_azure.go
+++ b/cli/storage_azure.go
@@ -24,7 +24,7 @@ func (c *storageAzureFlags) setup(_ storageProviderServices, cmd *kingpin.CmdCla
 	cmd.Flag("max-upload-speed", "Limit the upload speed.").PlaceHolder("BYTES_PER_SEC").IntVar(&c.azOptions.MaxUploadSpeedBytesPerSecond)
 }
 
-func (c *storageAzureFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
+func (c *storageAzureFlags) connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error) {
 	// nolint:wrapcheck
 	return azure.New(ctx, &c.azOptions)
 }

--- a/cli/storage_b2.go
+++ b/cli/storage_b2.go
@@ -22,7 +22,7 @@ func (c *storageB2Flags) setup(_ storageProviderServices, cmd *kingpin.CmdClause
 	cmd.Flag("max-upload-speed", "Limit the upload speed.").PlaceHolder("BYTES_PER_SEC").IntVar(&c.b2options.MaxUploadSpeedBytesPerSecond)
 }
 
-func (c *storageB2Flags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
+func (c *storageB2Flags) connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error) {
 	// nolint:wrapcheck
 	return b2.New(ctx, &c.b2options)
 }

--- a/cli/storage_b2.go
+++ b/cli/storage_b2.go
@@ -22,7 +22,7 @@ func (c *storageB2Flags) setup(_ storageProviderServices, cmd *kingpin.CmdClause
 	cmd.Flag("max-upload-speed", "Limit the upload speed.").PlaceHolder("BYTES_PER_SEC").IntVar(&c.b2options.MaxUploadSpeedBytesPerSecond)
 }
 
-func (c *storageB2Flags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {
+func (c *storageB2Flags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
 	// nolint:wrapcheck
 	return b2.New(ctx, &c.b2options)
 }

--- a/cli/storage_filesystem.go
+++ b/cli/storage_filesystem.go
@@ -38,7 +38,7 @@ func (c *storageFilesystemFlags) setup(_ storageProviderServices, cmd *kingpin.C
 	cmd.Flag("list-parallelism", "Set list parallelism").Hidden().IntVar(&c.options.ListParallelism)
 }
 
-func (c *storageFilesystemFlags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {
+func (c *storageFilesystemFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
 	fso := c.options
 
 	fso.Path = ospath.ResolveUserFriendlyPath(fso.Path, false)
@@ -64,16 +64,8 @@ func (c *storageFilesystemFlags) connect(ctx context.Context, isNew bool) (blob.
 		fso.DirectoryShards = []int{}
 	}
 
-	if isNew {
-		log(ctx).Debugf("creating directory for repository: %v dir mode: %v", fso.Path, fso.DirectoryMode)
-
-		if err := os.MkdirAll(fso.Path, fso.DirectoryMode); err != nil {
-			log(ctx).Errorf("unable to create directory: %v", fso.Path)
-		}
-	}
-
 	// nolint:wrapcheck
-	return filesystem.New(ctx, &fso)
+	return filesystem.New(ctx, &fso, isCreate)
 }
 
 func getIntPtrValue(value string, base int) *int {

--- a/cli/storage_gcs.go
+++ b/cli/storage_gcs.go
@@ -28,7 +28,7 @@ func (c *storageGCSFlags) setup(_ storageProviderServices, cmd *kingpin.CmdClaus
 	cmd.Flag("embed-credentials", "Embed GCS credentials JSON in Kopia configuration").BoolVar(&c.embedCredentials)
 }
 
-func (c *storageGCSFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
+func (c *storageGCSFlags) connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error) {
 	if c.embedCredentials {
 		data, err := os.ReadFile(c.options.ServiceAccountCredentialsFile)
 		if err != nil {

--- a/cli/storage_gcs.go
+++ b/cli/storage_gcs.go
@@ -28,7 +28,7 @@ func (c *storageGCSFlags) setup(_ storageProviderServices, cmd *kingpin.CmdClaus
 	cmd.Flag("embed-credentials", "Embed GCS credentials JSON in Kopia configuration").BoolVar(&c.embedCredentials)
 }
 
-func (c *storageGCSFlags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {
+func (c *storageGCSFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
 	if c.embedCredentials {
 		data, err := os.ReadFile(c.options.ServiceAccountCredentialsFile)
 		if err != nil {

--- a/cli/storage_providers.go
+++ b/cli/storage_providers.go
@@ -14,7 +14,7 @@ type storageProviderServices interface {
 
 type storageFlags interface {
 	setup(sps storageProviderServices, cmd *kingpin.CmdClause)
-	connect(ctx context.Context, isNew bool) (blob.Storage, error)
+	connect(ctx context.Context, isCreate bool) (blob.Storage, error)
 }
 
 type storageProvider struct {

--- a/cli/storage_providers.go
+++ b/cli/storage_providers.go
@@ -14,7 +14,7 @@ type storageProviderServices interface {
 
 type storageFlags interface {
 	setup(sps storageProviderServices, cmd *kingpin.CmdClause)
-	connect(ctx context.Context, isCreate bool) (blob.Storage, error)
+	connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error)
 }
 
 type storageProvider struct {

--- a/cli/storage_rclone.go
+++ b/cli/storage_rclone.go
@@ -30,7 +30,7 @@ func (c *storageRcloneFlags) setup(_ storageProviderServices, cmd *kingpin.CmdCl
 	cmd.Flag("atomic-writes", "Assume provider writes are atomic").Default("true").BoolVar(&c.opt.AtomicWrites)
 }
 
-func (c *storageRcloneFlags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {
+func (c *storageRcloneFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
 	if c.connectFlat {
 		c.opt.DirectoryShards = []int{}
 	}
@@ -45,5 +45,5 @@ func (c *storageRcloneFlags) connect(ctx context.Context, isNew bool) (blob.Stor
 	}
 
 	// nolint:wrapcheck
-	return rclone.New(ctx, &c.opt)
+	return rclone.New(ctx, &c.opt, isCreate)
 }

--- a/cli/storage_rclone.go
+++ b/cli/storage_rclone.go
@@ -30,10 +30,8 @@ func (c *storageRcloneFlags) setup(_ storageProviderServices, cmd *kingpin.CmdCl
 	cmd.Flag("atomic-writes", "Assume provider writes are atomic").Default("true").BoolVar(&c.opt.AtomicWrites)
 }
 
-func (c *storageRcloneFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
-	if c.connectFlat {
-		c.opt.DirectoryShards = []int{}
-	}
+func (c *storageRcloneFlags) connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error) {
+	c.opt.DirectoryShards = initialDirectoryShards(c.connectFlat, formatVersion)
 
 	if c.embedRCloneConfigFile != "" {
 		cfg, err := os.ReadFile(c.embedRCloneConfigFile)

--- a/cli/storage_s3.go
+++ b/cli/storage_s3.go
@@ -46,8 +46,8 @@ func (c *storageS3Flags) setup(_ storageProviderServices, cmd *kingpin.CmdClause
 	cmd.Flag("point-in-time", "Use a point-in-time view of the storage repository when supported").PlaceHolder(time.RFC3339).PreAction(pitPreAction).StringVar(&pointInTimeStr)
 }
 
-func (c *storageS3Flags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {
-	if isNew && c.s3options.PointInTime != nil && !c.s3options.PointInTime.IsZero() {
+func (c *storageS3Flags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
+	if isCreate && c.s3options.PointInTime != nil && !c.s3options.PointInTime.IsZero() {
 		return nil, errors.New("Cannot specify a 'point-in-time' option when creating a repository")
 	}
 

--- a/cli/storage_s3.go
+++ b/cli/storage_s3.go
@@ -46,7 +46,7 @@ func (c *storageS3Flags) setup(_ storageProviderServices, cmd *kingpin.CmdClause
 	cmd.Flag("point-in-time", "Use a point-in-time view of the storage repository when supported").PlaceHolder(time.RFC3339).PreAction(pitPreAction).StringVar(&pointInTimeStr)
 }
 
-func (c *storageS3Flags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
+func (c *storageS3Flags) connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error) {
 	if isCreate && c.s3options.PointInTime != nil && !c.s3options.PointInTime.IsZero() {
 		return nil, errors.New("Cannot specify a 'point-in-time' option when creating a repository")
 	}

--- a/cli/storage_sftp.go
+++ b/cli/storage_sftp.go
@@ -43,8 +43,7 @@ func (c *storageSFTPFlags) setup(_ storageProviderServices, cmd *kingpin.CmdClau
 	cmd.Flag("list-parallelism", "Set list parallelism").Hidden().IntVar(&c.options.ListParallelism)
 }
 
-// nolint:gocyclo
-func (c *storageSFTPFlags) getOptions() (*sftp.Options, error) {
+func (c *storageSFTPFlags) getOptions(formatVersion int) (*sftp.Options, error) {
 	sftpo := c.options
 
 	// nolint:nestif
@@ -103,15 +102,13 @@ func (c *storageSFTPFlags) getOptions() (*sftp.Options, error) {
 		}
 	}
 
-	if c.connectFlat {
-		sftpo.DirectoryShards = []int{}
-	}
+	sftpo.DirectoryShards = initialDirectoryShards(c.connectFlat, formatVersion)
 
 	return &sftpo, nil
 }
 
-func (c *storageSFTPFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
-	opt, err := c.getOptions()
+func (c *storageSFTPFlags) connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error) {
+	opt, err := c.getOptions(formatVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/storage_sftp.go
+++ b/cli/storage_sftp.go
@@ -110,12 +110,12 @@ func (c *storageSFTPFlags) getOptions() (*sftp.Options, error) {
 	return &sftpo, nil
 }
 
-func (c *storageSFTPFlags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {
+func (c *storageSFTPFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
 	opt, err := c.getOptions()
 	if err != nil {
 		return nil, err
 	}
 
 	// nolint:wrapcheck
-	return sftp.New(ctx, opt)
+	return sftp.New(ctx, opt, isCreate)
 }

--- a/cli/storage_sftp_test.go
+++ b/cli/storage_sftp_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/repo/blob/sftp"
+	"github.com/kopia/kopia/repo/blob/sharded"
 )
 
 func TestSFTPOptions(t *testing.T) {
@@ -129,12 +130,14 @@ func TestSFTPOptions(t *testing.T) {
 				connectFlat: true,
 			},
 			want: &sftp.Options{
-				Host:            "some-host",
-				Port:            222,
-				Username:        "user",
-				KnownHostsFile:  mustFileAbs(t, "my-known-hosts"),
-				Keyfile:         mustFileAbs(t, "my-key"),
-				DirectoryShards: []int{},
+				Host:           "some-host",
+				Port:           222,
+				Username:       "user",
+				KnownHostsFile: mustFileAbs(t, "my-known-hosts"),
+				Keyfile:        mustFileAbs(t, "my-key"),
+				Options: sharded.Options{
+					DirectoryShards: []int{},
+				},
 			},
 		},
 		// 7
@@ -150,12 +153,14 @@ func TestSFTPOptions(t *testing.T) {
 				connectFlat: true,
 			},
 			want: &sftp.Options{
-				Host:            "some-host",
-				Port:            222,
-				Username:        "user",
-				KnownHostsFile:  mustFileAbs(t, "my-known-hosts"),
-				Password:        "my-password",
-				DirectoryShards: []int{},
+				Host:           "some-host",
+				Port:           222,
+				Username:       "user",
+				KnownHostsFile: mustFileAbs(t, "my-known-hosts"),
+				Password:       "my-password",
+				Options: sharded.Options{
+					DirectoryShards: []int{},
+				},
 			},
 		},
 	}

--- a/cli/storage_sftp_test.go
+++ b/cli/storage_sftp_test.go
@@ -167,7 +167,7 @@ func TestSFTPOptions(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("case-%v", i), func(t *testing.T) {
-			got, err := tc.input.getOptions()
+			got, err := tc.input.getOptions(2)
 			if tc.wantErr == "" {
 				require.NoError(t, err)
 				require.Equal(t, tc.want, got)

--- a/cli/storage_webdav.go
+++ b/cli/storage_webdav.go
@@ -24,7 +24,7 @@ func (c *storageWebDAVFlags) setup(_ storageProviderServices, cmd *kingpin.CmdCl
 	cmd.Flag("atomic-writes", "Assume WebDAV provider implements atomic writes").BoolVar(&c.options.AtomicWrites)
 }
 
-func (c *storageWebDAVFlags) connect(ctx context.Context, isNew bool) (blob.Storage, error) {
+func (c *storageWebDAVFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
 	wo := c.options
 
 	if wo.Username != "" && wo.Password == "" {
@@ -41,5 +41,5 @@ func (c *storageWebDAVFlags) connect(ctx context.Context, isNew bool) (blob.Stor
 	}
 
 	// nolint:wrapcheck
-	return webdav.New(ctx, &wo)
+	return webdav.New(ctx, &wo, isCreate)
 }

--- a/cli/storage_webdav.go
+++ b/cli/storage_webdav.go
@@ -24,7 +24,7 @@ func (c *storageWebDAVFlags) setup(_ storageProviderServices, cmd *kingpin.CmdCl
 	cmd.Flag("atomic-writes", "Assume WebDAV provider implements atomic writes").BoolVar(&c.options.AtomicWrites)
 }
 
-func (c *storageWebDAVFlags) connect(ctx context.Context, isCreate bool) (blob.Storage, error) {
+func (c *storageWebDAVFlags) connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error) {
 	wo := c.options
 
 	if wo.Username != "" && wo.Password == "" {
@@ -36,9 +36,7 @@ func (c *storageWebDAVFlags) connect(ctx context.Context, isCreate bool) (blob.S
 		wo.Password = pass
 	}
 
-	if c.connectFlat {
-		wo.DirectoryShards = []int{}
-	}
+	wo.DirectoryShards = initialDirectoryShards(c.connectFlat, formatVersion)
 
 	// nolint:wrapcheck
 	return webdav.New(ctx, &wo, isCreate)

--- a/internal/blobtesting/verify.go
+++ b/internal/blobtesting/verify.go
@@ -159,7 +159,7 @@ func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage, opts blob.
 func AssertConnectionInfoRoundTrips(ctx context.Context, t *testing.T, s blob.Storage) {
 	ci := s.ConnectionInfo()
 
-	s2, err := blob.NewStorage(ctx, ci)
+	s2, err := blob.NewStorage(ctx, ci, false)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/internal/cache/cache_storage.go
+++ b/internal/cache/cache_storage.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kopia/kopia/internal/ospath"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/filesystem"
+	"github.com/kopia/kopia/repo/blob/sharded"
 )
 
 // DirMode is the directory mode for all caches.
@@ -42,9 +43,11 @@ func NewStorageOrNil(ctx context.Context, cacheDir string, maxBytes int64, subdi
 	}
 
 	fs, err := filesystem.New(ctxutil.Detach(ctx), &filesystem.Options{
-		Path:            contentCacheDir,
-		DirectoryShards: []int{2},
-	})
+		Path: contentCacheDir,
+		Options: sharded.Options{
+			DirectoryShards: []int{2},
+		},
+	}, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "error initializing filesystem cache")
 	}

--- a/internal/repotesting/reconnectable_storage.go
+++ b/internal/repotesting/reconnectable_storage.go
@@ -57,7 +57,7 @@ func init() {
 	blob.AddSupportedStorage(
 		reconnectableStorageType,
 		func() interface{} { return &reconnectableStorageOptions{} },
-		func(ctx context.Context, o interface{}) (blob.Storage, error) {
+		func(ctx context.Context, o interface{}, isCreate bool) (blob.Storage, error) {
 			opt, ok := o.(*reconnectableStorageOptions)
 			if !ok {
 				return nil, errors.Errorf("invalid options %T", o)

--- a/internal/server/api_repo.go
+++ b/internal/server/api_repo.go
@@ -111,7 +111,7 @@ func (s *Server) handleRepoCreate(ctx context.Context, r *http.Request, body []b
 		return nil, err
 	}
 
-	st, err := blob.NewStorage(ctx, req.Storage)
+	st, err := blob.NewStorage(ctx, req.Storage, true)
 	if err != nil {
 		return nil, requestError(serverapi.ErrorStorageConnection, "unable to connect to storage: "+err.Error())
 	}
@@ -154,7 +154,7 @@ func (s *Server) handleRepoExists(ctx context.Context, r *http.Request, body []b
 		return nil, requestError(serverapi.ErrorMalformedRequest, "unable to decode request: "+err.Error())
 	}
 
-	st, err := blob.NewStorage(ctx, req.Storage)
+	st, err := blob.NewStorage(ctx, req.Storage, false)
 	if err != nil {
 		return nil, internalServerError(err)
 	}
@@ -261,7 +261,7 @@ func (s *Server) connectAPIServerAndOpen(ctx context.Context, si *repo.APIServer
 }
 
 func (s *Server) connectAndOpen(ctx context.Context, conn blob.ConnectionInfo, password string, cliOpts repo.ClientOptions) *apiError {
-	st, err := blob.NewStorage(ctx, conn)
+	st, err := blob.NewStorage(ctx, conn, false)
 	if err != nil {
 		return requestError(serverapi.ErrorStorageConnection, "can't open storage: "+err.Error())
 	}

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -289,7 +289,7 @@ func init() {
 		func() interface{} {
 			return &Options{}
 		},
-		func(ctx context.Context, o interface{}) (blob.Storage, error) {
+		func(ctx context.Context, o interface{}, isCreate bool) (blob.Storage, error) {
 			return New(ctx, o.(*Options))
 		})
 }

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -285,7 +285,7 @@ func init() {
 		func() interface{} {
 			return &Options{}
 		},
-		func(ctx context.Context, o interface{}) (blob.Storage, error) {
+		func(ctx context.Context, o interface{}, isCreate bool) (blob.Storage, error) {
 			return New(ctx, o.(*Options))
 		})
 }

--- a/repo/blob/filesystem/filesystem_options.go
+++ b/repo/blob/filesystem/filesystem_options.go
@@ -1,12 +1,14 @@
 package filesystem
 
-import "os"
+import (
+	"os"
+
+	"github.com/kopia/kopia/repo/blob/sharded"
+)
 
 // Options defines options for Filesystem-backed storage.
 type Options struct {
 	Path string `json:"path"`
-
-	DirectoryShards []int `json:"dirShards"`
 
 	FileMode      os.FileMode `json:"fileMode,omitempty"`
 	DirectoryMode os.FileMode `json:"dirMode,omitempty"`
@@ -14,7 +16,7 @@ type Options struct {
 	FileUID *int `json:"uid,omitempty"`
 	FileGID *int `json:"gid,omitempty"`
 
-	ListParallelism int `json:"listParallelism,omitempty"`
+	sharded.Options
 }
 
 func (fso *Options) fileMode() os.FileMode {
@@ -31,12 +33,4 @@ func (fso *Options) dirMode() os.FileMode {
 	}
 
 	return fso.DirectoryMode
-}
-
-func (fso *Options) shards() []int {
-	if fso.DirectoryShards == nil {
-		return fsDefaultShards
-	}
-
-	return fso.DirectoryShards
 }

--- a/repo/blob/filesystem/filesystem_storage_test.go
+++ b/repo/blob/filesystem/filesystem_storage_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/sharded"
 )
 
 func TestFileStorage(t *testing.T) {
@@ -36,9 +37,11 @@ func TestFileStorage(t *testing.T) {
 		path := testutil.TempDirectory(t)
 
 		r, err := New(ctx, &Options{
-			Path:            path,
-			DirectoryShards: shardSpec,
-		})
+			Path: path,
+			Options: sharded.Options{
+				DirectoryShards: shardSpec,
+			},
+		}, true)
 
 		if r == nil || err != nil {
 			t.Errorf("unexpected result: %v %v", r, err)
@@ -70,7 +73,7 @@ func TestFileStorageTouch(t *testing.T) {
 
 	r, err := New(ctx, &Options{
 		Path: path,
-	})
+	}, true)
 
 	if r == nil || err != nil {
 		t.Errorf("unexpected result: %v %v", r, err)
@@ -112,7 +115,7 @@ func TestFileStorageConcurrency(t *testing.T) {
 
 	st, err := New(ctx, &Options{
 		Path: path,
-	})
+	}, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,9 +140,11 @@ func TestFilesystemStorageDirectoryShards(t *testing.T) {
 	dataDir := testutil.TempDirectory(t)
 
 	st, err := New(ctx, &Options{
-		Path:            dataDir,
-		DirectoryShards: []int{5, 2},
-	})
+		Path: dataDir,
+		Options: sharded.Options{
+			DirectoryShards: []int{5, 2},
+		},
+	}, true)
 	if err != nil {
 		t.Fatalf("unable to connect to rclone backend: %v", err)
 	}

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -287,7 +287,7 @@ func init() {
 		func() interface{} {
 			return &Options{}
 		},
-		func(ctx context.Context, o interface{}) (blob.Storage, error) {
+		func(ctx context.Context, o interface{}, isCreate bool) (blob.Storage, error) {
 			return New(ctx, o.(*Options))
 		})
 }

--- a/repo/blob/rclone/rclone_options.go
+++ b/repo/blob/rclone/rclone_options.go
@@ -1,5 +1,7 @@
 package rclone
 
+import "github.com/kopia/kopia/repo/blob/sharded"
+
 // Options defines options for RClone storage.
 type Options struct {
 	RemotePath         string   `json:"remotePath"`                   // remote:path supported by RClone
@@ -9,8 +11,8 @@ type Options struct {
 	StartupTimeout     int      `json:"startupTimeout,omitempty"`     // time to wait for rclone to start
 	Debug              bool     `json:"debug,omitempty"`              // log rclone output
 	NoWaitForTransfers bool     `json:"noWaitForTransfers,omitempty"` // when set to true, don't wait for transfers to finish when closing
-	DirectoryShards    []int    `json:"dirShards"`
 	EmbeddedConfig     string   `json:"embeddedConfig,omitempty"`
-	ListParallelism    int      `json:"listParallelism,omitempty"`
 	AtomicWrites       bool     `json:"atomicWrites"`
+
+	sharded.Options
 }

--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -185,7 +185,7 @@ func (r *rcloneStorage) runRCloneAndWaitForServerAddress(ctx context.Context, c 
 
 // New creates new RClone storage with specified options.
 // nolint:funlen
-func New(ctx context.Context, opt *Options) (blob.Storage, error) {
+func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error) {
 	// generate directory for all temp files.
 	td, err := os.MkdirTemp("", "kopia-rclone")
 	if err != nil {
@@ -291,10 +291,9 @@ func New(ctx context.Context, opt *Options) (blob.Storage, error) {
 		Username:                            webdavUsername,
 		Password:                            webdavPassword,
 		TrustedServerCertificateFingerprint: hex.EncodeToString(fingerprintBytes[:]),
-		ListParallelism:                     opt.ListParallelism,
 		AtomicWrites:                        opt.AtomicWrites,
-		DirectoryShards:                     opt.DirectoryShards,
-	})
+		Options:                             opt.Options,
+	}, isCreate)
 	if err != nil {
 		return nil, errors.Wrap(err, "error connecting to webdav storage")
 	}
@@ -310,7 +309,7 @@ func init() {
 		func() interface{} {
 			return &Options{}
 		},
-		func(ctx context.Context, o interface{}) (blob.Storage, error) {
-			return New(ctx, o.(*Options))
+		func(ctx context.Context, o interface{}, isCreate bool) (blob.Storage, error) {
+			return New(ctx, o.(*Options), isCreate)
 		})
 }

--- a/repo/blob/registry.go
+++ b/repo/blob/registry.go
@@ -6,19 +6,23 @@ import (
 	"github.com/pkg/errors"
 )
 
+// CreateStorageFunc is a function that returns Storage with provided options, optionally
+// creating the underlying storage location (e.g. directory), when possible.
+type CreateStorageFunc func(ctx context.Context, options interface{}, isCreate bool) (Storage, error)
+
 var factories = map[string]*storageFactory{}
 
 // StorageFactory allows creation of repositories in a generic way.
 type storageFactory struct {
 	defaultConfigFunc func() interface{}
-	createStorageFunc func(context.Context, interface{}) (Storage, error)
+	createStorageFunc CreateStorageFunc
 }
 
 // AddSupportedStorage registers factory function to create storage with a given type name.
 func AddSupportedStorage(
 	urlScheme string,
 	defaultConfigFunc func() interface{},
-	createStorageFunc func(context.Context, interface{}) (Storage, error),
+	createStorageFunc CreateStorageFunc,
 ) {
 	f := &storageFactory{
 		defaultConfigFunc: defaultConfigFunc,
@@ -30,9 +34,9 @@ func AddSupportedStorage(
 
 // NewStorage creates new storage based on ConnectionInfo.
 // The storage type must be previously registered using AddSupportedStorage.
-func NewStorage(ctx context.Context, cfg ConnectionInfo) (Storage, error) {
+func NewStorage(ctx context.Context, cfg ConnectionInfo, isCreate bool) (Storage, error) {
 	if factory, ok := factories[cfg.Type]; ok {
-		return factory.createStorageFunc(ctx, cfg.Config)
+		return factory.createStorageFunc(ctx, cfg.Config, isCreate)
 	}
 
 	return nil, errors.Errorf("unknown storage type: %s", cfg.Type)

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -363,7 +363,7 @@ func init() {
 		func() interface{} {
 			return &Options{}
 		},
-		func(ctx context.Context, o interface{}) (blob.Storage, error) {
+		func(ctx context.Context, o interface{}, isCreate bool) (blob.Storage, error) {
 			return New(ctx, o.(*Options))
 		})
 }

--- a/repo/blob/sftp/sftp_options.go
+++ b/repo/blob/sftp/sftp_options.go
@@ -3,6 +3,8 @@ package sftp
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/kopia/kopia/repo/blob/sharded"
 )
 
 // Options defines options for sftp-backed storage.
@@ -23,16 +25,7 @@ type Options struct {
 	SSHCommand   string `json:"sshCommand,omitempty"` // default "ssh"
 	SSHArguments string `json:"sshArguments,omitempty"`
 
-	DirectoryShards []int `json:"dirShards"`
-	ListParallelism int   `json:"listParallelism,omitempty"`
-}
-
-func (sftpo *Options) shards() []int {
-	if sftpo.DirectoryShards == nil {
-		return sftpDefaultShards
-	}
-
-	return sftpo.DirectoryShards
+	sharded.Options
 }
 
 func (sftpo *Options) knownHostsFile() string {

--- a/repo/blob/sftp/sftp_storage_test.go
+++ b/repo/blob/sftp/sftp_storage_test.go
@@ -285,7 +285,7 @@ func TestSFTPStorageRelativeKeyFile(t *testing.T) {
 		KnownHostsFile: kh,
 	}
 
-	_, err := sftp.New(testlogging.Context(t), opt)
+	_, err := sftp.New(testlogging.Context(t), opt, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "key file path must be absolute")
 }
@@ -302,7 +302,7 @@ func TestSFTPStorageRelativeKnownHostsFile(t *testing.T) {
 		KnownHostsFile: "some-relative-path",
 	}
 
-	_, err := sftp.New(testlogging.Context(t), opt)
+	_, err := sftp.New(testlogging.Context(t), opt, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "known hosts path must be absolute")
 }
@@ -333,7 +333,7 @@ func createSFTPStorage(ctx context.Context, t *testing.T, opt sftp.Options, embe
 		opt.KnownHostsFile = ""
 	}
 
-	return sftp.New(ctx, &opt)
+	return sftp.New(ctx, &opt, true)
 }
 
 func mustReadFileToString(t *testing.T, fname string) string {

--- a/repo/blob/sharded/sharded_options.go
+++ b/repo/blob/sharded/sharded_options.go
@@ -1,0 +1,7 @@
+package sharded
+
+// Options must be anonymously embedded in sharded provider options.
+type Options struct {
+	DirectoryShards []int `json:"dirShards"`
+	ListParallelism int   `json:"listParallelism,omitempty"`
+}

--- a/repo/blob/webdav/webdav_options.go
+++ b/repo/blob/webdav/webdav_options.go
@@ -1,20 +1,14 @@
 package webdav
 
+import "github.com/kopia/kopia/repo/blob/sharded"
+
 // Options defines options for Filesystem-backed storage.
 type Options struct {
 	URL                                 string `json:"url"`
-	DirectoryShards                     []int  `json:"dirShards"`
 	Username                            string `json:"username,omitempty"`
 	Password                            string `json:"password,omitempty" kopia:"sensitive"`
 	TrustedServerCertificateFingerprint string `json:"trustedServerCertificateFingerprint,omitempty"`
-	ListParallelism                     int    `json:"listParallelism,omitempty"`
 	AtomicWrites                        bool   `json:"atomicWrites"`
-}
 
-func (fso *Options) shards() []int {
-	if fso.DirectoryShards == nil {
-		return fsDefaultShards
-	}
-
-	return fso.DirectoryShards
+	sharded.Options
 }

--- a/repo/blob/webdav/webdav_storage_test.go
+++ b/repo/blob/webdav/webdav_storage_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/sharded"
 )
 
 func basicAuth(h http.Handler) http.HandlerFunc {
@@ -148,11 +149,13 @@ func verifyWebDAVStorage(t *testing.T, url, username, password string, shardSpec
 	ctx := testlogging.Context(t)
 
 	st, err := New(testlogging.Context(t), &Options{
-		URL:             url,
-		DirectoryShards: shardSpec,
-		Username:        username,
-		Password:        password,
-	})
+		URL: url,
+		Options: sharded.Options{
+			DirectoryShards: shardSpec,
+		},
+		Username: username,
+		Password: password,
+	}, false)
 
 	if st == nil || err != nil {
 		t.Errorf("unexpected result: %v %v", st, err)

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kopia/kopia/internal/ownwrites"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/filesystem"
+	"github.com/kopia/kopia/repo/blob/sharded"
 	"github.com/kopia/kopia/repo/compression"
 	"github.com/kopia/kopia/repo/hashing"
 	"github.com/kopia/kopia/repo/logging"
@@ -342,9 +343,11 @@ func newCacheBackingStorage(ctx context.Context, caching *CachingOptions, subdir
 
 	// nolint:wrapcheck
 	return filesystem.New(ctx, &filesystem.Options{
-		Path:            blobListCacheDir,
-		DirectoryShards: []int{},
-	})
+		Path: blobListCacheDir,
+		Options: sharded.Options{
+			DirectoryShards: []int{},
+		},
+	}, false)
 }
 
 func (sm *SharedManager) namedLogger(n string) logging.Logger {

--- a/repo/open.go
+++ b/repo/open.go
@@ -141,7 +141,7 @@ func openDirect(ctx context.Context, configFile string, lc *LocalConfig, passwor
 		return nil, errors.Errorf("storage not set in the configuration file")
 	}
 
-	st, err := blob.NewStorage(ctx, *lc.Storage)
+	st, err := blob.NewStorage(ctx, *lc.Storage, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot open storage")
 	}

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -54,7 +54,7 @@ func newUploadTestHarness(ctx context.Context, t *testing.T) *uploadTestHarness 
 
 	storage, err := filesystem.New(ctx, &filesystem.Options{
 		Path: repoDir,
-	})
+	}, true)
 	if err != nil {
 		panic("cannot create storage directory: " + err.Error())
 	}

--- a/tests/repository_stress_test/repository_stress_test.go
+++ b/tests/repository_stress_test/repository_stress_test.go
@@ -210,11 +210,9 @@ func runStress(t *testing.T, opt *StressOptions) {
 
 	storagePath := filepath.Join(tmpPath, "storage")
 
-	assertNoError(t, os.MkdirAll(storagePath, 0o700))
-
 	st, err := filesystem.New(ctx, &filesystem.Options{
 		Path: storagePath,
-	})
+	}, true)
 	if err != nil {
 		t.Fatalf("unable to initialize storage: %v", err)
 	}
@@ -541,12 +539,4 @@ func writeRandomManifest(ctx context.Context, r repo.DirectRepositoryWriter, rs 
 	rs.WriteManifest(mid)
 
 	return err
-}
-
-func assertNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Errorf("err: %v", err)
-	}
 }

--- a/tests/tools/kopiaclient/kopiaclient.go
+++ b/tests/tools/kopiaclient/kopiaclient.go
@@ -199,7 +199,7 @@ func (kc *KopiaClient) getStorage(ctx context.Context, repoDir, bucketName strin
 		fsOpts := &filesystem.Options{
 			Path: repoDir,
 		}
-		st, err = filesystem.New(ctx, fsOpts)
+		st, err = filesystem.New(ctx, fsOpts, false)
 	}
 
 	return st, errors.Wrap(err, "unable to get storage")


### PR DESCRIPTION
Turns out for very large repository around 100TB (5M blobs),
we end up creating millions of directories which is way too much
and slows down listing. Currently each leaf directory only has a handful
of files.

Simple sharding of {1,3} should work much better and will end up creating
directories with meaningful shard sizes - 12 K files per directory
should not be too slow and will reduce the overhead of listing by
4096 times.

The change is done in a backwards-compatible way and will respect
custom sharding (.shards) file written by previous 0.9 builds
as well as older repositories that don't have the .shards file (which
we assume to be {3,3}).

The layout produces repositories looking like:

```
/.shards
/_/log/_20211114104830_a3a5_1636915710_1636915723_1_ff05424d9d270febdb2c504f28d30db6.f
/_/log/_20211114104830_a3a5_1636915723_1636915727_2_d5ab683b3057c5a193895e7db0d217ad.f
/_/log/_20211114104830_3c01_1636915710_1636915710_1_d094b4064422442d634c700b8eb75aeb.f
/kopia.repository.f
/kopia.maintenance.f
/q/a85/70517963bee3521d69e7dec844cb7-saa5e639eaff4d1dc10a.f
/q/865/3a42e8eea6223cc6c045b12cab871-saa5e639eaff4d1dc10a.f
/q/85e/837f10b6238e74a2afbcf82e66a72-sa0f28471f1d7e0bb10a.f
/x/n0_/30e2817ffa969600081aa4cf314a6a3e-sa0f28471f1d7e0bb10a-c1.f
/x/n0_/b76c7150880f7580bf819bb006b25f41-saa5e639eaff4d1dc10a-c1.f
/p/797/91bc7fec987458460f2f5322b2fb3-saa5e639eaff4d1dc10a.f
/p/d12/8caec69e1912052a962db0f0e338d-saa5e639eaff4d1dc10a.f
/p/ed9/3745d2216cf512711558c5987b599-saa5e639eaff4d1dc10a.f
/p/0f9/c974fd398319b49844b3081a5b2e0-saa5e639eaff4d1dc10a.f
/p/36e/a270cffeab38b5b04a1ec4ab9c498-saa5e639eaff4d1dc10a.f
/p/95d/f7c1b24f1b10d980e73f6ad8e2a9c-saa5e639eaff4d1dc10a.f
```