### PR TITLE
Change Mbit/s units to MB/s (base-10)

### DIFF
--- a/cli/command_repository_sync.go
+++ b/cli/command_repository_sync.go
@@ -246,7 +246,7 @@ func (c *commandRepositorySyncTo) runSyncBlobs(ctx context.Context, src blob.Rea
 
 				if est, ok := tt.Estimate(float64(bytesCopied), float64(totalBytes)); ok {
 					eta = fmt.Sprintf("%v (%v)", est.Remaining, formatTimestamp(est.EstimatedEndTime))
-					speed = units.BytesPerSecondsString(est.SpeedPerSecond) //nolint:gomnd
+					speed = units.BytesPerSecondsString(est.SpeedPerSecond)
 				}
 
 				c.outputSyncProgress(

--- a/cli/command_repository_sync.go
+++ b/cli/command_repository_sync.go
@@ -246,7 +246,7 @@ func (c *commandRepositorySyncTo) runSyncBlobs(ctx context.Context, src blob.Rea
 
 				if est, ok := tt.Estimate(float64(bytesCopied), float64(totalBytes)); ok {
 					eta = fmt.Sprintf("%v (%v)", est.Remaining, formatTimestamp(est.EstimatedEndTime))
-					speed = units.BitsPerSecondsString(est.SpeedPerSecond * 8) //nolint:gomnd
+					speed = units.BytesPerSecondsString(est.SpeedPerSecond) //nolint:gomnd
 				}
 
 				c.outputSyncProgress(

--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -24,7 +24,7 @@ import (
 const (
 	restoreCommandHelp = `Restore a directory or a file.
 
-Restore can operate in two modes: 
+Restore can operate in two modes:
 
 * from a snapshot: restoring (possibly shallowly) a specified file or
 directory from a snapshot into a target path. By default, the target
@@ -33,7 +33,7 @@ path will be created by the restore command if it does not exist.
 * by expanding a shallow placeholder in situ where the placeholder was
 created by a previous restore.
 
-In the from-snapshot mode: 
+In the from-snapshot mode:
 
 The source to be restored is specified in the form of a directory or file ID and
 optionally a sub-directory path.
@@ -87,7 +87,6 @@ followed by the path of the directory for the contents to be restored.
 2. one or more placeholder files of the form path.kopia-entry
 `
 
-	bitsPerByte    = 8
 	unlimitedDepth = math.MaxInt32
 )
 
@@ -362,9 +361,8 @@ func (c *commandRestore) run(ctx context.Context, rep repo.Repository) error {
 				var maybeRemaining, maybeSkipped, maybeErrors string
 
 				if est, ok := eta.Estimate(float64(stats.RestoredTotalFileSize), float64(stats.EnqueuedTotalFileSize)); ok {
-					bitsPerSecond := est.SpeedPerSecond * float64(bitsPerByte)
 					maybeRemaining = fmt.Sprintf(" %v (%.1f%%) remaining %v",
-						units.BitsPerSecondsString(bitsPerSecond),
+						units.BytesPerSecondsString(est.SpeedPerSecond),
 						est.PercentComplete,
 						est.Remaining)
 				}

--- a/internal/units/units.go
+++ b/internal/units/units.go
@@ -39,10 +39,10 @@ func BytesStringBase2(b int64) string {
 	return toDecimalUnitString(float64(b), 1024.0, base2UnitPrefixes, "B")
 }
 
-// BitsPerSecondsString formats the given value bits per second with the appropriate suffix (Kbit/s, Mbit/s, Gbit/s, ...)
-func BitsPerSecondsString(bps float64) string {
+// BytesPerSecondsString formats the given value bytes per second with the appropriate base-10 suffix (KB/s, MB/s, GB/s, ...)
+func BytesPerSecondsString(bps float64) string {
 	// nolint:gomnd
-	return toDecimalUnitString(bps, 1000, base10UnitPrefixes, "bit/s")
+	return toDecimalUnitString(bps, 1000, base10UnitPrefixes, "B/s")
 }
 
 // Count returns the given number with the appropriate base-10 suffix (K, M, G, ...)


### PR DESCRIPTION
Almost all numbers with units in Kopia uses byte (either base-2 or base-10) as the data unit. However, there are two cases use bit, which feels unnecessary and inconsistent. For example, a typical `kopia repository sync-to rclone` output looks like this:
```
Synchronizing repositories:
  Source:      Filesystem: <redacted>
  Destination: RClone <redacted>
Looking for BLOBs to synchronize...
  Found 241 BLOBs in the destination repository (2.4 GB)
  Found 244 BLOBs (2.5 GB) in the source repository, 3 (67.8 MB) to copy
  Found 0 BLOBs to delete (0 B), 241 in sync (2.4 GB)
Copying...
  Copied 2 blobs (45.2 MB), Speed: 14.9 Mbit/s, ETA: 3s (2021-11-17 22:20:38 PST)
```
The data sizes are all byte-based, but speed is suddenly changed to bit-based. Feels inconsistent. And most users aren't used to bits.

Is there a particular reason why it's bit-based to begin with? If not, shall we change it?