### PR TITLE
Cleanup cli2md to fix issue #1440

### DIFF
--- a/site/cli2md/cli2md.go
+++ b/site/cli2md/cli2md.go
@@ -236,13 +236,27 @@ func generateSubcommands(w io.Writer, dir, sectionTitle string, cmds []*kingpin.
 		}
 
 		if first {
-			fmt.Fprintf(w, "\n### %v\n\n", sectionTitle)
+			sectionTitleCutoffIndex := len(sectionTitle)
+			if sectionTitle[sectionTitleCutoffIndex-1] == '.' {
+				sectionTitleCutoffIndex -= 1
+			}
+
+			fmt.Fprintf(w, "\n### %v\n\n", sectionTitle[:sectionTitleCutoffIndex])
 
 			first = false
 		}
 
+		helpSummaryCutoffIndex := strings.Index(c.Help, "\n")
+		if helpSummaryCutoffIndex == -1 {
+			helpSummaryCutoffIndex = len(c.Help)
+		}
+		if c.Help[helpSummaryCutoffIndex-1] == '.' {
+			helpSummaryCutoffIndex -= 1
+		}
+
 		subcommandSlug := strings.Replace(c.FullCommand, " ", "-", -1)
-		fmt.Fprintf(w, "* [`%v`](%v) - %v\n", c.FullCommand, subcommandSlug+"/", c.Help)
+		helpSummary := c.Help[:helpSummaryCutoffIndex]
+		fmt.Fprintf(w, "* [`%v`](%v) - %v\n", c.FullCommand, subcommandSlug+"/", helpSummary)
 		generateSubcommandPage(filepath.Join(dir, subcommandSlug+".md"), c)
 	}
 }
@@ -259,6 +273,7 @@ func generateSubcommandPage(fname string, cmd *kingpin.CmdModel) {
 title: %q
 linkTitle: %q
 weight: 10
+toc_hide: true
 ---
 
 `, title, title)

--- a/site/cli2md/cli2md.go
+++ b/site/cli2md/cli2md.go
@@ -236,26 +236,14 @@ func generateSubcommands(w io.Writer, dir, sectionTitle string, cmds []*kingpin.
 		}
 
 		if first {
-			sectionTitleCutoffIndex := len(sectionTitle)
-			if sectionTitle[sectionTitleCutoffIndex-1] == '.' {
-				sectionTitleCutoffIndex -= 1
-			}
-
-			fmt.Fprintf(w, "\n### %v\n\n", sectionTitle[:sectionTitleCutoffIndex])
+			fmt.Fprintf(w, "\n### %v\n\n", strings.TrimSuffix(sectionTitle, "."))
 
 			first = false
 		}
 
-		helpSummaryCutoffIndex := strings.Index(c.Help, "\n")
-		if helpSummaryCutoffIndex == -1 {
-			helpSummaryCutoffIndex = len(c.Help)
-		}
-		if c.Help[helpSummaryCutoffIndex-1] == '.' {
-			helpSummaryCutoffIndex -= 1
-		}
-
 		subcommandSlug := strings.Replace(c.FullCommand, " ", "-", -1)
-		helpSummary := c.Help[:helpSummaryCutoffIndex]
+		helpSummary := strings.SplitN(c.Help, "\n", 2)[0] // nolint:gomnd
+		helpSummary = strings.TrimSuffix(helpSummary, ".")
 		fmt.Fprintf(w, "* [`%v`](%v) - %v\n", c.FullCommand, subcommandSlug+"/", helpSummary)
 		generateSubcommandPage(filepath.Join(dir, subcommandSlug+".md"), c)
 	}


### PR DESCRIPTION
As issue #1440 states, I can see several problems of the generated doc pages:

1. The top-level [Common Commands](https://kopia.io/docs/reference/command-line/common/) is very cluttered. This is because `cli2md` puts all the command's help string to the page, not accounting for how long the string could be (some such as `restore` are very long). This PR proposes to only put the summary of each help string, e.g. the first line, to the page.
2. The sidebar currently only shows [the first 50 pages in that doc level](https://github.com/kopia/kopia/blob/2394b420b02eaf301b3eb4e0f0626cd124f60469/site/themes/docsy/layouts/partials/sidebar-tree.html#L32). But there are more than 50 CLI commands. The inconsistency between the summary page content and sidebar confuses users. Since the summary page already lists all commands, this PR proposes to hide the commands in the sidebar.