### PR TITLE
policy: revamped policy merge mechanism

### DIFF
--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -157,8 +157,8 @@ func (c *commandRepositoryCreate) populateRepository(ctx context.Context, passwo
 			return errors.Wrap(err, "unable to set global policy")
 		}
 
-		printRetentionPolicy(&c.out, policy.DefaultPolicy, nil)
-		printCompressionPolicy(&c.out, policy.DefaultPolicy, nil)
+		printRetentionPolicy(&c.out, policy.DefaultPolicy, &policy.Definition{})
+		printCompressionPolicy(&c.out, policy.DefaultPolicy, &policy.Definition{})
 
 		c.out.printStderr("\nTo find more information about default policy run 'kopia policy get'.\nTo change the policy use 'kopia policy set' command.\n")
 

--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -177,7 +177,7 @@ func (c *commandSnapshotList) outputManifestGroups(ctx context.Context, rep repo
 		separator = "\n"
 		anyOutput = true
 
-		pol, _, err := policy.GetEffectivePolicy(ctx, rep, src)
+		pol, _, _, err := policy.GetEffectivePolicy(ctx, rep, src)
 		if err != nil {
 			log(ctx).Errorf("unable to determine effective policy for %v", src)
 		} else {

--- a/internal/server/api_snapshots.go
+++ b/internal/server/api_snapshots.go
@@ -32,7 +32,7 @@ func (s *Server) handleSnapshotList(ctx context.Context, r *http.Request, body [
 			continue
 		}
 
-		pol, _, err := policy.GetEffectivePolicy(ctx, s.rep, first.Source)
+		pol, _, _, err := policy.GetEffectivePolicy(ctx, s.rep, first.Source)
 		if err == nil {
 			pol.RetentionPolicy.ComputeRetentionReasons(grp)
 		}

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -329,7 +329,7 @@ func (s *sourceManager) refreshStatus(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, refreshTimeout)
 	defer cancel()
 
-	pol, _, err := policy.GetEffectivePolicy(ctx, s.server.rep, s.src)
+	pol, _, _, err := policy.GetEffectivePolicy(ctx, s.server.rep, s.src)
 	if err != nil {
 		s.setStatus("FAILED")
 		return

--- a/snapshot/policy/actions_policy.go
+++ b/snapshot/policy/actions_policy.go
@@ -1,5 +1,7 @@
 package policy
 
+import "github.com/kopia/kopia/snapshot"
+
 // ActionsPolicy describes actions to be invoked when taking snapshots.
 type ActionsPolicy struct {
 	// command runs once before and after the folder it's attached to (not inherited).
@@ -9,6 +11,12 @@ type ActionsPolicy struct {
 	// commands run once before and after each snapshot root (can be inherited).
 	BeforeSnapshotRoot *ActionCommand `json:"beforeSnapshotRoot,omitempty"`
 	AfterSnapshotRoot  *ActionCommand `json:"afterSnapshotRoot,omitempty"`
+}
+
+// ActionsPolicyDefinition specifies which policy definition provided the value of a particular field.
+type ActionsPolicyDefinition struct {
+	BeforeSnapshotRoot snapshot.SourceInfo `json:"beforeSnapshotRoot,omitempty"`
+	AfterSnapshotRoot  snapshot.SourceInfo `json:"afterSnapshotRoot,omitempty"`
 }
 
 // ActionCommand configures a action command.
@@ -25,14 +33,9 @@ type ActionCommand struct {
 }
 
 // Merge applies default values from the provided policy.
-func (p *ActionsPolicy) Merge(src ActionsPolicy) {
-	if p.BeforeSnapshotRoot == nil {
-		p.BeforeSnapshotRoot = src.BeforeSnapshotRoot
-	}
-
-	if p.AfterSnapshotRoot == nil {
-		p.AfterSnapshotRoot = src.AfterSnapshotRoot
-	}
+func (p *ActionsPolicy) Merge(src ActionsPolicy, def *ActionsPolicyDefinition, si snapshot.SourceInfo) {
+	mergeActionCommand(&p.BeforeSnapshotRoot, src.BeforeSnapshotRoot, &def.BeforeSnapshotRoot, si)
+	mergeActionCommand(&p.AfterSnapshotRoot, src.AfterSnapshotRoot, &def.AfterSnapshotRoot, si)
 }
 
 // MergeNonInheritable copies non-inheritable properties from the provided actions policy.

--- a/snapshot/policy/error_handling_policy.go
+++ b/snapshot/policy/error_handling_policy.go
@@ -1,5 +1,7 @@
 package policy
 
+import "github.com/kopia/kopia/snapshot"
+
 // ErrorHandlingPolicy controls error hadnling behavior when taking snapshots.
 type ErrorHandlingPolicy struct {
 	// IgnoreFileErrors controls whether or not snapshot operation should fail when a file throws an error on being read
@@ -12,11 +14,18 @@ type ErrorHandlingPolicy struct {
 	IgnoreUnknownTypes *OptionalBool `json:"ignoreUnknownTypes,omitempty"`
 }
 
+// ErrorHandlingPolicyDefinition specifies which policy definition provided the value of a particular field.
+type ErrorHandlingPolicyDefinition struct {
+	IgnoreFileErrors      snapshot.SourceInfo `json:"ignoreFileErrors,omitempty"`
+	IgnoreDirectoryErrors snapshot.SourceInfo `json:"ignoreDirectoryErrors,omitempty"`
+	IgnoreUnknownTypes    snapshot.SourceInfo `json:"ignoreUnknownTypes,omitempty"`
+}
+
 // Merge applies default values from the provided policy.
-func (p *ErrorHandlingPolicy) Merge(src ErrorHandlingPolicy) {
-	mergeOptionalBool(&p.IgnoreFileErrors, src.IgnoreFileErrors)
-	mergeOptionalBool(&p.IgnoreDirectoryErrors, src.IgnoreDirectoryErrors)
-	mergeOptionalBool(&p.IgnoreUnknownTypes, src.IgnoreUnknownTypes)
+func (p *ErrorHandlingPolicy) Merge(src ErrorHandlingPolicy, def *ErrorHandlingPolicyDefinition, si snapshot.SourceInfo) {
+	mergeOptionalBool(&p.IgnoreFileErrors, src.IgnoreFileErrors, &def.IgnoreFileErrors, si)
+	mergeOptionalBool(&p.IgnoreDirectoryErrors, src.IgnoreDirectoryErrors, &def.IgnoreDirectoryErrors, si)
+	mergeOptionalBool(&p.IgnoreUnknownTypes, src.IgnoreUnknownTypes, &def.IgnoreUnknownTypes, si)
 }
 
 // defaultErrorHandlingPolicy is the default error handling policy.

--- a/snapshot/policy/error_handling_policy_test.go
+++ b/snapshot/policy/error_handling_policy_test.go
@@ -3,6 +3,8 @@ package policy
 import (
 	"reflect"
 	"testing"
+
+	"github.com/kopia/kopia/snapshot"
 )
 
 func TestErrorHandlingPolicyMerge(t *testing.T) {
@@ -130,7 +132,8 @@ func TestErrorHandlingPolicyMerge(t *testing.T) {
 			IgnoreFileErrors:      tt.fields.IgnoreFileErrors,
 			IgnoreDirectoryErrors: tt.fields.IgnoreDirectoryErrors,
 		}
-		p.Merge(tt.args.src)
+
+		p.Merge(tt.args.src, &ErrorHandlingPolicyDefinition{}, snapshot.SourceInfo{})
 
 		if !reflect.DeepEqual(*p, tt.expResult) {
 			t.Errorf("Policy after merge was not what was expected\n%v != %v", p, tt.expResult)

--- a/snapshot/policy/expire.go
+++ b/snapshot/policy/expire.go
@@ -51,7 +51,7 @@ func getExpiredSnapshots(ctx context.Context, rep repo.Repository, snapshots []*
 func getExpiredSnapshotsForSource(ctx context.Context, rep repo.Repository, snapshots []*snapshot.Manifest) ([]*snapshot.Manifest, error) {
 	src := snapshots[0].Source
 
-	pol, _, err := GetEffectivePolicy(ctx, rep, src)
+	pol, _, _, err := GetEffectivePolicy(ctx, rep, src)
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot/policy/files_policy.go
+++ b/snapshot/policy/files_policy.go
@@ -1,41 +1,38 @@
 package policy
 
+import "github.com/kopia/kopia/snapshot"
+
 // FilesPolicy describes files to be ignored when taking snapshots.
 type FilesPolicy struct {
-	IgnoreRules         []string `json:"ignore,omitempty"`
-	NoParentIgnoreRules bool     `json:"noParentIgnore,omitempty"`
-
-	DotIgnoreFiles         []string `json:"ignoreDotFiles,omitempty"`
-	NoParentDotIgnoreFiles bool     `json:"noParentDotFiles,omitempty"`
-
+	IgnoreRules            []string      `json:"ignore,omitempty"`
+	NoParentIgnoreRules    bool          `json:"noParentIgnore,omitempty"`
+	DotIgnoreFiles         []string      `json:"ignoreDotFiles,omitempty"`
+	NoParentDotIgnoreFiles bool          `json:"noParentDotFiles,omitempty"`
 	IgnoreCacheDirectories *OptionalBool `json:"ignoreCacheDirs,omitempty"`
+	MaxFileSize            int64         `json:"maxFileSize,omitempty"`
+	OneFileSystem          *OptionalBool `json:"oneFileSystem,omitempty"`
+}
 
-	MaxFileSize int64 `json:"maxFileSize,omitempty"`
-
-	OneFileSystem *OptionalBool `json:"oneFileSystem,omitempty"`
+// FilesPolicyDefinition specifies which policy definition provided the value of a particular field.
+type FilesPolicyDefinition struct {
+	IgnoreRules            snapshot.SourceInfo `json:"ignore,omitempty"`
+	NoParentIgnoreRules    snapshot.SourceInfo `json:"noParentIgnore,omitempty"`
+	DotIgnoreFiles         snapshot.SourceInfo `json:"ignoreDotFiles,omitempty"`
+	NoParentDotIgnoreFiles snapshot.SourceInfo `json:"noParentDotFiles,omitempty"`
+	IgnoreCacheDirectories snapshot.SourceInfo `json:"ignoreCacheDirs,omitempty"`
+	MaxFileSize            snapshot.SourceInfo `json:"maxFileSize,omitempty"`
+	OneFileSystem          snapshot.SourceInfo `json:"oneFileSystem,omitempty"`
 }
 
 // Merge applies default values from the provided policy.
-func (p *FilesPolicy) Merge(src FilesPolicy) {
-	if p.MaxFileSize == 0 {
-		p.MaxFileSize = src.MaxFileSize
-	}
-
-	if len(p.IgnoreRules) == 0 {
-		p.IgnoreRules = src.IgnoreRules
-	}
-
-	if len(p.DotIgnoreFiles) == 0 {
-		p.DotIgnoreFiles = src.DotIgnoreFiles
-	}
-
-	if p.IgnoreCacheDirectories == nil {
-		p.IgnoreCacheDirectories = src.IgnoreCacheDirectories
-	}
-
-	if p.OneFileSystem == nil {
-		p.OneFileSystem = src.OneFileSystem
-	}
+func (p *FilesPolicy) Merge(src FilesPolicy, def *FilesPolicyDefinition, si snapshot.SourceInfo) {
+	mergeStringList(&p.IgnoreRules, src.IgnoreRules, &def.IgnoreRules, si)
+	mergeBool(&p.NoParentIgnoreRules, src.NoParentIgnoreRules, &def.NoParentIgnoreRules, si)
+	mergeStringsReplace(&p.DotIgnoreFiles, src.DotIgnoreFiles, &def.DotIgnoreFiles, si)
+	mergeBool(&p.NoParentDotIgnoreFiles, src.NoParentDotIgnoreFiles, &def.NoParentDotIgnoreFiles, si)
+	mergeOptionalBool(&p.IgnoreCacheDirectories, src.IgnoreCacheDirectories, &def.IgnoreCacheDirectories, si)
+	mergeInt64(&p.MaxFileSize, src.MaxFileSize, &def.MaxFileSize, si)
+	mergeOptionalBool(&p.OneFileSystem, src.OneFileSystem, &def.OneFileSystem, si)
 }
 
 // defaultFilesPolicy is the default file ignore policy.

--- a/snapshot/policy/log_detail.go
+++ b/snapshot/policy/log_detail.go
@@ -23,11 +23,3 @@ func (l *LogDetail) OrDefault(def LogDetail) LogDetail {
 func NewLogDetail(l LogDetail) *LogDetail {
 	return &l
 }
-
-func mergeLogLevel(target **LogDetail, src *LogDetail) {
-	if *target == nil && src != nil {
-		b := *src
-
-		*target = &b
-	}
-}

--- a/snapshot/policy/logging_policy.go
+++ b/snapshot/policy/logging_policy.go
@@ -1,15 +1,23 @@
 package policy
 
+import "github.com/kopia/kopia/snapshot"
+
 // DirLoggingPolicy represents the policy for logging directory information when snapshotting.
 type DirLoggingPolicy struct {
 	Snapshotted *LogDetail `json:"snapshotted,omitempty"`
 	Ignored     *LogDetail `json:"ignored,omitempty"`
 }
 
+// DirLoggingPolicyDefinition specifies which policy definition provided the value of a particular field.
+type DirLoggingPolicyDefinition struct {
+	Snapshotted snapshot.SourceInfo `json:"snapshotted,omitempty"`
+	Ignored     snapshot.SourceInfo `json:"ignored,omitempty"`
+}
+
 // Merge merges the provided directory logging policy.
-func (p *DirLoggingPolicy) Merge(src DirLoggingPolicy) {
-	mergeLogLevel(&p.Snapshotted, src.Snapshotted)
-	mergeLogLevel(&p.Ignored, src.Ignored)
+func (p *DirLoggingPolicy) Merge(src DirLoggingPolicy, def *DirLoggingPolicyDefinition, si snapshot.SourceInfo) {
+	mergeLogLevel(&p.Snapshotted, src.Snapshotted, &def.Snapshotted, si)
+	mergeLogLevel(&p.Ignored, src.Ignored, &def.Ignored, si)
 }
 
 // EntryLoggingPolicy represents the policy for logging entry information when snapshotting.
@@ -20,12 +28,20 @@ type EntryLoggingPolicy struct {
 	CacheMiss   *LogDetail `json:"cacheMiss,omitempty"`
 }
 
+// EntryLoggingPolicyDefinition specifies which policy definition provided the value of a particular field.
+type EntryLoggingPolicyDefinition struct {
+	Snapshotted snapshot.SourceInfo `json:"snapshotted,omitempty"`
+	Ignored     snapshot.SourceInfo `json:"ignored,omitempty"`
+	CacheHit    snapshot.SourceInfo `json:"cacheHit,omitempty"`
+	CacheMiss   snapshot.SourceInfo `json:"cacheMiss,omitempty"`
+}
+
 // Merge merges the provided entry logging policy.
-func (p *EntryLoggingPolicy) Merge(src EntryLoggingPolicy) {
-	mergeLogLevel(&p.Snapshotted, src.Snapshotted)
-	mergeLogLevel(&p.Ignored, src.Ignored)
-	mergeLogLevel(&p.CacheHit, src.CacheHit)
-	mergeLogLevel(&p.CacheMiss, src.CacheMiss)
+func (p *EntryLoggingPolicy) Merge(src EntryLoggingPolicy, def *EntryLoggingPolicyDefinition, si snapshot.SourceInfo) {
+	mergeLogLevel(&p.Snapshotted, src.Snapshotted, &def.Snapshotted, si)
+	mergeLogLevel(&p.Ignored, src.Ignored, &def.Ignored, si)
+	mergeLogLevel(&p.CacheHit, src.CacheHit, &def.CacheHit, si)
+	mergeLogLevel(&p.CacheMiss, src.CacheMiss, &def.CacheMiss, si)
 }
 
 // LoggingPolicy describes policy for emitting logs during snapshots.
@@ -34,10 +50,16 @@ type LoggingPolicy struct {
 	Entries     EntryLoggingPolicy `json:"entries,omitempty"`
 }
 
+// LoggingPolicyDefinition specifies which policy definition provided the value of a particular field.
+type LoggingPolicyDefinition struct {
+	Directories DirLoggingPolicyDefinition   `json:"directories,omitempty"`
+	Entries     EntryLoggingPolicyDefinition `json:"entries,omitempty"`
+}
+
 // Merge applies default values from the provided policy.
-func (p *LoggingPolicy) Merge(src LoggingPolicy) {
-	p.Directories.Merge(src.Directories)
-	p.Entries.Merge(src.Entries)
+func (p *LoggingPolicy) Merge(src LoggingPolicy, def *LoggingPolicyDefinition, si snapshot.SourceInfo) {
+	p.Directories.Merge(src.Directories, &def.Directories, si)
+	p.Entries.Merge(src.Entries, &def.Entries, si)
 }
 
 // defaultLoggingPolicy is the default logs policy.

--- a/snapshot/policy/optional.go
+++ b/snapshot/policy/optional.go
@@ -15,11 +15,3 @@ func (b *OptionalBool) OrDefault(def bool) bool {
 func newOptionalBool(b OptionalBool) *OptionalBool {
 	return &b
 }
-
-func mergeOptionalBool(target **OptionalBool, src *OptionalBool) {
-	if *target == nil && src != nil {
-		v := *src
-
-		*target = &v
-	}
-}

--- a/snapshot/policy/policy.go
+++ b/snapshot/policy/policy.go
@@ -27,9 +27,21 @@ type Policy struct {
 	ErrorHandlingPolicy ErrorHandlingPolicy `json:"errorHandling,omitempty"`
 	SchedulingPolicy    SchedulingPolicy    `json:"scheduling,omitempty"`
 	CompressionPolicy   CompressionPolicy   `json:"compression,omitempty"`
-	Actions             ActionsPolicy       `json:"actions"`
-	LoggingPolicy       LoggingPolicy       `json:"logging"`
+	Actions             ActionsPolicy       `json:"actions,omitempty"`
+	LoggingPolicy       LoggingPolicy       `json:"logging,omitempty"`
 	NoParent            bool                `json:"noParent,omitempty"`
+}
+
+// Definition corresponds 1:1 to Policy and each field specifies the snapshot.SourceInfo
+// where a particular policy field was specified.
+type Definition struct {
+	RetentionPolicy     RetentionPolicyDefinition     `json:"retention,omitempty"`
+	FilesPolicy         FilesPolicyDefinition         `json:"files,omitempty"`
+	ErrorHandlingPolicy ErrorHandlingPolicyDefinition `json:"errorHandling,omitempty"`
+	SchedulingPolicy    SchedulingPolicyDefinition    `json:"scheduling,omitempty"`
+	CompressionPolicy   CompressionPolicyDefinition   `json:"compression,omitempty"`
+	Actions             ActionsPolicyDefinition       `json:"actions,omitempty"`
+	LoggingPolicy       LoggingPolicyDefinition       `json:"logging,omitempty"`
 }
 
 func (p *Policy) String() string {
@@ -57,40 +69,6 @@ func (p *Policy) Target() snapshot.SourceInfo {
 		UserName: p.Labels["username"],
 		Path:     p.Labels["path"],
 	}
-}
-
-// MergePolicies computes the policy by applying the specified list of policies in order.
-func MergePolicies(policies []*Policy) *Policy {
-	var merged Policy
-
-	for _, p := range policies {
-		if p.NoParent {
-			return &merged
-		}
-
-		merged.RetentionPolicy.Merge(p.RetentionPolicy)
-		merged.FilesPolicy.Merge(p.FilesPolicy)
-		merged.ErrorHandlingPolicy.Merge(p.ErrorHandlingPolicy)
-		merged.SchedulingPolicy.Merge(p.SchedulingPolicy)
-		merged.CompressionPolicy.Merge(p.CompressionPolicy)
-		merged.Actions.Merge(p.Actions)
-		merged.LoggingPolicy.Merge(p.LoggingPolicy)
-	}
-
-	// Merge default expiration policy.
-	merged.RetentionPolicy.Merge(defaultRetentionPolicy)
-	merged.FilesPolicy.Merge(defaultFilesPolicy)
-	merged.ErrorHandlingPolicy.Merge(defaultErrorHandlingPolicy)
-	merged.SchedulingPolicy.Merge(defaultSchedulingPolicy)
-	merged.CompressionPolicy.Merge(defaultCompressionPolicy)
-	merged.Actions.Merge(defaultActionsPolicy)
-	merged.LoggingPolicy.Merge(defaultLoggingPolicy)
-
-	if len(policies) > 0 {
-		merged.Actions.MergeNonInheritable(policies[0].Actions)
-	}
-
-	return &merged
 }
 
 // ValidatePolicy returns error if the given policy is invalid.

--- a/snapshot/policy/policy_merge.go
+++ b/snapshot/policy/policy_merge.go
@@ -1,0 +1,149 @@
+package policy
+
+import (
+	"sort"
+
+	"github.com/kopia/kopia/repo/compression"
+	"github.com/kopia/kopia/snapshot"
+)
+
+// MergePolicies computes the policy by applying the specified list of policies in order from most
+// specific to most general.
+func MergePolicies(policies []*Policy) (*Policy, *Definition) {
+	var (
+		merged Policy
+		def    Definition
+	)
+
+	for _, p := range policies {
+		merged.RetentionPolicy.Merge(p.RetentionPolicy, &def.RetentionPolicy, p.Target())
+		merged.FilesPolicy.Merge(p.FilesPolicy, &def.FilesPolicy, p.Target())
+		merged.ErrorHandlingPolicy.Merge(p.ErrorHandlingPolicy, &def.ErrorHandlingPolicy, p.Target())
+		merged.SchedulingPolicy.Merge(p.SchedulingPolicy, &def.SchedulingPolicy, p.Target())
+		merged.CompressionPolicy.Merge(p.CompressionPolicy, &def.CompressionPolicy, p.Target())
+		merged.Actions.Merge(p.Actions, &def.Actions, p.Target())
+		merged.LoggingPolicy.Merge(p.LoggingPolicy, &def.LoggingPolicy, p.Target())
+
+		if p.NoParent {
+			return &merged, &def
+		}
+	}
+
+	// Merge default expiration policy.
+	merged.RetentionPolicy.Merge(defaultRetentionPolicy, &def.RetentionPolicy, GlobalPolicySourceInfo)
+	merged.FilesPolicy.Merge(defaultFilesPolicy, &def.FilesPolicy, GlobalPolicySourceInfo)
+	merged.ErrorHandlingPolicy.Merge(defaultErrorHandlingPolicy, &def.ErrorHandlingPolicy, GlobalPolicySourceInfo)
+	merged.SchedulingPolicy.Merge(defaultSchedulingPolicy, &def.SchedulingPolicy, GlobalPolicySourceInfo)
+	merged.CompressionPolicy.Merge(defaultCompressionPolicy, &def.CompressionPolicy, GlobalPolicySourceInfo)
+	merged.Actions.Merge(defaultActionsPolicy, &def.Actions, GlobalPolicySourceInfo)
+	merged.LoggingPolicy.Merge(defaultLoggingPolicy, &def.LoggingPolicy, GlobalPolicySourceInfo)
+
+	if len(policies) > 0 {
+		merged.Actions.MergeNonInheritable(policies[0].Actions)
+	}
+
+	return &merged, &def
+}
+
+func mergeOptionalBool(target **OptionalBool, src *OptionalBool, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+	if *target == nil && src != nil {
+		v := *src
+
+		*target = &v
+		*def = si
+	}
+}
+
+func mergeOptionalInt(target **int, src *int, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+	if *target == nil && src != nil {
+		v := *src
+
+		*target = &v
+		*def = si
+	}
+}
+
+func mergeStringsReplace(target *[]string, src []string, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+	if len(*target) == 0 && len(src) > 0 {
+		*target = src
+		*def = si
+	}
+}
+
+func mergeStrings(target *[]string, targetNoParent *bool, src []string, noParent bool, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+	if *targetNoParent {
+		// merges prevented
+		return
+	}
+
+	merged := map[string]bool{}
+
+	for _, v := range *target {
+		merged[v] = true
+	}
+
+	for _, v := range src {
+		merged[v] = true
+		*def = si
+	}
+
+	var result []string
+	for v := range merged {
+		result = append(result, v)
+	}
+
+	sort.Strings(result)
+
+	*target = result
+
+	if noParent {
+		// prevent future merges.
+		*targetNoParent = noParent
+	}
+}
+
+func mergeCompressionName(target *compression.Name, src compression.Name, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+	if *target == "" && src != "" {
+		*target = src
+		*def = si
+	}
+}
+
+func mergeInt64(target *int64, src int64, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+	if *target == 0 && src != 0 {
+		*target = src
+		*def = si
+	}
+}
+
+func mergeBool(target *bool, src bool, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+	if !*target && src {
+		*target = src
+		*def = si
+	}
+}
+
+func mergeStringList(target *[]string, src []string, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+	if len(*target) == 0 && len(src) != 0 {
+		*target = src
+		*def = si
+	}
+}
+
+func mergeLogLevel(target **LogDetail, src *LogDetail, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+	if *target == nil && src != nil {
+		b := *src
+
+		*target = &b
+		*def = si
+	}
+}
+
+func mergeActionCommand(target **ActionCommand, src *ActionCommand, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+	if *target == nil && src != nil {
+		b := *src
+
+		*target = &b
+		*def = si
+	}
+}

--- a/snapshot/policy/policy_merge_test.go
+++ b/snapshot/policy/policy_merge_test.go
@@ -1,0 +1,317 @@
+package policy_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/repo/compression"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/policy"
+)
+
+var omittedDefinitionFields = map[string]bool{
+	"Definition.NoParent":                               true, // special
+	"Definition.Labels":                                 true, // special
+	"ActionsPolicyDefinition.BeforeFolder":              true, // non-inheritable field
+	"ActionsPolicyDefinition.AfterFolder":               true, // non-inheritable field
+	"SchedulingPolicyDefinition.NoParentTimesOfDay":     true, // special
+	"CompressionPolicyDefinition.NoParentOnlyCompress":  true,
+	"CompressionPolicyDefinition.NoParentNeverCompress": true,
+}
+
+func TestPolicyDefinition(t *testing.T) {
+	// verify that each field in the policy struct recursively matches a corresponding field
+	// from the policy.Definition() struct.
+	ensureTypesMatch(t, reflect.TypeOf(policy.Policy{}), reflect.TypeOf(policy.Definition{}))
+}
+
+func ensureTypesMatch(t *testing.T, policyType, definitionType reflect.Type) {
+	t.Helper()
+
+	sourceInfoType := reflect.TypeOf(snapshot.SourceInfo{})
+
+	for i := 0; i < policyType.NumField(); i++ {
+		f := policyType.Field(i)
+
+		dt, ok := definitionType.FieldByName(f.Name)
+		if !ok {
+			require.True(t, omittedDefinitionFields[definitionType.Name()+"."+f.Name], "definition field %q not found in %q", f.Name, definitionType.Name())
+			continue
+		}
+
+		t.Logf("f: %v %v", definitionType.Name(), f.Name)
+
+		if f.Type.Kind() == reflect.Struct {
+			ensureTypesMatch(t, f.Type, dt.Type)
+		} else {
+			require.True(t, sourceInfoType.AssignableTo(dt.Type), "invalid type of %v.%v - %v", definitionType.Name(), dt.Name, dt.Type)
+		}
+
+		require.Equal(t, f.Tag.Get("json"), dt.Tag.Get("json"), dt.Name)
+	}
+}
+
+func TestPolicyMerge(t *testing.T) {
+	testPolicyMerge(t, reflect.TypeOf(policy.Policy{}), reflect.TypeOf(policy.Definition{}), "")
+}
+
+// nolint:thelper
+func testPolicyMerge(t *testing.T, policyType, definitionType reflect.Type, prefix string) {
+	for i := 0; i < policyType.NumField(); i++ {
+		f := policyType.Field(i)
+
+		dt, ok := definitionType.FieldByName(f.Name)
+		if !ok {
+			continue
+		}
+
+		if f.Type.Kind() == reflect.Struct {
+			testPolicyMerge(t, f.Type, dt.Type, prefix+f.Name+".")
+
+			continue
+		}
+
+		t.Run(prefix+f.Name, func(t *testing.T) {
+			testPolicyMergeSingleField(t, prefix+f.Name, f.Type)
+		})
+	}
+}
+
+// nolint:thelper
+func testPolicyMergeSingleField(t *testing.T, fieldName string, typ reflect.Type) {
+	var v0, v1, v2 reflect.Value
+
+	switch typ.String() {
+	case "*int":
+		i1 := 111
+		i2 := 222
+
+		v0 = reflect.ValueOf((*int)(nil))
+		v1 = reflect.ValueOf(&i1)
+		v2 = reflect.ValueOf(&i2)
+
+	case "[]string":
+		s1 := []string{"aa"}
+		s2 := []string{"bb", "cc"}
+
+		v0 = reflect.ValueOf([]string{})
+		v1 = reflect.ValueOf(s1)
+		v2 = reflect.ValueOf(s2)
+
+	case "*policy.OptionalBool":
+		ob1 := policy.OptionalBool(false)
+		ob2 := policy.OptionalBool(true)
+
+		v0 = reflect.ValueOf((*policy.OptionalBool)(nil))
+		v1 = reflect.ValueOf(&ob1)
+		v2 = reflect.ValueOf(&ob2)
+	case "bool":
+		v0 = reflect.ValueOf(false)
+		v1 = reflect.ValueOf(false)
+		v2 = reflect.ValueOf(true)
+	case "int64":
+		v0 = reflect.ValueOf(int64(0))
+		v1 = reflect.ValueOf(int64(1))
+		v2 = reflect.ValueOf(int64(2))
+	case "*policy.LogDetail":
+		ld1 := policy.LogDetail(1)
+		ld2 := policy.LogDetail(2)
+
+		v0 = reflect.ValueOf((*policy.LogDetail)(nil))
+		v1 = reflect.ValueOf(&ld1)
+		v2 = reflect.ValueOf(&ld2)
+	case "*policy.ActionCommand":
+		v0 = reflect.ValueOf((*policy.ActionCommand)(nil))
+		v1 = reflect.ValueOf(&policy.ActionCommand{Command: "foo"})
+		v2 = reflect.ValueOf(&policy.ActionCommand{Command: "bar"})
+	case "[]policy.TimeOfDay":
+		v0 = reflect.ValueOf([]policy.TimeOfDay{})
+		v1 = reflect.ValueOf([]policy.TimeOfDay{{Hour: 10}})
+		v2 = reflect.ValueOf([]policy.TimeOfDay{{Hour: 11}})
+	case "compression.Name":
+		v0 = reflect.ValueOf(compression.Name(""))
+		v1 = reflect.ValueOf(compression.Name("foo"))
+		v2 = reflect.ValueOf(compression.Name("bar"))
+
+	default:
+		t.Fatalf("unhandled case: %v - %v - please update test", fieldName, typ)
+	}
+
+	pol0 := policyWithField(fieldName, v0)
+	pol1 := policyWithField(fieldName, v1)
+	pol2 := policyWithField(fieldName, v2)
+
+	pol0.Labels = map[string]string{
+		"hostname": "host",
+		"username": "user",
+		"path":     "/xx",
+	}
+
+	pol1.Labels = map[string]string{
+		"hostname": "host",
+		"username": "user",
+		"path":     "/xx/aa",
+	}
+
+	pol2.Labels = map[string]string{
+		"hostname": "host",
+		"username": "user",
+		"path":     "/xx/bb",
+	}
+
+	tmp := *policy.DefaultPolicy
+	defaultPolicyMod := &tmp
+
+	disableParentMerging(defaultPolicyMod)
+
+	// merging default policy with no-op policy results in default policy
+	result, _ := policy.MergePolicies([]*policy.Policy{pol0, defaultPolicyMod})
+	require.Equal(t, defaultPolicyMod.String(), result.String())
+
+	result, _ = policy.MergePolicies([]*policy.Policy{pol1, pol0, defaultPolicyMod})
+	require.Equal(t, pol1.String(), result.String())
+
+	result, _ = policy.MergePolicies([]*policy.Policy{pol2, pol1, pol0, defaultPolicyMod})
+	require.Equal(t, pol2.String(), result.String())
+
+	result, _ = policy.MergePolicies([]*policy.Policy{pol2, pol0, defaultPolicyMod})
+	require.Equal(t, pol2.String(), result.String())
+}
+
+func policyWithField(fname string, val reflect.Value) *policy.Policy {
+	pol := *policy.DefaultPolicy
+	p := &pol
+
+	disableParentMerging(p)
+	cur := reflect.ValueOf(p).Elem()
+
+	parts := strings.Split(fname, ".")
+	for _, part := range parts[:len(parts)-1] {
+		cur = cur.FieldByName(part)
+	}
+
+	cur.FieldByName(parts[len(parts)-1]).Set(val)
+
+	return p
+}
+
+func disableParentMerging(p *policy.Policy) {
+	// set flags that disable merging of values with the parent, we will
+	// test those cases separately.
+	p.CompressionPolicy.NoParentNeverCompress = true
+	p.CompressionPolicy.NoParentOnlyCompress = true
+	p.SchedulingPolicy.NoParentTimesOfDay = true
+}
+
+func TestPolicyMergeOnlyCompressIncludingParents(t *testing.T) {
+	p0 := &policy.Policy{
+		CompressionPolicy: policy.CompressionPolicy{
+			OnlyCompress: []string{"a", "c", "e"},
+		},
+	}
+
+	p1 := &policy.Policy{
+		CompressionPolicy: policy.CompressionPolicy{
+			OnlyCompress: []string{"b", "d"},
+		},
+	}
+
+	p2 := &policy.Policy{
+		CompressionPolicy: policy.CompressionPolicy{
+			OnlyCompress: []string{"f", "g"},
+		},
+	}
+
+	result, _ := policy.MergePolicies([]*policy.Policy{p0, p1, p2})
+
+	want := *policy.DefaultPolicy
+	want.CompressionPolicy.OnlyCompress = []string{"a", "b", "c", "d", "e", "f", "g"}
+
+	require.Equal(t, want.String(), result.String())
+
+	p2.NoParent = true
+	result, _ = policy.MergePolicies([]*policy.Policy{p0, p1, p2})
+
+	want = policy.Policy{}
+	want.CompressionPolicy.OnlyCompress = []string{"a", "b", "c", "d", "e", "f", "g"}
+
+	require.Equal(t, want.String(), result.String())
+
+	p1.NoParent = true
+	result, _ = policy.MergePolicies([]*policy.Policy{p0, p1, p2})
+
+	want = policy.Policy{}
+	want.CompressionPolicy.OnlyCompress = []string{"a", "b", "c", "d", "e"}
+
+	require.Equal(t, want.String(), result.String())
+
+	p0.NoParent = true
+	result, _ = policy.MergePolicies([]*policy.Policy{p0, p1, p2})
+
+	want = policy.Policy{}
+	want.CompressionPolicy.OnlyCompress = []string{"a", "c", "e"}
+
+	require.Equal(t, want.String(), result.String())
+}
+
+func TestPolicyMergeTimesOfDayIncludingParents(t *testing.T) {
+	tod0 := policy.TimeOfDay{Hour: 10}
+	tod1 := policy.TimeOfDay{Hour: 11}
+	tod2 := policy.TimeOfDay{Hour: 12}
+	tod3 := policy.TimeOfDay{Hour: 13}
+	tod4 := policy.TimeOfDay{Hour: 14}
+	tod5 := policy.TimeOfDay{Hour: 15}
+	tod6 := policy.TimeOfDay{Hour: 16}
+
+	p0 := &policy.Policy{
+		SchedulingPolicy: policy.SchedulingPolicy{
+			TimesOfDay: []policy.TimeOfDay{tod0, tod2, tod4},
+		},
+	}
+
+	p1 := &policy.Policy{
+		SchedulingPolicy: policy.SchedulingPolicy{
+			TimesOfDay: []policy.TimeOfDay{tod1, tod3},
+		},
+	}
+
+	p2 := &policy.Policy{
+		SchedulingPolicy: policy.SchedulingPolicy{
+			TimesOfDay: []policy.TimeOfDay{tod5, tod6},
+		},
+	}
+
+	result, _ := policy.MergePolicies([]*policy.Policy{p0, p1, p2})
+
+	want := *policy.DefaultPolicy
+	want.SchedulingPolicy.TimesOfDay = []policy.TimeOfDay{tod0, tod1, tod2, tod3, tod4, tod5, tod6}
+
+	require.Equal(t, want.String(), result.String())
+
+	p2.NoParent = true
+	result, _ = policy.MergePolicies([]*policy.Policy{p0, p1, p2})
+
+	want = policy.Policy{}
+	want.SchedulingPolicy.TimesOfDay = []policy.TimeOfDay{tod0, tod1, tod2, tod3, tod4, tod5, tod6}
+
+	require.Equal(t, want.String(), result.String())
+
+	p1.NoParent = true
+	result, _ = policy.MergePolicies([]*policy.Policy{p0, p1, p2})
+
+	want = policy.Policy{}
+	want.SchedulingPolicy.TimesOfDay = []policy.TimeOfDay{tod0, tod1, tod2, tod3, tod4}
+
+	require.Equal(t, want.String(), result.String())
+
+	p0.NoParent = true
+	result, _ = policy.MergePolicies([]*policy.Policy{p0, p1, p2})
+
+	want = policy.Policy{}
+	want.SchedulingPolicy.TimesOfDay = []policy.TimeOfDay{tod0, tod2, tod4}
+
+	require.Equal(t, want.String(), result.String())
+}

--- a/snapshot/policy/policy_tree.go
+++ b/snapshot/policy/policy_tree.go
@@ -15,6 +15,9 @@ var DefaultPolicy = &Policy{
 	Actions:             defaultActionsPolicy,
 }
 
+// DefaultDefinition provides the Definition for the default policy.
+var DefaultDefinition = &Definition{}
+
 // Tree represents a node in the policy tree, where a policy can be
 // defined. A nil tree is a valid tree with default policy.
 type Tree struct {

--- a/snapshot/policy/retention_policy.go
+++ b/snapshot/policy/retention_policy.go
@@ -25,6 +25,16 @@ type RetentionPolicy struct {
 	KeepAnnual  *int `json:"keepAnnual,omitempty"`
 }
 
+// RetentionPolicyDefinition specifies which policy definition provided the value of a particular field.
+type RetentionPolicyDefinition struct {
+	KeepLatest  snapshot.SourceInfo `json:"keepLatest,omitempty"`
+	KeepHourly  snapshot.SourceInfo `json:"keepHourly,omitempty"`
+	KeepDaily   snapshot.SourceInfo `json:"keepDaily,omitempty"`
+	KeepWeekly  snapshot.SourceInfo `json:"keepWeekly,omitempty"`
+	KeepMonthly snapshot.SourceInfo `json:"keepMonthly,omitempty"`
+	KeepAnnual  snapshot.SourceInfo `json:"keepAnnual,omitempty"`
+}
+
 // ComputeRetentionReasons computes the reasons why each snapshot is retained, based on
 // the settings in retention policy and stores them in RetentionReason field.
 func (r *RetentionPolicy) ComputeRetentionReasons(manifests []*snapshot.Manifest) {
@@ -193,28 +203,11 @@ var defaultRetentionPolicy = RetentionPolicy{
 }
 
 // Merge applies default values from the provided policy.
-func (r *RetentionPolicy) Merge(src RetentionPolicy) {
-	if r.KeepLatest == nil {
-		r.KeepLatest = src.KeepLatest
-	}
-
-	if r.KeepHourly == nil {
-		r.KeepHourly = src.KeepHourly
-	}
-
-	if r.KeepDaily == nil {
-		r.KeepDaily = src.KeepDaily
-	}
-
-	if r.KeepWeekly == nil {
-		r.KeepWeekly = src.KeepWeekly
-	}
-
-	if r.KeepMonthly == nil {
-		r.KeepMonthly = src.KeepMonthly
-	}
-
-	if r.KeepAnnual == nil {
-		r.KeepAnnual = src.KeepAnnual
-	}
+func (r *RetentionPolicy) Merge(src RetentionPolicy, def *RetentionPolicyDefinition, si snapshot.SourceInfo) {
+	mergeOptionalInt(&r.KeepLatest, src.KeepLatest, &def.KeepLatest, si)
+	mergeOptionalInt(&r.KeepHourly, src.KeepHourly, &def.KeepHourly, si)
+	mergeOptionalInt(&r.KeepDaily, src.KeepDaily, &def.KeepDaily, si)
+	mergeOptionalInt(&r.KeepWeekly, src.KeepWeekly, &def.KeepWeekly, si)
+	mergeOptionalInt(&r.KeepMonthly, src.KeepMonthly, &def.KeepMonthly, si)
+	mergeOptionalInt(&r.KeepAnnual, src.KeepAnnual, &def.KeepAnnual, si)
 }


### PR DESCRIPTION
Added policy.Definition which allows us to precisely report where
each piece of policy came from.

Fixed a one-off bug with "noParent", which prevented merging of parent
policies one level too soon.

Added a whole bunch of merging helpers and generic reflection-based
test that ensures every single merge is tested.