### PR TITLE
cache: prevent metadata cache thrashing if working set exceeds max defined size

### DIFF
--- a/cli/command_cache_set.go
+++ b/cli/command_cache_set.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/content"
 )
 
 type commandCacheSetParams struct {
@@ -15,6 +16,9 @@ type commandCacheSetParams struct {
 	contentCacheSizeMB     int64
 	maxMetadataCacheSizeMB int64
 	maxListCacheDuration   time.Duration
+	contentMinSweepAge     time.Duration
+	metadataMinSweepAge    time.Duration
+	indexMinSweepAge       time.Duration
 
 	svc appServices
 }
@@ -22,9 +26,16 @@ type commandCacheSetParams struct {
 func (c *commandCacheSetParams) setup(svc appServices, parent commandParent) {
 	cmd := parent.Command("set", "Sets parameters local caching of repository data")
 
+	c.contentMinSweepAge = -1
+	c.metadataMinSweepAge = -1
+	c.indexMinSweepAge = -1
+
 	cmd.Flag("cache-directory", "Directory where to store cache files").StringVar(&c.directory)
 	cmd.Flag("content-cache-size-mb", "Size of local content cache").PlaceHolder("MB").Default("-1").Int64Var(&c.contentCacheSizeMB)
+	cmd.Flag("content-min-sweep-age", "Minimal age of content cache item to be subject to sweeping").DurationVar(&c.contentMinSweepAge)
 	cmd.Flag("metadata-cache-size-mb", "Size of local metadata cache").PlaceHolder("MB").Default("-1").Int64Var(&c.maxMetadataCacheSizeMB)
+	cmd.Flag("metadata-min-sweep-age", "Minimal age of metadata cache item to be subject to sweeping").DurationVar(&c.metadataMinSweepAge)
+	cmd.Flag("index-min-sweep-age", "Minimal age of index cache item to be subject to sweeping").DurationVar(&c.indexMinSweepAge)
 	cmd.Flag("max-list-cache-duration", "Duration of index cache").Default("-1ns").DurationVar(&c.maxListCacheDuration)
 	cmd.Action(svc.repositoryWriterAction(c.run))
 	c.svc = svc
@@ -60,7 +71,25 @@ func (c *commandCacheSetParams) run(ctx context.Context, rep repo.RepositoryWrit
 
 	if v := c.maxListCacheDuration; v != -1 {
 		log(ctx).Infof("changing list cache duration to %v", v)
-		opts.MaxListCacheDurationSec = int(v.Seconds())
+		opts.MaxListCacheDuration = content.DurationSeconds(v.Seconds())
+		changed++
+	}
+
+	if v := c.metadataMinSweepAge; v != -1 {
+		log(ctx).Infof("changing minimum metadata sweep age to %v", v)
+		opts.MinMetadataSweepAge = content.DurationSeconds(v.Seconds())
+		changed++
+	}
+
+	if v := c.contentMinSweepAge; v != -1 {
+		log(ctx).Infof("changing minimum content sweep age to %v", v)
+		opts.MinContentSweepAge = content.DurationSeconds(v.Seconds())
+		changed++
+	}
+
+	if v := c.indexMinSweepAge; v != -1 {
+		log(ctx).Infof("changing minimum index sweep age to %v", v)
+		opts.MinIndexSweepAge = content.DurationSeconds(v.Seconds())
 		changed++
 	}
 

--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -90,7 +90,7 @@ func (c *connectOptions) toRepoConnectOptions() *repo.ConnectOptions {
 			CacheDirectory:            c.connectCacheDirectory,
 			MaxCacheSizeBytes:         c.connectMaxCacheSizeMB << 20,         //nolint:gomnd
 			MaxMetadataCacheSizeBytes: c.connectMaxMetadataCacheSizeMB << 20, //nolint:gomnd
-			MaxListCacheDurationSec:   int(c.connectMaxListCacheDuration.Seconds()),
+			MaxListCacheDuration:      content.DurationSeconds(c.connectMaxListCacheDuration.Seconds()),
 		},
 		ClientOptions: repo.ClientOptions{
 			Hostname:                c.connectHostname,

--- a/internal/cache/persistent_lru_cache_test.go
+++ b/internal/cache/persistent_lru_cache_test.go
@@ -27,7 +27,11 @@ func TestPersistentLRUCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pc, err := cache.NewPersistentCache(ctx, "testing", cs, cache.ChecksumProtection([]byte{1, 2, 3}), maxSizeBytes, cache.DefaultTouchThreshold, cache.DefaultSweepFrequency)
+	pc, err := cache.NewPersistentCache(ctx, "testing", cs, cache.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{
+		MaxSizeBytes:   maxSizeBytes,
+		TouchThreshold: cache.DefaultTouchThreshold,
+		SweepFrequency: cache.DefaultSweepFrequency,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +74,11 @@ func TestPersistentLRUCache(t *testing.T) {
 	verifyBlobExists(ctx, t, cs, "key3")
 	verifyBlobExists(ctx, t, cs, "key4")
 
-	pc, err = cache.NewPersistentCache(ctx, "testing", cs, cache.ChecksumProtection([]byte{1, 2, 3}), maxSizeBytes, cache.DefaultTouchThreshold, cache.DefaultSweepFrequency)
+	pc, err = cache.NewPersistentCache(ctx, "testing", cs, cache.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{
+		MaxSizeBytes:   maxSizeBytes,
+		TouchThreshold: cache.DefaultTouchThreshold,
+		SweepFrequency: cache.DefaultSweepFrequency,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +90,11 @@ func TestPersistentLRUCache(t *testing.T) {
 
 	// create another persistent cache based on the same storage but wrong protection key.
 	// all reads from cache will be invalid, which means GetOrLoad will fetch them from the source.
-	pc2, err := cache.NewPersistentCache(ctx, "testing", cs, cache.ChecksumProtection([]byte{3, 2, 1}), maxSizeBytes, cache.DefaultTouchThreshold, cache.DefaultSweepFrequency)
+	pc2, err := cache.NewPersistentCache(ctx, "testing", cs, cache.ChecksumProtection([]byte{3, 2, 1}), cache.SweepSettings{
+		MaxSizeBytes:   maxSizeBytes,
+		TouchThreshold: cache.DefaultTouchThreshold,
+		SweepFrequency: cache.DefaultSweepFrequency,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repo/caching.go
+++ b/repo/caching.go
@@ -69,7 +69,10 @@ func setupCachingOptionsWithDefaults(ctx context.Context, configPath string, lc 
 
 	lc.Caching.MaxCacheSizeBytes = opt.MaxCacheSizeBytes
 	lc.Caching.MaxMetadataCacheSizeBytes = opt.MaxMetadataCacheSizeBytes
-	lc.Caching.MaxListCacheDurationSec = opt.MaxListCacheDurationSec
+	lc.Caching.MaxListCacheDuration = opt.MaxListCacheDuration
+	lc.Caching.MinContentSweepAge = opt.MinContentSweepAge
+	lc.Caching.MinMetadataSweepAge = opt.MinMetadataSweepAge
+	lc.Caching.MinIndexSweepAge = opt.MinIndexSweepAge
 
 	log(ctx).Debugf("Creating cache directory '%v' with max size %v", lc.Caching.CacheDirectory, lc.Caching.MaxCacheSizeBytes)
 

--- a/repo/content/caching_options.go
+++ b/repo/content/caching_options.go
@@ -1,12 +1,29 @@
 package content
 
+import "time"
+
+// DurationSeconds represents the duration in seconds.
+type DurationSeconds float64
+
+// DurationOrDefault returns the duration or the provided default if not set or zero.
+func (s DurationSeconds) DurationOrDefault(def time.Duration) time.Duration {
+	if s == 0 {
+		return def
+	}
+
+	return time.Duration(float64(s) * float64(time.Second))
+}
+
 // CachingOptions specifies configuration of local cache.
 type CachingOptions struct {
-	CacheDirectory            string `json:"cacheDirectory,omitempty"`
-	MaxCacheSizeBytes         int64  `json:"maxCacheSize,omitempty"`
-	MaxMetadataCacheSizeBytes int64  `json:"maxMetadataCacheSize,omitempty"`
-	MaxListCacheDurationSec   int    `json:"maxListCacheDuration,omitempty"`
-	HMACSecret                []byte `json:"-"`
+	CacheDirectory            string          `json:"cacheDirectory,omitempty"`
+	MaxCacheSizeBytes         int64           `json:"maxCacheSize,omitempty"`
+	MaxMetadataCacheSizeBytes int64           `json:"maxMetadataCacheSize,omitempty"`
+	MaxListCacheDuration      DurationSeconds `json:"maxListCacheDuration,omitempty"`
+	MinMetadataSweepAge       DurationSeconds `json:"minMetadataSweepAge,omitempty"`
+	MinContentSweepAge        DurationSeconds `json:"minContentSweepAge,omitempty"`
+	MinIndexSweepAge          DurationSeconds `json:"minIndexSweepAge,omitempty"`
+	HMACSecret                []byte          `json:"-"`
 }
 
 // CloneOrDefault returns a clone of the caching options or empty options for nil.

--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -325,12 +325,13 @@ func newCommittedContentIndex(caching *CachingOptions,
 	indexVersion int,
 	fetchOne func(ctx context.Context, blobID blob.ID, output *gather.WriteBuffer) error,
 	log logging.Logger,
+	minSweepAge time.Duration,
 ) *committedContentIndex {
 	var cache committedContentIndexCache
 
 	if caching.CacheDirectory != "" {
 		dirname := filepath.Join(caching.CacheDirectory, "indexes")
-		cache = &diskCommittedContentIndexCache{dirname, clock.Now, v1PerContentOverhead, log}
+		cache = &diskCommittedContentIndexCache{dirname, clock.Now, v1PerContentOverhead, log, minSweepAge}
 	} else {
 		cache = &memoryCommittedContentIndexCache{
 			contents:             map[blob.ID]packIndex{},

--- a/repo/content/committed_content_index_cache_test.go
+++ b/repo/content/committed_content_index_cache_test.go
@@ -20,7 +20,7 @@ func TestCommittedContentIndexCache_Disk(t *testing.T) {
 
 	ta := faketime.NewClockTimeWithOffset(0)
 
-	testCache(t, &diskCommittedContentIndexCache{testutil.TempDirectory(t), ta.NowFunc(), 3, logging.Printf(t.Logf, "test")}, ta)
+	testCache(t, &diskCommittedContentIndexCache{testutil.TempDirectory(t), ta.NowFunc(), 3, logging.Printf(t.Logf, "test"), DefaultIndexCacheSweepAge}, ta)
 }
 
 func TestCommittedContentIndexCache_Memory(t *testing.T) {

--- a/repo/content/content_cache_data.go
+++ b/repo/content/content_cache_data.go
@@ -39,12 +39,12 @@ func (c *contentCacheForData) close(ctx context.Context) {
 	c.pc.Close(ctx)
 }
 
-func newContentCacheForData(ctx context.Context, st blob.Storage, cacheStorage cache.Storage, maxSizeBytes int64, hmacSecret []byte) (contentCache, error) {
+func newContentCacheForData(ctx context.Context, st blob.Storage, cacheStorage cache.Storage, sweep cache.SweepSettings, hmacSecret []byte) (contentCache, error) {
 	if cacheStorage == nil {
 		return passthroughContentCache{st}, nil
 	}
 
-	pc, err := cache.NewPersistentCache(ctx, "content cache", cacheStorage, cache.ChecksumProtection(hmacSecret), maxSizeBytes, cache.DefaultTouchThreshold, cache.DefaultSweepFrequency)
+	pc, err := cache.NewPersistentCache(ctx, "content cache", cacheStorage, cache.ChecksumProtection(hmacSecret), sweep)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create base cache")
 	}

--- a/repo/content/content_cache_metadata.go
+++ b/repo/content/content_cache_metadata.go
@@ -125,12 +125,12 @@ func (c *contentCacheForMetadata) close(ctx context.Context) {
 	c.pc.Close(ctx)
 }
 
-func newContentCacheForMetadata(ctx context.Context, st blob.Storage, cacheStorage cache.Storage, maxSizeBytes int64) (contentCache, error) {
+func newContentCacheForMetadata(ctx context.Context, st blob.Storage, cacheStorage cache.Storage, sweep cache.SweepSettings) (contentCache, error) {
 	if cacheStorage == nil {
 		return passthroughContentCache{st}, nil
 	}
 
-	pc, err := cache.NewPersistentCache(ctx, "metadata cache", cacheStorage, cache.NoProtection(), maxSizeBytes, cache.DefaultTouchThreshold, cache.DefaultSweepFrequency)
+	pc, err := cache.NewPersistentCache(ctx, "metadata cache", cacheStorage, cache.NoProtection(), sweep)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create base cache")
 	}

--- a/repo/content/content_cache_test.go
+++ b/repo/content/content_cache_test.go
@@ -55,7 +55,11 @@ func TestCacheExpiration(t *testing.T) {
 
 	underlyingStorage := newUnderlyingStorageForContentCacheTesting(t)
 
-	pc, err := cache.NewPersistentCache(testlogging.Context(t), "test cache", cacheStorage.(cache.Storage), cache.NoProtection(), 10000, 0, 500*time.Millisecond)
+	pc, err := cache.NewPersistentCache(testlogging.Context(t), "test cache", cacheStorage.(cache.Storage), cache.NoProtection(), cache.SweepSettings{
+		MaxSizeBytes:   10000,
+		SweepFrequency: 500 * time.Millisecond,
+		TouchThreshold: -1,
+	})
 	if err != nil {
 		t.Fatalf("unable to create base cache: %v", err)
 	}
@@ -121,7 +125,9 @@ func TestDiskContentCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cc, err := newContentCacheForData(ctx, newUnderlyingStorageForContentCacheTesting(t), cacheStorage, maxBytes, nil)
+	cc, err := newContentCacheForData(ctx, newUnderlyingStorageForContentCacheTesting(t), cacheStorage, cache.SweepSettings{
+		MaxSizeBytes: maxBytes,
+	}, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -216,7 +222,7 @@ func TestCacheFailureToOpen(t *testing.T) {
 	}
 
 	// Will fail because of ListBlobs failure.
-	_, err := newContentCacheForData(testlogging.Context(t), underlyingStorage, withoutTouchBlob{faultyCache}, 10000, nil)
+	_, err := newContentCacheForData(testlogging.Context(t), underlyingStorage, withoutTouchBlob{faultyCache}, cache.SweepSettings{MaxSizeBytes: 10000}, nil)
 	if err == nil || !strings.Contains(err.Error(), someError.Error()) {
 		t.Errorf("invalid error %v, wanted: %v", err, someError)
 	}
@@ -224,7 +230,7 @@ func TestCacheFailureToOpen(t *testing.T) {
 	// ListBlobs fails only once, next time it succeeds.
 	ctx := testlogging.Context(t)
 
-	cc, err := newContentCacheForData(ctx, underlyingStorage, withoutTouchBlob{faultyCache}, 10000, nil)
+	cc, err := newContentCacheForData(ctx, underlyingStorage, withoutTouchBlob{faultyCache}, cache.SweepSettings{MaxSizeBytes: 10000}, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -242,7 +248,7 @@ func TestCacheFailureToWrite(t *testing.T) {
 		Base: cacheStorage,
 	}
 
-	cc, err := newContentCacheForData(testlogging.Context(t), underlyingStorage, withoutTouchBlob{faultyCache}, 10000, nil)
+	cc, err := newContentCacheForData(testlogging.Context(t), underlyingStorage, withoutTouchBlob{faultyCache}, cache.SweepSettings{MaxSizeBytes: 10000}, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -288,7 +294,7 @@ func TestCacheFailureToRead(t *testing.T) {
 		Base: cacheStorage,
 	}
 
-	cc, err := newContentCacheForData(testlogging.Context(t), underlyingStorage, withoutTouchBlob{faultyCache}, 10000, nil)
+	cc, err := newContentCacheForData(testlogging.Context(t), underlyingStorage, withoutTouchBlob{faultyCache}, cache.SweepSettings{MaxSizeBytes: 10000}, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/repo/open.go
+++ b/repo/open.go
@@ -122,7 +122,10 @@ func getContentCacheOrNil(ctx context.Context, opt *content.CachingOptions, pass
 		return nil, errors.Wrap(err, "unable to initialize protection")
 	}
 
-	pc, err := cache.NewPersistentCache(ctx, "cache-storage", cs, prot, opt.MaxCacheSizeBytes, cache.DefaultTouchThreshold, cache.DefaultSweepFrequency)
+	pc, err := cache.NewPersistentCache(ctx, "cache-storage", cs, prot, cache.SweepSettings{
+		MaxSizeBytes: opt.MaxCacheSizeBytes,
+		MinSweepAge:  opt.MinContentSweepAge.DurationOrDefault(content.DefaultDataCacheSweepAge),
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open persistent cache")
 	}


### PR DESCRIPTION
This is done by protecting newly added cache items from being swept for
X amount of time where X defaults to:

* `metadata` - 24 hours (new)
* `data` - 10 min (new)
* `indexes` - 1 hours (same as today)

Fixes #1540