### PR TITLE
Merge retention tags in snapshot lists

### DIFF
--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -280,9 +280,16 @@ func (c *commandSnapshotList) mergeIdenticalRows(rows []*snapshotListRow) []*sna
 		if r.oid == last.oid {
 			last.count++
 			last.lastStartTime = r.lastStartTime
+			last.retentionReasons = append(last.retentionReasons, r.retentionReasons...)
+			last.pins = append(last.pins, r.pins...)
 		} else {
 			result = append(result, r)
 		}
+	}
+
+	for _, r := range result {
+		r.retentionReasons = policy.CompactRetentionReasons(r.retentionReasons)
+		r.pins = policy.CompactPins(r.pins)
 	}
 
 	return result

--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -196,29 +196,26 @@ func (c *commandSnapshotList) outputManifestGroups(ctx context.Context, rep repo
 	return nil
 }
 
+type snapshotListRow struct {
+	firstStartTime   time.Time
+	lastStartTime    time.Time
+	count            int
+	oid              object.ID
+	bits             []string
+	retentionReasons []string
+	pins             []string
+	color            *color.Color
+}
+
 func (c *commandSnapshotList) outputManifestFromSingleSource(ctx context.Context, rep repo.Repository, manifests []*snapshot.Manifest, parts []string) error {
-	var (
-		count             int
-		lastTotalFileSize int64
-		previousOID       object.ID
-		elidedCount       int
-		maxElidedTime     time.Time
-	)
+	var lastTotalFileSize int64
 
 	manifests = snapshot.SortByTime(manifests, false)
 	if c.maxResultsPerPath > 0 && len(manifests) > c.maxResultsPerPath {
 		manifests = manifests[len(manifests)-c.maxResultsPerPath:]
 	}
 
-	outputElided := func() {
-		if elidedCount > 0 {
-			c.out.printStdout(
-				"  + %v identical snapshots until %v\n",
-				elidedCount,
-				formatTimestamp(maxElidedTime),
-			)
-		}
-	}
+	var rows []*snapshotListRow
 
 	for _, m := range manifests {
 		root, err := snapshotfs.SnapshotRoot(rep, m)
@@ -244,32 +241,77 @@ func (c *commandSnapshotList) outputManifestFromSingleSource(ctx context.Context
 
 		bits, col := c.entryBits(ctx, m, ent, lastTotalFileSize)
 
-		oid := ent.(object.HasObjectID).ObjectID()
-		if !c.snapshotListShowIdentical && oid == previousOID {
-			elidedCount++
-
-			maxElidedTime = m.StartTime
-
-			continue
-		}
-
-		outputElided()
-
-		elidedCount = 0
-		previousOID = oid
-
-		col.Fprint(c.out.stdout(), fmt.Sprintf("  %v %v %v\n", formatTimestamp(m.StartTime), oid, strings.Join(bits, " "))) //nolint:errcheck
-
-		count++
+		rows = append(rows, &snapshotListRow{
+			firstStartTime:   m.StartTime,
+			lastStartTime:    m.StartTime,
+			count:            1,
+			oid:              ent.(object.HasObjectID).ObjectID(),
+			bits:             bits,
+			retentionReasons: m.RetentionReasons,
+			pins:             m.Pins,
+			color:            col,
+		})
 
 		if m.IncompleteReason == "" {
 			lastTotalFileSize = m.Stats.TotalFileSize
 		}
 	}
 
-	outputElided()
+	if !c.snapshotListShowIdentical {
+		rows = c.mergeIdenticalRows(rows)
+	}
+
+	c.outputSnapshotRows(rows)
 
 	return nil
+}
+
+func (c *commandSnapshotList) mergeIdenticalRows(rows []*snapshotListRow) []*snapshotListRow {
+	var result []*snapshotListRow
+
+	for _, r := range rows {
+		if len(result) == 0 {
+			result = append(result, r)
+			continue
+		}
+
+		last := result[len(result)-1]
+
+		if r.oid == last.oid {
+			last.count++
+			last.lastStartTime = r.lastStartTime
+		} else {
+			result = append(result, r)
+		}
+	}
+
+	return result
+}
+
+func (c *commandSnapshotList) outputSnapshotRows(rows []*snapshotListRow) {
+	for _, row := range rows {
+		bits := append([]string(nil), row.bits...)
+
+		if c.snapshotListShowRetentionReasons {
+			if len(row.retentionReasons) > 0 {
+				bits = append(bits, "("+strings.Join(row.retentionReasons, ",")+")")
+			}
+		}
+
+		if len(row.pins) > 0 {
+			bits = append(bits, "pins:"+strings.Join(row.pins, ","))
+		}
+
+		row.color.Fprint(c.out.stdout(), fmt.Sprintf("  %v %v %v\n", formatTimestamp(row.firstStartTime), row.oid, strings.Join(bits, " "))) //nolint:errcheck
+
+		if row.count > 1 {
+			c.out.printStdout(
+				"  + %v identical snapshots until %v\n",
+				row.count-1,
+				formatTimestamp(row.lastStartTime),
+			)
+		}
+	}
 }
 
 func (c *commandSnapshotList) entryBits(ctx context.Context, m *snapshot.Manifest, ent fs.Entry, lastTotalFileSize int64) (bits []string, col *color.Color) {
@@ -310,16 +352,6 @@ func (c *commandSnapshotList) entryBits(ctx context.Context, m *snapshot.Manifes
 				col = errorColor
 			}
 		}
-	}
-
-	if c.snapshotListShowRetentionReasons {
-		if len(m.RetentionReasons) > 0 {
-			bits = append(bits, "("+strings.Join(m.RetentionReasons, ",")+")")
-		}
-	}
-
-	if len(m.Pins) > 0 {
-		bits = append(bits, "pins:"+strings.Join(m.Pins, ","))
 	}
 
 	return bits, col

--- a/internal/server/api_policies.go
+++ b/internal/server/api_policies.go
@@ -42,7 +42,7 @@ func (s *Server) handlePolicyList(ctx context.Context, r *http.Request, body []b
 	return resp, nil
 }
 
-func getPolicyTargetFromURL(u *url.URL) snapshot.SourceInfo {
+func getSnapshotSourceFromURL(u *url.URL) snapshot.SourceInfo {
 	host := u.Query().Get("host")
 	path := u.Query().Get("path")
 	username := u.Query().Get("userName")
@@ -55,7 +55,7 @@ func getPolicyTargetFromURL(u *url.URL) snapshot.SourceInfo {
 }
 
 func (s *Server) handlePolicyGet(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
-	pol, err := policy.GetDefinedPolicy(ctx, s.rep, getPolicyTargetFromURL(r.URL))
+	pol, err := policy.GetDefinedPolicy(ctx, s.rep, getSnapshotSourceFromURL(r.URL))
 	if errors.Is(err, policy.ErrPolicyNotFound) {
 		return nil, requestError(serverapi.ErrorNotFound, "policy not found")
 	}
@@ -70,7 +70,7 @@ func (s *Server) handlePolicyResolve(ctx context.Context, r *http.Request, body 
 		return nil, requestError(serverapi.ErrorMalformedRequest, "unable to decode request: "+err.Error())
 	}
 
-	target := getPolicyTargetFromURL(r.URL)
+	target := getSnapshotSourceFromURL(r.URL)
 
 	// build a list of parents
 	policies, err := policy.GetPolicyHierarchy(ctx, s.rep, target, nil)
@@ -110,7 +110,7 @@ func (s *Server) handlePolicyDelete(ctx context.Context, r *http.Request, body [
 		return nil, repositoryNotWritableError()
 	}
 
-	sourceInfo := getPolicyTargetFromURL(r.URL)
+	sourceInfo := getSnapshotSourceFromURL(r.URL)
 
 	if err := repo.WriteSession(ctx, s.rep, repo.WriteSessionOptions{
 		Purpose: "PolicyDelete",
@@ -135,7 +135,7 @@ func (s *Server) handlePolicyPut(ctx context.Context, r *http.Request, body []by
 		return nil, repositoryNotWritableError()
 	}
 
-	sourceInfo := getPolicyTargetFromURL(r.URL)
+	sourceInfo := getSnapshotSourceFromURL(r.URL)
 
 	if err := repo.WriteSession(ctx, s.rep, repo.WriteSessionOptions{
 		Purpose: "PolicyPut",

--- a/internal/serverapi/client_wrappers.go
+++ b/internal/serverapi/client_wrappers.go
@@ -128,10 +128,16 @@ func ListSources(ctx context.Context, c *apiclient.KopiaAPIClient, match *snapsh
 	return resp, nil
 }
 
-// ListSnapshots lists the snapshots managed by the server for a given source filter.
-func ListSnapshots(ctx context.Context, c *apiclient.KopiaAPIClient, match *snapshot.SourceInfo) (*SnapshotsResponse, error) {
+// ListSnapshots lists the snapshots managed by the server for a given source source.
+func ListSnapshots(ctx context.Context, c *apiclient.KopiaAPIClient, src snapshot.SourceInfo, all bool) (*SnapshotsResponse, error) {
 	resp := &SnapshotsResponse{}
-	if err := c.Get(ctx, "snapshots"+matchSourceParameters(match), nil, resp); err != nil {
+
+	u := "snapshots" + matchSourceParameters(&src)
+	if all {
+		u += "&all=1"
+	}
+
+	if err := c.Get(ctx, u, nil, resp); err != nil {
 		return nil, errors.Wrap(err, "ListSnapshots")
 	}
 

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -149,7 +149,6 @@ type CreateSnapshotSourceResponse struct {
 // Snapshot describes single snapshot entry.
 type Snapshot struct {
 	ID               manifest.ID          `json:"id"`
-	Source           snapshot.SourceInfo  `json:"source"`
 	Description      string               `json:"description"`
 	StartTime        time.Time            `json:"startTime"`
 	EndTime          time.Time            `json:"endTime"`
@@ -157,11 +156,14 @@ type Snapshot struct {
 	Summary          *fs.DirectorySummary `json:"summary"`
 	RootEntry        string               `json:"rootID"`
 	RetentionReasons []string             `json:"retention"`
+	Pins             []string             `json:"pins"`
 }
 
 // SnapshotsResponse contains a list of snapshots.
 type SnapshotsResponse struct {
-	Snapshots []*Snapshot `json:"snapshots"`
+	Snapshots       []*Snapshot `json:"snapshots"`
+	UnfilteredCount int         `json:"unfilteredCount"`
+	UniqueCount     int         `json:"uniqueCount"`
 }
 
 // MountSnapshotRequest contains request to mount a snapshot.


### PR DESCRIPTION
Kopia will now merge retention tags over identical snapshots and show the range instead of a single tag:

```
  2021-11-21 23:46:13 PST kd8198056ac88f8c638cb2b170a1e8ec4 860.4 KB drwxr-xr-x files:178 dirs:26 (weekly-3)
  2021-11-28 22:40:00 PST k04684e8a4b152adbb5716e84ea617f98 860.4 KB drwxr-xr-x files:178 dirs:26 (daily-6..7,weekly-2)
  + 1 identical snapshots until 2021-11-29 20:40:03 PST
  2021-11-30 22:50:00 PST k50d56093831023a1cb22e805e8238f93 860.7 KB drwxr-xr-x files:178 dirs:26 (daily-5,monthly-2)
  2021-12-01 21:30:01 PST k8eee61e10b2cdd8a680f90692bc9a224 860.4 KB drwxr-xr-x files:178 dirs:26 (daily-3..4)
  + 1 identical snapshots until 2021-12-02 20:40:15 PST
  2021-12-03 12:20:01 PST k54c67ba7964d7424b2c391c5813af9a5 860.4 KB drwxr-xr-x files:178 dirs:26 (latest-8..10)
  + 2 identical snapshots until 2021-12-03 12:40:02 PST
  2021-12-03 22:37:43 PST k8eb9eaf6fbfc04d620888a23e67f0077 860.4 KB drwxr-xr-x files:178 dirs:26 (latest-1..7,hourly-1..2,daily-1..2,weekly-1,monthly-1,annual-1)
  + 6 identical snapshots until 2021-12-04 10:10:01 PST
```

Same in UI:

![image](https://user-images.githubusercontent.com/249880/144785078-9a265e63-477f-4b9a-9772-473ce206aacf.png)

Fixes #1558 