### PR TITLE
blob: replaced blob.Storage.SetTime() method with blob.PutOptions.SetTime

### DIFF
--- a/internal/blobtesting/asserts.go
+++ b/internal/blobtesting/asserts.go
@@ -17,6 +17,21 @@ import (
 
 const maxTimeDiffBetweenGetAndList = time.Minute
 
+// AssertTimestampsCloseEnough asserts that two provided times are close enough - some providers
+// don't store timestamps exactly but round them up/down by several seconds.
+func AssertTimestampsCloseEnough(t *testing.T, blobID blob.ID, got, want time.Time) {
+	t.Helper()
+
+	timeDiff := got.Sub(want)
+	if timeDiff < 0 {
+		timeDiff = -timeDiff
+	}
+
+	if timeDiff > maxTimeDiffBetweenGetAndList {
+		t.Fatalf("invalid timestamp on %v: got %v, want %v", blobID, got, want)
+	}
+}
+
 // AssertGetBlob asserts that the specified BLOB has correct content.
 func AssertGetBlob(ctx context.Context, t *testing.T, s blob.Storage, blobID blob.ID, expected []byte) {
 	t.Helper()

--- a/internal/blobtesting/eventually_consistent.go
+++ b/internal/blobtesting/eventually_consistent.go
@@ -176,10 +176,6 @@ func (s *eventuallyConsistentStorage) PutBlob(ctx context.Context, id blob.ID, d
 	return nil
 }
 
-func (s *eventuallyConsistentStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) error {
-	return s.realStorage.SetTime(ctx, id, t)
-}
-
 func (s *eventuallyConsistentStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
 	s.randomFrontendCache().put(id, nil)
 

--- a/internal/blobtesting/faulty.go
+++ b/internal/blobtesting/faulty.go
@@ -3,7 +3,6 @@ package blobtesting
 
 import (
 	"context"
-	"time"
 
 	"github.com/kopia/kopia/internal/fault"
 	"github.com/kopia/kopia/repo/blob"
@@ -14,7 +13,6 @@ const (
 	MethodGetBlob fault.Method = iota
 	MethodGetMetadata
 	MethodPutBlob
-	MethodSetTime
 	MethodDeleteBlob
 	MethodListBlobs
 	MethodListBlobsItem
@@ -61,15 +59,6 @@ func (s *FaultyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes
 	}
 
 	return s.base.PutBlob(ctx, id, data, opts)
-}
-
-// SetTime implements blob.Storage.
-func (s *FaultyStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) error {
-	if ok, err := s.GetNextFault(ctx, MethodSetTime, id); ok {
-		return err
-	}
-
-	return s.base.SetTime(ctx, id, t)
 }
 
 // DeleteBlob implements blob.Storage.

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -83,13 +83,21 @@ func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, o
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	s.keyTime[id] = s.timeNow()
+	if !opts.SetModTime.IsZero() {
+		s.keyTime[id] = opts.SetModTime
+	} else {
+		s.keyTime[id] = s.timeNow()
+	}
 
 	var b bytes.Buffer
 
 	data.WriteTo(&b)
 
 	s.data[id] = b.Bytes()
+
+	if opts.GetModTime != nil {
+		*opts.GetModTime = s.keyTime[id]
+	}
 
 	return nil
 }
@@ -144,15 +152,6 @@ func (s *mapStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback fun
 }
 
 func (s *mapStorage) Close(ctx context.Context) error {
-	return nil
-}
-
-func (s *mapStorage) SetTime(ctx context.Context, blobID blob.ID, t time.Time) error {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	s.keyTime[blobID] = t
-
 	return nil
 }
 

--- a/internal/blobtesting/object_locking_map.go
+++ b/internal/blobtesting/object_locking_map.go
@@ -205,20 +205,6 @@ func (s *objectLockingMap) Close(ctx context.Context) error {
 	return nil
 }
 
-func (s *objectLockingMap) SetTime(ctx context.Context, id blob.ID, t time.Time) error {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	e, err := s.getLatestForMutationLocked(id)
-	if err != nil {
-		return err
-	}
-
-	e.mtime = t
-
-	return nil
-}
-
 func (s *objectLockingMap) TouchBlob(ctx context.Context, id blob.ID, threshold time.Duration) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()

--- a/internal/blobtesting/object_locking_map.go
+++ b/internal/blobtesting/object_locking_map.go
@@ -122,7 +122,12 @@ func (s *objectLockingMap) PutBlob(ctx context.Context, id blob.ID, data blob.By
 
 	e := &entry{
 		value: b.Bytes(),
-		mtime: s.timeNow(),
+	}
+
+	if opts.SetModTime.IsZero() {
+		e.mtime = s.timeNow()
+	} else {
+		e.mtime = opts.SetModTime
 	}
 
 	if opts.HasRetentionOptions() {
@@ -130,6 +135,10 @@ func (s *objectLockingMap) PutBlob(ctx context.Context, id blob.ID, data blob.By
 	}
 
 	s.data[id] = append(s.data[id], e)
+
+	if opts.GetModTime != nil {
+		*opts.GetModTime = e.mtime
+	}
 
 	return nil
 }

--- a/internal/blobtesting/verify.go
+++ b/internal/blobtesting/verify.go
@@ -120,37 +120,73 @@ func VerifyStorage(ctx context.Context, t *testing.T, r blob.Storage, opts blob.
 		}
 	})
 
-	ts := time.Date(2020, 1, 1, 15, 30, 45, 0, time.UTC)
+	t.Run("DeleteBlobsAndList", func(t *testing.T) {
+		require.NoError(t, r.DeleteBlob(ctx, blocks[0].blk))
+		require.NoError(t, r.DeleteBlob(ctx, blocks[0].blk))
 
-	t.Run("SetTime", func(t *testing.T) {
+		AssertListResults(ctx, t, r, "ab", blocks[2].blk, blocks[3].blk)
+		AssertListResults(ctx, t, r, "", blocks[1].blk, blocks[2].blk, blocks[3].blk, blocks[4].blk)
+	})
+
+	t.Run("PutBlobsWithSetTime", func(t *testing.T) {
 		for _, b := range blocks {
 			b := b
 
 			t.Run(string(b.blk), func(t *testing.T) {
 				t.Parallel()
 
-				err := r.SetTime(ctx, b.blk, ts)
+				inTime := time.Date(2020, 1, 2, 12, 30, 40, 0, time.UTC)
+
+				err := r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents), blob.PutOptions{
+					SetModTime: inTime,
+				})
+
 				if errors.Is(err, blob.ErrSetTimeUnsupported) {
-					return
+					t.Skip("setting time unsupported")
 				}
 
+				bm, err := r.GetMetadata(ctx, b.blk)
 				require.NoError(t, err)
 
-				md, err := r.GetMetadata(ctx, b.blk)
-				if err != nil {
-					t.Errorf("unable to get blob metadata")
-				}
+				AssertTimestampsCloseEnough(t, bm.BlobID, bm.Timestamp, inTime)
 
-				require.True(t, md.Timestamp.Equal(ts), "invalid time after SetTme(): %vm want %v", md.Timestamp, ts)
+				all, err := blob.ListAllBlobs(ctx, r, b.blk)
+				require.NoError(t, err)
+				require.Len(t, all, 1)
+
+				AssertTimestampsCloseEnough(t, all[0].BlobID, all[0].Timestamp, inTime)
 			})
 		}
 	})
 
-	require.NoError(t, r.DeleteBlob(ctx, blocks[0].blk))
-	require.NoError(t, r.DeleteBlob(ctx, blocks[0].blk))
+	t.Run("PutBlobsWithGetTime", func(t *testing.T) {
+		for _, b := range blocks {
+			b := b
 
-	AssertListResults(ctx, t, r, "ab", blocks[2].blk, blocks[3].blk)
-	AssertListResults(ctx, t, r, "", blocks[1].blk, blocks[2].blk, blocks[3].blk, blocks[4].blk)
+			t.Run(string(b.blk), func(t *testing.T) {
+				t.Parallel()
+
+				var outTime time.Time
+
+				require.NoError(t, r.PutBlob(ctx, b.blk, gather.FromSlice(b.contents), blob.PutOptions{
+					GetModTime: &outTime,
+				}))
+
+				require.False(t, outTime.IsZero(), "modification time was not returned")
+
+				bm, err := r.GetMetadata(ctx, b.blk)
+				require.NoError(t, err)
+
+				AssertTimestampsCloseEnough(t, bm.BlobID, bm.Timestamp, outTime)
+
+				all, err := blob.ListAllBlobs(ctx, r, b.blk)
+				require.NoError(t, err)
+				require.Len(t, all, 1)
+
+				AssertTimestampsCloseEnough(t, all[0].BlobID, all[0].Timestamp, outTime)
+			})
+		}
+	})
 }
 
 // AssertConnectionInfoRoundTrips verifies that the ConnectionInfo returned by a given storage can be used to create

--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -770,17 +770,12 @@ func (e *Manager) writeIndexShards(ctx context.Context, dataShards map[blob.ID]b
 			return errWriteIndexTryAgain
 		}
 
-		if err := e.st.PutBlob(ctx, blobID, data, blob.PutOptions{}); err != nil {
+		bm, err := blob.PutBlobAndGetMetadata(ctx, e.st, blobID, data, blob.PutOptions{})
+		if err != nil {
 			return errors.Wrap(err, "error writing index blob")
 		}
 
-		bm, err := e.st.GetMetadata(ctx, blobID)
-		if err != nil {
-			return errors.Wrap(err, "error getting index metadata")
-		}
-
-		e.log.Debugw("wrote-index-shard",
-			"metadata", bm)
+		e.log.Debugw("wrote-index-shard", "metadata", bm)
 
 		written[bm.BlobID] = bm
 	}

--- a/internal/ownwrites/ownwrites.go
+++ b/internal/ownwrites/ownwrites.go
@@ -125,6 +125,8 @@ func (s *CacheStorage) ListBlobs(ctx context.Context, prefix blob.ID, cb func(bl
 func (s *CacheStorage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	err := s.Storage.PutBlob(ctx, blobID, data, opts)
 	if err == nil && s.isCachedPrefix(blobID) {
+		opts.GetModTime = nil
+
 		// nolint:errcheck
 		s.cacheStorage.PutBlob(ctx, prefixAdd+blobID, markerData, opts)
 	}

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -7,6 +7,7 @@ import (
 	cryptorand "crypto/rand"
 	"fmt"
 	"math/rand"
+	"os"
 	"sync"
 	"time"
 
@@ -52,6 +53,10 @@ var log = logging.Module("providervalidation")
 // it can be used with Kopia.
 // nolint:gomnd,funlen,gocyclo
 func ValidateProvider(ctx context.Context, st blob.Storage, opt Options) error {
+	if os.Getenv("KOPIA_SKIP_PROVIDER_VALIDATION") != "" {
+		return nil
+	}
+
 	uberPrefix := blob.ID("z" + uuid.NewString())
 	defer cleanupAllBlobs(ctx, st, uberPrefix)
 

--- a/internal/timestampmeta/timestampmeta.go
+++ b/internal/timestampmeta/timestampmeta.go
@@ -1,0 +1,30 @@
+// Package timestampmeta provides utilities for preserving timestamps
+// using per-blob key-value-pairs (metadata, tags, etc.)
+package timestampmeta
+
+import (
+	"strconv"
+	"time"
+)
+
+// ToMap returns a map containing single entry representing the provided time or nil map
+// if the time is zero. The key-value pair map should be stored alongside the blob.
+func ToMap(t time.Time, mapKey string) map[string]string {
+	if t.IsZero() {
+		return nil
+	}
+
+	return map[string]string{
+		mapKey: strconv.FormatInt(t.UnixNano(), 10), // nolint:gomnd
+	}
+}
+
+// FromValue attempts to convert the provided value stored in metadata into time.Time.
+func FromValue(v string) (t time.Time, ok bool) {
+	nanos, err := strconv.ParseInt(v, 10, 64) // nolint:gomnd
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return time.Unix(0, nanos), true
+}

--- a/internal/timestampmeta/timestampmeta_test.go
+++ b/internal/timestampmeta/timestampmeta_test.go
@@ -1,0 +1,23 @@
+package timestampmeta_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/timestampmeta"
+)
+
+var (
+	timeValue   = time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	storedValue = "1577934245000000000"
+)
+
+func TestToMap(t *testing.T) {
+	require.Equal(t, map[string]string{
+		"aaa": storedValue,
+	}, timestampmeta.ToMap(timeValue, "aaa"))
+
+	require.Nil(t, timestampmeta.ToMap(time.Time{}, "aaa"))
+}

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -20,7 +20,7 @@ import (
 const (
 	azStorageType = "azureBlob"
 
-	timeMapKey = "Kopiamtime" // this must be capital letter followed by lowercase, don't ask
+	timeMapKey = "Kopiamtime" // this must be capital letter followed by lowercase, to comply with AZ tags naming convention.
 )
 
 type azStorage struct {
@@ -132,11 +132,7 @@ func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, op
 	}
 
 	if opts.GetModTime != nil {
-		if opts.SetModTime.IsZero() {
-			*opts.GetModTime = *resp.LastModified
-		} else {
-			*opts.GetModTime = opts.SetModTime
-		}
+		*opts.GetModTime = *resp.LastModified
 	}
 
 	return nil

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -204,7 +204,7 @@ func (az *azStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback fun
 				// fall back to using last modified time.
 				t, err := time.Parse(time.RFC1123, it.Properties.LastModified)
 				if err != nil {
-					return errors.Wrap(err, "invalid timestamp")
+					return errors.Wrapf(err, "invalid timestamp for BLOB '%v': %q", bm.BlobID, it.Properties.LastModified)
 				}
 
 				bm.Timestamp = t

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -13,12 +13,15 @@ import (
 	"gopkg.in/kothar/go-backblaze.v0"
 
 	"github.com/kopia/kopia/internal/iocopy"
+	"github.com/kopia/kopia/internal/timestampmeta"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/retrying"
 )
 
 const (
 	b2storageType = "b2"
+
+	timeMapKey = "kopia-mtime" // case is important, must be all-lowercase
 )
 
 type b2Storage struct {
@@ -99,11 +102,17 @@ func (s *b2Storage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata,
 		return blob.Metadata{}, errors.Wrap(translateError(err), "GetFileInfo")
 	}
 
-	return blob.Metadata{
+	bm := blob.Metadata{
 		BlobID:    id,
 		Length:    fi.ContentLength,
 		Timestamp: time.Unix(0, fi.UploadTimestamp*1e6),
-	}, nil
+	}
+
+	if t, ok := timestampmeta.FromValue(fi.FileInfo[timeMapKey]); ok {
+		bm.Timestamp = t
+	}
+
+	return bm, nil
 }
 
 func translateError(err error) error {
@@ -149,13 +158,20 @@ func (s *b2Storage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, op
 		r = http.NoBody
 	}
 
-	_, err := s.bucket.UploadFile(fileName, nil, r)
+	fi, err := s.bucket.UploadFile(fileName, timestampmeta.ToMap(opts.SetModTime, timeMapKey), r)
+	if err != nil {
+		return translateError(err)
+	}
 
-	return translateError(err)
-}
+	if opts.GetModTime != nil {
+		if opts.SetModTime.IsZero() {
+			*opts.GetModTime = time.Unix(0, fi.UploadTimestamp*1e6)
+		} else {
+			*opts.GetModTime = opts.SetModTime
+		}
+	}
 
-func (s *b2Storage) SetTime(ctx context.Context, b blob.ID, t time.Time) error {
-	return blob.ErrSetTimeUnsupported
+	return nil
 }
 
 func (s *b2Storage) DeleteBlob(ctx context.Context, id blob.ID) error {
@@ -193,6 +209,10 @@ func (s *b2Storage) ListBlobs(ctx context.Context, prefix blob.ID, callback func
 				BlobID:    blob.ID(f.Name[len(s.Prefix):]),
 				Length:    f.ContentLength,
 				Timestamp: time.Unix(0, f.UploadTimestamp*int64(time.Millisecond)),
+			}
+
+			if t, ok := timestampmeta.FromValue(f.FileInfo[timeMapKey]); ok {
+				bm.Timestamp = t
 			}
 
 			if err := callback(bm); err != nil {

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -164,11 +164,7 @@ func (s *b2Storage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, op
 	}
 
 	if opts.GetModTime != nil {
-		if opts.SetModTime.IsZero() {
-			*opts.GetModTime = time.Unix(0, fi.UploadTimestamp*1e6)
-		} else {
-			*opts.GetModTime = opts.SetModTime
-		}
+		*opts.GetModTime = time.Unix(0, fi.UploadTimestamp*1e6)
 	}
 
 	return nil

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -190,7 +190,7 @@ func (fs *fsImpl) PutBlobInPath(ctx context.Context, dirPath, path string, data 
 
 		if t := opts.SetModTime; !t.IsZero() {
 			if chtimesErr := fs.osi.Chtimes(path, t, t); err != nil {
-				return errors.Wrap(chtimesErr, "can't change file times")
+				return errors.Wrapf(chtimesErr, "can't change file %q times", path)
 			}
 		}
 

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -197,7 +197,7 @@ func (fs *fsImpl) PutBlobInPath(ctx context.Context, dirPath, path string, data 
 		if t := opts.GetModTime; t != nil {
 			fi, err := fs.osi.Stat(path)
 			if err != nil {
-				return errors.Wrap(err, "can't get mod time")
+				return errors.Wrapf(err, "can't get mod time for file %q", path)
 			}
 
 			*t = fi.ModTime()

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -149,7 +149,7 @@ func (fs *fsImpl) GetMetadataFromPath(ctx context.Context, dirPath, path string)
 	return v.(blob.Metadata), nil
 }
 
-func (fs *fsImpl) PutBlobInPath(ctx context.Context, dirPath, path string, data blob.Bytes) error {
+func (fs *fsImpl) PutBlobInPath(ctx context.Context, dirPath, path string, data blob.Bytes, opts blob.PutOptions) error {
 	// nolint:wrapcheck
 	return retry.WithExponentialBackoffNoValue(ctx, "PutBlobInPath:"+path, func() error {
 		randSuffix := make([]byte, tempFileRandomSuffixLen)

--- a/repo/blob/filesystem/filesystem_storage_test.go
+++ b/repo/blob/filesystem/filesystem_storage_test.go
@@ -251,6 +251,7 @@ func TestFileStorage_PutBlob_RetriesOnErrors(t *testing.T) {
 		renameRemainingErrors:          1,
 		removeRemainingRetriableErrors: 3,
 		chownRemainingErrors:           3,
+		chtimesRemainingErrors:         3,
 
 		effectiveUID: 0, // running as root
 	}
@@ -279,6 +280,16 @@ func TestFileStorage_PutBlob_RetriesOnErrors(t *testing.T) {
 
 	require.NoError(t, st.GetBlob(ctx, "someblob1234567812345678", 1, 2, &buf))
 	require.Equal(t, []byte{2, 3}, buf.ToByteSlice())
+
+	var mt time.Time
+
+	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{
+		GetModTime: &mt,
+	}))
+
+	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{
+		SetModTime: time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC),
+	}))
 }
 
 func TestFileStorage_DeleteBlob_ErrorHandling(t *testing.T) {

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -130,11 +130,7 @@ func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, 
 	}
 
 	if opts.GetModTime != nil {
-		if opts.SetModTime.IsZero() {
-			*opts.GetModTime = writer.Attrs().Updated
-		} else {
-			*opts.GetModTime = opts.SetModTime
-		}
+		*opts.GetModTime = writer.Attrs().Updated
 	}
 
 	return nil

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 
 	gcsclient "cloud.google.com/go/storage"
 	"github.com/pkg/errors"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/iocopy"
+	"github.com/kopia/kopia/internal/timestampmeta"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/retrying"
 )
@@ -26,6 +26,8 @@ import (
 const (
 	gcsStorageType  = "gcs"
 	writerChunkSize = 1 << 20
+
+	timeMapKey = "Kopia-Mtime" // case is important, first letter must be capitalized.
 )
 
 type gcsStorage struct {
@@ -65,11 +67,17 @@ func (gcs *gcsStorage) GetMetadata(ctx context.Context, b blob.ID) (blob.Metadat
 		return blob.Metadata{}, errors.Wrap(translateError(err), "Attrs")
 	}
 
-	return blob.Metadata{
+	bm := blob.Metadata{
 		BlobID:    b,
 		Length:    attrs.Size,
 		Timestamp: attrs.Created,
-	}, nil
+	}
+
+	if t, ok := timestampmeta.FromValue(attrs.Metadata[timeMapKey]); ok {
+		bm.Timestamp = t
+	}
+
+	return bm, nil
 }
 
 func translateError(err error) error {
@@ -102,6 +110,7 @@ func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, 
 	writer := obj.NewWriter(ctx)
 	writer.ChunkSize = writerChunkSize
 	writer.ContentType = "application/x-kopia"
+	writer.ObjectAttrs.Metadata = timestampmeta.ToMap(opts.SetModTime, timeMapKey)
 
 	err := iocopy.JustCopy(writer, data.Reader())
 	if err != nil {
@@ -116,11 +125,19 @@ func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, 
 	defer cancel()
 
 	// calling close before cancel() causes it to commit the upload.
-	return translateError(writer.Close())
-}
+	if err := writer.Close(); err != nil {
+		return translateError(err)
+	}
 
-func (gcs *gcsStorage) SetTime(ctx context.Context, b blob.ID, t time.Time) error {
-	return blob.ErrSetTimeUnsupported
+	if opts.GetModTime != nil {
+		if opts.SetModTime.IsZero() {
+			*opts.GetModTime = writer.Attrs().Updated
+		} else {
+			*opts.GetModTime = opts.SetModTime
+		}
+	}
+
+	return nil
 }
 
 func (gcs *gcsStorage) DeleteBlob(ctx context.Context, b blob.ID) error {
@@ -143,11 +160,17 @@ func (gcs *gcsStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback f
 
 	oa, err := lst.Next()
 	for err == nil {
-		if cberr := callback(blob.Metadata{
+		bm := blob.Metadata{
 			BlobID:    blob.ID(oa.Name[len(gcs.Prefix):]),
 			Length:    oa.Size,
 			Timestamp: oa.Created,
-		}); cberr != nil {
+		}
+
+		if t, ok := timestampmeta.FromValue(oa.Metadata[timeMapKey]); ok {
+			bm.Timestamp = t
+		}
+
+		if cberr := callback(bm); cberr != nil {
 			return cberr
 		}
 

--- a/repo/blob/logging/logging_storage.go
+++ b/repo/blob/logging/logging_storage.go
@@ -3,7 +3,6 @@ package logging
 
 import (
 	"context"
-	"time"
 
 	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/repo/blob"
@@ -58,22 +57,6 @@ func (s *loggingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Byte
 	s.logger.Debugw(s.prefix+"PutBlob",
 		"blobID", id,
 		"length", data.Length(),
-		"error", err,
-		"duration", dt,
-	)
-
-	// nolint:wrapcheck
-	return err
-}
-
-func (s *loggingStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) error {
-	timer := timetrack.StartTimer()
-	err := s.base.SetTime(ctx, id, t)
-	dt := timer.Elapsed()
-
-	s.logger.Debugw(s.prefix+"SetTime",
-		"blobID", id,
-		"time", t,
 		"error", err,
 		"duration", dt,
 	)

--- a/repo/blob/readonly/readonly_storage.go
+++ b/repo/blob/readonly/readonly_storage.go
@@ -3,7 +3,6 @@ package readonly
 
 import (
 	"context"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -26,10 +25,6 @@ func (s readonlyStorage) GetBlob(ctx context.Context, id blob.ID, offset, length
 func (s readonlyStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata, error) {
 	// nolint:wrapcheck
 	return s.base.GetMetadata(ctx, id)
-}
-
-func (s readonlyStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) error {
-	return ErrReadonly
 }
 
 func (s readonlyStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/repo/blob"
@@ -36,15 +35,6 @@ func (s retryingStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Meta
 	}
 
 	return v.(blob.Metadata), nil
-}
-
-func (s retryingStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) error {
-	_, err := retry.WithExponentialBackoff(ctx, "GetMetadata("+string(id)+")", func() (interface{}, error) {
-		// nolint:wrapcheck
-		return true, s.Storage.SetTime(ctx, id, t)
-	}, isRetriable)
-
-	return err // nolint:wrapcheck
 }
 
 func (s retryingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -129,16 +129,12 @@ func (s *s3Storage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opt
 	_, err := s.putBlob(ctx, b, data, opts)
 
 	if opts.GetModTime != nil {
-		if opts.SetModTime.IsZero() {
-			bm, err2 := s.GetMetadata(ctx, b)
-			if err2 != nil {
-				return err2
-			}
-
-			*opts.GetModTime = bm.Timestamp
-		} else {
-			*opts.GetModTime = opts.SetModTime
+		bm, err2 := s.GetMetadata(ctx, b)
+		if err2 != nil {
+			return err2
 		}
+
+		*opts.GetModTime = bm.Timestamp
 	}
 
 	return err

--- a/repo/blob/s3/s3_versioned.go
+++ b/repo/blob/s3/s3_versioned.go
@@ -96,12 +96,14 @@ func toBlobID(blobName, prefix string) blob.ID {
 }
 
 func infoToVersionMetadata(prefix string, oi *minio.ObjectInfo) versionMetadata {
+	bm := blob.Metadata{
+		BlobID:    toBlobID(oi.Key, prefix),
+		Length:    oi.Size,
+		Timestamp: oi.LastModified,
+	}
+
 	return versionMetadata{
-		Metadata: blob.Metadata{
-			BlobID:    toBlobID(oi.Key, prefix),
-			Length:    oi.Size,
-			Timestamp: oi.LastModified,
-		},
+		Metadata:       bm,
 		IsLatest:       oi.IsLatest,
 		IsDeleteMarker: oi.IsDeleteMarker,
 		Version:        oi.VersionID,

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/pkg/sftp"
@@ -202,15 +201,22 @@ func (s *sftpImpl) PutBlobInPath(ctx context.Context, dirPath, fullPath string, 
 			return errors.Wrap(err, "unexpected error renaming file on SFTP")
 		}
 
-		return nil
-	})
-}
+		if t := opts.SetModTime; !t.IsZero() {
+			if chtimesErr := sftpClientFromConnection(conn).Chtimes(fullPath, t, t); err != nil {
+				return errors.Wrap(chtimesErr, "can't change file times")
+			}
+		}
 
-func (s *sftpImpl) SetTimeInPath(ctx context.Context, dirPath, fullPath string, n time.Time) error {
-	// nolint:wrapcheck
-	return s.rec.UsingConnectionNoResult(ctx, "SetTimeInPath", func(conn connection.Connection) error {
-		// nolint:wrapcheck
-		return sftpClientFromConnection(conn).Chtimes(fullPath, n, n)
+		if t := opts.GetModTime; t != nil {
+			fi, err := sftpClientFromConnection(conn).Stat(fullPath)
+			if err != nil {
+				return errors.Wrap(err, "can't get mod time")
+			}
+
+			*t = fi.ModTime()
+		}
+
+		return nil
 	})
 }
 

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -170,7 +170,7 @@ func (s *sftpImpl) GetMetadataFromPath(ctx context.Context, dirPath, fullPath st
 	return v.(blob.Metadata), nil
 }
 
-func (s *sftpImpl) PutBlobInPath(ctx context.Context, dirPath, fullPath string, data blob.Bytes) error {
+func (s *sftpImpl) PutBlobInPath(ctx context.Context, dirPath, fullPath string, data blob.Bytes, opts blob.PutOptions) error {
 	// nolint:wrapcheck
 	return s.rec.UsingConnectionNoResult(ctx, "PutBlobInPath", func(conn connection.Connection) error {
 		randSuffix := make([]byte, tempFileRandomSuffixLen)

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -28,7 +27,6 @@ type Impl interface {
 	GetBlobFromPath(ctx context.Context, dirPath, filePath string, offset, length int64, output blob.OutputBuffer) error
 	GetMetadataFromPath(ctx context.Context, dirPath, filePath string) (blob.Metadata, error)
 	PutBlobInPath(ctx context.Context, dirPath, filePath string, dataSlices blob.Bytes, opts blob.PutOptions) error
-	SetTimeInPath(ctx context.Context, dirPath, filePath string, t time.Time) error
 	DeleteBlobInPath(ctx context.Context, dirPath, filePath string) error
 	ReadDir(ctx context.Context, path string) ([]os.FileInfo, error)
 }
@@ -191,17 +189,6 @@ func (s *Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, 
 
 	// nolint:wrapcheck
 	return s.Impl.PutBlobInPath(ctx, dirPath, filePath, data, opts)
-}
-
-// SetTime implements blob.Storage.
-func (s *Storage) SetTime(ctx context.Context, blobID blob.ID, n time.Time) error {
-	dirPath, filePath, err := s.GetShardedPathAndFilePath(ctx, blobID)
-	if err != nil {
-		return errors.Wrap(err, "error determining sharded path")
-	}
-
-	// nolint:wrapcheck
-	return s.Impl.SetTimeInPath(ctx, dirPath, filePath, n)
 }
 
 // DeleteBlob implements blob.Storage.

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -27,7 +27,7 @@ var log = logging.Module("sharded")
 type Impl interface {
 	GetBlobFromPath(ctx context.Context, dirPath, filePath string, offset, length int64, output blob.OutputBuffer) error
 	GetMetadataFromPath(ctx context.Context, dirPath, filePath string) (blob.Metadata, error)
-	PutBlobInPath(ctx context.Context, dirPath, filePath string, dataSlices blob.Bytes) error
+	PutBlobInPath(ctx context.Context, dirPath, filePath string, dataSlices blob.Bytes, opts blob.PutOptions) error
 	SetTimeInPath(ctx context.Context, dirPath, filePath string, t time.Time) error
 	DeleteBlobInPath(ctx context.Context, dirPath, filePath string) error
 	ReadDir(ctx context.Context, path string) ([]os.FileInfo, error)
@@ -190,7 +190,7 @@ func (s *Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, 
 	}
 
 	// nolint:wrapcheck
-	return s.Impl.PutBlobInPath(ctx, dirPath, filePath, data)
+	return s.Impl.PutBlobInPath(ctx, dirPath, filePath, data, opts)
 }
 
 // SetTime implements blob.Storage.
@@ -243,7 +243,7 @@ func (s *Storage) getParameters(ctx context.Context) (*Parameters, error) {
 			return nil, errors.Wrap(err, "error serializing sharding parameters")
 		}
 
-		if err := s.Impl.PutBlobInPath(ctx, s.RootPath, dotShardsFile, tmp.Bytes()); err != nil {
+		if err := s.Impl.PutBlobInPath(ctx, s.RootPath, dotShardsFile, tmp.Bytes(), blob.PutOptions{}); err != nil {
 			log(ctx).Warnf("unable to persist sharding parameters: %v", err)
 		}
 	} else {

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -61,6 +61,11 @@ type Reader interface {
 type PutOptions struct {
 	RetentionMode   string
 	RetentionPeriod time.Duration
+
+	// if not empty, set the provided timestamp on the blob instead of server-assigned,
+	// if unsupported by the server return ErrSetTimeUnsupported
+	SetModTime time.Time
+	GetModTime *time.Time // if != nil, populate the value pointed at with the actual modification time
 }
 
 // HasRetentionOptions returns true when blob-retention settings have been
@@ -86,9 +91,6 @@ type Storage interface {
 	// PutBlob uploads the blob with given data to the repository or replaces existing blob with the provided
 	// id with contents gathered from the specified list of slices.
 	PutBlob(ctx context.Context, blobID ID, data Bytes, opts PutOptions) error
-
-	// SetTime changes last modification time of a given blob, if supported, returns ErrSetTimeUnsupported otherwise.
-	SetTime(ctx context.Context, blobID ID, t time.Time) error
 
 	// DeleteBlob removes the blob from storage. Future Get() operations will fail with ErrNotFound.
 	DeleteBlob(ctx context.Context, blobID ID) error

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -263,15 +263,16 @@ func DeleteMultiple(ctx context.Context, st Storage, ids []ID, parallelism int) 
 
 // PutBlobAndGetMetadata invokes PutBlob and returns the resulting Metadata.
 func PutBlobAndGetMetadata(ctx context.Context, st Storage, blobID ID, data Bytes, opts PutOptions) (Metadata, error) {
-	var mt time.Time
-
-	opts.GetModTime = &mt
+	// ensure GetModTime is set, or reuse existing one.
+	if opts.GetModTime == nil {
+		opts.GetModTime = new(time.Time)
+	}
 
 	err := st.PutBlob(ctx, blobID, data, opts)
 
 	return Metadata{
 		BlobID:    blobID,
 		Length:    int64(data.Length()),
-		Timestamp: mt,
+		Timestamp: *opts.GetModTime,
 	}, err // nolint:wrapcheck
 }

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -260,3 +260,18 @@ func DeleteMultiple(ctx context.Context, st Storage, ids []ID, parallelism int) 
 
 	return errors.Wrap(eg.Wait(), "error deleting blobs")
 }
+
+// PutBlobAndGetMetadata invokes PutBlob and returns the resulting Metadata.
+func PutBlobAndGetMetadata(ctx context.Context, st Storage, blobID ID, data Bytes, opts PutOptions) (Metadata, error) {
+	var mt time.Time
+
+	opts.GetModTime = &mt
+
+	err := st.PutBlob(ctx, blobID, data, opts)
+
+	return Metadata{
+		BlobID:    blobID,
+		Length:    int64(data.Length()),
+		Timestamp: mt,
+	}, err // nolint:wrapcheck
+}

--- a/repo/blob/storage_test.go
+++ b/repo/blob/storage_test.go
@@ -185,3 +185,17 @@ func TestMetataJSONString(t *testing.T) {
 
 	require.Equal(t, `{"id":"foo","length":12345,"timestamp":"2000-01-02T03:04:05.000000006Z"}`, bm.String())
 }
+
+func TestPutBlobAndGetMetadata(t *testing.T) {
+	data := blobtesting.DataMap{}
+
+	fixedTime := time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC)
+
+	st := blobtesting.NewMapStorage(data, nil, func() time.Time {
+		return fixedTime
+	})
+
+	bm, err := blob.PutBlobAndGetMetadata(context.Background(), st, "foo", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{})
+	require.NoError(t, err)
+	require.Equal(t, fixedTime, bm.Timestamp)
+}

--- a/repo/blob/throttling/throttling_storage.go
+++ b/repo/blob/throttling/throttling_storage.go
@@ -4,7 +4,6 @@ package throttling
 
 import (
 	"context"
-	"time"
 
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -18,7 +17,6 @@ const (
 	operationGetBlob     = "GetBlob"
 	operationGetMetadata = "GetMetadata"
 	operationListBlobs   = "ListBlobs"
-	operationSetTime     = "SetTime"
 	operationPutBlob     = "PutBlob"
 	operationDeleteBlob  = "DeleteBlob"
 )
@@ -82,11 +80,6 @@ func (s *throttlingStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.M
 func (s *throttlingStorage) ListBlobs(ctx context.Context, blobIDPrefix blob.ID, cb func(bm blob.Metadata) error) error {
 	s.throttler.BeforeOperation(ctx, operationListBlobs)
 	return s.Storage.ListBlobs(ctx, blobIDPrefix, cb) // nolint:wrapcheck
-}
-
-func (s *throttlingStorage) SetTime(ctx context.Context, id blob.ID, t time.Time) error {
-	s.throttler.BeforeOperation(ctx, operationSetTime)
-	return s.Storage.SetTime(ctx, id, t) // nolint:wrapcheck
 }
 
 func (s *throttlingStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {

--- a/repo/blob/throttling/throttling_storage_test.go
+++ b/repo/blob/throttling/throttling_storage_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/blobtesting"
-	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
@@ -119,13 +118,6 @@ func TestThrottling(t *testing.T) {
 	require.Equal(t, []string{
 		"BeforeOperation(GetMetadata)",
 		"inner.GetMetadata",
-	}, m.activity)
-
-	m.Reset()
-	require.NoError(t, wrapped.SetTime(ctx, "blob1", clock.Now()))
-	require.Equal(t, []string{
-		"BeforeOperation(SetTime)",
-		"inner.SetTime",
 	}, m.activity)
 
 	m.Reset()

--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -134,7 +134,7 @@ func (d *davStorageImpl) ReadDir(ctx context.Context, dir string) ([]os.FileInfo
 	return nil, errors.Wrap(err, "error reading WebDAV dir")
 }
 
-func (d *davStorageImpl) PutBlobInPath(ctx context.Context, dirPath, filePath string, data blob.Bytes) error {
+func (d *davStorageImpl) PutBlobInPath(ctx context.Context, dirPath, filePath string, data blob.Bytes, opts blob.PutOptions) error {
 	var writePath string
 
 	if d.Options.AtomicWrites {

--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/studio-b12/gowebdav"
@@ -135,6 +134,10 @@ func (d *davStorageImpl) ReadDir(ctx context.Context, dir string) ([]os.FileInfo
 }
 
 func (d *davStorageImpl) PutBlobInPath(ctx context.Context, dirPath, filePath string, data blob.Bytes, opts blob.PutOptions) error {
+	if !opts.SetModTime.IsZero() {
+		return blob.ErrSetTimeUnsupported
+	}
+
 	var writePath string
 
 	if d.Options.AtomicWrites {
@@ -150,7 +153,7 @@ func (d *davStorageImpl) PutBlobInPath(ctx context.Context, dirPath, filePath st
 	b := buf.Bytes()
 
 	// nolint:wrapcheck
-	return retry.WithExponentialBackoffNoValue(ctx, "WriteTemporaryFileAndCreateParentDirs", func() error {
+	if err := retry.WithExponentialBackoffNoValue(ctx, "WriteTemporaryFileAndCreateParentDirs", func() error {
 		mkdirAttempted := false
 
 		for {
@@ -181,11 +184,20 @@ func (d *davStorageImpl) PutBlobInPath(ctx context.Context, dirPath, filePath st
 
 			return err
 		}
-	}, isRetriable)
-}
+	}, isRetriable); err != nil {
+		return err
+	}
 
-func (d *davStorageImpl) SetTimeInPath(ctx context.Context, dirPath, filePath string, n time.Time) error {
-	return blob.ErrSetTimeUnsupported
+	if opts.GetModTime != nil {
+		bm, err := d.GetMetadataFromPath(ctx, dirPath, filePath)
+		if err != nil {
+			return err
+		}
+
+		*opts.GetModTime = bm.Timestamp
+	}
+
+	return nil
 }
 
 func (d *davStorageImpl) DeleteBlobInPath(ctx context.Context, dirPath, filePath string) error {

--- a/repo/content/encrypted_blob_mgr.go
+++ b/repo/content/encrypted_blob_mgr.go
@@ -37,16 +37,10 @@ func (m *encryptedBlobMgr) encryptAndWriteBlob(ctx context.Context, data gather.
 		return blob.Metadata{}, errors.Wrap(err, "error encrypting")
 	}
 
-	err = m.st.PutBlob(ctx, blobID, data2.Bytes(), blob.PutOptions{})
+	bm, err := blob.PutBlobAndGetMetadata(ctx, m.st, blobID, data2.Bytes(), blob.PutOptions{})
 	if err != nil {
 		m.log.Debugf("write-index-blob %v failed %v", blobID, err)
 		return blob.Metadata{}, errors.Wrapf(err, "error writing blob %v", blobID)
-	}
-
-	bm, err := m.st.GetMetadata(ctx, blobID)
-	if err != nil {
-		m.log.Debugf("write-index-blob-get-metadata %v failed %v", blobID, err)
-		return blob.Metadata{}, errors.Wrap(err, "unable to get blob metadata")
 	}
 
 	m.log.Debugf("write-index-blob %v %v %v", blobID, bm.Length, bm.Timestamp)

--- a/repo/content/encrypted_blob_mgr_test.go
+++ b/repo/content/encrypted_blob_mgr_test.go
@@ -78,11 +78,6 @@ func TestEncryptedBlobManager(t *testing.T) {
 	_, err = ebm.encryptAndWriteBlob(ctx, gather.FromSlice([]byte{1, 2, 3, 4}), "x", "session1")
 	require.ErrorIs(t, err, someError)
 
-	fs.AddFault(blobtesting.MethodGetMetadata).ErrorInstead(someError)
-
-	_, err = ebm.encryptAndWriteBlob(ctx, gather.FromSlice([]byte{1, 2, 3, 4}), "x", "session1")
-	require.ErrorIs(t, err, someError)
-
 	someError2 := errors.Errorf("some error 2")
 
 	cr.Encryptor = failingEncryptor{nil, someError2}


### PR DESCRIPTION
This was only used for `kopia repo sync-to` and got replaced with
an equivalent blob.PutOptions.SetTime, which when set to non-zero time
will attempt to set the modification time on a file.

Since some providers don't support changing modification time, we
are able to emulate it using per-blob metadata (on B2, Azure and GCS),
sadly S3 is still unsupported, because it does not support returning
metadata in list results.

Also added PutOptions.GetTime, which when set to not nil, will
populate the provided variable with actual time that got assigned
to the blob.

Added tests that verify that each provider supports GetTime
and SetTime according to this spec.
