### PR TITLE
Fix typo in policy help documentation

### DIFF
--- a/cli/command_policy_edit.go
+++ b/cli/command_policy_edit.go
@@ -36,7 +36,7 @@ const policyEditRetentionHelpText = `  # Retention for snapshots of this directo
 const policyEditFilesHelpText = `
   # Which files to include in snapshots. Options include:
   #   "ignore": ["*.ext", "*.ext2"]
-  #   "dotIgnoreFiles": [".gitignore", ".kopiaignore"]
+  #   "ignoreDotFiles": [".gitignore", ".kopiaignore"]
   #   "maxFileSize": number
   #   "noParentDotFiles": true
   #   "noParentIgnore": true


### PR DESCRIPTION
The field is called ignoreDotFiles in JSON, but the documentation says
dotIgnoreFiles. Fix the docs to refer to the correct field name.