### PR TITLE
s3/test: refactor retention tests

### DIFF
--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -182,7 +182,7 @@ func TestS3StorageAWSSTS(t *testing.T) {
 	testStorage(t, options, false, blob.PutOptions{})
 }
 
-func TestS3StorageAWSRetentionUnlockedBucket(t *testing.T) {
+func TestS3StorageRetentionUnlockedBucket(t *testing.T) {
 	t.Parallel()
 
 	// skip the test if AWS creds are not provided
@@ -212,7 +212,7 @@ func TestS3StorageAWSRetentionUnlockedBucket(t *testing.T) {
 	})
 }
 
-func TestS3StorageAWSRetentionLockedBucket(t *testing.T) {
+func TestS3StorageRetentionLockedBucket(t *testing.T) {
 	t.Parallel()
 
 	// skip the test if AWS creds are not provided

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -225,28 +225,19 @@ func TestS3StorageAWSRetentionLockedBucket(t *testing.T) {
 	}
 
 	createBucket(t, options)
-	testStorage(t, options, false, blob.PutOptions{
-		RetentionMode:   minio.Governance.String(),
-		RetentionPeriod: time.Hour * 24,
+
+	t.Run("testStorage", func(t *testing.T) {
+		testStorage(t, options, false, blob.PutOptions{
+			RetentionMode:   minio.Governance.String(),
+			RetentionPeriod: time.Hour * 24,
+		})
 	})
-}
 
-func TestS3StorageAWSRetentionInvalidPeriodLockedBucket(t *testing.T) {
-	t.Parallel()
-
-	// skip the test if AWS creds are not provided
-	options := &Options{
-		Endpoint:        getEnv(testEndpointEnv, awsEndpoint),
-		AccessKeyID:     getEnvOrSkip(t, testAccessKeyIDEnv),
-		SecretAccessKey: getEnvOrSkip(t, testSecretAccessKeyEnv),
-		BucketName:      getEnvOrSkip(t, testLockedBucketEnv),
-		Region:          getEnvOrSkip(t, testRegionEnv),
-	}
-
-	createBucket(t, options)
-	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
-		RetentionMode:   minio.Governance.String(),
-		RetentionPeriod: time.Nanosecond,
+	t.Run("invalid period", func(t *testing.T) {
+		testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
+			RetentionMode:   minio.Governance.String(),
+			RetentionPeriod: time.Nanosecond,
+		})
 	})
 }
 

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -522,6 +522,9 @@ func getOrMakeBucket(tb testing.TB, cli *minio.Client, opt *Options, objectLocki
 
 	ctx := context.Background()
 
+	// check whether the bucket exists before attempting to create it to avoid
+	// and reduce the overall number of potentially expensive bucket creation
+	// calls.
 	if loc, err := cli.GetBucketLocation(ctx, opt.BucketName); err == nil {
 		tb.Log("found bucket", opt.BucketName, "in location", loc)
 

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -393,7 +392,7 @@ func TestNeedMD5AWS(t *testing.T) {
 	require.NoError(t, err, "could not create storage")
 
 	t.Cleanup(func() {
-		blobtesting.CleanupOldData(context.Background(), t, s, 0)
+		blobtesting.CleanupOldData(ctx, t, s, 0)
 	})
 
 	err = s.PutBlob(ctx, blob.ID("test-put-blob-0"), gather.FromSlice([]byte("xxyasdf243z")), blob.PutOptions{})
@@ -407,7 +406,7 @@ func testStorage(t *testing.T, options *Options, runValidationTest bool, opts bl
 
 	require.Equal(t, "", options.Prefix)
 
-	st0, err := New(testlogging.Context(t), options)
+	st0, err := New(ctx, options)
 	require.NoError(t, err)
 
 	defer st0.Close(ctx)
@@ -416,7 +415,7 @@ func testStorage(t *testing.T, options *Options, runValidationTest bool, opts bl
 
 	options.Prefix = uuid.NewString()
 
-	st, err := New(testlogging.Context(t), options)
+	st, err := New(ctx, options)
 	require.NoError(t, err)
 
 	defer st.Close(ctx)
@@ -438,7 +437,7 @@ func testPutBlobWithInvalidRetention(t *testing.T, options Options, opts blob.Pu
 	options.Prefix = uuid.NewString()
 
 	// non-retrying storage
-	st, err := newStorage(testlogging.Context(t), &options)
+	st, err := newStorage(ctx, &options)
 	require.NoError(t, err)
 
 	defer st.Close(ctx)
@@ -522,7 +521,7 @@ func getOrCreateBucket(tb testing.TB, opt *Options) {
 func getOrMakeBucket(tb testing.TB, cli *minio.Client, opt *Options, objectLocking bool) {
 	tb.Helper()
 
-	ctx := context.Background()
+	ctx := testlogging.Context(tb)
 
 	// check whether the bucket exists before attempting to create it to avoid
 	// and reduce the overall number of potentially expensive bucket creation

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -429,7 +429,7 @@ func testStorage(t *testing.T, options *Options, runValidationTest bool, opts bl
 	}
 }
 
-// nolint:thelper
+// nolint:thelper,gocritic
 func testPutBlobWithInvalidRetention(t *testing.T, options Options, opts blob.PutOptions) {
 	ctx := testlogging.Context(t)
 

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -195,9 +195,20 @@ func TestS3StorageAWSRetentionUnlockedBucket(t *testing.T) {
 	}
 
 	createBucket(t, options)
-	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
-		RetentionMode:   minio.Governance.String(),
-		RetentionPeriod: time.Hour * 24,
+
+	t.Run("valid period", func(t *testing.T) {
+		// expected to fail on non-locked buckets
+		testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
+			RetentionMode:   minio.Governance.String(),
+			RetentionPeriod: time.Hour * 24,
+		})
+	})
+
+	t.Run("invalid period", func(t *testing.T) {
+		testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
+			RetentionMode:   minio.Governance.String(),
+			RetentionPeriod: time.Nanosecond,
+		})
 	})
 }
 
@@ -217,25 +228,6 @@ func TestS3StorageAWSRetentionLockedBucket(t *testing.T) {
 	testStorage(t, options, false, blob.PutOptions{
 		RetentionMode:   minio.Governance.String(),
 		RetentionPeriod: time.Hour * 24,
-	})
-}
-
-func TestS3StorageAWSRetentionInvalidPeriod(t *testing.T) {
-	t.Parallel()
-
-	// skip the test if AWS creds are not provided
-	options := &Options{
-		Endpoint:        getEnv(testEndpointEnv, awsEndpoint),
-		AccessKeyID:     getEnvOrSkip(t, testAccessKeyIDEnv),
-		SecretAccessKey: getEnvOrSkip(t, testSecretAccessKeyEnv),
-		BucketName:      getEnvOrSkip(t, testBucketEnv),
-		Region:          getEnvOrSkip(t, testRegionEnv),
-	}
-
-	createBucket(t, options)
-	testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
-		RetentionMode:   minio.Governance.String(),
-		RetentionPeriod: time.Nanosecond,
 	})
 }
 

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -182,7 +182,7 @@ func TestS3StorageAWSSTS(t *testing.T) {
 	testStorage(t, options, false, blob.PutOptions{})
 }
 
-func TestS3StorageAWSRetentionUnversionedBucket(t *testing.T) {
+func TestS3StorageAWSRetentionUnlockedBucket(t *testing.T) {
 	t.Parallel()
 
 	// skip the test if AWS creds are not provided


### PR DESCRIPTION
Refactors retention tests to coalesce a couple of tests. It has the following effects:

- serializes the tests;
- reuses the bucket and reduces bucket creation calls.

Also, checks whether a bucket exists before attempting to create it to reduce the number of bucket creation calls.