### PR TITLE
logging: log maximum concurrency level when talking to backend storage

### DIFF
--- a/repo/blob/throttling/throttling_storage_test.go
+++ b/repo/blob/throttling/throttling_storage_test.go
@@ -63,6 +63,7 @@ func TestThrottling(t *testing.T) {
 	require.Equal(t, []string{
 		"BeforeOperation(GetBlob)",
 		"BeforeDownload(20000000)",
+		"inner.concurrency level reached",
 		"inner.GetBlob",
 		"ReturnUnusedDownloadBytes(20000000)",
 	}, m.activity)


### PR DESCRIPTION
Trying to understand if we're doing something wrong for #1560 