### PR TITLE
ui: add support for authentication using one-time tokens passed via URL

### DIFF
--- a/cli/command_server_tls.go
+++ b/cli/command_server_tls.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/server"
 	"github.com/kopia/kopia/internal/tlsutil"
 )
 
@@ -131,7 +132,7 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 		return errors.Wrap(httpServer.ServeTLS(listener, "", ""), "error starting TLS server")
 
 	default:
-		if !c.serverStartInsecure {
+		if !c.serverStartInsecure && !server.IsLocalhost(httpServer.Addr) {
 			return errors.Errorf("TLS not configured. To start server without encryption pass --insecure.")
 		}
 

--- a/internal/server/server_authz_checks.go
+++ b/internal/server/server_authz_checks.go
@@ -12,6 +12,13 @@ func requireUIUser(s *Server, r *http.Request) bool {
 		return true
 	}
 
+	if c, err := r.Cookie(kopiaUISessionCookie); err == nil && c != nil {
+		if remaining := s.isAuthCookieValid(s.options.UIUser, c.Value); remaining > 0 {
+			// found a short-term JWT cookie that matches given username, trust it.
+			return true
+		}
+	}
+
 	user, _, _ := r.BasicAuth()
 
 	return user == s.options.UIUser

--- a/internal/server/ui_token_login.go
+++ b/internal/server/ui_token_login.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/serverapi"
+)
+
+const (
+	// number of random bytes per UI token.
+	uiTokenLengthBytes = 16
+
+	// query string parameter to pass the UI token, when present, the server will redirect to
+	// URL without this query parameter and set the equivalent session cookie.
+	uiTokenLoginQueryParameter = "uiAuthToken"
+
+	// name of the cookie that grants user access to the UI without having to provide
+	// HTTP authentication.
+	kopiaUISessionCookie = "Kopia-UI-Session"
+)
+
+func (s *Server) sweepTokens(ctx context.Context) {
+	n := clock.Now()
+
+	s.pendingUITokens.Range(func(key, value interface{}) bool {
+		exp, _ := value.(time.Time)
+
+		if n.After(exp) {
+			if _, ok := s.pendingUITokens.LoadAndDelete(key); ok {
+				log(ctx).Debugw("removing unclaimed UI token", "expired", exp, "now", n)
+			}
+		}
+
+		return true
+	})
+}
+
+func (s *Server) generateUITokenLogin(ctx context.Context) (serverapi.UIAuthToken, error) {
+	if s.options.SingleUseUIAuthTokenTTL <= 0 {
+		return serverapi.UIAuthToken{}, errors.Errorf("UI token authentication is disabled")
+	}
+
+	var b [uiTokenLengthBytes]byte
+
+	_, err := io.ReadFull(rand.Reader, b[:])
+	if err != nil {
+		return serverapi.UIAuthToken{}, errors.Wrap(err, "unable to generate random token")
+	}
+
+	tok := hex.EncodeToString(b[:])
+	exp := clock.Now().Add(s.options.SingleUseUIAuthTokenTTL)
+
+	s.sweepTokens(ctx)
+	s.pendingUITokens.Store(tok, exp)
+
+	return serverapi.UIAuthToken{
+		Token:   tok,
+		Expires: exp,
+	}, nil
+}
+
+// checkAndInvalidateUIToken returns true if the provided token is valid and immediately
+// invalidates it.
+func (s *Server) checkAndInvalidateUIToken(token string) bool {
+	v, ok := s.pendingUITokens.LoadAndDelete(token)
+	if !ok {
+		return false
+	}
+
+	expireTime, _ := v.(time.Time)
+
+	return !clock.Now().After(expireTime)
+}
+
+func (s *Server) handleGenerateUIToken(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
+	// UI tokens only work for localhost.
+	if !IsLocalhost(r.Host) {
+		return nil, requestError(serverapi.ErrorMalformedRequest, "this API only supports localhost")
+	}
+
+	v, err := s.generateUITokenLogin(ctx)
+	if err != nil {
+		return nil, internalServerError(err)
+	}
+
+	return v, nil
+}
+
+// authenticateUsingUIToken checks if the request has `uiAuthToken` query string parameter,
+// and if it's present and valid, exchanges it with a short-term session cookie and redirects
+// to the same URL but without 'uiAuthToken' parameter.
+func (s *Server) authenticateUsingUIToken(ctx context.Context, w http.ResponseWriter, r *http.Request) bool {
+	// UI tokens only work for localhost.
+	if !IsLocalhost(r.Host) {
+		return false
+	}
+
+	q, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		log(ctx).Errorf("unable to parse URL query: %v", err)
+		return false
+	}
+
+	uitl := q.Get(uiTokenLoginQueryParameter)
+	if uitl == "" {
+		// no query parameter provided.
+		return false
+	}
+
+	if !s.checkAndInvalidateUIToken(uitl) {
+		log(ctx).Debugw("invalid UI login token", "token", uitl)
+		return false
+	}
+
+	s.setUIAuthorizedCookie(ctx, w)
+
+	q.Del(uiTokenLoginQueryParameter)
+	r.URL.RawQuery = q.Encode()
+
+	http.Redirect(w, r, r.URL.String(), http.StatusFound)
+
+	return true
+}
+
+func (s *Server) setUIAuthorizedCookie(ctx context.Context, w http.ResponseWriter) {
+	now := clock.Now()
+
+	ac, err := s.generateAuthCookie(s.options.UIUser, now, s.options.UISessionCookieTTL)
+	if err != nil {
+		log(ctx).Debugw("unable to generate UI auth cookie", "error", err)
+		return
+	}
+
+	c := &http.Cookie{
+		Name:     kopiaUISessionCookie,
+		Value:    ac,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Path:     "/",
+		Expires:  clock.Now().Add(s.options.UISessionCookieTTL),
+	}
+
+	http.SetCookie(w, c)
+}

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -256,3 +256,10 @@ type CLIInfo struct {
 type UIPreferences struct {
 	Theme string `json:"theme"` // 'dark', 'light' or ''
 }
+
+// UIAuthToken is a token for accessing the UI from localhost only.
+// The token expires immediately after use.
+type UIAuthToken struct {
+	Token   string    `json:"token"`
+	Expires time.Time `json:"expires"`
+}


### PR DESCRIPTION
This only works for http://localhost addresses and allows opening of
Kopia UI without the user having to log in.

The server maintains a set of short-lived, single-use tokens,
which are checked on each request. If a request arrives which has
`uiAuthToken` set to a valid token, it gets exchanged for a JWT session
cookie, which will authorize the UI user for the duration of the
session. Session cookie is short-lived and auto-extends on each request.

The server will invalidate the token immediately to prevent reuse.

One-time tokens can be generated by the new API: `POST /api/v1/ui-token`
and are valid for maximum of one minute, just enough to open web browser
to open the UI.

To enable this, pass `--ui-auth-token-ttl=30s` or similar duration.

The intended (FUTURE) flows are:

1. Kopia UI shell (this is similar to what KopiaUI does today but in a
   future without Electron we won't be able to auto-login and work with
   self-signed TLS, so we need to switch to http://localhost URIs)

   - ui shell launches kopia server on random port passing
     `--random-password` parameter and captures the random password as
    it's printed to stderr
   - it generates token by POST http://localhost:port/api/v1/ui-token
     authenticated as `kopia` with the password captured before
   - opens http://localhost:port/?uiAuthToken=<token> in user's browser

2. In the future we can add new flags that will start a one-off server
   and automatically open browser for certain CLI operations to avoid
   having to pass tons of flags in the CLI or to better visualize:

   `kopia repository connect --ui`
   `kopia snapshot list <source> --ui`
   `kopia policy edit <source> --ui`
