### PR TITLE
fix(security): prevent cross-site request forgery in the UI website

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/alecthomas/kingpin"
 	"github.com/fatih/color"
+	"github.com/gorilla/mux"
 	"github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
 
@@ -425,21 +426,21 @@ func (c *App) maybeRepositoryAction(act func(ctx context.Context, rep repo.Repos
 			defer gather.DumpStats(ctx)
 
 			if c.metricsListenAddr != "" {
-				mux := http.NewServeMux()
-				if err := initPrometheus(mux); err != nil {
+				m := mux.NewRouter()
+				if err := initPrometheus(m); err != nil {
 					return errors.Wrap(err, "unable to initialize prometheus.")
 				}
 
 				if c.enablePProf {
-					mux.HandleFunc("/debug/pprof/", pprof.Index)
-					mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-					mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-					mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-					mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+					m.HandleFunc("/debug/pprof/", pprof.Index)
+					m.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+					m.HandleFunc("/debug/pprof/profile", pprof.Profile)
+					m.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+					m.HandleFunc("/debug/pprof/trace", pprof.Trace)
 				}
 
 				log(ctx).Infof("starting prometheus metrics on %v", c.metricsListenAddr)
-				go http.ListenAndServe(c.metricsListenAddr, mux) // nolint:errcheck
+				go http.ListenAndServe(c.metricsListenAddr, m) // nolint:errcheck
 			}
 
 			memtrack.Dump(ctx, "before openRepository")

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -22,30 +24,61 @@ var log = logging.Module("client")
 type KopiaAPIClient struct {
 	BaseURL    string
 	HTTPClient *http.Client
+
+	CSRFToken string
 }
 
 // Get is a helper that performs HTTP GET on a URL with the specified suffix and decodes the response
 // onto respPayload which must be a pointer to byte slice or JSON-serializable structure.
 func (c *KopiaAPIClient) Get(ctx context.Context, urlSuffix string, onNotFound error, respPayload interface{}) error {
-	return c.runRequest(ctx, http.MethodGet, c.BaseURL+urlSuffix, onNotFound, nil, respPayload)
+	return c.runRequest(ctx, http.MethodGet, c.actualURL(urlSuffix), onNotFound, nil, respPayload)
 }
 
 // Post is a helper that performs HTTP POST on a URL with the specified body from reqPayload and decodes the response
 // onto respPayload which must be a pointer to byte slice or JSON-serializable structure.
 func (c *KopiaAPIClient) Post(ctx context.Context, urlSuffix string, reqPayload, respPayload interface{}) error {
-	return c.runRequest(ctx, http.MethodPost, c.BaseURL+urlSuffix, nil, reqPayload, respPayload)
+	return c.runRequest(ctx, http.MethodPost, c.actualURL(urlSuffix), nil, reqPayload, respPayload)
 }
 
 // Put is a helper that performs HTTP PUT on a URL with the specified body from reqPayload and decodes the response
 // onto respPayload which must be a pointer to byte slice or JSON-serializable structure.
 func (c *KopiaAPIClient) Put(ctx context.Context, urlSuffix string, reqPayload, respPayload interface{}) error {
-	return c.runRequest(ctx, http.MethodPut, c.BaseURL+urlSuffix, nil, reqPayload, respPayload)
+	return c.runRequest(ctx, http.MethodPut, c.actualURL(urlSuffix), nil, reqPayload, respPayload)
 }
 
 // Delete is a helper that performs HTTP DELETE on a URL with the specified body from reqPayload and decodes the response
 // onto respPayload which must be a pointer to byte slice or JSON-serializable structure.
 func (c *KopiaAPIClient) Delete(ctx context.Context, urlSuffix string, onNotFound error, reqPayload, respPayload interface{}) error {
-	return c.runRequest(ctx, http.MethodDelete, c.BaseURL+urlSuffix, onNotFound, reqPayload, respPayload)
+	return c.runRequest(ctx, http.MethodDelete, c.actualURL(urlSuffix), onNotFound, reqPayload, respPayload)
+}
+
+// FetchCSRFTokenForTesting fetches the CSRF token and session cookie for use when making subsequent calls to the API.
+// This simulates the browser behavior of downloading the "/" and is required to call the UI-only methods.
+func (c *KopiaAPIClient) FetchCSRFTokenForTesting(ctx context.Context) error {
+	var b []byte
+
+	if err := c.Get(ctx, "/", nil, &b); err != nil {
+		return err
+	}
+
+	re := regexp.MustCompile(`<meta name="kopia-csrf-token" content="(.*)" />`)
+
+	match := re.FindSubmatch(b)
+	if match == nil {
+		return errors.Errorf("CSRF token not found")
+	}
+
+	c.CSRFToken = string(match[1])
+
+	return nil
+}
+
+func (c *KopiaAPIClient) actualURL(suffix string) string {
+	if strings.HasPrefix(suffix, "/") {
+		return c.BaseURL + suffix
+	}
+
+	return c.BaseURL + "/api/v1/" + suffix
 }
 
 func (c *KopiaAPIClient) runRequest(ctx context.Context, method, url string, notFoundError error, reqPayload, respPayload interface{}) error {
@@ -57,6 +90,10 @@ func (c *KopiaAPIClient) runRequest(ctx context.Context, method, url string, not
 	req, err := http.NewRequestWithContext(ctx, method, url, payload)
 	if err != nil {
 		return errors.Wrap(err, "error creating request")
+	}
+
+	if c.CSRFToken != "" {
+		req.Header.Add("X-Kopia-Csrf-Token", c.CSRFToken)
 	}
 
 	if contentType != "" {
@@ -165,11 +202,12 @@ func NewKopiaAPIClient(options Options) (*KopiaAPIClient, error) {
 	}
 
 	return &KopiaAPIClient{
-		options.BaseURL + "/api/v1/",
+		options.BaseURL,
 		&http.Client{
 			Jar:       cj,
 			Transport: transport,
 		},
+		"",
 	}, nil
 }
 

--- a/internal/server/api_cli_test.go
+++ b/internal/server/api_cli_test.go
@@ -23,6 +23,7 @@ func TestCLIAPI(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
 
 	resp := &serverapi.CLIInfo{}
 	require.NoError(t, cli.Get(ctx, "cli", nil, resp))

--- a/internal/server/api_paths_test.go
+++ b/internal/server/api_paths_test.go
@@ -23,6 +23,7 @@ func TestPathsAPI(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
 
 	dir0 := testutil.TempDirectory(t)
 

--- a/internal/server/api_policies_test.go
+++ b/internal/server/api_policies_test.go
@@ -29,6 +29,7 @@ func TestPolicies(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
 
 	dir0 := testutil.TempDirectory(t)
 	si0 := localSource(env, dir0)

--- a/internal/server/api_sources_test.go
+++ b/internal/server/api_sources_test.go
@@ -30,6 +30,7 @@ func TestSnapshotCounters(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
 
 	dir := testutil.TempDirectory(t)
 	si := localSource(env, dir)
@@ -103,6 +104,7 @@ func TestSourceRefreshesAfterPolicy(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
 
 	dir := testutil.TempDirectory(t)
 	si := localSource(env, dir)

--- a/internal/server/api_ui_pref_test.go
+++ b/internal/server/api_ui_pref_test.go
@@ -23,6 +23,8 @@ func TestUIPreferences(t *testing.T) {
 
 	require.NoError(t, err)
 
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
 	var p, p2 serverapi.UIPreferences
 
 	require.NoError(t, cli.Get(ctx, "ui-preferences", nil, &p))

--- a/internal/server/server_authz_checks.go
+++ b/internal/server/server_authz_checks.go
@@ -2,14 +2,64 @@ package server
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"io"
 	"net/http"
 
 	"github.com/kopia/kopia/internal/auth"
 )
 
+const kopiaSessionCookie = "Kopia-Session-Cookie"
+
+func (s *Server) generateCSRFToken(sessionID string) string {
+	h := hmac.New(sha256.New, s.authCookieSigningKey)
+	io.WriteString(h, sessionID) //nolint:errcheck
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (s *Server) validateCSRFToken(r *http.Request) bool {
+	if s.options.DisableCSRFTokenChecks {
+		return true
+	}
+
+	ctx := r.Context()
+	path := r.URL.Path
+
+	sessionCookie, err := r.Cookie(kopiaSessionCookie)
+	if err != nil {
+		log(ctx).Warnf("missing or invalid session cookie for %v", path)
+
+		return false
+	}
+
+	validToken := s.generateCSRFToken(sessionCookie.Value)
+
+	token := r.Header.Get("X-Kopia-Csrf-Token")
+	if token == "" {
+		log(ctx).Warnf("missing CSRF token for %v", path)
+		return false
+	}
+
+	if subtle.ConstantTimeCompare([]byte(validToken), []byte(token)) == 1 {
+		return true
+	}
+
+	log(ctx).Warnf("got invalid CSRF token for %v: %v, want %v, session %v", path, token, validToken, sessionCookie.Value)
+
+	return false
+}
+
 func requireUIUser(s *Server, r *http.Request) bool {
 	if s.authenticator == nil {
 		return true
+	}
+
+	if s.options.UIUser == "" {
+		return false
 	}
 
 	user, _, _ := r.BasicAuth()
@@ -20,6 +70,10 @@ func requireUIUser(s *Server, r *http.Request) bool {
 func requireServerControlUser(s *Server, r *http.Request) bool {
 	if s.authenticator == nil {
 		return true
+	}
+
+	if s.options.ServerControlUser == "" {
+		return false
 	}
 
 	user, _, _ := r.BasicAuth()

--- a/internal/server/server_authz_checks_test.go
+++ b/internal/server/server_authz_checks_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateCSRFToken(t *testing.T) {
+	s1 := &Server{
+		authCookieSigningKey: []byte("some-key"),
+	}
+
+	s2 := &Server{
+		authCookieSigningKey: []byte("some-other-key"),
+	}
+
+	cases := []struct {
+		srv       *Server
+		session   string
+		wantToken string
+	}{
+		// CSRF token is a stable function of session ID and per-server so we can hardcode it
+		{s1, "session1", "557c279a9203afbd5e1edd8a3b091fbcaf699841cd95058954e11886f0a3e6d0"},
+		{s2, "session1", "7fd10608493e844581247d44e61de56b80df83ecdae49891f150823f73524ef7"},
+		{s1, "session2", "e3aeba64243485ac4664e27445f48711b987c3bf5c7e58d1b89eb1e2722fedcd"},
+		{s2, "session2", "714a124df0f6b6e79500fb06a900e7870a94f50b6d1e532c92a0abc0c63146f8"},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.wantToken, tc.srv.generateCSRFToken(tc.session))
+	}
+}
+
+func TestValidateCSRFToken(t *testing.T) {
+	s1 := &Server{
+		authCookieSigningKey: []byte("some-key"),
+	}
+
+	s2 := &Server{
+		authCookieSigningKey: []byte("some-other-key"),
+	}
+
+	s3 := &Server{
+		options: Options{
+			DisableCSRFTokenChecks: true,
+		},
+	}
+
+	cases := []struct {
+		srv     *Server
+		session string
+		token   string
+		valid   bool
+	}{
+		// valid
+		{s1, "session1", "557c279a9203afbd5e1edd8a3b091fbcaf699841cd95058954e11886f0a3e6d0", true},
+		{s2, "session1", "7fd10608493e844581247d44e61de56b80df83ecdae49891f150823f73524ef7", true},
+		{s1, "session2", "e3aeba64243485ac4664e27445f48711b987c3bf5c7e58d1b89eb1e2722fedcd", true},
+		{s2, "session2", "714a124df0f6b6e79500fb06a900e7870a94f50b6d1e532c92a0abc0c63146f8", true},
+
+		// invalid cases
+		{s1, "", "557c279a9203afbd5e1edd8a3b091fbcaf699841cd95058954e11886f0a3e6d0", false}, // missing session ID
+		{s1, "session2", "", false},        // missing token
+		{s2, "session2", "invalid", false}, // invalid token
+
+		// token is invalid but ignored, since 's3' does not validate tokens.
+		{s3, "", "557c279a9203afbd5e1edd8a3b091fbcaf699841cd95058954e11886f0a3e6d0", true},
+		{s3, "session2", "", true},
+		{s3, "session2", "invalid-token", true},
+	}
+
+	ctx := context.Background()
+
+	for i, tc := range cases {
+		tc := tc
+
+		t.Run(fmt.Sprintf("case-%v", i), func(t *testing.T) {
+			req, err := http.NewRequestWithContext(ctx, "GET", "/somepath", http.NoBody)
+			require.NoError(t, err)
+
+			if tc.session != "" {
+				req.AddCookie(&http.Cookie{
+					Name:  "Kopia-Session-Cookie",
+					Value: tc.session,
+				})
+			}
+
+			if tc.token != "" {
+				req.Header.Add("X-Kopia-Csrf-Token", tc.token)
+			}
+
+			require.Equal(t, tc.valid, tc.srv.validateCSRFToken(req))
+		})
+	}
+}


### PR DESCRIPTION
This fixes a [cross-site request forgery (CSRF)](https://en.wikipedia.org/wiki/Cross-site_request_forgery)
vulnerability in self-hosted UI for Kopia server.

The vulnerability allows potential attacker to make unauthorized API calls against a running Kopia server. It requires an attacker to trick the user into visiting a malicious website while also logged into a Kopia website.

The vulnerability only affected self-hosted Kopia servers with UI. The following configurations were not vulnerable:

* Kopia Repository Server without UI
* KopiaUI (desktop app)
* command-line usage of `kopia`

All users are strongly recommended to upgrade at the earliest convenience.