### PR TITLE
feat(providers): expand PutBlob API to allow for idempotent puts

### DIFF
--- a/cli/command_repository_validate_provider.go
+++ b/cli/command_repository_validate_provider.go
@@ -23,6 +23,7 @@ func (c *commandRepositoryValidateProvider) setup(svc advancedAppServices, paren
 	cmd.Flag("put-blob-workers", "Number of PutBlob workers").IntVar(&c.opt.NumPutBlobWorkers)
 	cmd.Flag("get-blob-workers", "Number of GetBlob workers").IntVar(&c.opt.NumGetBlobWorkers)
 	cmd.Flag("get-metadata-workers", "Number of GetMetadata workers").IntVar(&c.opt.NumGetMetadataWorkers)
+	cmd.Flag("support-idempotent-creates", "Whether store supports idempotent blob creates").BoolVar(&c.opt.SupportIdempotentCreates)
 	c.out.setup(svc)
 
 	cmd.Action(c.out.svc.directRepositoryWriteAction(c.run))

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -76,8 +76,11 @@ func (s *mapStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata
 }
 
 func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
-	if opts.HasRetentionOptions() {
+	switch {
+	case opts.HasRetentionOptions():
 		return errors.New("setting blob-retention is not supported")
+	case opts.DoNotRecreate:
+		return errors.New("setting blob do-not-recreate is not supported")
 	}
 
 	s.mutex.Lock()

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -78,9 +78,9 @@ func (s *mapStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata
 func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	switch {
 	case opts.HasRetentionOptions():
-		return errors.New("setting blob-retention is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob-retention")
 	case opts.DoNotRecreate:
-		return errors.New("setting blob do-not-recreate is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "do-not-recreate")
 	}
 
 	s.mutex.Lock()

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -190,8 +190,8 @@ func ValidateProvider(ctx context.Context, st blob.Storage, opt Options) error {
 
 	if !opt.SupportIdempotentCreates {
 		err := st.PutBlob(ctx, "dummy_id", gather.FromSlice([]byte{99}), blob.PutOptions{DoNotRecreate: true})
-		if err == nil {
-			return errors.New("store should not support put-blob-no-overwrite, expected error")
+		if !errors.As(err, &blob.ErrUnsupportedPutBlobOption) {
+			return errors.Errorf("expected error 'unsupported put-blob option', but got %v", err)
 		}
 	}
 

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -111,8 +111,11 @@ func translateError(err error) error {
 }
 
 func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
-	if opts.HasRetentionOptions() {
+	switch {
+	case opts.HasRetentionOptions():
 		return errors.New("setting blob-retention is not supported")
+	case opts.DoNotRecreate:
+		return errors.New("setting blob do-not-recreate is not supported")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -113,9 +113,9 @@ func translateError(err error) error {
 func (az *azStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	switch {
 	case opts.HasRetentionOptions():
-		return errors.New("setting blob-retention is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob-retention")
 	case opts.DoNotRecreate:
-		return errors.New("setting blob do-not-recreate is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "do-not-recreate")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -154,9 +154,9 @@ func (fs *fsImpl) GetMetadataFromPath(ctx context.Context, dirPath, path string)
 func (fs *fsImpl) PutBlobInPath(ctx context.Context, dirPath, path string, data blob.Bytes, opts blob.PutOptions) error {
 	switch {
 	case opts.HasRetentionOptions():
-		return errors.New("setting blob-retention is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob-retention")
 	case opts.DoNotRecreate:
-		return errors.New("setting blob do-not-recreate is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "do-not-recreate")
 	}
 
 	return retry.WithExponentialBackoffNoValue(ctx, "PutBlobInPath:"+path, func() error {

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -150,8 +150,15 @@ func (fs *fsImpl) GetMetadataFromPath(ctx context.Context, dirPath, path string)
 	return v.(blob.Metadata), nil //nolint:forcetypeassert
 }
 
+//nolint:wrapcheck,gocyclo
 func (fs *fsImpl) PutBlobInPath(ctx context.Context, dirPath, path string, data blob.Bytes, opts blob.PutOptions) error {
-	// nolint:wrapcheck
+	switch {
+	case opts.HasRetentionOptions():
+		return errors.New("setting blob-retention is not supported")
+	case opts.DoNotRecreate:
+		return errors.New("setting blob do-not-recreate is not supported")
+	}
+
 	return retry.WithExponentialBackoffNoValue(ctx, "PutBlobInPath:"+path, func() error {
 		randSuffix := make([]byte, tempFileRandomSuffixLen)
 		if _, err := rand.Read(randSuffix); err != nil {

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -100,8 +100,11 @@ func translateError(err error) error {
 }
 
 func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
-	if opts.HasRetentionOptions() {
+	switch {
+	case opts.HasRetentionOptions():
 		return errors.New("setting blob-retention is not supported")
+	case opts.DoNotRecreate:
+		return errors.New("setting blob do-not-recreate is not supported")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -84,8 +84,11 @@ func translateError(err error) error {
 	var ae *googleapi.Error
 
 	if errors.As(err, &ae) {
-		if ae.Code == http.StatusRequestedRangeNotSatisfiable {
+		switch ae.Code {
+		case http.StatusRequestedRangeNotSatisfiable:
 			return blob.ErrInvalidRange
+		case http.StatusPreconditionFailed:
+			return blob.ErrBlobAlreadyExists
 		}
 	}
 
@@ -109,7 +112,8 @@ func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, 
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	obj := gcs.bucket.Object(gcs.getObjectNameString(b))
+	conds := gcsclient.Conditions{DoesNotExist: opts.DoNotRecreate}
+	obj := gcs.bucket.Object(gcs.getObjectNameString(b)).If(conds)
 	writer := obj.NewWriter(ctx)
 	writer.ChunkSize = writerChunkSize
 	writer.ContentType = "application/x-kopia"

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -105,9 +105,9 @@ func translateError(err error) error {
 func (gcs *gcsStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	switch {
 	case opts.HasRetentionOptions():
-		return errors.New("setting blob-retention is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob-retention")
 	case opts.DoNotRecreate:
-		return errors.New("setting blob do-not-recreate is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "do-not-recreate")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -44,7 +44,15 @@ func TestGCSStorage(t *testing.T) {
 	defer st.Close(ctx)
 	defer blobtesting.CleanupOldData(ctx, t, st, 0)
 
-	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
+	options := []blob.PutOptions{
+		{},
+		{DoNotRecreate: true},
+	}
+
+	for _, opt := range options {
+		blobtesting.VerifyStorage(ctx, t, st, opt)
+	}
+
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
 	validateOpts := blobtesting.TestValidationOptions
 	validateOpts.SupportIdempotentCreates = true

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -46,7 +46,9 @@ func TestGCSStorage(t *testing.T) {
 
 	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
-	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
+	validateOpts := blobtesting.TestValidationOptions
+	validateOpts.SupportIdempotentCreates = true
+	require.NoError(t, providervalidation.ValidateProvider(ctx, st, validateOpts))
 }
 
 func TestGCSStorageInvalid(t *testing.T) {

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -71,6 +71,9 @@ func isRetriable(err error) bool {
 	case errors.Is(err, blob.ErrSetTimeUnsupported):
 		return false
 
+	case errors.Is(err, blob.ErrBlobAlreadyExists):
+		return false
+
 	default:
 		return true
 	}

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -124,7 +124,7 @@ func (s *s3Storage) getVersionMetadata(ctx context.Context, b blob.ID, version s
 func (s *s3Storage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	switch {
 	case opts.DoNotRecreate:
-		return errors.New("setting blob do-not-recreate is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "do-not-recreate")
 	case !opts.SetModTime.IsZero():
 		return blob.ErrSetTimeUnsupported
 	}

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -122,7 +122,10 @@ func (s *s3Storage) getVersionMetadata(ctx context.Context, b blob.ID, version s
 }
 
 func (s *s3Storage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
-	if !opts.SetModTime.IsZero() {
+	switch {
+	case opts.DoNotRecreate:
+		return errors.New("setting blob do-not-recreate is not supported")
+	case !opts.SetModTime.IsZero():
 		return blob.ErrSetTimeUnsupported
 	}
 

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -173,9 +173,9 @@ func (s *sftpImpl) GetMetadataFromPath(ctx context.Context, dirPath, fullPath st
 func (s *sftpImpl) PutBlobInPath(ctx context.Context, dirPath, fullPath string, data blob.Bytes, opts blob.PutOptions) error {
 	switch {
 	case opts.HasRetentionOptions():
-		return errors.New("setting blob-retention is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob-retention")
 	case opts.DoNotRecreate:
-		return errors.New("setting blob do-not-recreate is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "do-not-recreate")
 	}
 
 	// nolint:wrapcheck

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -171,6 +171,13 @@ func (s *sftpImpl) GetMetadataFromPath(ctx context.Context, dirPath, fullPath st
 }
 
 func (s *sftpImpl) PutBlobInPath(ctx context.Context, dirPath, fullPath string, data blob.Bytes, opts blob.PutOptions) error {
+	switch {
+	case opts.HasRetentionOptions():
+		return errors.New("setting blob-retention is not supported")
+	case opts.DoNotRecreate:
+		return errors.New("setting blob do-not-recreate is not supported")
+	}
+
 	// nolint:wrapcheck
 	return s.rec.UsingConnectionNoResult(ctx, "PutBlobInPath", func(conn connection.Connection) error {
 		randSuffix := make([]byte, tempFileRandomSuffixLen)

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -178,13 +178,6 @@ func (s *Storage) GetMetadata(ctx context.Context, blobID blob.ID) (blob.Metadat
 
 // PutBlob implements blob.Storage.
 func (s *Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.PutOptions) error {
-	switch {
-	case opts.HasRetentionOptions():
-		return errors.New("setting blob-retention is not supported")
-	case opts.DoNotRecreate:
-		return errors.New("setting blob do-not-recreate is not supported")
-	}
-
 	dirPath, filePath, err := s.GetShardedPathAndFilePath(ctx, blobID)
 	if err != nil {
 		return errors.Wrap(err, "error determining sharded path")

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -178,8 +178,11 @@ func (s *Storage) GetMetadata(ctx context.Context, blobID blob.ID) (blob.Metadat
 
 // PutBlob implements blob.Storage.
 func (s *Storage) PutBlob(ctx context.Context, blobID blob.ID, data blob.Bytes, opts blob.PutOptions) error {
-	if opts.HasRetentionOptions() {
+	switch {
+	case opts.HasRetentionOptions():
 		return errors.New("setting blob-retention is not supported")
+	case opts.DoNotRecreate:
+		return errors.New("setting blob do-not-recreate is not supported")
 	}
 
 	dirPath, filePath, err := s.GetShardedPathAndFilePath(ctx, blobID)

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -17,6 +17,9 @@ var ErrSetTimeUnsupported = errors.Errorf("SetTime is not supported")
 // ErrInvalidRange is returned when the requested blob offset or length is invalid.
 var ErrInvalidRange = errors.Errorf("invalid blob offset or length")
 
+// ErrBlobAlreadyExists is returned when attempting to put a blob that already exists.
+var ErrBlobAlreadyExists = errors.New("blob already exists")
+
 // Bytes encapsulates a sequence of bytes, possibly stored in a non-contiguous buffers,
 // which can be written sequentially or treated as a io.Reader.
 type Bytes interface {
@@ -81,6 +84,9 @@ func (r RetentionMode) IsValid() bool {
 type PutOptions struct {
 	RetentionMode   RetentionMode
 	RetentionPeriod time.Duration
+
+	// if true, PutBlob will fail with ErrBlobAlreadyExists if a blob with the same ID exists.
+	DoNotRecreate bool
 
 	// if not empty, set the provided timestamp on the blob instead of server-assigned,
 	// if unsupported by the server return ErrSetTimeUnsupported

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -20,6 +20,10 @@ var ErrInvalidRange = errors.Errorf("invalid blob offset or length")
 // ErrBlobAlreadyExists is returned when attempting to put a blob that already exists.
 var ErrBlobAlreadyExists = errors.New("blob already exists")
 
+// ErrUnsupportedPutBlobOption is returned when a PutBlob option that is not supported
+// by an implementation of Storage is specified in a PutBlob call.
+var ErrUnsupportedPutBlobOption = errors.New("unsupported put-blob option")
+
 // Bytes encapsulates a sequence of bytes, possibly stored in a non-contiguous buffers,
 // which can be written sequentially or treated as a io.Reader.
 type Bytes interface {

--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -136,9 +136,9 @@ func (d *davStorageImpl) ReadDir(ctx context.Context, dir string) ([]os.FileInfo
 func (d *davStorageImpl) PutBlobInPath(ctx context.Context, dirPath, filePath string, data blob.Bytes, opts blob.PutOptions) error {
 	switch {
 	case opts.HasRetentionOptions():
-		return errors.New("setting blob-retention is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob-retention")
 	case opts.DoNotRecreate:
-		return errors.New("setting blob do-not-recreate is not supported")
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "do-not-recreate")
 	}
 
 	if !opts.SetModTime.IsZero() {

--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -134,6 +134,13 @@ func (d *davStorageImpl) ReadDir(ctx context.Context, dir string) ([]os.FileInfo
 }
 
 func (d *davStorageImpl) PutBlobInPath(ctx context.Context, dirPath, filePath string, data blob.Bytes, opts blob.PutOptions) error {
+	switch {
+	case opts.HasRetentionOptions():
+		return errors.New("setting blob-retention is not supported")
+	case opts.DoNotRecreate:
+		return errors.New("setting blob do-not-recreate is not supported")
+	}
+
 	if !opts.SetModTime.IsZero() {
 		return blob.ErrSetTimeUnsupported
 	}


### PR DESCRIPTION
Today, executing a PutBlob operation will always overwrite a blob if it exists. It would be helpful for some customer workflows to be able to write blobs only if they don't exist (i.e. don't overwrite/recreate blobs). This PR expands the PutBlob API with an additional option `DoNotRecreate`, which toggles this feature. Note that not all backends support idempotent creates, so this PR also implements error logic to rejects such PutBlobs if they can't be executed.