### PR TITLE
fix(ci): fix regression when publishing APT repository

### DIFF
--- a/tools/apt-publish.sh
+++ b/tools/apt-publish.sh
@@ -118,7 +118,7 @@ echo Generating Release files
 # generate Release/InRelease/Release.gpg files for all distributions
 for d in $distributions; do
   echo Generating $WORK_DIR/dists/$d/Release...
-  apt-ftparchive release \
+  docker run -i --rm -v $WORK_DIR/dists/$d:/root marshallofsound/apt-ftparchive release \
     -o APT::FTPArchive::Release::Architectures="$architectures" \
     -o APT::FTPArchive::Release::Codename="$d" \
     -o APT::FTPArchive::Release::Suite="$d" \


### PR DESCRIPTION
Fixes #1657

`stable` and `testing` repos have been updated, merging this will fix `unstable` too.