### PR TITLE
feat(providers): improved sharded directory creation

### DIFF
--- a/internal/dirutil/mksubdirall.go
+++ b/internal/dirutil/mksubdirall.go
@@ -1,0 +1,75 @@
+// Package dirutil contains directory manipulation helpers.
+package dirutil
+
+import (
+	"io/fs"
+
+	"github.com/pkg/errors"
+)
+
+// ErrTopLevelDirectoryNotFound is returned by MkSubdir if the top-level directory is not found.
+var ErrTopLevelDirectoryNotFound = errors.New("top-level directory not found")
+
+// OSInterface represents operating system functions used by MkSubdirAll.
+type OSInterface interface {
+	Mkdir(dirname string, perm fs.FileMode) error
+	IsExist(err error) bool
+	IsNotExist(err error) bool
+	IsPathSeparator(s byte) bool
+}
+
+// MkSubdirAll is like os.MkdirAll(subDir, perm) but will only create missing subdirectories of topLevelDir (but not topLevelDir itself).
+// If a top-level directory is unmounted, we want to avoid recreating it, which is what os.MkdirAll() does.
+func MkSubdirAll(osi OSInterface, topLevelDir, subDir string, perm fs.FileMode) error {
+	topLevelDir = trimTrailingSeparator(osi, topLevelDir)
+	subDir = trimTrailingSeparator(osi, subDir)
+
+	if len(subDir) <= len(topLevelDir) {
+		return errors.Wrapf(ErrTopLevelDirectoryNotFound, "can't re-create top-level directory %v", topLevelDir)
+	}
+
+	err := osi.Mkdir(subDir, perm)
+	if osi.IsNotExist(err) {
+		// parent does not exist, recursively create it
+		if perr := MkSubdirAll(osi, topLevelDir, getParent(osi, subDir), perm); perr != nil {
+			return perr
+		}
+
+		// try to create the subdir again
+		err = osi.Mkdir(subDir, perm)
+	}
+
+	switch {
+	case err == nil:
+		// created subdir, which means parent exists, all good.
+		return nil
+
+	case osi.IsExist(err):
+		// got an error indicating the directory exists, all good.
+		return nil
+
+	default:
+		return errors.Wrap(err, "unexpected error creating directory")
+	}
+}
+
+func trimTrailingSeparator(osi OSInterface, s string) string {
+	p := len(s)
+
+	for p > 0 && osi.IsPathSeparator(s[p-1]) {
+		p--
+	}
+
+	return s[0:p]
+}
+
+func getParent(osi OSInterface, s string) string {
+	s = trimTrailingSeparator(osi, s)
+	p := len(s)
+
+	for p > 0 && !osi.IsPathSeparator(s[p-1]) {
+		p--
+	}
+
+	return trimTrailingSeparator(osi, s[0:p])
+}

--- a/internal/dirutil/mssubdirall_test.go
+++ b/internal/dirutil/mssubdirall_test.go
@@ -1,0 +1,65 @@
+package dirutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/dirutil"
+	"github.com/kopia/kopia/internal/testutil"
+)
+
+type testOSI struct {
+	t        *testing.T
+	mkdirErr error
+}
+
+func (testOSI) IsPathSeparator(c byte) bool { return os.IsPathSeparator(c) }
+func (testOSI) IsExist(err error) bool      { return os.IsExist(err) }
+func (testOSI) IsNotExist(err error) bool   { return os.IsNotExist(err) }
+func (r testOSI) Mkdir(name string, perm os.FileMode) error {
+	if r.mkdirErr != nil {
+		r.t.Logf("returning error for %v", name)
+		return r.mkdirErr
+	}
+
+	r.t.Logf("creating %v", name)
+
+	return os.Mkdir(name, perm)
+}
+
+func TestMkSubdirAll(t *testing.T) {
+	osi := testOSI{t, nil}
+
+	td := testutil.TempDirectory(t)
+
+	// notice - cases are evaluated in order
+	cases := []struct {
+		topLevelDir string
+		subDir      string
+		wantErr     error
+	}{
+		{td, td, dirutil.ErrTopLevelDirectoryNotFound},
+		{filepath.Join(td, "subdir2"), td, dirutil.ErrTopLevelDirectoryNotFound},
+		{td, filepath.Join(td, "subdir1"), nil},            // will create one subdirectory
+		{td, filepath.Join(td, "subdir2", "subdir3"), nil}, // will create two subdirectories
+		{td, filepath.Join(td, "subdir2"), nil},            // already exists
+	}
+
+	for _, tc := range cases {
+		err := dirutil.MkSubdirAll(osi, tc.topLevelDir, tc.subDir, 0o755)
+		if tc.wantErr == nil {
+			require.NoError(t, err)
+			require.DirExists(t, tc.subDir)
+		} else {
+			require.ErrorIs(t, err, tc.wantErr)
+		}
+	}
+
+	osi.mkdirErr = errors.Errorf("some error")
+
+	require.ErrorIs(t, dirutil.MkSubdirAll(osi, td, filepath.Join(td, "somedir4"), 0o755), osi.mkdirErr)
+}

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/dirutil"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/repo/blob"
@@ -210,7 +211,7 @@ func (fs *fsImpl) PutBlobInPath(ctx context.Context, dirPath, path string, data 
 func (fs *fsImpl) createTempFileAndDir(tempFile string) (osWriteFile, error) {
 	f, err := fs.osi.CreateNewFile(tempFile, fs.fileMode())
 	if fs.osi.IsNotExist(err) {
-		if err = fs.osi.MkdirAll(filepath.Dir(tempFile), fs.dirMode()); err != nil {
+		if err = dirutil.MkSubdirAll(fs.osi, fs.Path, filepath.Dir(tempFile), fs.dirMode()); err != nil {
 			return nil, errors.Wrap(err, "cannot create directory")
 		}
 

--- a/repo/blob/filesystem/osinterface.go
+++ b/repo/blob/filesystem/osinterface.go
@@ -14,11 +14,13 @@ type osInterface interface {
 	IsExist(err error) bool
 	IsPathError(err error) bool
 	IsLinkError(err error) bool
+	IsPathSeparator(c byte) bool
 	Remove(fname string) error
 	Rename(oldname, newname string) error
 	ReadDir(dirname string) ([]fs.DirEntry, error)
 	Stat(fname string) (os.FileInfo, error)
 	CreateNewFile(fname string, mode os.FileMode) (osWriteFile, error)
+	Mkdir(fname string, mode os.FileMode) error
 	MkdirAll(fname string, mode os.FileMode) error
 	Chtimes(fname string, atime, mtime time.Time) error
 	Geteuid() int

--- a/repo/blob/filesystem/osinterface_mock_test.go
+++ b/repo/blob/filesystem/osinterface_mock_test.go
@@ -55,6 +55,8 @@ func (osi *mockOS) Rename(oldname, newname string) error {
 	return osi.osInterface.Rename(oldname, newname)
 }
 
+func (osi *mockOS) IsPathSeparator(c byte) bool { return os.IsPathSeparator(c) }
+
 func (osi *mockOS) ReadDir(dirname string) ([]fs.DirEntry, error) {
 	if atomic.AddInt32(&osi.readDirRemainingErrors, -1) >= 0 {
 		return nil, &os.PathError{Op: "readdir", Err: errors.Errorf("underlying problem")}
@@ -137,12 +139,12 @@ func (osi *mockOS) CreateNewFile(fname string, perm os.FileMode) (osWriteFile, e
 	return wf, nil
 }
 
-func (osi *mockOS) MkdirAll(fname string, mode os.FileMode) error {
+func (osi *mockOS) Mkdir(fname string, mode os.FileMode) error {
 	if atomic.AddInt32(&osi.mkdirAllRemainingErrors, -1) >= 0 {
 		return &os.PathError{Op: "mkdir", Err: errors.Errorf("underlying problem")}
 	}
 
-	return osi.osInterface.MkdirAll(fname, mode)
+	return osi.osInterface.Mkdir(fname, mode)
 }
 
 func (osi *mockOS) Geteuid() int {

--- a/repo/blob/filesystem/osinterface_realos.go
+++ b/repo/blob/filesystem/osinterface_realos.go
@@ -24,6 +24,8 @@ func (realOS) IsNotExist(err error) bool { return os.IsNotExist(err) }
 
 func (realOS) IsExist(err error) bool { return os.IsExist(err) }
 
+func (realOS) IsPathSeparator(c byte) bool { return os.IsPathSeparator(c) }
+
 func (realOS) Rename(oldname, newname string) error {
 	// nolint:wrapcheck
 	return os.Rename(oldname, newname)
@@ -59,6 +61,11 @@ func (realOS) Stat(fname string) (os.FileInfo, error) {
 func (realOS) CreateNewFile(fname string, perm os.FileMode) (osWriteFile, error) {
 	// nolint:wrapcheck,gosec
 	return os.OpenFile(fname, os.O_CREATE|os.O_EXCL|os.O_WRONLY, perm)
+}
+
+func (realOS) Mkdir(fname string, mode os.FileMode) error {
+	// nolint:wrapcheck
+	return os.Mkdir(fname, mode)
 }
 
 func (realOS) MkdirAll(fname string, mode os.FileMode) error {


### PR DESCRIPTION
When a sharded directory is missing do not attempt to create all
its parents, but only children of the repository root.

This way when a top-level directory is unmounted, we won't recreate
it unnecessarily.

This is implemented for filesystem and SFTP providers.