### PR TITLE
Fail when opening an uninitialized repo

### DIFF
--- a/repo/open.go
+++ b/repo/open.go
@@ -159,6 +159,17 @@ func openDirect(ctx context.Context, configFile string, lc *LocalConfig, passwor
 		return nil, errors.Wrap(err, "cannot open storage")
 	}
 
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	if err = st.GetBlob(ctx, FormatBlobID, 0, -1, &tmp); err != nil {
+		if errors.Is(err, blob.ErrBlobNotFound) {
+			return nil, errors.Errorf("repository not initialized")
+		}
+
+		return nil, errors.Wrap(err, "unable to read format blob")
+	}
+
 	if options.TraceStorage {
 		st = loggingwrapper.NewWrapper(st, log(ctx), "[STORAGE] ")
 	}


### PR DESCRIPTION
Fix for #9.

This is my first work in this project and my first time using Go, so hopefully this is the right way to go about this. Let me know if not and I'm happy to fix it.

It seemed to make sense to do this check whenever opening a "direct" repo, not just when creating a snapshot - I couldn't think of a situation where you'd want to have an opened repo that didn't exist.