### PR TITLE
feat(cli): allow changing retention parameters from cli

### DIFF
--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -90,6 +90,12 @@ func (c *commandRepositoryStatus) run(ctx context.Context, rep repo.Repository) 
 		c.out.printStdout("Epoch Manager:       disabled\n")
 	}
 
+	if blobcfg := dr.BlobCfg(); blobcfg.IsRetentionEnabled() {
+		c.out.printStdout("\n")
+		c.out.printStdout("Blob retention mode:     %s\n", blobcfg.RetentionMode)
+		c.out.printStdout("Blob retention period:   %s\n", blobcfg.RetentionPeriod)
+	}
+
 	if !c.statusReconnectToken {
 		return nil
 	}

--- a/repo/blobcfg_blob.go
+++ b/repo/blobcfg_blob.go
@@ -1,56 +1,49 @@
 package repo
 
 import (
+	"context"
 	"encoding/json"
-	"time"
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/content"
 )
 
 // BlobCfgBlobID is the identifier of a BLOB that describes BLOB retention
 // settings for the repository.
 const BlobCfgBlobID = "kopia.blobcfg"
 
-type blobCfgBlob struct {
-	RetentionMode   blob.RetentionMode `json:"retentionMode,omitempty"`
-	RetentionPeriod time.Duration      `json:"retentionPeriod,omitempty"`
-}
-
-func (r *blobCfgBlob) IsRetentionEnabled() bool {
-	return r.RetentionMode != "" && r.RetentionPeriod != 0
-}
-
-func blobCfgBlobFromOptions(opt *NewRepositoryOptions) *blobCfgBlob {
-	return &blobCfgBlob{
+func blobCfgBlobFromOptions(opt *NewRepositoryOptions) content.BlobCfgBlob {
+	return content.BlobCfgBlob{
 		RetentionMode:   opt.RetentionMode,
 		RetentionPeriod: opt.RetentionPeriod,
 	}
 }
 
-func serializeBlobCfgBytes(f *formatBlob, r *blobCfgBlob, masterKey []byte) ([]byte, error) {
-	content, err := json.Marshal(r)
+func serializeBlobCfgBytes(f *formatBlob, r content.BlobCfgBlob, masterKey []byte) ([]byte, error) {
+	data, err := json.Marshal(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't marshal blobCfgBlob to JSON")
 	}
 
 	switch f.EncryptionAlgorithm {
 	case "NONE":
-		return content, nil
+		return data, nil
 
 	case aes256GcmEncryption:
-		return encryptRepositoryBlobBytesAes256Gcm(content, masterKey, f.UniqueID)
+		return encryptRepositoryBlobBytesAes256Gcm(data, masterKey, f.UniqueID)
 
 	default:
 		return nil, errors.Errorf("unknown encryption algorithm: '%v'", f.EncryptionAlgorithm)
 	}
 }
 
-func deserializeBlobCfgBytes(f *formatBlob, encryptedBlobCfgBytes, masterKey []byte) (blobCfgBlob, error) {
+func deserializeBlobCfgBytes(f *formatBlob, encryptedBlobCfgBytes, masterKey []byte) (content.BlobCfgBlob, error) {
 	var (
 		plainText []byte
-		r         blobCfgBlob
+		r         content.BlobCfgBlob
 		err       error
 	)
 
@@ -65,16 +58,32 @@ func deserializeBlobCfgBytes(f *formatBlob, encryptedBlobCfgBytes, masterKey []b
 	case aes256GcmEncryption:
 		plainText, err = decryptRepositoryBlobBytesAes256Gcm(encryptedBlobCfgBytes, masterKey, f.UniqueID)
 		if err != nil {
-			return blobCfgBlob{}, errors.Errorf("unable to decrypt repository retention blob")
+			return content.BlobCfgBlob{}, errors.Errorf("unable to decrypt repository blobcfg blob")
 		}
 
 	default:
-		return blobCfgBlob{}, errors.Errorf("unknown encryption algorithm: '%v'", f.EncryptionAlgorithm)
+		return content.BlobCfgBlob{}, errors.Errorf("unknown encryption algorithm: '%v'", f.EncryptionAlgorithm)
 	}
 
 	if err = json.Unmarshal(plainText, &r); err != nil {
-		return blobCfgBlob{}, errors.Wrap(err, "invalid repository retention blob")
+		return content.BlobCfgBlob{}, errors.Wrap(err, "invalid repository blobcfg blob")
 	}
 
 	return r, nil
+}
+
+func writeBlobCfgBlob(ctx context.Context, st blob.Storage, f *formatBlob, blobcfg content.BlobCfgBlob, formatEncryptionKey []byte) error {
+	blobCfgBytes, err := serializeBlobCfgBytes(f, blobcfg, formatEncryptionKey)
+	if err != nil {
+		return errors.Wrap(err, "unable to encrypt blobcfg bytes")
+	}
+
+	if err := st.PutBlob(ctx, BlobCfgBlobID, gather.FromSlice(blobCfgBytes), blob.PutOptions{
+		RetentionMode:   blobcfg.RetentionMode,
+		RetentionPeriod: blobcfg.RetentionPeriod,
+	}); err != nil {
+		return errors.Wrapf(err, "PutBlob() failed for %q", BlobCfgBlobID)
+	}
+
+	return nil
 }

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -95,20 +95,8 @@ func Initialize(ctx context.Context, st blob.Storage, opt *NewRepositoryOptions,
 		return errors.Wrap(err, "unable to encrypt format bytes")
 	}
 
-	if blobcfg.IsRetentionEnabled() {
-		retentionBytes, err := serializeBlobCfgBytes(format, blobcfg, formatEncryptionKey)
-		if err != nil {
-			return errors.Wrap(err, "unable to encrypt blobcfg bytes")
-		}
-
-		// Write the blobcfg blob first so that we'll consider the repository
-		// corrupted if writing the format blob fails later.
-		if err := st.PutBlob(ctx, BlobCfgBlobID, gather.FromSlice(retentionBytes), blob.PutOptions{
-			RetentionMode:   blobcfg.RetentionMode,
-			RetentionPeriod: blobcfg.RetentionPeriod,
-		}); err != nil {
-			return errors.Wrap(err, "unable to write blobcfg blob")
-		}
+	if err := writeBlobCfgBlob(ctx, st, format, blobcfg, formatEncryptionKey); err != nil {
+		return errors.Wrap(err, "unable to write blobcfg blob")
 	}
 
 	if err := writeFormatBlob(ctx, st, format, blobcfg); err != nil {

--- a/repo/maintenance/blob_gc_test.go
+++ b/repo/maintenance/blob_gc_test.go
@@ -58,7 +58,7 @@ func (s *formatSpecificTestSuite) TestDeleteUnreferencedBlobs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := len(blobsBefore), 3; got != want {
+	if got, want := len(blobsBefore), 4; got != want {
 		t.Fatalf("unexpected number of blobs after writing: %v", blobsBefore)
 	}
 

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -45,6 +45,7 @@ type DirectRepository interface {
 	Repository
 
 	ObjectFormat() object.Format
+	BlobCfg() content.BlobCfgBlob
 	BlobReader() blob.Reader
 	ContentReader() content.Reader
 	IndexBlobs(ctx context.Context, includeInactive bool) ([]content.IndexBlobInfo, error)
@@ -66,7 +67,7 @@ type DirectRepositoryWriter interface {
 
 	BlobStorage() blob.Storage
 	ContentManager() *content.WriteManager
-	SetParameters(ctx context.Context, m content.MutableParameters) error
+	SetParameters(ctx context.Context, m content.MutableParameters, blobcfg content.BlobCfgBlob) error
 	ChangePassword(ctx context.Context, newPassword string) error
 }
 
@@ -77,7 +78,7 @@ type directRepositoryParameters struct {
 	cliOpts             ClientOptions
 	timeNow             func() time.Time
 	formatBlob          *formatBlob
-	blobCfgBlob         *blobCfgBlob
+	blobCfgBlob         content.BlobCfgBlob
 	formatEncryptionKey []byte
 	nextWriterID        *int32
 }
@@ -304,6 +305,10 @@ func (r *directRepository) Refresh(ctx context.Context) error {
 // Time returns the current local time for the repo.
 func (r *directRepository) Time() time.Time {
 	return defaultTime(r.timeNow)()
+}
+
+func (r *directRepository) BlobCfg() content.BlobCfgBlob {
+	return r.directRepositoryParameters.blobCfgBlob
 }
 
 // WriteSessionOptions describes options for a write session.

--- a/tests/testenv/cli_inproc_runner.go
+++ b/tests/testenv/cli_inproc_runner.go
@@ -48,6 +48,13 @@ func NewInProcRunner(t *testing.T) *CLIInProcRunner {
 
 	return &CLIInProcRunner{
 		RepoPassword: TestRepoPassword,
+		CustomizeApp: func(a *cli.App, kp *kingpin.Application) {
+			a.AddStorageProvider(cli.StorageProvider{
+				Name:        "in-memory",
+				Description: "in-memory storage backend",
+				NewFlags:    func() cli.StorageFlags { return &storageInMemoryFlags{} },
+			})
+		},
 	}
 }
 

--- a/tests/testenv/storage_inmemory.go
+++ b/tests/testenv/storage_inmemory.go
@@ -1,4 +1,4 @@
-package cli_test
+package testenv
 
 import (
 	"context"


### PR DESCRIPTION
This PR enabled the CLI to set the rendition parameters after the repository has been initialized.

```sh
$ kopia repository set-parameters --password 12345678 --config-file /tmp/kopia/repository.config --retention-mode GOVERNANCE --retention-period 24h
 - setting storage backend blob retention period to 24h0m0s.

 - setting storage backend blob retention mode to GOVERNANCE.

NOTE: Repository parameters updated, you must disconnect and re-connect all other Kopia clients.
```

With unsupported backends:

```sh
$ kopia repository set-parameters --password 12345678 --config-file /tmp/kopia/repository.config --retention-mode GOVERNANCE --retention-period 24h
 - setting storage backend blob retention period to 24h0m0s.

 - setting storage backend blob retention mode to GOVERNANCE.

ERROR error setting parameters: unable to write blobcfg blob: PutBlob() failed for "kopia.blobcfg": setting blob-retention is not supported
```

With invalid period:

```sh
$ kopia repository set-parameters --password 12345678 --config-file /tmp/kopia/repository.config --retention-mode GOVERNANCE --retention-period 1m
 - setting storage backend blob retention period to 1m0s.

 - setting storage backend blob retention mode to GOVERNANCE.

ERROR error setting parameters: invalid blob-config options: invalid retention-period, the minimum required is 1-day and there is no maximum limit
```

With invalid mode:

```sh
$ kopia repository set-parameters --password 12345678 --config-file /tmp/kopia/repository.config --retention-mode GOVERNANC
kopia: error: enum value must be one of GOVERNANCE,COMPLIANCE, got 'GOVERNANC', try --help
```