### PR TITLE
fix(providers): fixed b2 provider failure

### DIFF
--- a/.github/workflows/provider-tests.yml
+++ b/.github/workflows/provider-tests.yml
@@ -5,8 +5,8 @@ on:
     tags:
       - v*
   schedule:
-    # run every 2 hours
-    - cron:  '19 */2 * * *'
+    # run once per day
+    - cron:  '19 7 * * *'
 jobs:
   endurance-test:
     name: Provider Test

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -146,6 +146,13 @@ func translateError(err error) error {
 }
 
 func (s *b2Storage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
+	switch {
+	case opts.HasRetentionOptions():
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob-retention")
+	case opts.DoNotRecreate:
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "do-not-recreate")
+	}
+
 	fileName := s.getObjectNameString(id)
 
 	// Backblaze always expects Content-Length to be set, even in http.Request ContentLength==0

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -71,6 +71,9 @@ func isRetriable(err error) bool {
 	case errors.Is(err, blob.ErrSetTimeUnsupported):
 		return false
 
+	case errors.Is(err, blob.ErrUnsupportedPutBlobOption):
+		return false
+
 	case errors.Is(err, blob.ErrBlobAlreadyExists):
 		return false
 


### PR DESCRIPTION
There was a small regression in #1654 - only in negative tests.

Also removed unnecessary retries on ErrUnsupportedPutBlobOption
+ switched provider test to run once per day, instead of 12 times/day.