### PR TITLE
fix(providers): fixed DoNotRecreate and tests for gcs

### DIFF
--- a/cli/command_repository_validate_provider.go
+++ b/cli/command_repository_validate_provider.go
@@ -23,7 +23,6 @@ func (c *commandRepositoryValidateProvider) setup(svc advancedAppServices, paren
 	cmd.Flag("put-blob-workers", "Number of PutBlob workers").IntVar(&c.opt.NumPutBlobWorkers)
 	cmd.Flag("get-blob-workers", "Number of GetBlob workers").IntVar(&c.opt.NumGetBlobWorkers)
 	cmd.Flag("get-metadata-workers", "Number of GetMetadata workers").IntVar(&c.opt.NumGetMetadataWorkers)
-	cmd.Flag("support-idempotent-creates", "Whether store supports idempotent blob creates").BoolVar(&c.opt.SupportIdempotentCreates)
 	c.out.setup(svc)
 
 	cmd.Action(c.out.svc.directRepositoryWriteAction(c.run))

--- a/internal/blobtesting/verify.go
+++ b/internal/blobtesting/verify.go
@@ -216,12 +216,11 @@ func AssertConnectionInfoRoundTrips(ctx context.Context, t *testing.T, s blob.St
 // TestValidationOptions is the set of options used when running providing validation from tests.
 // nolint:gomnd
 var TestValidationOptions = providervalidation.Options{
-	MaxClockDrift:            3 * time.Minute,
-	ConcurrencyTestDuration:  15 * time.Second,
-	NumPutBlobWorkers:        3,
-	NumGetBlobWorkers:        3,
-	NumGetMetadataWorkers:    3,
-	NumListBlobsWorkers:      3,
-	MaxBlobLength:            10e6,
-	SupportIdempotentCreates: false,
+	MaxClockDrift:           3 * time.Minute,
+	ConcurrencyTestDuration: 15 * time.Second,
+	NumPutBlobWorkers:       3,
+	NumGetBlobWorkers:       3,
+	NumGetMetadataWorkers:   3,
+	NumListBlobsWorkers:     3,
+	MaxBlobLength:           10e6,
 }

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -44,19 +44,10 @@ func TestGCSStorage(t *testing.T) {
 	defer st.Close(ctx)
 	defer blobtesting.CleanupOldData(ctx, t, st, 0)
 
-	options := []blob.PutOptions{
-		{},
-		{DoNotRecreate: true},
-	}
-
-	for _, opt := range options {
-		blobtesting.VerifyStorage(ctx, t, st, opt)
-	}
+	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
-	validateOpts := blobtesting.TestValidationOptions
-	validateOpts.SupportIdempotentCreates = true
-	require.NoError(t, providervalidation.ValidateProvider(ctx, st, validateOpts))
+	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
 }
 
 func TestGCSStorageInvalid(t *testing.T) {


### PR DESCRIPTION
Also simplified the validation test suite, which will check whether the provider supports `DoNotRecreate` or properly rejects it without external configuration.

@julio-lopez There were a number of suble issues there all stacked up behind "empty conditions" failure. They could only have been caught by running the test against actual GCS and were not easy to spot in the code review. 

We need to figure out how to run provider tests (which require credentials) as part of pull requests to catch those kinds of things early. There's an obvious security issue for untrusted PRs, but perhaps there's a way we can trigger these tests with access to secrets as one-off after eyeballing that PR can be trusted?

@adowair FYI
