### PR TITLE
feat(kopiaui): connect to repository asynchronously on startup

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -44,7 +44,7 @@ When developing the UI, the most convenient way is to use two terminals. The fir
 In the first terminal do:
 
 ```shell
-$ go run . server --insecure --without-password
+$ go run . server --insecure --without-password --disable-csrf-token-checks
 ```
 
 In the second terminal, in the `htmlui` repository run:
@@ -59,6 +59,20 @@ Changes to `htmlui` need to be individually submitted to their own repository an
 
 ```shell
 go get -u github.com/kopia/htmluibuild
+```
+
+It is also possible to test Kopia HTML UI with pre-built HTML. To do this:
+
+1. In `htmlui` repository run:
+
+```shell
+$ npm run build
+```
+
+2. In the `kopia` repository run:
+
+```shell
+go run . server --insecure --without-password --html=../htmlui/build
 ```
 
 ## KopiaUI App

--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -352,10 +352,14 @@ function updateTrayContextMenu() {
     const sd = serverForRepo(repoID).getServerStatusDetails();
     let desc = "";
 
-    if (sd.connecting) {
+    if (sd.startingUp) {
       desc = "<starting up>";
     } else if (!sd.connected) {
-      desc = "<not connected>";
+      if (sd.initTaskID) {
+        desc = "<initializing>";
+      } else {
+        desc = "<not connected>";
+      }
     } else {
       desc = sd.description;
     }

--- a/app/public/server.js
+++ b/app/public/server.js
@@ -17,7 +17,7 @@ function newServerForRepo(repoID) {
     let runningServerAddress = "";
     let runningServerCertificate = "";
     let runningServerStatusDetails = {
-        connecting: true,
+        startingUp: true,
     };
     let serverLog = [];
 
@@ -40,6 +40,7 @@ function newServerForRepo(repoID) {
                 '--random-password',
                 '--random-server-control-password',
                 '--tls-generate-cert',
+                '--async-repo-connect',
                 '--shutdown-on-stdin', // shutdown the server when parent dies
                 '--address=localhost:0');
     

--- a/cli/app.go
+++ b/cli/app.go
@@ -78,6 +78,8 @@ type appServices interface {
 	repositoryReaderAction(act func(ctx context.Context, rep repo.Repository) error) func(ctx *kingpin.ParseContext) error
 	repositoryWriterAction(act func(ctx context.Context, rep repo.RepositoryWriter) error) func(ctx *kingpin.ParseContext) error
 	maybeRepositoryAction(act func(ctx context.Context, rep repo.Repository) error, mode repositoryAccessMode) func(ctx *kingpin.ParseContext) error
+	baseActionWithContext(act func(ctx context.Context) error) func(ctx *kingpin.ParseContext) error
+	openRepository(ctx context.Context, mustBeConnected bool) (repo.Repository, error)
 	advancedCommand(ctx context.Context)
 	repositoryConfigFileName() string
 	getProgress() *cliProgress
@@ -412,7 +414,7 @@ type repositoryAccessMode struct {
 	disableMaintenance bool
 }
 
-func (c *App) maybeRepositoryAction(act func(ctx context.Context, rep repo.Repository) error, mode repositoryAccessMode) func(ctx *kingpin.ParseContext) error {
+func (c *App) baseActionWithContext(act func(ctx context.Context) error) func(ctx *kingpin.ParseContext) error {
 	return func(kpc *kingpin.ParseContext) error {
 		ctx0 := c.rootContext()
 
@@ -440,38 +442,7 @@ func (c *App) maybeRepositoryAction(act func(ctx context.Context, rep repo.Repos
 				go http.ListenAndServe(c.metricsListenAddr, m) // nolint:errcheck
 			}
 
-			memtrack.Dump(ctx, "before openRepository")
-
-			rep, err := c.openRepository(ctx, mode.mustBeConnected)
-
-			memtrack.Dump(ctx, "after openRepository")
-			if err != nil && mode.mustBeConnected {
-				return errors.Wrap(err, "open repository")
-			}
-
-			err = act(ctx, rep)
-
-			if rep != nil && !mode.disableMaintenance {
-				memtrack.Dump(ctx, "before auto maintenance")
-
-				if merr := c.maybeRunMaintenance(ctx, rep); merr != nil {
-					log(ctx).Errorf("error running maintenance: %v", merr)
-				}
-
-				memtrack.Dump(ctx, "after auto maintenance")
-			}
-
-			if rep != nil && mode.mustBeConnected {
-				memtrack.Dump(ctx, "before close repository")
-
-				if cerr := rep.Close(ctx); cerr != nil {
-					return errors.Wrap(cerr, "unable to close repository")
-				}
-
-				memtrack.Dump(ctx, "after close repository")
-			}
-
-			return err
+			return act(ctx)
 		})
 
 		c.runOnExit()
@@ -484,6 +455,43 @@ func (c *App) maybeRepositoryAction(act func(ctx context.Context, rep repo.Repos
 
 		return nil
 	}
+}
+
+func (c *App) maybeRepositoryAction(act func(ctx context.Context, rep repo.Repository) error, mode repositoryAccessMode) func(ctx *kingpin.ParseContext) error {
+	return c.baseActionWithContext(func(ctx context.Context) error {
+		memtrack.Dump(ctx, "before openRepository")
+
+		rep, err := c.openRepository(ctx, mode.mustBeConnected)
+
+		memtrack.Dump(ctx, "after openRepository")
+		if err != nil && mode.mustBeConnected {
+			return errors.Wrap(err, "open repository")
+		}
+
+		err = act(ctx, rep)
+
+		if rep != nil && !mode.disableMaintenance {
+			memtrack.Dump(ctx, "before auto maintenance")
+
+			if merr := c.maybeRunMaintenance(ctx, rep); merr != nil {
+				log(ctx).Errorf("error running maintenance: %v", merr)
+			}
+
+			memtrack.Dump(ctx, "after auto maintenance")
+		}
+
+		if rep != nil && mode.mustBeConnected {
+			memtrack.Dump(ctx, "before close repository")
+
+			if cerr := rep.Close(ctx); cerr != nil {
+				return errors.Wrap(cerr, "unable to close repository")
+			}
+
+			memtrack.Dump(ctx, "after close repository")
+		}
+
+		return err
+	})
 }
 
 func (c *App) maybeRunMaintenance(ctx context.Context, rep repo.Repository) error {

--- a/go.mod
+++ b/go.mod
@@ -116,8 +116,11 @@ require (
 )
 
 require (
-	github.com/chromedp/cdproto v0.0.0-20211126220118-81fa0469ad77 // indirect
-	github.com/chromedp/chromedp v0.7.6 // indirect
+	github.com/chromedp/cdproto v0.0.0-20211126220118-81fa0469ad77
+	github.com/chromedp/chromedp v0.7.6
+)
+
+require (
 	github.com/chromedp/sysutil v1.0.0 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -401,10 +401,6 @@ github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/kopia/htmluibuild v0.0.0-20211226001320-eed13dea3815 h1:tYyVCQw7MOqceTvuKIWQ2eCp/caJg5HRp1pO0Q68Z7Y=
-github.com/kopia/htmluibuild v0.0.0-20211226001320-eed13dea3815/go.mod h1:eWer4rx9P8lJo2eKc+Q7AZ1dE1x1hJNdkbDFPzMu1Hw=
-github.com/kopia/htmluibuild v0.0.0-20220103200652-9a7b3d8f5556 h1:ILqrzWYFuTpTAcAW5GMujLlnxs7v/cvlrpSjUWpUmco=
-github.com/kopia/htmluibuild v0.0.0-20220103200652-9a7b3d8f5556/go.mod h1:eWer4rx9P8lJo2eKc+Q7AZ1dE1x1hJNdkbDFPzMu1Hw=
 github.com/kopia/htmluibuild v0.0.0-20220129092742-eb509f9584dd h1:FLZhx3aqZF9cWB1G0f3K18uuNDhu7KFytdSN+5jeGwc=
 github.com/kopia/htmluibuild v0.0.0-20220129092742-eb509f9584dd/go.mod h1:eWer4rx9P8lJo2eKc+Q7AZ1dE1x1hJNdkbDFPzMu1Hw=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
@@ -492,6 +488,7 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5 h1:1SoBaSPudixRecmlHXb/GxmaD3fLMtHIDN13QujwQuc=
 github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -12,6 +12,7 @@ import (
 	"go.opencensus.io/stats"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/ctxutil"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/repo/blob"
@@ -284,7 +285,7 @@ func NewPersistentCache(ctx context.Context, description string, cacheStorage St
 
 	c.periodicSweepRunning.Add(1)
 
-	go c.sweepDirectoryPeriodically(ctx)
+	go c.sweepDirectoryPeriodically(ctxutil.Detach(ctx))
 
 	return c, nil
 }

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -29,6 +29,9 @@ type StatusResponse struct {
 	SupportsContentCompression bool   `json:"supportsContentCompression"`
 
 	repo.ClientOptions
+
+	// non-empty while the repository is being initialized (opened, created or connected).
+	InitRepoTaskID string `json:"initTaskID,omitempty"`
 }
 
 // SourcesResponse is the response of 'sources' HTTP API command.
@@ -116,11 +119,12 @@ type CheckRepositoryExistsRequest struct {
 
 // ConnectRepositoryRequest contains request to connect to a repository.
 type ConnectRepositoryRequest struct {
-	Storage       blob.ConnectionInfo `json:"storage"`
-	Password      string              `json:"password"`
-	Token         string              `json:"token"` // when set, overrides Storage and Password
-	APIServer     *repo.APIServerInfo `json:"apiServer"`
-	ClientOptions repo.ClientOptions  `json:"clientOptions"`
+	Storage             blob.ConnectionInfo `json:"storage"`
+	Password            string              `json:"password"`
+	Token               string              `json:"token"` // when set, overrides Storage and Password
+	APIServer           *repo.APIServerInfo `json:"apiServer"`
+	ClientOptions       repo.ClientOptions  `json:"clientOptions"`
+	SyncWaitTimeSeconds int                 `json:"syncWaitTime"` // if non-zero, force particular wait time, negative == forever
 }
 
 // SupportedAlgorithmsResponse returns the list of supported algorithms for repository creation.

--- a/internal/uitask/uitask.go
+++ b/internal/uitask/uitask.go
@@ -64,6 +64,7 @@ type Info struct {
 	ErrorMessage string                  `json:"errorMessage,omitempty"`
 	Counters     map[string]CounterValue `json:"counters"`
 	LogLines     []LogEntry              `json:"-"`
+	Error        error                   `json:"-"`
 
 	sequenceNumber int
 }
@@ -149,6 +150,10 @@ func (t *runningTaskInfo) addLogEntry(module string, level LogLevel, msg string,
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	if t.Status.IsFinished() {
+		return
+	}
 
 	t.LogLines = append(t.LogLines, LogEntry{
 		Timestamp: float64(clock.Now().UnixNano()) / 1e9,


### PR DESCRIPTION
This allows KopiaUI server to start when the repository directory is not mounted or otherwise unavailable. Connection attempts will be retried indefinitely and user will see new `Initializing` page.

This also exposes `Open` and `Connect` as tasks allowing the user to see logs directly in the UI and cancel the operation.

Fixes #1643

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/249880/151681535-1ce4a9af-0db1-4643-a358-a50405ea3575.png">
