### PR TITLE
feat(providers): Add Google Drive support.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,7 @@ coverage:
         threshold: 1%  # the leniency in hitting the target
 ignore:
  - repo/blob/gcs/
+ - repo/blob/gdrive/
  - repo/blob/s3/
  - repo/blob/azure/
  - repo/blob/gcs/

--- a/.github/workflows/provider-tests.yml
+++ b/.github/workflows/provider-tests.yml
@@ -43,6 +43,12 @@ jobs:
         KOPIA_GCS_CREDENTIALS_JSON_GZIP: ${{ secrets.KOPIA_GCS_CREDENTIALS_JSON_GZIP }}
         KOPIA_GCS_TEST_BUCKET: ${{ secrets.KOPIA_GCS_TEST_BUCKET }}
       if: ${{ success() || failure() }}
+    - name: GDrive
+      run: make provider-tests PROVIDER_TEST_TARGET=gdrive
+      env:
+        KOPIA_GDRIVE_CREDENTIALS_JSON_GZIP: ${{ secrets.KOPIA_GDRIVE_CREDENTIALS_JSON_GZIP }}
+        KOPIA_GDRIVE_TEST_FOLDER_ID: ${{ secrets.KOPIA_GDRIVE_TEST_FOLDER_ID }}
+      if: ${{ success() || failure() }}
     - name: S3
       run: make provider-tests PROVIDER_TEST_TARGET=s3
       env:

--- a/cli/app.go
+++ b/cli/app.go
@@ -282,6 +282,8 @@ func NewApp() *App {
 			{"b2", "a B2 bucket", func() StorageFlags { return &storageB2Flags{} }},
 			{"filesystem", "a filesystem", func() StorageFlags { return &storageFilesystemFlags{} }},
 			{"gcs", "a Google Cloud Storage bucket", func() StorageFlags { return &storageGCSFlags{} }},
+			{"gdrive", "a Google Drive folder", func() StorageFlags { return &storageGDriveFlags{} }},
+
 			{"rclone", "a rclone-based provided", func() StorageFlags { return &storageRcloneFlags{} }},
 			{"s3", "an S3 bucket", func() StorageFlags { return &storageS3Flags{} }},
 			{"sftp", "an SFTP storage", func() StorageFlags { return &storageSFTPFlags{} }},

--- a/cli/storage_gdrive.go
+++ b/cli/storage_gdrive.go
@@ -19,7 +19,7 @@ type storageGDriveFlags struct {
 }
 
 func (c *storageGDriveFlags) Setup(_ StorageProviderServices, cmd *kingpin.CmdClause) {
-	cmd.Flag("folder-id", "FolderId to use for objects in the bucket").Required().StringVar(&c.options.FolderId)
+	cmd.Flag("folder-id", "FolderID to use for objects in the bucket").Required().StringVar(&c.options.FolderID)
 	cmd.Flag("read-only", "Use read-only scope to prevent write access").BoolVar(&c.options.ReadOnly)
 	cmd.Flag("credentials-file", "Use the provided JSON file with credentials").ExistingFileVar(&c.options.ServiceAccountCredentialsFile)
 	cmd.Flag("embed-credentials", "Embed GCS credentials JSON in Kopia configuration").BoolVar(&c.embedCredentials)

--- a/cli/storage_gdrive.go
+++ b/cli/storage_gdrive.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/alecthomas/kingpin"
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/gdrive"
+)
+
+type storageGDriveFlags struct {
+	options gdrive.Options
+
+	embedCredentials bool
+}
+
+func (c *storageGDriveFlags) Setup(_ StorageProviderServices, cmd *kingpin.CmdClause) {
+	cmd.Flag("folder-id", "FolderId to use for objects in the bucket").Required().StringVar(&c.options.FolderId)
+	cmd.Flag("read-only", "Use read-only scope to prevent write access").BoolVar(&c.options.ReadOnly)
+	cmd.Flag("credentials-file", "Use the provided JSON file with credentials").ExistingFileVar(&c.options.ServiceAccountCredentialsFile)
+	cmd.Flag("embed-credentials", "Embed GCS credentials JSON in Kopia configuration").BoolVar(&c.embedCredentials)
+
+	commonThrottlingFlags(cmd, &c.options.Limits)
+}
+
+func (c *storageGDriveFlags) Connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error) {
+	if c.embedCredentials {
+		data, err := os.ReadFile(c.options.ServiceAccountCredentialsFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to open service account credentials file")
+		}
+
+		c.options.ServiceAccountCredentialJSON = json.RawMessage(data)
+		c.options.ServiceAccountCredentialsFile = ""
+	}
+
+	// nolint:wrapcheck
+	return gdrive.New(ctx, &c.options)
+}

--- a/go.sum
+++ b/go.sum
@@ -400,8 +400,6 @@ github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/kopia/htmluibuild v0.0.0-20220131042136-3e252f22c951 h1:5Ax9T6D+EFzIP0uTabNDTVQQPCOk4QlD/VnL+6cN8E4=
-github.com/kopia/htmluibuild v0.0.0-20220131042136-3e252f22c951/go.mod h1:eWer4rx9P8lJo2eKc+Q7AZ1dE1x1hJNdkbDFPzMu1Hw=
 github.com/kopia/htmluibuild v0.0.0-20220206023946-bd8fce6ec20d h1:bE9j+g8iiICIJjYr6K56OrnxRFKSfrnLCpOhD1vOBTc=
 github.com/kopia/htmluibuild v0.0.0-20220206023946-bd8fce6ec20d/go.mod h1:eWer4rx9P8lJo2eKc+Q7AZ1dE1x1hJNdkbDFPzMu1Hw=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -82,7 +82,7 @@ func internalRetry(ctx context.Context, desc string, attempt AttemptFunc, isRetr
 		}
 	}
 
-	return nil, errors.Errorf("unable to complete %v despite %v retries, last error: %v", desc, count, lastError)
+	return nil, errors.Wrapf(lastError, "unable to complete %v despite %v retries", desc, count)
 }
 
 // WithExponentialBackoffNoValue is a shorthand for WithExponentialBackoff except the

--- a/repo/blob/gdrive/file_id_cache.go
+++ b/repo/blob/gdrive/file_id_cache.go
@@ -1,0 +1,130 @@
+package gdrive
+
+import (
+	"sync"
+
+	"github.com/kopia/kopia/repo/blob"
+)
+
+const (
+	changeLogCacheSize = 1 << 8
+)
+
+// FileIDCache is a cache for managing the association of blobID -> fileID.
+type FileIDCache struct {
+	// Map of blobID -> *CacheEntry.
+	Blobs sync.Map
+	// Record of recent cache changes.
+	// It's stored as a synchronized circular buffer.
+	ChangeLog [changeLogCacheSize]ChangeEntry
+	// ChangeLogIdx indicates the next location to write to.
+	// The log entry range is [ChangeLogIdx+1, ChangeLogIdx-1].
+	ChangeLogIdx int
+	// Guards access to ChangeLog.
+	ChangeLogMut sync.RWMutex
+}
+
+// CacheEntry is a blob cache entry.
+type CacheEntry struct {
+	// Guards access to the entry. Must be taken before accessing fields.
+	Mut sync.Mutex
+	// blobID. Is always populated.
+	BlobID blob.ID
+	// Associated fileID. If empty, the blob doesn't have a cached fileID.
+	FileID string
+}
+
+// ChangeEntry is a blob change entry.
+type ChangeEntry struct {
+	// blobID. If empty, the entry has not been written to yet.
+	BlobID blob.ID
+	// Associated fileID. If empty, the blob is deleted.
+	FileID string
+}
+
+// Lookup finds the cache entry for blobID.
+// The entry may be read or mutated.
+// The callback is guaranteed to have exclusive access to the entry.
+func (cache *FileIDCache) Lookup(blobID blob.ID, callback func(entry *CacheEntry) (interface{}, error)) (interface{}, error) {
+	entry := cache.getEntry(blobID)
+
+	entry.Mut.Lock()
+
+	result, err := callback(entry)
+
+	entry.Mut.Unlock()
+
+	return result, err
+}
+
+// Internal method for retrieving an entry.
+func (cache *FileIDCache) getEntry(blobID blob.ID) *CacheEntry {
+	loaded, _ := cache.Blobs.LoadOrStore(blobID, &CacheEntry{
+		Mut:    sync.Mutex{},
+		BlobID: blobID,
+		FileID: "",
+	})
+
+	return loaded.(*CacheEntry) //nolint:forcetypeassert
+}
+
+// BlindPut blindly mutates the association for a blobID.
+func (cache *FileIDCache) BlindPut(blobID blob.ID, fileID string) {
+	_, _ = cache.Lookup(blobID, func(entry *CacheEntry) (interface{}, error) {
+		entry.FileID = fileID
+		return nil, nil
+	})
+}
+
+// RecordBlobChange records a newly created or deleted blob.
+// An empty fileID signals that the blob is deleted.
+func (cache *FileIDCache) RecordBlobChange(blobID blob.ID, fileID string) {
+	cache.ChangeLogMut.Lock()
+
+	i := cache.ChangeLogIdx
+	cache.ChangeLog[i] = ChangeEntry{
+		BlobID: blobID,
+		FileID: fileID,
+	}
+	cache.ChangeLogIdx = circularBufferNext(i)
+
+	cache.ChangeLogMut.Unlock()
+}
+
+// VisitBlobChanges iterates through newly created or deleted blobs.
+func (cache *FileIDCache) VisitBlobChanges(callback func(blobID blob.ID, fileID string)) {
+	cache.ChangeLogMut.RLock()
+
+	for i := circularBufferNext(cache.ChangeLogIdx); i != cache.ChangeLogIdx; i = circularBufferNext(i) {
+		entry := cache.ChangeLog[i]
+		if entry.BlobID != "" {
+			callback(entry.BlobID, entry.FileID)
+		}
+	}
+
+	cache.ChangeLogMut.RUnlock()
+}
+
+// Clear resets the file ID cache.
+func (cache *FileIDCache) Clear() {
+	cache.Blobs = sync.Map{}
+	cache.ChangeLog = [changeLogCacheSize]ChangeEntry{}
+}
+
+func circularBufferNext(curr int) int {
+	if curr == changeLogCacheSize-1 {
+		return 0
+	}
+
+	return curr + 1
+}
+
+// NewFileIDCache creates a new FileIDCache.
+func NewFileIDCache() (*FileIDCache, error) {
+	return &FileIDCache{
+		Blobs:        sync.Map{},
+		ChangeLog:    [changeLogCacheSize]ChangeEntry{},
+		ChangeLogIdx: 0,
+		ChangeLogMut: sync.RWMutex{},
+	}, nil
+}

--- a/repo/blob/gdrive/gdrive_options.go
+++ b/repo/blob/gdrive/gdrive_options.go
@@ -1,0 +1,24 @@
+package gdrive
+
+import (
+	"encoding/json"
+
+	"github.com/kopia/kopia/repo/blob/throttling"
+)
+
+// Options defines options Google Cloud Storage-backed storage.
+type Options struct {
+	// FolderId is Google Drive's ID of a folder where data is stored.
+	FolderId string `json:"folderId"`
+
+	// ServiceAccountCredentialsFile specifies the name of the file with Drive credentials.
+	ServiceAccountCredentialsFile string `json:"credentialsFile,omitempty"`
+
+	// ServiceAccountCredentialJSON specifies the raw JSON credentials.
+	ServiceAccountCredentialJSON json.RawMessage `kopia:"sensitive" json:"credentials,omitempty"`
+
+	// ReadOnly causes GCS connection to be opened with read-only scope to prevent accidental mutations.
+	ReadOnly bool `json:"readOnly,omitempty"`
+
+	throttling.Limits
+}

--- a/repo/blob/gdrive/gdrive_options.go
+++ b/repo/blob/gdrive/gdrive_options.go
@@ -9,7 +9,7 @@ import (
 // Options defines options Google Cloud Storage-backed storage.
 type Options struct {
 	// FolderId is Google Drive's ID of a folder where data is stored.
-	FolderId string `json:"folderId"`
+	FolderID string `json:"folderID"`
 
 	// ServiceAccountCredentialsFile specifies the name of the file with Drive credentials.
 	ServiceAccountCredentialsFile string `json:"credentialsFile,omitempty"`

--- a/repo/blob/gdrive/gdrive_storage.go
+++ b/repo/blob/gdrive/gdrive_storage.go
@@ -64,6 +64,7 @@ func (gdrive *gdriveStorage) GetBlob(ctx context.Context, b blob.ID, offset, len
 	req := gdrive.client.Get(fileID)
 	req.Header().Set("Range", toRange(offset, length))
 	res, err := req.Context(ctx).Download()
+	
 	if err != nil {
 		return errors.Wrapf(translateError(err), "Get in GetBlob(%s)", b)
 	}

--- a/repo/blob/gdrive/gdrive_storage.go
+++ b/repo/blob/gdrive/gdrive_storage.go
@@ -63,8 +63,8 @@ func (gdrive *gdriveStorage) GetBlob(ctx context.Context, b blob.ID, offset, len
 
 	req := gdrive.client.Get(fileID)
 	req.Header().Set("Range", toRange(offset, length))
+
 	res, err := req.Context(ctx).Download()
-	
 	if err != nil {
 		return errors.Wrapf(translateError(err), "Get in GetBlob(%s)", b)
 	}

--- a/repo/blob/gdrive/gdrive_storage.go
+++ b/repo/blob/gdrive/gdrive_storage.go
@@ -1,0 +1,460 @@
+// Package gdrive implements Storage based on Google Drive.
+package gdrive
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	drive "google.golang.org/api/drive/v3"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/iocopy"
+	"github.com/kopia/kopia/internal/retry"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/retrying"
+)
+
+const (
+	gdriveStorageType = "gdrive"
+	gdriveMimeType    = "application/x-kopia"
+	
+	uploadChunkSize   = 1 << 20
+	uploadContentType = "application/octet-stream"
+	maxPrefixLen      = 26
+	queryRetryDelay   = 100 * time.Millisecond
+	queryRetryMax     = 3
+
+  // googleapi.Field values.
+	listIdFields       = "files(name,id)"
+	listMetadataFields = "files(name,id,mimeType,size,modifiedTime)"
+	getMetadataFields  = "name,id,mimeType,size,modifiedTime"
+)
+
+type gdriveStorage struct {
+	Options
+
+	client      *drive.Service
+	folderId    string
+	// Caches blob id -> drive file id associations.
+	fileIdCache map[blob.ID]string
+}
+
+func (gdrive *gdriveStorage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output blob.OutputBuffer) error {
+	if offset < 0 {
+		return blob.ErrInvalidRange
+	}
+
+	fileId, err := gdrive.GetFileId(ctx, b)
+	if err != nil {
+		return err
+	}
+
+	get_req := gdrive.client.Files.Get(fileId)
+	get_req.Header().Set("Range", toRange(offset, length))
+	res, err := get_req.Context(ctx).Download()
+	if err != nil {
+		return errors.Wrap(translateError(err), "Get blob")
+	}
+	defer res.Body.Close() //nolint:errcheck
+
+	if length != 0 {
+		// nolint:wrapcheck
+		if err := iocopy.JustCopy(output, res.Body); err != nil {
+			return translateError(err)
+		}
+	}
+
+	// nolint:wrapcheck
+	return blob.EnsureLengthExactly(output.Length(), length)
+}
+
+func (gdrive *gdriveStorage) GetMetadata(ctx context.Context, b blob.ID) (blob.Metadata, error) {
+	fileId, ok := gdrive.fileIdCache[b]
+	var file *drive.File
+	var err error
+
+	if ok {
+		file, err = gdrive.client.Files.Get(fileId).Fields(getMetadataFields).Context(ctx).Do()
+		err = translateError(err)
+	} else {
+		file, err = gdrive.QueryForBlob(ctx, b, listMetadataFields)
+	}
+	if err != nil {
+		return blob.Metadata{}, errors.Wrap(err, "get blob metadata")
+	}
+
+	bm, err := parseBlobMetadata(file, b)
+	if err != nil {
+		return blob.Metadata{}, err
+	}
+
+	return bm, nil
+}
+
+func (gdrive *gdriveStorage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
+	switch {
+	case opts.HasRetentionOptions():
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob-retention")
+	}
+
+	fileId, err := gdrive.GetFileId(ctx, b)
+	existingFile := true
+	if errors.Is(err, blob.ErrBlobNotFound) {
+		existingFile = false
+	} else if err != nil {
+		return err
+	}
+	if existingFile && opts.DoNotRecreate {
+		return blob.ErrBlobAlreadyExists
+	}
+
+	var file *drive.File
+	mtime := ""
+
+	if !opts.SetModTime.IsZero() {
+		mtime = opts.SetModTime.Format(time.RFC3339)
+	}
+
+	if !existingFile {
+		file, err = gdrive.client.Files.Create(&drive.File{
+			Name:         toFileName(b),
+			Parents:      []string{gdrive.folderId},
+			MimeType:     gdriveMimeType,
+			ModifiedTime: mtime,
+		}).Media(data.Reader(),
+			googleapi.ChunkSize(uploadChunkSize),
+			googleapi.ContentType(uploadContentType),
+		).Context(ctx).Do()
+	} else {
+		file, err = gdrive.client.Files.Update(fileId, &drive.File{
+			ModifiedTime: mtime,
+		}).Media(
+			data.Reader(),
+			googleapi.ChunkSize(uploadChunkSize),
+			googleapi.ContentType(uploadContentType),
+		).Context(ctx).Do()
+	}
+	if err != nil {
+		return translateError(err)
+	}
+
+	gdrive.fileIdCache[b] = file.Id
+	if opts.GetModTime != nil {
+		if mtime, err := parseModifiedTime(file); err == nil {
+			*opts.GetModTime = mtime
+		}
+	}
+
+	return nil
+}
+
+func (gdrive *gdriveStorage) DeleteBlob(ctx context.Context, b blob.ID) error {
+	fileId, err := gdrive.GetFileId(ctx, b)
+	if errors.Is(err, blob.ErrBlobNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	err = gdrive.client.Files.Delete(fileId).Context(ctx).Do()
+	return translateError(err)
+}
+
+func (gdrive *gdriveStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback func(blob.Metadata) error) error {
+	// Tracks blob matches in cache but not returned by API.
+	unvisitedIds := make(map[blob.ID]bool)
+
+	consumer := func(files *drive.FileList) error {
+		for _, file := range files.Files {
+			blobId := toBlobId(file.Name)
+			gdrive.fileIdCache[blobId] = file.Id
+
+			if !matchesPrefix(blobId, prefix) {
+				return nil
+			}
+
+			// Mark blob as visited.
+			delete(unvisitedIds, blobId)
+
+			bm, err := parseBlobMetadata(file, blobId)
+			if err != nil {
+				return err
+			}
+
+			if err := callback(bm); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	query := fmt.Sprintf("'%s' in parents and mimeType = '%s'", gdrive.folderId, gdriveMimeType)
+	if prefix != "" {
+		query = fmt.Sprintf("'%s' in parents and name contains '%s' and mimeType = '%s'", gdrive.folderId, capPrefix(prefix), gdriveMimeType)
+
+		// Populate unvisited cache.
+		for blobId, _ := range gdrive.fileIdCache {
+			if matchesPrefix(blobId, prefix) {
+				unvisitedIds[blobId] = true
+			}
+		}
+	}
+
+	err := gdrive.client.Files.List().Q(query).Fields("nextPageToken", listMetadataFields).Pages(ctx, consumer)
+	if err != nil {
+		return translateError(err)
+	}
+
+	// Catch any blobs that the API didn't return.
+	if len(unvisitedIds) != 0 {
+		for blobId, _ := range unvisitedIds {
+			bm, err := gdrive.GetMetadata(ctx, blobId)
+			if err != nil {
+				return translateError(err)
+			}
+
+			if err := callback(bm); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (gdrive *gdriveStorage) ConnectionInfo() blob.ConnectionInfo {
+	return blob.ConnectionInfo{
+		Type:   gdriveStorageType,
+		Config: &gdrive.Options,
+	}
+}
+
+func (gdrive *gdriveStorage) DisplayName() string {
+	return fmt.Sprintf("Google Drive: %v", gdrive.FolderId)
+}
+
+func (gdrive *gdriveStorage) Close(ctx context.Context) error {
+	return nil
+}
+
+func (gdrive *gdriveStorage) FlushCaches(ctx context.Context) error {
+	return nil
+}
+
+func (gdrive *gdriveStorage) GetFileId(ctx context.Context, blobId blob.ID) (string, error) {
+	_, ok := gdrive.fileIdCache[blobId]
+	if !ok {
+		_, err := gdrive.QueryForBlob(ctx, blobId, listIdFields)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return gdrive.fileIdCache[blobId], nil
+}
+
+func (gdrive *gdriveStorage) QueryForBlob(ctx context.Context, blobId blob.ID, fields googleapi.Field) (*drive.File, error) {
+
+	runQuery := func() (interface{}, error) {
+		files, err := gdrive.client.Files.List().Q(fmt.Sprintf("'%s' in parents and name = '%s' and mimeType = '%s'", gdrive.folderId, string(blobId), gdriveMimeType)).Fields(fields).PageSize(1).Context(ctx).Do()
+		if err != nil {
+			return nil, translateError(err)
+		} else if len(files.Files) != 1 {
+			return nil, blob.ErrBlobNotFound
+		} else {
+			return files.Files[0], nil
+		}
+	}
+
+	f, err := retry.Periodically(ctx, queryRetryDelay, queryRetryMax, fmt.Sprintf("QueryForBlob(%v)", blobId), runQuery, retryNotFound)
+	if err != nil {
+		return nil, err
+	}
+
+	file := f.(*drive.File) //nolint:forcetypeassert
+	gdrive.fileIdCache[toBlobId(file.Name)] = file.Id
+	return file, nil
+}
+
+func matchesPrefix(blobId blob.ID, prefix blob.ID) bool {
+	return strings.HasPrefix(string(blobId), string(prefix))
+}
+
+// Drive doesn't support prefix match beyond a certain length.
+func capPrefix(prefix blob.ID) string {
+	if len(prefix) >= maxPrefixLen {
+		return string(prefix)[:maxPrefixLen]
+	}
+
+	return string(prefix)
+}
+
+// Returns a valid HTTP Range header value.
+func toRange(offset, length int64) string {
+	if length < 0 {
+		return fmt.Sprintf("bytes=%d-", offset)
+	} else if length == 0 {
+		// There's no way to read 0 bytes, so we read 1 byte instead.
+		return fmt.Sprintf("bytes=%d-%d", offset, offset)
+	} else {
+		return fmt.Sprintf("bytes=%d-%d", offset, offset+length-1)
+	}
+}
+
+func toFileName(blobId blob.ID) string {
+	return string(blobId)
+}
+
+func toBlobId(fileName string) blob.ID {
+	return blob.ID(fileName)
+}
+
+func parseBlobMetadata(file *drive.File, blobId blob.ID) (blob.Metadata, error) {
+	mtime, err := parseModifiedTime(file)
+	if err != nil {
+		return blob.Metadata{}, errors.Wrap(err, "error parsing file modified time")
+	}
+
+	bm := blob.Metadata{
+		BlobID:    blobId,
+		Length:    file.Size,
+		Timestamp: mtime,
+	}
+
+	return bm, nil
+}
+
+func parseModifiedTime(file *drive.File) (time.Time, error) {
+	return time.Parse(time.RFC3339, file.ModifiedTime)
+}
+
+func retryNotFound(err error) bool {
+	return errors.Is(err, blob.ErrBlobNotFound)
+}
+
+func translateError(err error) error {
+	var ae *googleapi.Error
+
+	if errors.As(err, &ae) {
+		switch ae.Code {
+		case http.StatusNotFound:
+			return blob.ErrBlobNotFound
+		case http.StatusRequestedRangeNotSatisfiable:
+			return blob.ErrInvalidRange
+		case http.StatusPreconditionFailed:
+			return blob.ErrBlobAlreadyExists
+		}
+	}
+
+	switch {
+	case err == nil:
+		return nil
+	default:
+		return errors.Wrap(err, "unexpected Google Drive error")
+	}
+}
+
+func tokenSourceFromCredentialsFile(ctx context.Context, fn string, scopes ...string) (oauth2.TokenSource, error) {
+	data, err := os.ReadFile(fn) //nolint:gosec
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading credentials file")
+	}
+
+	cfg, err := google.JWTConfigFromJSON(data, scopes...)
+	if err != nil {
+		return nil, errors.Wrap(err, "google.JWTConfigFromJSON")
+	}
+
+	return cfg.TokenSource(ctx), nil
+}
+
+func tokenSourceFromCredentialsJSON(ctx context.Context, data json.RawMessage, scopes ...string) (oauth2.TokenSource, error) {
+	cfg, err := google.JWTConfigFromJSON([]byte(data), scopes...)
+	if err != nil {
+		return nil, errors.Wrap(err, "google.JWTConfigFromJSON")
+	}
+
+	return cfg.TokenSource(ctx), nil
+}
+
+// New creates new Google Cloud Storage-backed storage with specified options:
+//
+// - the 'FolderId' field is required and all other parameters are optional.
+//
+// By default the connection reuses credentials managed by (https://cloud.google.com/sdk/),
+// but this can be disabled by setting IgnoreDefaultCredentials to true.
+func New(ctx context.Context, opt *Options) (blob.Storage, error) {
+	var err error
+	var ts oauth2.TokenSource
+
+	scope := drive.DriveFileScope
+	if opt.ReadOnly {
+		scope = drive.DriveReadonlyScope
+	}
+
+	if sa := opt.ServiceAccountCredentialJSON; len(sa) > 0 {
+		ts, err = tokenSourceFromCredentialsJSON(ctx, sa, scope)
+	} else if sa := opt.ServiceAccountCredentialsFile; sa != "" {
+		ts, err = tokenSourceFromCredentialsFile(ctx, sa, scope)
+	} else {
+		ts, err = google.DefaultTokenSource(ctx, scope)
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to initialize token source")
+	}
+
+	hc := oauth2.NewClient(ctx, ts)
+
+	service, err := drive.NewService(ctx, option.WithHTTPClient(hc))
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create Drive client")
+	}
+
+	if opt.FolderId == "" {
+		return nil, errors.New("folder-id must be specified")
+	}
+
+	gdrive := &gdriveStorage{
+		Options:     *opt,
+		client:      service,
+		folderId:    opt.FolderId,
+		fileIdCache: make(map[blob.ID]string),
+	}
+
+	// verify GCS connection is functional by listing blobs in a bucket, which will fail if the bucket
+	// does not exist. We list with a prefix that will not exist, to avoid iterating through any objects.
+	nonExistentPrefix := fmt.Sprintf("kopia-gdrive-storage-initializing-%v", clock.Now().UnixNano())
+	err = gdrive.ListBlobs(ctx, blob.ID(nonExistentPrefix), func(md blob.Metadata) error {
+		return nil
+	})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list from the bucket")
+	}
+
+	return retrying.NewWrapper(gdrive), nil
+}
+
+func init() {
+	blob.AddSupportedStorage(
+		gdriveStorageType,
+		func() interface{} {
+			return &Options{}
+		},
+		func(ctx context.Context, o interface{}, isCreate bool) (blob.Storage, error) {
+			return New(ctx, o.(*Options)) //nolint:forcetypeassert
+		})
+}

--- a/repo/blob/gdrive/gdrive_storage_test.go
+++ b/repo/blob/gdrive/gdrive_storage_test.go
@@ -1,0 +1,109 @@
+package gdrive_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/providervalidation"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/gdrive"
+)
+
+func TestCleanupOldData(t *testing.T) {
+	t.Parallel()
+	testutil.ProviderTest(t)
+	ctx := testlogging.Context(t)
+
+	st, err := gdrive.New(ctx, mustGetOptionsOrSkip(t))
+	require.NoError(t, err)
+
+	defer st.Close(ctx)
+
+	blobtesting.CleanupOldData(ctx, t, st, blobtesting.MinCleanupAge)
+}
+
+func TestGDriveStorage(t *testing.T) {
+	t.Parallel()
+	testutil.ProviderTest(t)
+
+	ctx := testlogging.Context(t)
+
+	// use context that gets canceled after opening storage to ensure it's not used beyond New().
+	newctx, cancel := context.WithCancel(ctx)
+	st, err := gdrive.New(newctx, mustGetOptionsOrSkip(t))
+
+	cancel()
+	require.NoError(t, err)
+
+	defer st.Close(ctx)
+	defer blobtesting.CleanupOldData(ctx, t, st, 0)
+
+	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
+
+	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
+	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
+}
+
+func TestGdriveStorageInvalid(t *testing.T) {
+	t.Parallel()
+	testutil.ProviderTest(t)
+
+	folderID := os.Getenv("KOPIA_GDRIVE_TEST_FOLDER_ID")
+	if folderID == "" {
+		t.Skip("KOPIA_GDRIVE_TEST_FOLDER_ID not provided")
+	}
+
+	ctx := testlogging.Context(t)
+
+	if _, err := gdrive.New(ctx, &gdrive.Options{
+		FolderID:                      folderID + "-no-such-folder",
+		ServiceAccountCredentialsFile: os.Getenv("KOPIA_GDRIVE_CREDENTIALS_FILE"),
+	}); err == nil {
+		t.Fatalf("unexpected success connecting to Drive, wanted error")
+	}
+}
+
+func gunzip(d []byte) ([]byte, error) {
+	z, err := gzip.NewReader(bytes.NewReader(d))
+	if err != nil {
+		return nil, err
+	}
+
+	defer z.Close()
+
+	return io.ReadAll(z)
+}
+
+func mustGetOptionsOrSkip(t *testing.T) *gdrive.Options {
+	t.Helper()
+
+	folderID := os.Getenv("KOPIA_GDRIVE_TEST_FOLDER_ID")
+	if folderID == "" {
+		t.Skip("KOPIA_GDRIVE_TEST_FOLDER_ID not provided")
+	}
+
+	credDataGZ, err := base64.StdEncoding.DecodeString(os.Getenv("KOPIA_GDRIVE_CREDENTIALS_JSON_GZIP"))
+	if err != nil {
+		t.Skip("skipping test because GDrive credentials file can't be decoded")
+	}
+
+	credData, err := gunzip(credDataGZ)
+	if err != nil {
+		t.Skip("skipping test because GDrive credentials file can't be unzipped")
+	}
+
+	return &gdrive.Options{
+		FolderID:                     folderID,
+		ServiceAccountCredentialJSON: credData,
+	}
+}


### PR DESCRIPTION
Hi @jkowalski,

I'm requesting early review for this feature before I finish up with tests and documentation. This PR implements https://github.com/kopia/kopia/issues/90 and passes `validate-provider`.

The implementation strategy is the one we discussed in https://github.com/kopia/kopia/issues/90#issuecomment-1025507405:
* FileIdCache: A BlobId -> FileId map is put in place to speed up file look ups.
* GetBlob / GetBlobMetadata: Use exact name match with aggressive retrying (100ms x 3 times). 
* ListBlobs: Use name prefix search with a cap of 26 characters (Drive limitation). Additionally, we search through FileIdCache for any local matches in case the Drive-side index is not stable yet.

I would like your input on:
* The general implementation strategy - is it sensible? Don't worry about go readability right now as I can clean it up after the big picture is set.
* Right now, FileIdCache is an ephemeral and uncapped cache. The fact is that this cache is effectively append-only since the id mapping is stable. Would it be better to turn it into a LRU cache or persist it on disk?

List of changes in PR:
* `repo/blob/gdrive`: Implement blob storage in GDrive.
* `cli/`: Implement `gdrive` storage subcommands.
* `internal/retry/retry.go`: Fix a bug affecting gdrive where `Errorf` is used instead of `Wrapf`, obscuring the error chain.

Thanks,

Kexiang