### PR TITLE
fix(snapshots): treat empty retention policy as retaining ALL, not NONE

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -19,6 +19,7 @@ options:
       - repository
       - server
       - providers
+      - snapshots
       - testing
       - lint
       - deps
@@ -37,6 +38,7 @@ options:
       ui: Graphical User Interface
       lint: Linter
       deps: Dependencies
+      snapshots: Snapshots
       deps-dev: Development Dependencies
       infra: Infrastructure
       general: General Improvements
@@ -48,6 +50,7 @@ options:
       - general
       - repository
       - server
+      - snapshots
       - providers
       - deps
       - testing

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: deepakputhraya/action-pr-title@master
       with:
-        regex: '^(feat|fix|breaking|build|chore|docs|style|refactor|test)\((kopiaui|cli|ui|repository|server|providers|deps|deps-dev|site|ci|infra|general)\)!{0,1}: .*$'
+        regex: '^(feat|fix|breaking|build|chore|docs|style|refactor|test)\((kopiaui|cli|ui|repository|snapshots|server|providers|deps|deps-dev|site|ci|infra|general)\)!{0,1}: .*$'

--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -166,7 +166,7 @@ func applyPolicyStringList(ctx context.Context, desc string, val *[]string, add,
 	*val = s
 }
 
-func applyPolicyNumber(ctx context.Context, desc string, val **int, str string, changeCount *int) error {
+func applyOptionalInt(ctx context.Context, desc string, val **policy.OptionalInt, str string, changeCount *int) error {
 	if str == "" {
 		// not changed
 		return nil
@@ -188,7 +188,7 @@ func applyPolicyNumber(ctx context.Context, desc string, val **int, str string, 
 		return errors.Wrapf(err, "can't parse the %v %q", desc, str)
 	}
 
-	i := int(v)
+	i := policy.OptionalInt(v)
 	*changeCount++
 
 	log(ctx).Infof(" - setting %q to %v.", desc, i)

--- a/cli/command_policy_set_retention.go
+++ b/cli/command_policy_set_retention.go
@@ -29,7 +29,7 @@ func (c *policyRetentionFlags) setup(cmd *kingpin.CmdClause) {
 func (c *policyRetentionFlags) setRetentionPolicyFromFlags(ctx context.Context, rp *policy.RetentionPolicy, changeCount *int) error {
 	cases := []struct {
 		desc      string
-		max       **int
+		max       **policy.OptionalInt
 		flagValue string
 	}{
 		{"number of annual backups to keep", &rp.KeepAnnual, c.policySetKeepAnnual},
@@ -41,7 +41,7 @@ func (c *policyRetentionFlags) setRetentionPolicyFromFlags(ctx context.Context, 
 	}
 
 	for _, c := range cases {
-		if err := applyPolicyNumber(ctx, c.desc, c.max, c.flagValue, changeCount); err != nil {
+		if err := applyOptionalInt(ctx, c.desc, c.max, c.flagValue, changeCount); err != nil {
 			return err
 		}
 	}

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -309,7 +309,7 @@ func printActionCommand(out *textOutput, h *policy.ActionCommand) {
 	out.printStdout("\n")
 }
 
-func valueOrNotSet(p *int) string {
+func valueOrNotSet(p *policy.OptionalInt) string {
 	if p == nil {
 		return "-"
 	}

--- a/snapshot/policy/optional.go
+++ b/snapshot/policy/optional.go
@@ -15,3 +15,19 @@ func (b *OptionalBool) OrDefault(def bool) bool {
 func newOptionalBool(b OptionalBool) *OptionalBool {
 	return &b
 }
+
+// OptionalInt provides convenience methods for manipulating optional integers.
+type OptionalInt int
+
+// OrDefault returns the value of the integer or provided default if it's nil.
+func (b *OptionalInt) OrDefault(def int) int {
+	if b == nil {
+		return def
+	}
+
+	return int(*b)
+}
+
+func newOptionalInt(b OptionalInt) *OptionalInt {
+	return &b
+}

--- a/snapshot/policy/policy.go
+++ b/snapshot/policy/policy.go
@@ -85,7 +85,3 @@ func validatePolicyPath(p string) error {
 
 	return nil
 }
-
-func intPtr(n int) *int {
-	return &n
-}

--- a/snapshot/policy/policy_manager_test.go
+++ b/snapshot/policy/policy_manager_test.go
@@ -24,7 +24,7 @@ func TestPolicyManagerInheritanceTest(t *testing.T) {
 		Host: "host-a",
 	}, &Policy{
 		RetentionPolicy: RetentionPolicy{
-			KeepDaily: intPtr(44),
+			KeepDaily: newOptionalInt(44),
 		},
 	}))
 
@@ -34,7 +34,7 @@ func TestPolicyManagerInheritanceTest(t *testing.T) {
 		Path:     "/some/path2",
 	}, &Policy{
 		RetentionPolicy: RetentionPolicy{
-			KeepMonthly: intPtr(66),
+			KeepMonthly: newOptionalInt(66),
 		},
 	}))
 
@@ -42,7 +42,7 @@ func TestPolicyManagerInheritanceTest(t *testing.T) {
 		Host: "host-b",
 	}, &Policy{
 		RetentionPolicy: RetentionPolicy{
-			KeepDaily: intPtr(55),
+			KeepDaily: newOptionalInt(55),
 		},
 	}))
 
@@ -185,7 +185,7 @@ func policyWithLabels(p *Policy, l map[string]string) *Policy {
 	return &p2
 }
 
-func policyWithKeepDaily(t *testing.T, base *Policy, keepDaily int) *Policy {
+func policyWithKeepDaily(t *testing.T, base *Policy, keepDaily OptionalInt) *Policy {
 	t.Helper()
 
 	p := clonePolicy(t, base)
@@ -194,7 +194,7 @@ func policyWithKeepDaily(t *testing.T, base *Policy, keepDaily int) *Policy {
 	return p
 }
 
-func policyWithKeepMonthly(t *testing.T, base *Policy, keepMonthly int) *Policy {
+func policyWithKeepMonthly(t *testing.T, base *Policy, keepMonthly OptionalInt) *Policy {
 	t.Helper()
 
 	p := clonePolicy(t, base)
@@ -212,13 +212,13 @@ func TestPolicyManagerResolvesConflicts(t *testing.T) {
 
 	require.NoError(t, SetPolicy(ctx, r1, sourceInfo, &Policy{
 		RetentionPolicy: RetentionPolicy{
-			KeepDaily: intPtr(44),
+			KeepDaily: newOptionalInt(44),
 		},
 	}))
 
 	require.NoError(t, SetPolicy(ctx, r2, sourceInfo, &Policy{
 		RetentionPolicy: RetentionPolicy{
-			KeepDaily: intPtr(33),
+			KeepDaily: newOptionalInt(33),
 		},
 	}))
 
@@ -275,87 +275,87 @@ func TestApplicablePoliciesForSource(t *testing.T) {
 	setPols := map[snapshot.SourceInfo]*Policy{
 		// unix-style path names
 		{Host: "host-a"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(0)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(0)},
 		},
 		{Host: "host-a", UserName: "myuser", Path: "/home"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(1)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(1)},
 		},
 		{Host: "host-a", UserName: "myuser", Path: "/home/users"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(2)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(2)},
 		},
 		// on Unix \ a regular character so the directory name is 'user-with\\backslash'
 		{Host: "host-a", UserName: "myuser", Path: "/home/users/user-with\\backslash"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(2)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(2)},
 		},
 		{Host: "host-a", UserName: "myuser", Path: "/home/users/user-with\\backslash/x"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(2)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(2)},
 		},
 		{Host: "host-a", UserName: "myuser", Path: "/home/users/myuser"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(3)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(3)},
 		},
 		{Host: "host-a", UserName: "myuser", Path: "/home/users/myuser/dir1"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(4)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(4)},
 		},
 		{Host: "host-a", UserName: "myuser", Path: "/home/users/myuser/dir2"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(5)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(5)},
 		},
 		{Host: "host-a", UserName: "myuser", Path: "/home/users/myuser/dir2/a"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(6)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(6)},
 		},
 		{Host: "host-a", UserName: "myuser", Path: "/home/users/myuser2"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(7)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(7)},
 		},
 
 		// windows-style path names with backslash
 		{Host: "host-b"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(0)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(0)},
 		},
 		{Host: "host-b", UserName: "myuser", Path: "C:\\"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(1)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(1)},
 		},
 		{Host: "host-b", UserName: "myuser", Path: "C:\\Users"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(2)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(2)},
 		},
 		{Host: "host-b", UserName: "myuser", Path: "C:\\Users\\myuser"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(3)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(3)},
 		},
 		{Host: "host-b", UserName: "myuser", Path: "C:\\Users\\myuser\\dir1"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(4)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(4)},
 		},
 		{Host: "host-b", UserName: "myuser", Path: "C:\\Users\\myuser\\dir2"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(5)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(5)},
 		},
 		{Host: "host-b", UserName: "myuser", Path: "C:\\Users\\myuser\\dir2\\a"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(6)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(6)},
 		},
 		{Host: "host-b", UserName: "myuser", Path: "C:\\Users\\myuser2"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(7)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(7)},
 		},
 
 		// windows-style path names with slashes
 		{Host: "host-c"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(0)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(0)},
 		},
 		{Host: "host-c", UserName: "myuser", Path: "C:/Users"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(1)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(1)},
 		},
 		{Host: "host-c", UserName: "myuser", Path: "C:/Users"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(2)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(2)},
 		},
 		{Host: "host-c", UserName: "myuser", Path: "C:/Users/myuser"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(3)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(3)},
 		},
 		{Host: "host-c", UserName: "myuser", Path: "C:/Users/myuser/dir1"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(4)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(4)},
 		},
 		{Host: "host-c", UserName: "myuser", Path: "C:/Users/myuser/dir2"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(5)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(5)},
 		},
 		{Host: "host-c", UserName: "myuser", Path: "C:/Users/myuser/dir2/a"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(6)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(6)},
 		},
 		{Host: "host-c", UserName: "myuser", Path: "C:/Users/myuser2"}: {
-			RetentionPolicy: RetentionPolicy{KeepDaily: intPtr(7)},
+			RetentionPolicy: RetentionPolicy{KeepDaily: newOptionalInt(7)},
 		},
 	}
 

--- a/snapshot/policy/policy_merge.go
+++ b/snapshot/policy/policy_merge.go
@@ -56,7 +56,7 @@ func mergeOptionalBool(target **OptionalBool, src *OptionalBool, def *snapshot.S
 	}
 }
 
-func mergeOptionalInt(target **int, src *int, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
+func mergeOptionalInt(target **OptionalInt, src *OptionalInt, def *snapshot.SourceInfo, si snapshot.SourceInfo) {
 	if *target == nil && src != nil {
 		v := *src
 

--- a/snapshot/policy/policy_merge_test.go
+++ b/snapshot/policy/policy_merge_test.go
@@ -108,6 +108,15 @@ func testPolicyMergeSingleField(t *testing.T, fieldName string, typ reflect.Type
 		v0 = reflect.ValueOf((*policy.OptionalBool)(nil))
 		v1 = reflect.ValueOf(&ob1)
 		v2 = reflect.ValueOf(&ob2)
+
+	case "*policy.OptionalInt":
+		ob1 := policy.OptionalInt(1)
+		ob2 := policy.OptionalInt(7)
+
+		v0 = reflect.ValueOf((*policy.OptionalInt)(nil))
+		v1 = reflect.ValueOf(&ob1)
+		v2 = reflect.ValueOf(&ob2)
+
 	case "bool":
 		v0 = reflect.ValueOf(false)
 		v1 = reflect.ValueOf(false)

--- a/snapshot/policy/policy_tree.go
+++ b/snapshot/policy/policy_tree.go
@@ -40,12 +40,12 @@ var (
 	}
 
 	defaultRetentionPolicy = RetentionPolicy{
-		KeepLatest:  intPtr(defaultKeepLatest),
-		KeepHourly:  intPtr(defaultKeepHourly),
-		KeepDaily:   intPtr(defaultKeepDaily),
-		KeepWeekly:  intPtr(defaultKeepWeekly),
-		KeepMonthly: intPtr(defaultKeepMonthly),
-		KeepAnnual:  intPtr(defaultKeepAnnual),
+		KeepLatest:  newOptionalInt(defaultKeepLatest),
+		KeepHourly:  newOptionalInt(defaultKeepHourly),
+		KeepDaily:   newOptionalInt(defaultKeepDaily),
+		KeepWeekly:  newOptionalInt(defaultKeepWeekly),
+		KeepMonthly: newOptionalInt(defaultKeepMonthly),
+		KeepAnnual:  newOptionalInt(defaultKeepAnnual),
 	}
 
 	defaultSchedulingPolicy = SchedulingPolicy{}

--- a/snapshot/policy/retention_policy_test.go
+++ b/snapshot/policy/retention_policy_test.go
@@ -18,8 +18,17 @@ func TestRetentionPolicyTest(t *testing.T) {
 		timeToExpectedTags map[string][]string
 	}{
 		{
+			&RetentionPolicy{}, // empty policy is treated as {"keepLatest": maxInt}
+			map[string][]string{
+				"2020-01-01T12:00:00Z": {"latest-4"},
+				"2020-01-01T12:01:00Z": {"latest-3"},
+				"2020-01-01T12:02:00Z": {"latest-2"},
+				"2020-01-01T12:03:00Z": {"latest-1"},
+			},
+		},
+		{
 			&RetentionPolicy{
-				KeepLatest: intPtr(3),
+				KeepLatest: newOptionalInt(3),
 			},
 			map[string][]string{
 				"2020-01-01T12:00:00Z": {}, // not retained, only keep 3 latest
@@ -30,7 +39,7 @@ func TestRetentionPolicyTest(t *testing.T) {
 		},
 		{
 			&RetentionPolicy{
-				KeepDaily: intPtr(3),
+				KeepDaily: newOptionalInt(3),
 			},
 			map[string][]string{
 				"2020-01-01T12:00:00Z": {},
@@ -45,7 +54,7 @@ func TestRetentionPolicyTest(t *testing.T) {
 		},
 		{
 			&RetentionPolicy{
-				KeepMonthly: intPtr(3),
+				KeepMonthly: newOptionalInt(3),
 			},
 			map[string][]string{
 				"2020-01-01T12:00:00Z": {},
@@ -60,7 +69,7 @@ func TestRetentionPolicyTest(t *testing.T) {
 		},
 		{
 			&RetentionPolicy{
-				KeepMonthly: intPtr(3),
+				KeepMonthly: newOptionalInt(3),
 			},
 			map[string][]string{
 				"2020-01-01T12:00:00Z": {},
@@ -73,10 +82,10 @@ func TestRetentionPolicyTest(t *testing.T) {
 		},
 		{
 			&RetentionPolicy{
-				KeepLatest:  intPtr(3),
-				KeepHourly:  intPtr(7),
-				KeepDaily:   intPtr(5),
-				KeepMonthly: intPtr(2),
+				KeepLatest:  newOptionalInt(3),
+				KeepHourly:  newOptionalInt(7),
+				KeepDaily:   newOptionalInt(5),
+				KeepMonthly: newOptionalInt(2),
 			},
 			map[string][]string{
 				"2020-01-01T12:00:00Z": {},
@@ -124,7 +133,7 @@ func TestRetentionPolicyTest(t *testing.T) {
 		},
 		{
 			&RetentionPolicy{
-				KeepLatest: intPtr(3),
+				KeepLatest: newOptionalInt(3),
 			},
 			map[string][]string{
 				"2020-04-02T15:00:00Z":            {"latest-1"},
@@ -138,7 +147,7 @@ func TestRetentionPolicyTest(t *testing.T) {
 		},
 		{
 			&RetentionPolicy{
-				KeepWeekly: intPtr(3),
+				KeepWeekly: newOptionalInt(3),
 			},
 			map[string][]string{
 				"2020-01-01T12:00:00Z": {},

--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -142,7 +142,7 @@ func TestServerStart(t *testing.T) {
 	err = json.Unmarshal(rootPayload, &dummy)
 	require.NoError(t, err)
 
-	keepDaily := 77
+	keepDaily := policy.OptionalInt(77)
 
 	createResp, err = serverapi.CreateSnapshotSource(ctx, cli, &serverapi.CreateSnapshotSourceRequest{
 		Path: sharedTestDataDir3,


### PR DESCRIPTION
This is a safety measure which addresses P0 improvement for #1732.

Given that retention policies that retain nothing make no sense, this is not considered a breaking change.