### PR TITLE
docs(site): update homebrew installation instructions

### DIFF
--- a/site/content/docs/Installation/_index.md
+++ b/site/content/docs/Installation/_index.md
@@ -74,7 +74,7 @@ On macOS, you can use [Homebrew](https://brew.sh) to install and keep Kopia up-t
 To install:
 
 ```shell
-$ brew install kopia/kopia/kopia
+$ brew install kopia
 ```
 
 To upgrade Kopia:


### PR DESCRIPTION
Since we now have official kopia formula in the `homebrew-core` repo,
dedicated `kopia` TAP is no longer needed (we will keep publishing to
it for a while so it's available as a fallback).

Fixes #1728