### PR TITLE
feat(snapshots): big upload performance improvements by parallelizing directory traversal

### DIFF
--- a/internal/workshare/workshare_pool.go
+++ b/internal/workshare/workshare_pool.go
@@ -1,0 +1,77 @@
+// Package workshare implements work sharing worker pool.
+package workshare
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// ProcessFunc processes the provided input, the result must be written within the input itself.
+// To avoid allocations, the function should not be a local closure but a named function (either global or
+// a method).
+type ProcessFunc func(c *Pool, input interface{})
+
+type workItem struct {
+	process ProcessFunc     // function to call
+	input   interface{}     // parameter to the function
+	wg      *sync.WaitGroup // signal the provided WaitGroup after work is done
+}
+
+// Pool manages a pool of generic workers that can process workItem.
+type Pool struct {
+	activeWorkers int32
+
+	semaphore chan struct{}
+
+	work   chan workItem
+	closed chan struct{}
+
+	wg sync.WaitGroup
+}
+
+// ActiveWorkers returns the number of active workers.
+func (w *Pool) ActiveWorkers() int {
+	return int(atomic.LoadInt32(&w.activeWorkers))
+}
+
+// NewPool creates a worker pool that launches a given number of goroutines that can invoke shared work.
+func NewPool(numWorkers int) *Pool {
+	if numWorkers < 0 {
+		numWorkers = 0
+	}
+
+	w := &Pool{
+		work:      make(chan workItem), // channel must be unbuffered
+		closed:    make(chan struct{}),
+		semaphore: make(chan struct{}, numWorkers),
+	}
+
+	for i := 0; i < numWorkers; i++ {
+		w.wg.Add(1)
+
+		go func() {
+			defer w.wg.Done()
+
+			for {
+				select {
+				case it := <-w.work:
+					atomic.AddInt32(&w.activeWorkers, 1)
+					it.process(w, it.input)
+					atomic.AddInt32(&w.activeWorkers, -1)
+					<-w.semaphore
+					it.wg.Done()
+
+				case <-w.closed:
+					return
+				}
+			}
+		}()
+	}
+
+	return w
+}
+
+// Close closes the worker pool.
+func (w *Pool) Close() {
+	close(w.closed)
+}

--- a/internal/workshare/workshare_test.go
+++ b/internal/workshare/workshare_test.go
@@ -1,0 +1,128 @@
+package workshare_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/workshare"
+)
+
+type treeNode struct {
+	value    int
+	children []*treeNode
+}
+
+func buildTree(level int) *treeNode {
+	n := &treeNode{
+		value: 1,
+	}
+
+	if level <= 0 {
+		return n
+	}
+
+	for i := 0; i < level; i++ {
+		n.children = append(n.children, buildTree(level-1))
+	}
+
+	return n
+}
+
+type computeTreeSumRequest struct {
+	input *treeNode
+
+	result int
+	err    error
+}
+
+func dispatchComputeTreeSumRequest(w *workshare.Pool, input interface{}) {
+	req := input.(*computeTreeSumRequest)
+
+	if w.ActiveWorkers() == 0 {
+		panic("unexpected worker count")
+	}
+
+	res, err := computeTreeSum(w, req.input)
+	if err != nil {
+		req.err = err
+		return
+	}
+
+	req.result = res
+}
+
+func computeTreeSum(workPool *workshare.Pool, n *treeNode) (int, error) {
+	total := n.value
+
+	var cs workshare.AsyncGroup
+
+	for _, child := range n.children {
+		if cs.CanShareWork(workPool) {
+			// run the request on another goroutine, the results will be available
+			cs.RunAsync(workPool, dispatchComputeTreeSumRequest, &computeTreeSumRequest{
+				input: child,
+			})
+		} else {
+			chtot, err := computeTreeSum(workPool, child)
+			if err != nil {
+				return 0, err
+			}
+
+			total += chtot
+		}
+	}
+
+	for _, req := range cs.Wait() {
+		twr := req.(*computeTreeSumRequest)
+
+		if twr.err != nil {
+			return 0, twr.err
+		}
+
+		total += twr.result
+	}
+
+	return total, nil
+}
+
+func TestComputeTreeSum10(t *testing.T) {
+	testComputeTreeSum(t, 10)
+}
+
+func TestComputeTreeSum1(t *testing.T) {
+	testComputeTreeSum(t, 1)
+}
+
+func TestComputeTreeSum0(t *testing.T) {
+	testComputeTreeSum(t, 0)
+}
+
+func TestComputeTreeSumNegative(t *testing.T) {
+	testComputeTreeSum(t, -1)
+}
+
+// nolint:thelper
+func testComputeTreeSum(t *testing.T, numWorkers int) {
+	w := workshare.NewPool(numWorkers)
+	defer w.Close()
+
+	n := buildTree(6)
+
+	sum, err := computeTreeSum(w, n)
+	require.NoError(t, err)
+	require.Equal(t, 1957, sum)
+}
+
+var treeToWalk = buildTree(6)
+
+func BenchmarkComputeTreeSum(b *testing.B) {
+	w := workshare.NewPool(10)
+	defer w.Close()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		computeTreeSum(w, treeToWalk)
+	}
+}

--- a/internal/workshare/workshare_waitgroup.go
+++ b/internal/workshare/workshare_waitgroup.go
@@ -1,4 +1,44 @@
 // Package workshare implements work sharing worker pool.
+//
+// It is commonly used to traverse tree-like structures:
+//
+// type processWorkRequest struct {
+//   node *someNode
+//   err error
+// }
+//
+// func processWork(p *workshare.Pool, req interface{}) {
+//   req := req.(*processWorkRequest)
+//   req.err = visitNode(p, req.node)
+// }
+//
+// func visitNode(p *workshare.Pool, n *someNode) error {
+//   var wg workshare.AsyncGroup
+//
+//   for _, child := range n.children {
+//     if wg.CanShareWork(p) {
+//       // run asynchronously, collect result using wg.Wait() below.
+//       RunAsync(p, processWork, processWorkRequest{child})
+//     } else {
+// 	      if err := visitNode(p, n); err != nil {
+//          return err
+//        }
+//     }
+//   }
+//
+//   // wait for results from all shared work and handle them.
+//   for _, req := range wg.Wait() {
+//     if err := req.(*processWorkRequest).err; err != nil {
+//       return err
+//     }
+//   }
+//
+//   return nil
+// }
+//
+// wp = workshare.NewPool(10)
+// defer wp.Close()
+// visitNode(wp, root)
 package workshare
 
 import (
@@ -7,6 +47,8 @@ import (
 
 // AsyncGroup launches and awaits asynchronous work through a WorkerPool.
 // It provides API designed to minimize allocations while being reasonably easy to use.
+// AsyncGroup is very lightweight and NOT safe for concurrent use, all interactions must
+// be from the same goroutine.
 type AsyncGroup struct {
 	wg       *sync.WaitGroup
 	requests []interface{}
@@ -23,19 +65,20 @@ func (g *AsyncGroup) Wait() []interface{} {
 	return g.requests
 }
 
-// RunAsync starts the asynchronous work to process the provided input, the user must call Wait().
-func (g *AsyncGroup) RunAsync(w *Pool, process ProcessFunc, input interface{}) {
+// RunAsync starts the asynchronous work to process the provided request,
+// the user must call Wait() after all RunAsync() have been scheduled.
+func (g *AsyncGroup) RunAsync(w *Pool, process ProcessFunc, request interface{}) {
 	if g.wg == nil {
 		g.wg = &sync.WaitGroup{}
 	}
 
 	g.wg.Add(1)
 
-	g.requests = append(g.requests, input)
+	g.requests = append(g.requests, request)
 
 	w.work <- workItem{
 		process: process,
-		input:   input,
+		request: request,
 		wg:      g.wg,
 	}
 }
@@ -46,9 +89,13 @@ func (g *AsyncGroup) RunAsync(w *Pool, process ProcessFunc, input interface{}) {
 func (g *AsyncGroup) CanShareWork(w *Pool) bool {
 	select {
 	case w.semaphore <- struct{}{}:
+		// we successfully added token to the channel, because we have exactly the same number
+		// of workers as the capacity of the channel, one worker will wake up to process
+		// item from w.work, which will be added by RunAsync().
 		return true
 
 	default:
+		// all workers are busy.
 		return false
 	}
 }

--- a/internal/workshare/workshare_waitgroup.go
+++ b/internal/workshare/workshare_waitgroup.go
@@ -1,0 +1,54 @@
+// Package workshare implements work sharing worker pool.
+package workshare
+
+import (
+	"sync"
+)
+
+// AsyncGroup launches and awaits asynchronous work through a WorkerPool.
+// It provides API designed to minimize allocations while being reasonably easy to use.
+type AsyncGroup struct {
+	wg       *sync.WaitGroup
+	requests []interface{}
+}
+
+// Wait waits for scheduled asynchronous work to complete and returns all asynchronously processed inputs.
+func (g *AsyncGroup) Wait() []interface{} {
+	if g.wg == nil {
+		return nil
+	}
+
+	g.wg.Wait()
+
+	return g.requests
+}
+
+// RunAsync starts the asynchronous work to process the provided input, the user must call Wait().
+func (g *AsyncGroup) RunAsync(w *Pool, process ProcessFunc, input interface{}) {
+	if g.wg == nil {
+		g.wg = &sync.WaitGroup{}
+	}
+
+	g.wg.Add(1)
+
+	g.requests = append(g.requests, input)
+
+	w.work <- workItem{
+		process: process,
+		input:   input,
+		wg:      g.wg,
+	}
+}
+
+// CanShareWork determines if the provided worker pool has capacity to share work.
+// If the function returns true, the use MUST call RunAsync() exactly once. This pattern avoids
+// allocations required to create asynchronous input if the worker pool is full.
+func (g *AsyncGroup) CanShareWork(w *Pool) bool {
+	select {
+	case w.semaphore <- struct{}{}:
+		return true
+
+	default:
+		return false
+	}
+}

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -1197,6 +1197,12 @@ func (u *Uploader) writeDirManifest(ctx context.Context, dirRelativePath string,
 }
 
 func (u *Uploader) reportErrorAndMaybeCancel(err error, isIgnored bool, dmb *dirManifestBuilder, entryRelativePath string) {
+	if u.IsCanceled() && atomic.LoadInt32(&u.stats.ErrorCount) > 0 {
+		// alrady canceled and we have reported a fatal error,
+		// do not report another.
+		return
+	}
+
 	if isIgnored {
 		atomic.AddInt32(&u.stats.IgnoredErrorCount, 1)
 	} else {

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -1197,9 +1197,8 @@ func (u *Uploader) writeDirManifest(ctx context.Context, dirRelativePath string,
 }
 
 func (u *Uploader) reportErrorAndMaybeCancel(err error, isIgnored bool, dmb *dirManifestBuilder, entryRelativePath string) {
-	if u.IsCanceled() && atomic.LoadInt32(&u.stats.ErrorCount) > 0 {
-		// alrady canceled and we have reported a fatal error,
-		// do not report another.
+	if u.IsCanceled() && errors.Is(err, errCanceled) {
+		// alrady canceled, do not report another.
 		return
 	}
 


### PR DESCRIPTION
Previously directories were walked strictly sequentially which means
we could never be uploading data from multiple directories in parallel,
even if they had just a few files each.

This change switches to using the new `workshare` utility which improves
parallelism. It also reduces memory allocations, goroutine creations
and overall memory usage when taking large snapshots, while increasing
CPU utilization.

Tests on realistic directory structures show huge speed-ups during cold
snapshots (without any metadata caching:)

Photo library - 160GB, files:41717 dirs:1350

    Before: 3m11s
    After: 1m50s
    Total time reduction: 43%

Working code directory - 30.7 GB files:194560 dirs:42455

    Before: 55s
    After: 25s
    Total time reduction: 55%