### PR TITLE
feat(general): Upgrade lock retries & monitoring during open & write sessions

### DIFF
--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -168,12 +168,12 @@ func (e *Environment) MustReopen(tb testing.TB, openOpts ...func(*repo.Options))
 }
 
 // MustOpenAnother opens another repository backend by the same storage.
-func (e *Environment) MustOpenAnother(tb testing.TB) repo.RepositoryWriter {
+func (e *Environment) MustOpenAnother(tb testing.TB, openOpts ...func(*repo.Options)) repo.RepositoryWriter {
 	tb.Helper()
 
 	ctx := testlogging.Context(tb)
 
-	rep2, err := repo.Open(ctx, e.ConfigFile(), e.Password, &repo.Options{})
+	rep2, err := repo.Open(ctx, e.ConfigFile(), e.Password, repoOptions(openOpts))
 	if err != nil {
 		tb.Fatalf("err: %v", err)
 	}

--- a/repo/blob/beforeop/beforeop.go
+++ b/repo/blob/beforeop/beforeop.go
@@ -71,3 +71,15 @@ func NewWrapper(wrapped blob.Storage, onGetBlob onGetBlobCallback, onGetMetadata
 		onPutBlob:     onPutBlob,
 	}
 }
+
+// NewUniformWrapper is same as NewWrapper except that it only accepts a single
+// uniform callback for all the operations for simpler use-cases.
+func NewUniformWrapper(wrapped blob.Storage, cb callback) blob.Storage {
+	return &beforeOp{
+		Storage:       wrapped,
+		onGetBlob:     func(_ blob.ID) error { return cb() },
+		onGetMetadata: cb,
+		onDeleteBlob:  cb,
+		onPutBlob:     func(_ blob.ID, _ *blob.PutOptions) error { return cb() },
+	}
+}

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -405,10 +405,9 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 	// verify that the blobcfg retention blob is created
 	require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, repo.BlobCfgBlobID, 0, -1, &d))
 	require.NoError(t, env.RepositoryWriter.ChangePassword(ctx, "new-password"))
-
 	// verify that the blobcfg retention blob is created and is different after
 	// password-change
-	require.NoError(t, env.RootStorage().GetBlob(ctx, repo.BlobCfgBlobID, 0, -1, &d))
+	require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, repo.BlobCfgBlobID, 0, -1, &d))
 
 	// verify that we cannot re-initialize the repo even after password change
 	require.EqualError(t, repo.Initialize(testlogging.Context(t), env.RootStorage(), nil, env.Password),
@@ -418,17 +417,17 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 	{
 		// backup & corrupt the blobcfg blob
 		d.Reset()
-		require.NoError(t, env.RootStorage().GetBlob(ctx, repo.BlobCfgBlobID, 0, -1, &d))
+		require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, repo.BlobCfgBlobID, 0, -1, &d))
 		corruptedData := d.Dup()
 		corruptedData.Append([]byte("bad bits"))
-		require.NoError(t, env.RootStorage().PutBlob(ctx, repo.BlobCfgBlobID, corruptedData.Bytes(), blob.PutOptions{}))
+		require.NoError(t, env.RepositoryWriter.BlobStorage().PutBlob(ctx, repo.BlobCfgBlobID, corruptedData.Bytes(), blob.PutOptions{}))
 
 		// verify that we error out on corrupted blobcfg blob
 		_, err := repo.Open(ctx, env.ConfigFile(), env.Password, &repo.Options{})
 		require.EqualError(t, err, "invalid repository password")
 
 		// restore the original blob
-		require.NoError(t, env.RootStorage().PutBlob(ctx, repo.BlobCfgBlobID, d.Bytes(), blob.PutOptions{}))
+		require.NoError(t, env.RepositoryWriter.BlobStorage().PutBlob(ctx, repo.BlobCfgBlobID, d.Bytes(), blob.PutOptions{}))
 	}
 
 	// verify that we'd hard-fail on unexpected errors on blobcfg blob-puts

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -406,16 +406,6 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 	require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, repo.BlobCfgBlobID, 0, -1, &d))
 	require.NoError(t, env.RepositoryWriter.ChangePassword(ctx, "new-password"))
 
-	// due to the upgrade lock monitor before-op hook, the next operation on
-	// the storage backend will fail with invalid password
-	require.EqualError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, repo.BlobCfgBlobID, 0, -1, &d),
-		"invalid repository password")
-
-	// verify that the blobcfg retention blob is created and is different after
-	// password-change, this should work because we are bypassing the upgrade
-	// monitor by working with the root storage directly
-	require.NoError(t, env.RootStorage().GetBlob(ctx, repo.BlobCfgBlobID, 0, -1, &d))
-
 	// verify that the blobcfg retention blob is created and is different after
 	// password-change
 	require.NoError(t, env.RootStorage().GetBlob(ctx, repo.BlobCfgBlobID, 0, -1, &d))


### PR DESCRIPTION
Upgrade lock monitor for Kopia does two things:

- Monitors the upgrade lock during runtime before each operation. This is protected by a cache-refresh timeout so that we do not do a hard pull on ever Get/Put etc or impact performance.
- The repository open() operation will wait poll and block on the upgrade lock until timeout.

POC PR: https://github.com/kopia/kopia/pull/1622
Monitor Design: https://docs.google.com/document/d/1zIghQc4i4vJSANjSDBOvjzMiqnZSEp1cCasxSUkltSk/edit#heading=h.khston2oxmxy