### PR TITLE
feat(cli): added `snapshot list` flags: `--storage-stats` and `--reverse`

### DIFF
--- a/cli/command_snapshot_storage_stats_test.go
+++ b/cli/command_snapshot_storage_stats_test.go
@@ -1,0 +1,136 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestSnapshotStorageStats(t *testing.T) {
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+	dir1 := testutil.TempDirectory(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir1, "file1.txt"), []byte{1, 2, 3, 4, 5}, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir1, "file2.txt"), []byte{2, 3, 4, 5, 6}, 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir1, "subdir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir1, "subdir", "file2.txt"), []byte{3, 4, 5, 6, 7}, 0o600))
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+	env.RunAndExpectSuccess(t, "snapshot", "create", dir1)
+
+	// same as ./file1.txt
+	require.NoError(t, os.WriteFile(filepath.Join(dir1, "subdir", "file3.txt"), []byte{1, 2, 3, 4, 5}, 0o600))
+
+	// new file
+	require.NoError(t, os.WriteFile(filepath.Join(dir1, "subdir", "file4.txt"), []byte{1, 2, 3, 4, 5, 6, 7, 8}, 0o600))
+	env.RunAndExpectSuccess(t, "snapshot", "create", dir1)
+
+	var manifests []*snapshot.Manifest
+
+	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(t, "snapshot", "ls", "--storage-stats", dir1, "--json"), &manifests)
+	require.Len(t, manifests, 2)
+
+	require.Equal(t, &snapshot.StorageStats{
+		NewData: snapshot.StorageUsageDetails{
+			FileObjectCount:      3,
+			DirObjectCount:       2,
+			ContentCount:         5,
+			ObjectBytes:          15,
+			OriginalContentBytes: 15,
+			PackedContentBytes:   99,
+		},
+		RunningTotal: snapshot.StorageUsageDetails{
+			FileObjectCount:      3,
+			DirObjectCount:       2,
+			ContentCount:         5,
+			ObjectBytes:          15,
+			OriginalContentBytes: 15,
+			PackedContentBytes:   99,
+		},
+	}, manifests[0].StorageStats)
+
+	require.Equal(t, &snapshot.StorageStats{
+		NewData: snapshot.StorageUsageDetails{
+			FileObjectCount:      1,
+			DirObjectCount:       2,
+			ContentCount:         3,
+			ObjectBytes:          8,
+			OriginalContentBytes: 8,
+			PackedContentBytes:   36,
+		},
+		RunningTotal: snapshot.StorageUsageDetails{
+			FileObjectCount:      4,
+			DirObjectCount:       4,
+			ContentCount:         8,
+			ObjectBytes:          23,
+			OriginalContentBytes: 23,
+			PackedContentBytes:   135,
+		},
+	}, manifests[1].StorageStats)
+
+	// same but in reverse order
+	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(t, "snapshot", "ls", "--storage-stats", dir1, "--reverse", "--json"), &manifests)
+	require.Len(t, manifests, 2)
+
+	require.Equal(t, &snapshot.StorageStats{
+		NewData: snapshot.StorageUsageDetails{
+			ObjectBytes:          23,
+			OriginalContentBytes: 23,
+			PackedContentBytes:   135,
+			FileObjectCount:      4,
+			DirObjectCount:       2,
+			ContentCount:         6,
+		},
+		RunningTotal: snapshot.StorageUsageDetails{
+			ObjectBytes:          23,
+			OriginalContentBytes: 23,
+			PackedContentBytes:   135,
+			FileObjectCount:      4,
+			DirObjectCount:       2,
+			ContentCount:         6,
+		},
+	}, manifests[0].StorageStats)
+
+	require.Equal(t, &snapshot.StorageStats{
+		NewData: snapshot.StorageUsageDetails{
+			ObjectBytes:          0, // all file data was already present
+			OriginalContentBytes: 0,
+			PackedContentBytes:   0,
+			FileObjectCount:      0,
+			DirObjectCount:       2, // new directories only
+			ContentCount:         2,
+		},
+		RunningTotal: snapshot.StorageUsageDetails{
+			ObjectBytes:          23,
+			OriginalContentBytes: 23,
+			PackedContentBytes:   135,
+			FileObjectCount:      4,
+			DirObjectCount:       4,
+			ContentCount:         8,
+		},
+	}, manifests[1].StorageStats)
+
+	out := env.RunAndExpectSuccess(t, "snapshot", "ls", "--storage-stats")
+	require.Len(t, out, 3)
+	require.Contains(t, out[1], "new-data:99 B ")
+	require.Contains(t, out[1], "new-files:3 ")
+	require.Contains(t, out[1], "new-dirs:2 ")
+	require.Contains(t, out[2], "new-data:36 B ")
+	require.Contains(t, out[2], "new-files:1 ")
+	require.Contains(t, out[2], "new-dirs:2 ")
+
+	out = env.RunAndExpectSuccess(t, "snapshot", "ls", "--storage-stats", "--reverse")
+	require.Len(t, out, 3)
+	require.Contains(t, out[1], "new-data:135 B ")
+	require.Contains(t, out[1], "new-files:4 ")
+	require.Contains(t, out[1], "new-dirs:2 ")
+	require.Contains(t, out[2], "new-data:0 B ")
+	require.Contains(t, out[2], "new-files:0 ")
+	require.Contains(t, out[2], "new-dirs:2 ")
+}

--- a/snapshot/manifest.go
+++ b/snapshot/manifest.go
@@ -32,6 +32,9 @@ type Manifest struct {
 
 	Tags map[string]string `json:"tags,omitempty"`
 
+	// usage, not persisted, values depend on walking snapshot list in a particular order
+	StorageStats *StorageStats `json:"storageStats,omitempty"`
+
 	// list of manually-defined pins which prevent the snapshot from being deleted.
 	Pins []string `json:"pins,omitempty"`
 }
@@ -156,6 +159,35 @@ func (m *Manifest) RootObjectID() object.ID {
 	}
 
 	return ""
+}
+
+// StorageStats encapsulates snapshot storage usage information and running totals.
+type StorageStats struct {
+	// amount of new unique data in this snapshot that wasn't there before.
+	// note that this depends on ordering of snapshots.
+	NewData      StorageUsageDetails `json:"newData,omitempty"`
+	RunningTotal StorageUsageDetails `json:"runningTotal,omitempty"`
+}
+
+// StorageUsageDetails provides details about snapshot storage usage.
+type StorageUsageDetails struct {
+	// number of bytes in all objects (ignoring content-level deduplication).
+	ObjectBytes int64 `json:"objectBytes"`
+
+	// number of bytes in all unique contents (original).
+	OriginalContentBytes int64 `json:"originalContentBytes"`
+
+	// number of bytes in all unique contents as stored in the repository.
+	PackedContentBytes int64 `json:"packedContentBytes"`
+
+	// number of unique file objects.
+	FileObjectCount int32 `json:"fileObjects"`
+
+	// number of unique objects.
+	DirObjectCount int32 `json:"dirObjects"`
+
+	// number of unique contents.
+	ContentCount int32 `json:"contents"`
 }
 
 // GroupBySource returns a slice of slices, such that each result item contains manifests from a single source.

--- a/snapshot/snapshotfs/snapshot_storage_stats.go
+++ b/snapshot/snapshotfs/snapshot_storage_stats.go
@@ -1,0 +1,106 @@
+package snapshotfs
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/object"
+	"github.com/kopia/kopia/snapshot"
+)
+
+// CalculateStorageStats calculates the storage statistics for a given list of snapshots,
+// by determining the count and size of unique contents and objects for each snapshot in
+// the slice as well as running total so far for all the previous snapshots.
+//
+// For each snapshot the provided callback is invoked as soon as the results
+// are available and iteration continues until the callback returns a non-nil error.
+func CalculateStorageStats(ctx context.Context, rep repo.Repository, manifests []*snapshot.Manifest, callback func(m *snapshot.Manifest) error) error {
+	unique := new(snapshot.StorageUsageDetails)
+	runningTotal := new(snapshot.StorageUsageDetails)
+
+	var uniqueContents sync.Map
+
+	tw, err := NewTreeWalker(TreeWalkerOptions{
+		EntryCallback: func(ctx context.Context, entry fs.Entry, oid object.ID, entryPath string) error {
+			if !entry.IsDir() {
+				atomic.AddInt32(&unique.FileObjectCount, 1)
+				atomic.AddInt32(&runningTotal.FileObjectCount, 1)
+
+				atomic.AddInt64(&unique.ObjectBytes, entry.Size())
+				atomic.AddInt64(&runningTotal.ObjectBytes, entry.Size())
+			} else {
+				atomic.AddInt32(&unique.DirObjectCount, 1)
+				atomic.AddInt32(&runningTotal.DirObjectCount, 1)
+			}
+
+			contentIDs, err := rep.VerifyObject(ctx, oid)
+			if err != nil {
+				return errors.Wrapf(err, "error verifying object %v", oid)
+			}
+
+			for _, cid := range contentIDs {
+				if _, loaded := uniqueContents.LoadOrStore(cid, struct{}{}); !loaded {
+					atomic.AddInt32(&unique.ContentCount, 1)
+					atomic.AddInt32(&runningTotal.ContentCount, 1)
+
+					if !entry.IsDir() {
+						info, err := rep.ContentInfo(ctx, cid)
+						if err != nil {
+							return errors.Wrapf(err, "error getting content info for %v", cid)
+						}
+
+						l := int64(info.GetOriginalLength())
+
+						atomic.AddInt64(&unique.OriginalContentBytes, l)
+						atomic.AddInt64(&runningTotal.OriginalContentBytes, l)
+
+						l2 := int64(info.GetPackedLength())
+
+						atomic.AddInt64(&unique.PackedContentBytes, l2)
+						atomic.AddInt64(&runningTotal.PackedContentBytes, l2)
+					}
+				}
+			}
+
+			return nil
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "unable to create tree walker")
+	}
+	defer tw.Close()
+
+	src := manifests[0].Source
+
+	for _, snap := range manifests {
+		*unique = snapshot.StorageUsageDetails{}
+
+		rootName := src.String() + "@" + snap.StartTime.Format(time.RFC3339)
+
+		root, err := SnapshotRoot(rep, snap)
+		if err != nil {
+			return errors.Wrapf(err, "unable to get snapshot root for %v", rootName)
+		}
+
+		if err := tw.Process(ctx, root, rootName); err != nil {
+			return errors.Wrapf(err, "error processing %v", rootName)
+		}
+
+		snap.StorageStats = &snapshot.StorageStats{
+			NewData:      *unique,
+			RunningTotal: *runningTotal,
+		}
+
+		if err := callback(snap); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/snapshot/snapshotfs/snapshot_storage_stats_test.go
+++ b/snapshot/snapshotfs/snapshot_storage_stats_test.go
@@ -1,0 +1,111 @@
+package snapshotfs_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/mockfs"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+)
+
+func TestCalculateStorageStats(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+
+	sourceRoot := mockfs.NewDirectory()
+	dir1 := sourceRoot.AddDir("dir1", 0o755)
+	dir2 := sourceRoot.AddDir("dir2", 0o755)
+
+	// root directory, 2 subdirectories + 2 unique files (dir1/file11 === dir2/file22)
+	dir1.AddFile("file11", []byte{1, 2, 3}, 0o644)
+	dir2.AddFile("file21", []byte{1, 2, 3, 4}, 0o644)
+	dir2.AddFile("file22", []byte{1, 2, 3}, 0o644) // same content as dir11/file11
+
+	src := snapshot.SourceInfo{
+		Host:     env.Repository.ClientOptions().Hostname,
+		UserName: env.Repository.ClientOptions().Username,
+		Path:     "/dummy",
+	}
+
+	u := snapshotfs.NewUploader(env.RepositoryWriter)
+	man1, err := u.Upload(ctx, sourceRoot, nil, src)
+	require.NoError(t, err)
+	require.NoError(t, env.RepositoryWriter.Flush(ctx))
+
+	man2, err := u.Upload(ctx, sourceRoot, nil, src)
+	require.NoError(t, err)
+	require.NoError(t, env.RepositoryWriter.Flush(ctx))
+
+	// add one more file, upload again
+	dir2.AddFile("file23", []byte{1, 2, 3, 4, 5}, 0o644)
+
+	man3, err := u.Upload(ctx, sourceRoot, nil, src)
+	require.NoError(t, err)
+	require.NoError(t, env.RepositoryWriter.Flush(ctx))
+
+	var stats []*snapshot.Manifest
+
+	require.NoError(t, snapshotfs.CalculateStorageStats(ctx, env.RepositoryWriter, []*snapshot.Manifest{
+		man1, man2, man3,
+	}, func(m *snapshot.Manifest) error {
+		stats = append(stats, m)
+		return nil
+	}))
+
+	require.Len(t, stats, 3)
+
+	// first stat
+	require.Equal(t, &snapshot.StorageStats{
+		NewData: snapshot.StorageUsageDetails{
+			FileObjectCount:      2,
+			DirObjectCount:       3,
+			ContentCount:         5,
+			ObjectBytes:          7, // 3 + 4 unique bytes
+			OriginalContentBytes: 7, // 3 + 4 unique bytes
+			PackedContentBytes:   63,
+		},
+		RunningTotal: snapshot.StorageUsageDetails{
+			FileObjectCount:      2,
+			DirObjectCount:       3,
+			ContentCount:         5,
+			ObjectBytes:          7,
+			OriginalContentBytes: 7, // 3 + 4 unique bytes
+			PackedContentBytes:   63,
+		},
+	}, stats[0].StorageStats)
+
+	// second has identical running totals and all-zero unique
+	require.Equal(t, &snapshot.StorageStats{
+		NewData: snapshot.StorageUsageDetails{}, // all-zero
+		RunningTotal: snapshot.StorageUsageDetails{
+			FileObjectCount:      2,
+			DirObjectCount:       3,
+			ContentCount:         5,
+			ObjectBytes:          7,
+			OriginalContentBytes: 7,
+			PackedContentBytes:   63,
+		},
+	}, stats[1].StorageStats)
+
+	// third has some additional file
+	require.Equal(t, &snapshot.StorageStats{
+		NewData: snapshot.StorageUsageDetails{
+			FileObjectCount:      1,
+			DirObjectCount:       2,
+			ContentCount:         3,
+			ObjectBytes:          5,
+			OriginalContentBytes: 5,
+			PackedContentBytes:   33,
+		},
+		RunningTotal: snapshot.StorageUsageDetails{
+			FileObjectCount:      3,
+			DirObjectCount:       5,
+			ContentCount:         8,
+			ObjectBytes:          12,
+			OriginalContentBytes: 12,
+			PackedContentBytes:   96,
+		},
+	}, stats[2].StorageStats)
+}


### PR DESCRIPTION
For #1722
Related #1755

Usage `kopia snapshot list --storage-stats`

The data is based on walking the snapshot list either chronologically or in reverse (when `--reverse` is passed). This is more costly than regular list, thus slower. For each snapshot we emit new bits of information:

* `new-data:X B`
* `new-files:N`
* `new-dirs:N`
* `compression:X%`

```
  2020-12-31 23:50:00 PST k7440c27bbddf3b7ee40f546b28bb7baa 572.5 KB drwxr-xr-x files:140 dirs:23 new-data:403.6 KB new-files:51 new-dirs:23 compression:0% (monthly-11,annual-3)
  2021-01-31 23:46:58 PST k1ff379103e7a8b413344b44007fa95ed 640.9 KB drwxr-xr-x files:151 dirs:25 new-data:501.5 KB new-files:77 new-dirs:25 compression:0% (monthly-10)
  2021-02-28 22:50:02 PST k0c8787879b81d39c72c85b82313684ab 680 KB drwxr-xr-x files:182 dirs:35 new-data:415.1 KB new-files:73 new-dirs:34 compression:0% (monthly-9)
  2021-03-31 23:20:03 PDT k7c35f67845b954968cf2562f61e11cd6 716 KB drwxr-xr-x files:207 dirs:42 new-data:264.9 KB new-files:201 new-dirs:42 compression:0% (monthly-8)
  2021-04-30 06:12:54 PDT ke66f878a256a363f42af49dc1e4e78dd 671 KB drwxr-xr-x files:151 dirs:23 new-data:151.9 KB new-files:73 new-dirs:23 compression:0% (monthly-7)
```

JSON is also supported which has additional data.