### PR TITLE
test(infra): Source an RC file before launching robustness job

### DIFF
--- a/tools/robustness-job.sh
+++ b/tools/robustness-job.sh
@@ -51,6 +51,7 @@ FIO_EXE=${FIO_EXE-}
 HOST_FIO_DATA_PATH:${HOST_FIO_DATA_PATH-}
 LOCAL_FIO_DATA_PATH=${LOCAL_FIO_DATA_PATH-}
 S3_BUCKET_NAME=${S3_BUCKET_NAME-}
+TEST_RC=${TEST_RC-}
 
 --- Other Env Vars ---
 GOBIN=${GOBIN-}
@@ -108,6 +109,11 @@ ENGINE_MODE="${ENGINE_MODE:-}"
 make_target="robustness-tests"
 if [[ "${ENGINE_MODE}" = SERVER ]]; then
     make_target="robustness-server-tests"
+fi
+
+# Source any pre-test rc files if provided
+if [[ -f ${TEST_RC} ]]; then
+    source ${TEST_RC}
 fi
 
 # Run the robustness tests


### PR DESCRIPTION
Before running a robustness test using tools/robustness_job.sh, it
may be useful to perform some other work or to set some environment
variables to prepare the environment/test repo (for example, to clean
up files, redirect input/output). This commit adds an additional
optional argument TEST_RC, to be consumed as an environment variable.
If TEST_RC is set, then the script sources its value before launching
the robustness job.