### PR TITLE
fix(infra): Fix failed robustness job script if TEST_RC unset

### DIFF
--- a/tools/robustness-job.sh
+++ b/tools/robustness-job.sh
@@ -112,6 +112,7 @@ if [[ "${ENGINE_MODE}" = SERVER ]]; then
 fi
 
 # Source any pre-test rc files if provided
+TEST_RC="${TEST_RC:-}"
 if [[ -f ${TEST_RC} ]]; then
     source ${TEST_RC}
 fi


### PR DESCRIPTION
If the TEST_RC environment variable is unset, the robustness_job.sh
script exits prematurely due to an unbound variable error, instead of
starting the robustness job without that argument. This commit
evaluates said variable conditionally so that the script doesn't fail.