### PR TITLE
fix(repository): fixed 'context canceled' regression

### DIFF
--- a/repo/open.go
+++ b/repo/open.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kopia/kopia/internal/atomicfile"
 	"github.com/kopia/kopia/internal/cache"
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/ctxutil"
 	"github.com/kopia/kopia/internal/epoch"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/retry"
@@ -88,6 +89,10 @@ func Open(ctx context.Context, configFile, password string, options *Options) (r
 			log(ctx).Errorf("failed to open repository: %v", err)
 		}
 	}()
+
+	// ignore cancellation/timeout from the provided context, since we may be spawning
+	// goroutines that should survive when the provided context is done.
+	ctx = ctxutil.Detach(ctx)
 
 	if options == nil {
 		options = &Options{}


### PR DESCRIPTION
This was broken in #1758 by holding onto a context beyond its intended lifetime.

More specifically `upgradeLockMonitor` was using `ctx` in a closure that lasted beyond the lifetime of the function and when the original context was canceled (which sometimes happens, e.g. in KopiaUI), the lock monitor would stop working.

Fixes #1796