### PR TITLE
chore(repository): added context to beforeop callbacks

### DIFF
--- a/repo/blob/beforeop/beforeop_test.go
+++ b/repo/blob/beforeop/beforeop_test.go
@@ -1,6 +1,7 @@
 package beforeop
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -15,16 +16,16 @@ import (
 
 func TestBeforeOpStorageNegative(t *testing.T) {
 	r := NewWrapper(blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, clock.Now),
-		func(id blob.ID) error {
+		func(ctx context.Context, id blob.ID) error {
 			return errors.Wrap(blob.ErrBlobNotFound, "GetBlob error")
 		},
-		func() error {
+		func(ctx context.Context) error {
 			return errors.Wrap(blob.ErrBlobNotFound, "GetMetadata error")
 		},
-		func() error {
+		func(ctx context.Context) error {
 			return errors.Wrap(blob.ErrBlobNotFound, "DeleteBlob error")
 		},
-		func(id blob.ID, opts *blob.PutOptions) error {
+		func(ctx context.Context, id blob.ID, opts *blob.PutOptions) error {
 			return errors.Wrap(blob.ErrBlobNotFound, "PutBlob error")
 		},
 	)
@@ -49,19 +50,19 @@ func TestBeforeOpStoragePositive(t *testing.T) {
 	var getBlobCbInvoked, getBlobMetadataCbInvoked, putBlobCbInvoked, deleteBlobCbInvoked bool
 
 	r := NewWrapper(blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, clock.Now),
-		func(id blob.ID) error {
+		func(ctx context.Context, id blob.ID) error {
 			getBlobCbInvoked = true
 			return nil
 		},
-		func() error {
+		func(ctx context.Context) error {
 			getBlobMetadataCbInvoked = true
 			return nil
 		},
-		func() error {
+		func(ctx context.Context) error {
 			deleteBlobCbInvoked = true
 			return nil
 		},
-		func(id blob.ID, opts *blob.PutOptions) error {
+		func(ctx context.Context, id blob.ID, opts *blob.PutOptions) error {
 			putBlobCbInvoked = true
 			return nil
 		},

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -437,7 +437,7 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 			beforeop.NewWrapper(
 				env.RootStorage(),
 				// GetBlob callback
-				func(id blob.ID) error {
+				func(ctx context.Context, id blob.ID) error {
 					if id == repo.BlobCfgBlobID {
 						return errors.New("unexpected error")
 					}
@@ -460,7 +460,7 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 			beforeop.NewWrapper(
 				env.RootStorage(),
 				// GetBlob callback
-				func(id blob.ID) error {
+				func(ctx context.Context, id blob.ID) error {
 					// simulate not-found for format-blob but let blobcfg
 					// blob appear as pre-existing
 					if id == repo.BlobCfgBlobID {
@@ -484,7 +484,7 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 			beforeop.NewWrapper(
 				env.RootStorage(),
 				// GetBlob callback
-				func(id blob.ID) error {
+				func(ctx context.Context, id blob.ID) error {
 					// simulate not-found for format-blob and blobcfg blob
 					if id == repo.BlobCfgBlobID || id == repo.FormatBlobID {
 						return blob.ErrBlobNotFound
@@ -493,7 +493,7 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 				},
 				nil, nil,
 				// PutBlob callback
-				func(id blob.ID, _ *blob.PutOptions) error {
+				func(ctx context.Context, id blob.ID, _ *blob.PutOptions) error {
 					if id == repo.BlobCfgBlobID {
 						return errors.New("unexpected error")
 					}
@@ -515,7 +515,7 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 			beforeop.NewWrapper(
 				env.RootStorage(),
 				// GetBlob callback
-				func(id blob.ID) error {
+				func(ctx context.Context, id blob.ID) error {
 					// simulate not-found for format-blob and blobcfg blob
 					if id == repo.FormatBlobID {
 						return errors.New("unexpected error")

--- a/repo/upgrade_lock_test.go
+++ b/repo/upgrade_lock_test.go
@@ -1,6 +1,7 @@
 package repo_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -232,13 +233,13 @@ func TestFormatUpgradeFailureToBackupFormatBlobOnLock(t *testing.T) {
 	st := repotesting.NewReconnectableStorage(t, beforeop.NewWrapper(
 		blobtesting.NewVersionedMapStorage(nil),
 		// GetBlob filter
-		func(id blob.ID) error {
+		func(ctx context.Context, id blob.ID) error {
 			if !allowGets && id == repo.FormatBlobBackupID(allowedLock) {
 				return errors.New("unexpected error on get")
 			}
 			return nil
 		}, nil,
-		func() error {
+		func(ctx context.Context) error {
 			if allowDeletes {
 				return nil
 			}
@@ -246,7 +247,7 @@ func TestFormatUpgradeFailureToBackupFormatBlobOnLock(t *testing.T) {
 			return errors.New("unexpected error")
 		},
 		// PutBlob callback
-		func(id blob.ID, _ *blob.PutOptions) error {
+		func(ctx context.Context, id blob.ID, _ *blob.PutOptions) error {
 			if !allowPuts || (strings.HasPrefix(string(id), repo.FormatBlobBackupIDPrefix) && id != repo.FormatBlobBackupID(allowedLock)) {
 				return errors.New("unexpected error")
 			}


### PR DESCRIPTION
This helps eliminate a class of bugs where 'ctx' used in a callbacks
is captured from a closure variable/parameter, which is almost never
correct, because it can be canceled while the beforeop wrapper is
still alive.

Follow-up for #1796.