### PR TITLE
feat(cli): New Upgrade CLI / Switch to Format Version 3 (upgrade coordination)

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -245,8 +245,8 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("advanced-commands", "Enable advanced (and potentially dangerous) commands.").Hidden().Envar(c.EnvName("KOPIA_ADVANCED_COMMANDS")).StringVar(&c.AdvancedCommands)
 	app.Flag("track-releasable", "Enable tracking of releasable resources.").Hidden().Envar(c.EnvName("KOPIA_TRACK_RELEASABLE")).StringsVar(&c.trackReleasable)
 	app.Flag("dump-allocator-stats", "Dump allocator stats at the end of execution.").Hidden().Envar(c.EnvName("KOPIA_DUMP_ALLOCATOR_STATS")).BoolVar(&c.dumpAllocatorStats)
-	app.Flag("upgrade-owner-id", "Repository format upgrade owner-id.").Hidden().Envar("KOPIA_REPO_UPGRADE_OWNER_ID").StringVar(&c.upgradeOwnerID)
-	app.Flag("upgrade-no-block", "Do not block when repository format upgrade is in progress.").Hidden().Default("false").Envar("KOPIA_REPO_UPGRADE_NO_BLOCK").BoolVar(&c.doNotWaitForUpgrade)
+	app.Flag("upgrade-owner-id", "Repository format upgrade owner-id.").Hidden().Envar(c.EnvName("KOPIA_REPO_UPGRADE_OWNER_ID")).StringVar(&c.upgradeOwnerID)
+	app.Flag("upgrade-no-block", "Do not block when repository format upgrade is in progress.").Hidden().Default("false").Envar(c.EnvName("KOPIA_REPO_UPGRADE_NO_BLOCK")).BoolVar(&c.doNotWaitForUpgrade)
 
 	c.observability.setup(c, app)
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -246,7 +246,7 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("track-releasable", "Enable tracking of releasable resources.").Hidden().Envar(c.EnvName("KOPIA_TRACK_RELEASABLE")).StringsVar(&c.trackReleasable)
 	app.Flag("dump-allocator-stats", "Dump allocator stats at the end of execution.").Hidden().Envar(c.EnvName("KOPIA_DUMP_ALLOCATOR_STATS")).BoolVar(&c.dumpAllocatorStats)
 	app.Flag("upgrade-owner-id", "Repository format upgrade owner-id.").Hidden().Envar("KOPIA_REPO_UPGRADE_OWNER_ID").StringVar(&c.upgradeOwnerID)
-	app.Flag("upgrade-no-block", "Do not block when repository format upgrade is in progress.").Default("false").Envar("KOPIA_REPO_UPGRADE_NO_BLOCK").BoolVar(&c.doNotWaitForUpgrade)
+	app.Flag("upgrade-no-block", "Do not block when repository format upgrade is in progress.").Hidden().Default("false").Envar("KOPIA_REPO_UPGRADE_NO_BLOCK").BoolVar(&c.doNotWaitForUpgrade)
 
 	c.observability.setup(c, app)
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -246,7 +246,7 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("track-releasable", "Enable tracking of releasable resources.").Hidden().Envar(c.EnvName("KOPIA_TRACK_RELEASABLE")).StringsVar(&c.trackReleasable)
 	app.Flag("dump-allocator-stats", "Dump allocator stats at the end of execution.").Hidden().Envar(c.EnvName("KOPIA_DUMP_ALLOCATOR_STATS")).BoolVar(&c.dumpAllocatorStats)
 	app.Flag("upgrade-owner-id", "Repository format upgrade owner-id.").Hidden().Envar(c.EnvName("KOPIA_REPO_UPGRADE_OWNER_ID")).StringVar(&c.upgradeOwnerID)
-	app.Flag("upgrade-no-block", "Do not block when repository format upgrade is in progress.").Hidden().Default("false").Envar(c.EnvName("KOPIA_REPO_UPGRADE_NO_BLOCK")).BoolVar(&c.doNotWaitForUpgrade)
+	app.Flag("upgrade-no-block", "Do not block when repository format upgrade is in progress, instead exit with a message.").Hidden().Default("false").Envar(c.EnvName("KOPIA_REPO_UPGRADE_NO_BLOCK")).BoolVar(&c.doNotWaitForUpgrade)
 
 	c.observability.setup(c, app)
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -126,7 +126,9 @@ type App struct {
 	cliStorageProviders           []StorageProvider
 	trackReleasable               []string
 
-	observability observabilityFlags
+	observability       observabilityFlags
+	upgradeOwnerID      string
+	doNotWaitForUpgrade bool
 
 	currentAction   string
 	onExitCallbacks []func()
@@ -243,6 +245,8 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("advanced-commands", "Enable advanced (and potentially dangerous) commands.").Hidden().Envar(c.EnvName("KOPIA_ADVANCED_COMMANDS")).StringVar(&c.AdvancedCommands)
 	app.Flag("track-releasable", "Enable tracking of releasable resources.").Hidden().Envar(c.EnvName("KOPIA_TRACK_RELEASABLE")).StringsVar(&c.trackReleasable)
 	app.Flag("dump-allocator-stats", "Dump allocator stats at the end of execution.").Hidden().Envar(c.EnvName("KOPIA_DUMP_ALLOCATOR_STATS")).BoolVar(&c.dumpAllocatorStats)
+	app.Flag("upgrade-owner-id", "Repository format upgrade owner-id.").Hidden().Envar("KOPIA_REPO_UPGRADE_OWNER_ID").StringVar(&c.upgradeOwnerID)
+	app.Flag("upgrade-no-block", "Do not block when repository format upgrade is in progress.").Default("false").Envar("KOPIA_REPO_UPGRADE_NO_BLOCK").BoolVar(&c.doNotWaitForUpgrade)
 
 	c.observability.setup(c, app)
 

--- a/cli/command_repository.go
+++ b/cli/command_repository.go
@@ -12,6 +12,7 @@ type commandRepository struct {
 	syncTo           commandRepositorySyncTo
 	throttle         commandRepositoryThrottle
 	validateProvider commandRepositoryValidateProvider
+	upgrade          commandRepositoryUpgrade
 }
 
 func (c *commandRepository) setup(svc advancedAppServices, parent commandParent) {
@@ -28,4 +29,5 @@ func (c *commandRepository) setup(svc advancedAppServices, parent commandParent)
 	c.throttle.setup(svc, cmd)
 	c.changePassword.setup(svc, cmd)
 	c.validateProvider.setup(svc, cmd)
+	c.upgrade.setup(svc, cmd)
 }

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -141,13 +141,13 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 	if s.formatVersion < content.MaxFormatVersion {
 		env.RunAndExpectSuccess(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s")
 	} else {
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s")
 	}

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -3,9 +3,11 @@ package cli_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/kopia/kopia/cli"
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/repo/blob"
@@ -146,8 +148,9 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
-			"--max-clock-drift", "1s",
 		}
+
+		cli.MaxPermittedClockDrift = func() time.Duration { return time.Second }
 
 		// You can only upgrade when you are not already upgraded
 		if s.formatVersion < content.MaxFormatVersion {

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -145,7 +145,7 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 		env.RunAndExpectSuccess(t, "index", "epoch", "list")
 	}
 
-	if s.formatVersion < content.FormatVersion3 {
+	if s.formatVersion < content.MaxFormatVersion {
 		env.RunAndExpectSuccess(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s",

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,15 +32,7 @@ func (s *formatSpecificTestSuite) TestRepositorySetParameters(t *testing.T) {
 
 	// default values
 	require.Contains(t, out, "Max pack length:     20 MiB")
-
-	switch s.formatVersion {
-	case content.FormatVersion1:
-		require.Contains(t, out, "Format version:      1")
-	case content.FormatVersion2:
-		require.Contains(t, out, "Format version:      2")
-	default:
-		require.Contains(t, out, "Format version:      3")
-	}
+	require.Contains(t, out, fmt.Sprintf("Format version:      %d", s.formatVersion))
 
 	// failure cases
 	env.RunAndExpectFailure(t, "repository", "set-parameters")

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -140,18 +140,21 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 
 	env.Environment["KOPIA_UPGRADE_LOCK_ENABLED"] = "1"
 
-	if s.formatVersion < content.MaxFormatVersion {
-		env.RunAndExpectSuccess(t, "repository", "upgrade",
+	{
+		cmd := []string{
+			"repository", "upgrade",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
-			"--max-clock-drift", "1s")
-	} else {
-		env.RunAndExpectFailure(t, "repository", "upgrade",
-			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
-			"--status-poll-interval", "1s",
-			"--max-clock-drift", "1s")
+			"--max-clock-drift", "1s",
+		}
+
+		// You can only upgrade when you are not already upgraded
+		if s.formatVersion < content.MaxFormatVersion {
+			env.RunAndExpectSuccess(t, cmd...)
+		} else {
+			env.RunAndExpectFailure(t, cmd...)
+		}
 	}
 
 	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--upgrade")

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -32,10 +32,13 @@ func (s *formatSpecificTestSuite) TestRepositorySetParameters(t *testing.T) {
 	// default values
 	require.Contains(t, out, "Max pack length:     20 MiB")
 
-	if s.formatVersion == content.FormatVersion1 {
+	switch s.formatVersion {
+	case content.FormatVersion1:
 		require.Contains(t, out, "Format version:      1")
-	} else {
+	case content.FormatVersion2:
 		require.Contains(t, out, "Format version:      2")
+	default:
+		require.Contains(t, out, "Format version:      3")
 	}
 
 	// failure cases
@@ -127,14 +130,33 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 	// default values
 	require.Contains(t, out, "Max pack length:     20 MiB")
 
-	if s.formatVersion == content.FormatVersion1 {
+	switch s.formatVersion {
+	case content.FormatVersion1:
 		require.Contains(t, out, "Format version:      1")
 		require.Contains(t, out, "Epoch Manager:       disabled")
 		env.RunAndExpectFailure(t, "index", "epoch", "list")
-	} else {
+	case content.FormatVersion2:
 		require.Contains(t, out, "Format version:      2")
 		require.Contains(t, out, "Epoch Manager:       enabled")
 		env.RunAndExpectSuccess(t, "index", "epoch", "list")
+	default:
+		require.Contains(t, out, "Format version:      3")
+		require.Contains(t, out, "Epoch Manager:       enabled")
+		env.RunAndExpectSuccess(t, "index", "epoch", "list")
+	}
+
+	if s.formatVersion < content.FormatVersion3 {
+		env.RunAndExpectSuccess(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+	} else {
+		env.RunAndExpectFailure(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
 	}
 
 	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--upgrade")
@@ -153,7 +175,7 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 	out = env.RunAndExpectSuccess(t, "repository", "status")
 	require.Contains(t, out, "Epoch Manager:       enabled")
 	require.Contains(t, out, "Index Format:        v2")
-	require.Contains(t, out, "Format version:      2")
+	require.Contains(t, out, "Format version:      3")
 	require.Contains(t, out, "Epoch cleanup margin:    23h0m0s")
 	require.Contains(t, out, "Epoch advance on:        22 blobs or 77 MiB, minimum 3h0m0s")
 	require.Contains(t, out, "Epoch checkpoint every:  9 epochs")

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -146,7 +146,7 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 		cmd := []string{
 			"repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 		}
 

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -138,6 +138,8 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 		env.RunAndExpectSuccess(t, "index", "epoch", "list")
 	}
 
+	env.Environment["KOPIA_UPGRADE_LOCK_ENABLED"] = "1"
+
 	if s.formatVersion < content.MaxFormatVersion {
 		env.RunAndExpectSuccess(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/epoch"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/content"
+)
+
+type commandRepositoryUpgrade struct {
+	forceRollback   bool
+	skip            bool
+	blockUntilDrain bool
+
+	// lock settings
+	advanceNoticeInterval  time.Duration
+	ioDrainTimeout         time.Duration
+	statusPollInterval     time.Duration
+	maxPermittedClockDrift time.Duration
+
+	svc advancedAppServices
+}
+
+func (c *commandRepositoryUpgrade) setup(svc advancedAppServices, parent commandParent) {
+	cmd := parent.Command("upgrade", "Upgrade repository format.")
+
+	cmd.Flag("advance-notice", "Advance notice for upgrade to allow enough time for other Kopia clients to notice the lock").DurationVar(&c.advanceNoticeInterval)
+	cmd.Flag("io-drain-timeout", "Max time it should take all other Kopia clients to drop repository connections").Default(repo.DefaultRepositoryBlobCacheDuration.String()).DurationVar(&c.ioDrainTimeout)
+	cmd.Flag("status-poll-interval", "An advisory polling interval to check for the status of upgrade").Default("60s").DurationVar(&c.statusPollInterval)
+	cmd.Flag("max-clock-drift", "Maximum tolerated drift on clocks between all Kopia clients").Default("5m").DurationVar(&c.maxPermittedClockDrift)
+	cmd.Flag("block-until-drain", "Drain all the clients but do not perform the upgrade").BoolVar(&c.blockUntilDrain)
+
+	cmd.Flag("force-rollback", "Force rollback the repository upgrade, this action can cause repository corruption").BoolVar(&c.forceRollback)
+
+	// upgrade sequence
+	cmd.Action(svc.directRepositoryWriteAction(c.runPhase(c.setLockIntent)))
+	cmd.Action(svc.directRepositoryWriteAction(c.runPhase(c.drainOrCommit)))
+	cmd.Action(svc.directRepositoryWriteAction(c.runPhase(c.upgrade)))
+	cmd.Action(svc.directRepositoryWriteAction(c.runPhase(c.commitUpgrade)))
+
+	c.svc = svc
+}
+
+func (c *commandRepositoryUpgrade) runPhase(act func(context.Context, repo.DirectRepositoryWriter) error) func(context.Context, repo.DirectRepositoryWriter) error {
+	return func(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+		if !c.skip {
+			if err := act(ctx, rep); err != nil {
+				// explicitly skip all stages on error because tests do not
+				// skip/exit on error because they override os.Exit()
+				c.skip = true
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func (c *commandRepositoryUpgrade) setLockIntent(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	if c.forceRollback {
+		if err := rep.RollbackUpgrade(ctx); err != nil {
+			return errors.Wrap(err, "failed to rollback the upgrade")
+		}
+
+		log(ctx).Infof("Repository upgrade lock has been revoked.")
+
+		c.skip = true
+
+		return nil
+	}
+
+	now := rep.Time()
+	mp := rep.ContentReader().ContentFormat().MutableParameters
+	openOpts := c.svc.optionsFromFlags(ctx)
+	l := &content.UpgradeLock{
+		OwnerID:                openOpts.UpgradeOwnerID,
+		CreationTime:           now,
+		AdvanceNoticeDuration:  c.advanceNoticeInterval,
+		IODrainTimeout:         c.ioDrainTimeout,
+		StatusPollInterval:     c.statusPollInterval,
+		Message:                fmt.Sprintf("Upgrading from format version %d -> %d", mp.Version, content.FormatVersion3),
+		MaxPermittedClockDrift: c.maxPermittedClockDrift,
+	}
+
+	// Update format-blob and clear the cache.
+	// This will fail if we have alread upgraded.
+	l, err := rep.SetUpgradeLockIntent(ctx, *l)
+	if err != nil {
+		return errors.Wrap(err, "error setting the upgrade lock intent")
+	}
+	// we need to reopen the repository after this point
+
+	locked, _ := l.IsLocked(now)
+	if l.AdvanceNoticeDuration != 0 && !locked && !c.blockUntilDrain {
+		upgradeTime := l.UpgradeTime()
+		log(ctx).Infof("Repository upgrade advance notice has been set, you must come back and perform the upgrade at %s.",
+			upgradeTime)
+
+		c.skip = true
+
+		return nil
+	}
+
+	log(ctx).Infof("Repository upgrade lock intent has been placed.")
+
+	return nil
+}
+
+func (c *commandRepositoryUpgrade) drainOrCommit(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	// skip next phases if requested
+	if c.blockUntilDrain {
+		c.skip = true
+	}
+
+	cf := rep.ContentReader().ContentFormat()
+	if cf.MutableParameters.EpochParameters.Enabled {
+		log(ctx).Infof("Repository indices have already been migrated to the epoch format, no need to drain other clients")
+
+		if cf.UpgradeLock.AdvanceNoticeDuration == 0 || !c.blockUntilDrain {
+			// let the upgrade continue to commit the new format blob
+			return nil
+		}
+
+		log(ctx).Infof("Continuing to drain since advance notice has been set and we have been requested to block until then")
+	}
+
+	if err := c.drainAllClients(ctx, rep); err != nil {
+		return errors.Wrap(err, "failed to upgrade the repository, lock is not released")
+	}
+	// we need to reopen the repository after this point
+
+	log(ctx).Infof("Successfully drained all repository clients, the lock has been fully-established now.")
+
+	return nil
+}
+
+// TODO(small): Better reuse.
+func sleepWithContext(ctx context.Context, dur time.Duration) {
+	t := time.NewTimer(dur)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}
+
+func (c *commandRepositoryUpgrade) drainAllClients(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	password, err := c.svc.getPasswordFromFlags(ctx, false, false)
+	if err != nil {
+		return errors.Wrap(err, "getting password")
+	}
+
+	configFile, err := filepath.Abs(c.svc.repositoryConfigFileName())
+	if err != nil {
+		return errors.Wrap(err, "error resolving config file path")
+	}
+
+	lc, err := repo.LoadConfigFromFile(configFile)
+	if err != nil {
+		return errors.Wrapf(err, "error loading config file %q", configFile)
+	}
+
+	cacheOpts := lc.Caching.CloneOrDefault()
+
+	for {
+		l, err := repo.ReadAndCacheRepoUpgradeLock(ctx, rep.BlobStorage(), password, cacheOpts, -1)
+		if err != nil {
+			return errors.Wrap(err, "unable to reload the repository format blob")
+		}
+
+		upgradeTime := l.UpgradeTime()
+		now := rep.Time()
+
+		log(ctx).Infof("Waiting for %s to allow all other kopia clients to drain ...", upgradeTime.Sub(rep.Time()).Round(time.Second))
+
+		locked, writersDrained := l.IsLocked(now)
+		if locked {
+			if writersDrained {
+				// we have the lock now
+				break
+			}
+		} else if !c.blockUntilDrain {
+			return errors.Wrap(err, "upgrade lock got revoked after the intent was placed, giving up")
+		}
+
+		// TODO: this can get stuck
+		sleepWithContext(ctx, l.StatusPollInterval)
+	}
+
+	return nil
+}
+
+func (c *commandRepositoryUpgrade) upgrade(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	mp := rep.ContentReader().ContentFormat().MutableParameters
+	if mp.EpochParameters.Enabled {
+		// nothing to upgrade on format, so let the next action commit the upgraded format blob
+		return nil
+	}
+
+	mp.EpochParameters = epoch.DefaultParameters()
+	mp.IndexVersion = 2
+
+	log(ctx).Infof("migrating current indices to epoch format")
+
+	if err := rep.ContentManager().PrepareUpgradeToIndexBlobManagerV1(ctx, mp.EpochParameters); err != nil {
+		return errors.Wrap(err, "error upgrading indices")
+	}
+
+	// update format-blob and clear the cache
+	if err := rep.SetParameters(ctx, mp, rep.BlobCfg()); err != nil {
+		return errors.Wrap(err, "error setting parameters")
+	}
+	// we need to reopen the repository after this point
+
+	log(ctx).Infof("Repository indices have been upgraded.")
+
+	return nil
+}
+
+func (c *commandRepositoryUpgrade) commitUpgrade(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+	if err := rep.CommitUpgrade(ctx); err != nil {
+		return errors.Wrap(err, "error finalizing upgrade")
+	}
+	// we need to reopen the repository after this point
+
+	log(ctx).Infof("Repository has been successfully upgraded.")
+
+	return nil
+}

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -29,7 +29,7 @@ type commandRepositoryUpgrade struct {
 }
 
 const (
-	experimentalWarning = `WARNING: The upgrade command is an EXPERIMENTAL feature. Please use with caution.
+	experimentalWarning = `WARNING: The upgrade command is an EXPERIMENTAL feature. Please DO NOT use it, it may corrupt your repository and cause data loss.
 
 You will need to set the env variable KOPIA_UPGRADE_LOCK_ENABLED in order to use this feature.
 `

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -99,16 +99,18 @@ func (c *commandRepositoryUpgrade) runPhase(act func(context.Context, repo.Direc
 		if c.skip {
 			return nil
 		}
-		if err := act(ctx, rep); err != nil {
+
+		err := act(ctx, rep)
+		if err != nil {
 			// Explicitly skip all stages on error because tests do not
 			// skip/exit on error. Tests override os.Exit() that prevents
 			// running rest of the phases until we set the skip flag here.
 			// This flag is designed for testability and also to support
 			// rollback.
 			c.skip = true
-			return err
 		}
 
+		return err
 	}
 }
 

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -89,7 +89,7 @@ func (c *commandRepositoryUpgrade) setLockIntent(ctx context.Context, rep repo.D
 	}
 
 	// Update format-blob and clear the cache.
-	// This will fail if we have alread upgraded.
+	// This will fail if we have already upgraded.
 	l, err := rep.SetUpgradeLockIntent(ctx, *l)
 	if err != nil {
 		return errors.Wrap(err, "error setting the upgrade lock intent")

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -19,7 +19,7 @@ type commandRepositoryUpgrade struct {
 	blockUntilDrain bool
 
 	// lock settings
-	advanceNoticeInterval  time.Duration
+	advanceNoticeDuration  time.Duration
 	ioDrainTimeout         time.Duration
 	statusPollInterval     time.Duration
 	maxPermittedClockDrift time.Duration
@@ -30,7 +30,7 @@ type commandRepositoryUpgrade struct {
 func (c *commandRepositoryUpgrade) setup(svc advancedAppServices, parent commandParent) {
 	cmd := parent.Command("upgrade", "Upgrade repository format.")
 
-	cmd.Flag("advance-notice", "Advance notice for upgrade to allow enough time for other Kopia clients to notice the lock").DurationVar(&c.advanceNoticeInterval)
+	cmd.Flag("advance-notice", "Advance notice for upgrade to allow enough time for other Kopia clients to notice the lock").DurationVar(&c.advanceNoticeDuration)
 	cmd.Flag("io-drain-timeout", "Max time it should take all other Kopia clients to drop repository connections").Default(repo.DefaultRepositoryBlobCacheDuration.String()).DurationVar(&c.ioDrainTimeout)
 	cmd.Flag("status-poll-interval", "An advisory polling interval to check for the status of upgrade").Default("60s").DurationVar(&c.statusPollInterval)
 	cmd.Flag("max-clock-drift", "Maximum tolerated drift on clocks between all Kopia clients").Default("5m").DurationVar(&c.maxPermittedClockDrift)
@@ -81,7 +81,7 @@ func (c *commandRepositoryUpgrade) setLockIntent(ctx context.Context, rep repo.D
 	l := &content.UpgradeLock{
 		OwnerID:                openOpts.UpgradeOwnerID,
 		CreationTime:           now,
-		AdvanceNoticeDuration:  c.advanceNoticeInterval,
+		AdvanceNoticeDuration:  c.advanceNoticeDuration,
 		IODrainTimeout:         c.ioDrainTimeout,
 		StatusPollInterval:     c.statusPollInterval,
 		Message:                fmt.Sprintf("Upgrading from format version %d -> %d", mp.Version, content.MaxFormatVersion),

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -42,7 +42,7 @@ func (c *commandRepositoryUpgrade) setup(svc advancedAppServices, parent command
 	cmd := parent.Command("upgrade", fmt.Sprintf("Upgrade repository format.\n\n%s", warningColor.Sprint(experimentalWarning))).Hidden().
 		Validate(func(tmpCmd *kingpin.CmdClause) error {
 			if v := os.Getenv(c.svc.EnvName(upgradeLockFeatureEnv)); v == "" {
-				return fmt.Errorf("Please set %q env variable to use this feature.", upgradeLockFeatureEnv)
+				return errors.Errorf("please set %q env variable to use this feature", upgradeLockFeatureEnv)
 			}
 			return nil
 		})

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -32,7 +32,7 @@ func (c *commandRepositoryUpgrade) setup(svc advancedAppServices, parent command
 	cmd := parent.Command("upgrade", "Upgrade repository format.")
 
 	cmd.Flag("advance-notice", "Advance notice for upgrade to allow enough time for other Kopia clients to notice the lock").DurationVar(&c.advanceNoticeDuration)
-	cmd.Flag("io-drain-timeout", "Max time it should take all other Kopia clients to drop repository connections").Default(repo.DefaultRepositoryBlobCacheDuration.String()).DurationVar(&c.ioDrainTimeout)
+	cmd.Flag("io-drain-timeout", "Max time it should take all other Kopia clients to drop repository connections").Default(repo.DefaultRepositoryBlobCacheDuration.String()).Envar("KOPIA_REPO_UPGRADE_IO_DRAIN_TIMEOUT").DurationVar(&c.ioDrainTimeout)
 	cmd.Flag("force", "Force using an unsafe io-drain-timeout").Default("false").Hidden().BoolVar(&c.force)
 	cmd.Flag("status-poll-interval", "An advisory polling interval to check for the status of upgrade").Default("60s").DurationVar(&c.statusPollInterval)
 	cmd.Flag("max-clock-drift", "Maximum tolerated drift on clocks between all Kopia clients").Default("5m").DurationVar(&c.maxPermittedClockDrift)

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -84,7 +84,7 @@ func (c *commandRepositoryUpgrade) setLockIntent(ctx context.Context, rep repo.D
 		AdvanceNoticeDuration:  c.advanceNoticeInterval,
 		IODrainTimeout:         c.ioDrainTimeout,
 		StatusPollInterval:     c.statusPollInterval,
-		Message:                fmt.Sprintf("Upgrading from format version %d -> %d", mp.Version, content.FormatVersion3),
+		Message:                fmt.Sprintf("Upgrading from format version %d -> %d", mp.Version, content.MaxFormatVersion),
 		MaxPermittedClockDrift: c.maxPermittedClockDrift,
 	}
 

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -57,7 +57,7 @@ func (c *commandRepositoryUpgrade) setup(svc advancedAppServices, parent command
 	beginCmd := parent.Command("begin", "Begin upgrade.").Default()
 	beginCmd.Flag("advance-notice", "Advance notice for upgrade to allow enough time for other Kopia clients to notice the lock").DurationVar(&c.advanceNoticeDuration)
 	beginCmd.Flag("io-drain-timeout", "Max time it should take all other Kopia clients to drop repository connections").Default(repo.DefaultRepositoryBlobCacheDuration.String()).DurationVar(&c.ioDrainTimeout)
-	beginCmd.Flag("force", "Force using an unsafe io-drain-timeout").Default("false").Hidden().BoolVar(&c.force)
+	beginCmd.Flag("allow-unsafe-upgrade", "Force using an unsafe io-drain-timeout for the upgrade lock").Default("false").Hidden().BoolVar(&c.force)
 	beginCmd.Flag("status-poll-interval", "An advisory polling interval to check for the status of upgrade").Default("60s").DurationVar(&c.statusPollInterval)
 
 	// upgrade phases

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -96,19 +96,19 @@ func (c *commandRepositoryUpgrade) forceRollbackAction(ctx context.Context, rep 
 
 func (c *commandRepositoryUpgrade) runPhase(act func(context.Context, repo.DirectRepositoryWriter) error) func(context.Context, repo.DirectRepositoryWriter) error {
 	return func(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-		if !c.skip {
-			if err := act(ctx, rep); err != nil {
-				// Explicitly skip all stages on error because tests do not
-				// skip/exit on error. Tests override os.Exit() that prevents
-				// running rest of the phases until we set the skip flag here.
-				// This flag is designed for testability and also to support
-				// rollback.
-				c.skip = true
-				return err
-			}
+		if c.skip {
+			return nil
+		}
+		if err := act(ctx, rep); err != nil {
+			// Explicitly skip all stages on error because tests do not
+			// skip/exit on error. Tests override os.Exit() that prevents
+			// running rest of the phases until we set the skip flag here.
+			// This flag is designed for testability and also to support
+			// rollback.
+			c.skip = true
+			return err
 		}
 
-		return nil
 	}
 }
 

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -32,7 +32,8 @@ func (c *commandRepositoryUpgrade) setup(svc advancedAppServices, parent command
 	cmd := parent.Command("upgrade", "Upgrade repository format.")
 
 	cmd.Flag("advance-notice", "Advance notice for upgrade to allow enough time for other Kopia clients to notice the lock").DurationVar(&c.advanceNoticeDuration)
-	cmd.Flag("io-drain-timeout", "Max time it should take all other Kopia clients to drop repository connections").Default(repo.DefaultRepositoryBlobCacheDuration.String()).Envar("KOPIA_REPO_UPGRADE_IO_DRAIN_TIMEOUT").DurationVar(&c.ioDrainTimeout)
+	cmd.Flag("io-drain-timeout", "Max time it should take all other Kopia clients to drop repository connections").Default(repo.DefaultRepositoryBlobCacheDuration.String()).
+		Envar(svc.EnvName("KOPIA_REPO_UPGRADE_IO_DRAIN_TIMEOUT")).DurationVar(&c.ioDrainTimeout)
 	cmd.Flag("force", "Force using an unsafe io-drain-timeout").Default("false").Hidden().BoolVar(&c.force)
 	cmd.Flag("status-poll-interval", "An advisory polling interval to check for the status of upgrade").Default("60s").DurationVar(&c.statusPollInterval)
 	cmd.Flag("max-clock-drift", "Maximum tolerated drift on clocks between all Kopia clients").Default("5m").DurationVar(&c.maxPermittedClockDrift)

--- a/cli/command_repository_upgrade_test.go
+++ b/cli/command_repository_upgrade_test.go
@@ -1,0 +1,202 @@
+package cli_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
+	env := testenv.NewCLITest(t, s.formatFlags, testenv.NewInProcRunner(t))
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+	out := env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
+
+	switch s.formatVersion {
+	case content.FormatVersion1:
+		require.Contains(t, out, "Format version:      1")
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+		require.Contains(t, stderr, "Repository indices have been upgraded.")
+		require.Contains(t, stderr, "Repository has been successfully upgraded.")
+	case content.FormatVersion2:
+		require.Contains(t, out, "Format version:      2")
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+		require.Contains(t, stderr, "Repository indices have already been migrated to the epoch format, no need to drain other clients")
+		require.Contains(t, stderr, "Repository has been successfully upgraded.")
+	default:
+		require.Contains(t, out, "Format version:      3")
+		env.RunAndExpectFailure(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+	}
+
+	out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
+	require.Contains(t, out, "Epoch Manager:       enabled")
+	require.Contains(t, out, "Index Format:        v2")
+	require.Contains(t, out, "Format version:      3")
+}
+
+func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.T) {
+	env := testenv.NewCLITest(t, s.formatFlags, testenv.NewInProcRunner(t))
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+	out := env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
+
+	switch s.formatVersion {
+	case content.FormatVersion1:
+		require.Contains(t, out, "Format version:      1")
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, strings.Join(stderr, "\n"),
+			"Repository upgrade advance notice has been set, you must come back and perform the upgrade")
+
+		// verify that non-owner clients will fail to connect/upgrade
+		env.RunAndExpectFailure(t, "repository", "upgrade",
+			"--upgrade-owner-id", "non-owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+
+		// until we drain, we would be able to see the upgrade status
+		out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
+		require.Contains(t, out, "Ongoing upgrade:     Upgrading from format version 1 -> 3")
+		require.Contains(t, out, "Upgrade lock:        Unlocked")
+		require.Contains(t, out, "Lock status:         Draining")
+
+		// attempt to rollback the upgrade and restart
+		env.RunAndExpectSuccess(t, "repository", "upgrade", "--force-rollback")
+		env.RunAndExpectSuccess(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+
+		// drain all clients
+		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--block-until-drain",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, stderr, "Successfully drained all repository clients, the lock has been fully-established now.")
+
+		// verify that access is denied after we drain
+		env.RunAndExpectFailure(t, "repository", "status", "--upgrade-no-block")
+
+		// verify that owner clients can check status
+		out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-owner-id", "owner")
+		require.Contains(t, out, "Ongoing upgrade:     Upgrading from format version 1 -> 3")
+		require.Contains(t, out, "Upgrade lock:        Locked")
+		require.Contains(t, out, "Lock status:         Fully Established")
+
+		// finalize the upgrade
+		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, stderr, "Repository has been successfully upgraded.")
+
+		// verify that non-owner clients can resume access
+		env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
+	case content.FormatVersion2:
+		require.Contains(t, out, "Format version:      2")
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, strings.Join(stderr, "\n"),
+			"Repository upgrade advance notice has been set, you must come back and perform the upgrade")
+
+		// verify that non-owner clients will fail to connect/upgrade
+		env.RunAndExpectFailure(t, "repository", "upgrade",
+			"--upgrade-owner-id", "non-owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s")
+
+		// until we drain, we would be able to see the upgrade status
+		out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
+		require.Contains(t, out, "Ongoing upgrade:     Upgrading from format version 2 -> 3")
+		require.Contains(t, out, "Upgrade lock:        Unlocked")
+		require.Contains(t, out, "Lock status:         Draining")
+
+		// attempt to rollback the upgrade and restart
+		env.RunAndExpectSuccess(t, "repository", "upgrade", "--force-rollback")
+		env.RunAndExpectSuccess(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+
+		// drain all clients
+		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--block-until-drain",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, stderr, "Repository indices have already been migrated to the epoch format, no need to drain other clients")
+		require.Contains(t, stderr, "Continuing to drain since advance notice has been set and we have been requested to block until then")
+		require.Contains(t, stderr, "Successfully drained all repository clients, the lock has been fully-established now.")
+
+		// verify that access is denied after we drain
+		env.RunAndExpectFailure(t, "repository", "status", "--upgrade-no-block")
+
+		// verify that owner clients can check status
+		out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-owner-id", "owner")
+		require.Contains(t, out, "Ongoing upgrade:     Upgrading from format version 2 -> 3")
+		require.Contains(t, out, "Upgrade lock:        Locked")
+		require.Contains(t, out, "Lock status:         Fully Established")
+
+		// finalize the upgrade
+		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+		require.Contains(t, stderr, "Repository has been successfully upgraded.")
+
+		// verify that non-owner clients can resume access
+		env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
+	default:
+		require.Contains(t, out, "Format version:      3")
+		env.RunAndExpectFailure(t, "repository", "upgrade",
+			"--upgrade-owner-id", "owner",
+			"--io-drain-timeout", "1s",
+			"--status-poll-interval", "1s",
+			"--max-clock-drift", "1s",
+			"--advance-notice", "30s")
+	}
+
+	out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
+	require.Contains(t, out, "Epoch Manager:       enabled")
+	require.Contains(t, out, "Index Format:        v2")
+	require.Contains(t, out, "Format version:      3")
+}

--- a/cli/command_repository_upgrade_test.go
+++ b/cli/command_repository_upgrade_test.go
@@ -27,7 +27,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 		require.Contains(t, out, "Format version:      1")
 		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s")
 		require.Contains(t, stderr, "Repository indices have been upgraded.")
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
@@ -35,7 +35,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 		require.Contains(t, out, "Format version:      2")
 		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s")
 		require.Contains(t, stderr, "Repository indices have already been migrated to the epoch format, no need to drain other clients")
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
@@ -43,7 +43,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 		require.Contains(t, out, "Format version:      3")
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s")
 	}
 
@@ -68,7 +68,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		require.Contains(t, out, "Format version:      1")
 		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--advance-notice", "30s")
 		require.Contains(t, strings.Join(stderr, "\n"),
@@ -77,7 +77,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		// verify that non-owner clients will fail to connect/upgrade
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "non-owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s")
 
 		// until we drain, we would be able to see the upgrade status
@@ -90,14 +90,14 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		env.RunAndExpectSuccess(t, "repository", "upgrade", "rollback", "--force")
 		env.RunAndExpectSuccess(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--advance-notice", "30s")
 
 		// setup advance-notice on upgrade, this will exit immediately
 		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--advance-notice", "30s")
 		require.Contains(t, strings.Join(stderr, "\n"),
@@ -119,7 +119,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		// finalize the upgrade
 		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--advance-notice", "30s")
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
@@ -130,7 +130,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		require.Contains(t, out, "Format version:      2")
 		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--advance-notice", "30s")
 		require.Contains(t, strings.Join(stderr, "\n"),
@@ -139,7 +139,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		// verify that non-owner clients will fail to connect/upgrade
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "non-owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s")
 
 		// until we drain, we would be able to see the upgrade status
@@ -154,7 +154,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		// setup advance-notice on upgrade, this will exit immediately
 		env.RunAndExpectSuccess(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--advance-notice", "30s")
 		require.Contains(t, strings.Join(stderr, "\n"),
@@ -176,7 +176,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		// finalize the upgrade
 		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--advance-notice", "30s")
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
@@ -187,7 +187,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		require.Contains(t, out, "Format version:      3")
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--force",
+			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--advance-notice", "30s")
 	}

--- a/cli/command_repository_upgrade_test.go
+++ b/cli/command_repository_upgrade_test.go
@@ -16,6 +16,8 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
 	out := env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
 
+	env.Environment["KOPIA_UPGRADE_LOCK_ENABLED"] = "1"
+
 	switch s.formatVersion {
 	case content.FormatVersion1:
 		require.Contains(t, out, "Format version:      1")
@@ -55,6 +57,8 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
 	out := env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
+
+	env.Environment["KOPIA_UPGRADE_LOCK_ENABLED"] = "1"
 
 	switch s.formatVersion {
 	case content.FormatVersion1:

--- a/cli/command_repository_upgrade_test.go
+++ b/cli/command_repository_upgrade_test.go
@@ -21,7 +21,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 		require.Contains(t, out, "Format version:      1")
 		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s")
 		require.Contains(t, stderr, "Repository indices have been upgraded.")
@@ -30,7 +30,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 		require.Contains(t, out, "Format version:      2")
 		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s")
 		require.Contains(t, stderr, "Repository indices have already been migrated to the epoch format, no need to drain other clients")
@@ -39,7 +39,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 		require.Contains(t, out, "Format version:      3")
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s")
 	}
@@ -61,7 +61,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		require.Contains(t, out, "Format version:      1")
 		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s",
 			"--advance-notice", "30s")
@@ -71,7 +71,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		// verify that non-owner clients will fail to connect/upgrade
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "non-owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s")
 
@@ -85,7 +85,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		env.RunAndExpectSuccess(t, "repository", "upgrade", "--force-rollback")
 		env.RunAndExpectSuccess(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s",
 			"--advance-notice", "30s")
@@ -94,7 +94,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--block-until-drain",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s",
 			"--advance-notice", "30s")
@@ -112,7 +112,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		// finalize the upgrade
 		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s",
 			"--advance-notice", "30s")
@@ -124,7 +124,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		require.Contains(t, out, "Format version:      2")
 		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s",
 			"--advance-notice", "30s")
@@ -134,7 +134,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		// verify that non-owner clients will fail to connect/upgrade
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "non-owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s")
 
@@ -148,7 +148,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		env.RunAndExpectSuccess(t, "repository", "upgrade", "--force-rollback")
 		env.RunAndExpectSuccess(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s",
 			"--advance-notice", "30s")
@@ -157,7 +157,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--block-until-drain",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s",
 			"--advance-notice", "30s")
@@ -177,7 +177,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		// finalize the upgrade
 		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s",
 			"--advance-notice", "30s")
@@ -189,7 +189,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		require.Contains(t, out, "Format version:      3")
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s",
+			"--io-drain-timeout", "1s", "--force",
 			"--status-poll-interval", "1s",
 			"--max-clock-drift", "1s",
 			"--advance-notice", "30s")

--- a/cli/command_repository_upgrade_test.go
+++ b/cli/command_repository_upgrade_test.go
@@ -87,7 +87,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		require.Contains(t, out, "Lock status:         Draining")
 
 		// attempt to rollback the upgrade and restart
-		env.RunAndExpectSuccess(t, "repository", "upgrade", "--force-rollback")
+		env.RunAndExpectSuccess(t, "repository", "upgrade", "rollback", "--force")
 		env.RunAndExpectSuccess(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--force",
@@ -149,7 +149,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		require.Contains(t, out, "Lock status:         Draining")
 
 		// attempt to rollback the upgrade and restart
-		env.RunAndExpectSuccess(t, "repository", "upgrade", "--force-rollback")
+		env.RunAndExpectSuccess(t, "repository", "upgrade", "rollback", "--force")
 
 		// setup advance-notice on upgrade, this will exit immediately
 		env.RunAndExpectSuccess(t, "repository", "upgrade",

--- a/cli/config.go
+++ b/cli/config.go
@@ -69,8 +69,10 @@ func (c *App) openRepository(ctx context.Context, required bool) (repo.Repositor
 
 func (c *App) optionsFromFlags(ctx context.Context) *repo.Options {
 	return &repo.Options{
-		TraceStorage:       c.traceStorage,
-		DisableInternalLog: c.disableInternalLog,
+		TraceStorage:        c.traceStorage,
+		DisableInternalLog:  c.disableInternalLog,
+		UpgradeOwnerID:      c.upgradeOwnerID,
+		DoNotWaitForUpgrade: c.doNotWaitForUpgrade,
 	}
 }
 

--- a/cli/suite_test.go
+++ b/cli/suite_test.go
@@ -21,3 +21,7 @@ func TestFormatV1(t *testing.T) {
 func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=2"}, content.FormatVersion2})
 }
+
+func TestFormatV3(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=3"}, content.FormatVersion3})
+}

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -267,7 +267,7 @@ func repoOptions(openOpts []func(*repo.Options)) *repo.Options {
 }
 
 // FormatNotImportant chooses arbitrary format version where it's not important to the test.
-const FormatNotImportant = content.FormatVersion2
+const FormatNotImportant = content.FormatVersion3
 
 // NewEnvironment creates a new repository testing environment and ensures its cleanup at the end of the test.
 func NewEnvironment(tb testing.TB, version content.FormatVersion, opts ...Options) (context.Context, *Environment) {

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/kopia/kopia/internal/retry"
+	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -78,6 +79,10 @@ func isRetriable(err error) bool {
 		return false
 
 	case errors.Is(err, blob.ErrBlobAlreadyExists):
+		return false
+
+	case errors.Is(err, repo.ErrRepositoryUnavailableDueToUpgrageInProgress):
+		// hard-fail when upgrade is in progress
 		return false
 
 	default:

--- a/repo/content/content_formatting_options.go
+++ b/repo/content/content_formatting_options.go
@@ -23,8 +23,9 @@ type FormatVersion int
 const (
 	FormatVersion1 FormatVersion = 1
 	FormatVersion2 FormatVersion = 2 // new in v0.9
+	FormatVersion3 FormatVersion = 3 // new in v0.11
 
-	MaxFormatVersion = FormatVersion2
+	MaxFormatVersion = FormatVersion3
 )
 
 // FormattingOptions describes the rules for formatting contents in repository.
@@ -41,7 +42,7 @@ type FormattingOptions struct {
 // ResolveFormatVersion applies format options parameters based on the format version.
 func (f *FormattingOptions) ResolveFormatVersion() error {
 	switch f.Version {
-	case FormatVersion2:
+	case FormatVersion2, FormatVersion3:
 		f.EnablePasswordChange = true
 		f.IndexVersion = index.Version2
 		f.EpochParameters = epoch.DefaultParameters()
@@ -63,7 +64,7 @@ func (f *FormattingOptions) ResolveFormatVersion() error {
 // MutableParameters represents parameters of the content manager that can be mutated after the repository
 // is created.
 type MutableParameters struct {
-	Version         FormatVersion    `json:"version,omitempty"`         // version number, must be "1" or "2"
+	Version         FormatVersion    `json:"version,omitempty"`         // version number, must be "1", "2" or "3"
 	MaxPackSize     int              `json:"maxPackSize,omitempty"`     // maximum size of a pack object
 	IndexVersion    int              `json:"indexVersion,omitempty"`    // force particular index format version (1,2,..)
 	EpochParameters epoch.Parameters `json:"epochParameters,omitempty"` // epoch manager parameters

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -60,13 +60,13 @@ const (
 	defaultMaxPreambleLength = 32
 	defaultPaddingUnit       = 4096
 
-	currentWriteVersion = FormatVersion2
+	currentWriteVersion = FormatVersion3
 
 	minSupportedWriteVersion = FormatVersion1
-	maxSupportedWriteVersion = FormatVersion2
+	maxSupportedWriteVersion = FormatVersion3
 
 	minSupportedReadVersion = FormatVersion1
-	maxSupportedReadVersion = FormatVersion2
+	maxSupportedReadVersion = FormatVersion3
 
 	indexLoadAttempts = 10
 )

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -125,8 +125,10 @@ func repositoryObjectFormatFromOptions(opt *NewRepositoryOptions) (*repositoryOb
 			fv = content.FormatVersion1
 		case "2":
 			fv = content.FormatVersion2
+		case "3":
+			fv = content.FormatVersion3
 		default:
-			fv = content.FormatVersion2
+			fv = content.FormatVersion3
 		}
 	}
 

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -52,7 +52,7 @@ func (o ClientOptions) ApplyDefaults(ctx context.Context, defaultDesc string) Cl
 	}
 
 	if o.FormatBlobCacheDuration == 0 {
-		o.FormatBlobCacheDuration = defaultRepositoryBlobCacheDuration
+		o.FormatBlobCacheDuration = DefaultRepositoryBlobCacheDuration
 	}
 
 	return o

--- a/repo/maintenance/suite_test.go
+++ b/repo/maintenance/suite_test.go
@@ -18,3 +18,7 @@ func TestFormatV1(t *testing.T) {
 func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion2})
 }
+
+func TestFormatV3(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion3})
+}

--- a/repo/open.go
+++ b/repo/open.go
@@ -235,9 +235,9 @@ func readAndCacheRepoConfig(ctx context.Context, st blob.Storage, password strin
 }
 
 // ReadAndCacheRepoUpgradeLock loads the lock config from cache and returns it.
-func ReadAndCacheRepoUpgradeLock(ctx context.Context, st blob.Storage, password string, cacheOpts *content.CachingOptions, validDuration time.Duration) (*content.UpgradeLock, error) {
+func ReadAndCacheRepoUpgradeLock(ctx context.Context, st blob.Storage, password string, cacheOpts *content.CachingOptions, validDuration time.Duration) (*UpgradeLockIntent, error) {
 	ufb, err := readAndCacheRepoConfig(ctx, st, password, cacheOpts, validDuration)
-	return ufb.repoConfig.FormattingOptions.UpgradeLock, err
+	return ufb.repoConfig.UpgradeLock, err
 }
 
 // openWithConfig opens the repository with a given configuration, avoiding the need for a config file.

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -76,6 +76,7 @@ type DirectRepositoryWriter interface {
 	ContentManager() *content.WriteManager
 	SetParameters(ctx context.Context, m content.MutableParameters, blobcfg content.BlobCfgBlob) error
 	ChangePassword(ctx context.Context, newPassword string) error
+	GetUpgradeLockIntent(ctx context.Context) (*UpgradeLockIntent, error)
 	SetUpgradeLockIntent(ctx context.Context, l UpgradeLockIntent) (*UpgradeLockIntent, error)
 	CommitUpgrade(ctx context.Context) error
 	RollbackUpgrade(ctx context.Context) error

--- a/repo/suite_test.go
+++ b/repo/suite_test.go
@@ -20,3 +20,7 @@ func TestFormatV1(t *testing.T) {
 func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion2})
 }
+
+func TestFormatV3(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion3})
+}

--- a/repo/upgrade_lock.go
+++ b/repo/upgrade_lock.go
@@ -189,3 +189,14 @@ func (r *directRepository) RollbackUpgrade(ctx context.Context) error {
 
 	return nil
 }
+
+func (r *directRepository) GetUpgradeLockIntent(ctx context.Context) (*UpgradeLockIntent, error) {
+	f := r.formatBlob
+
+	repoConfig, err := f.decryptFormatBytes(r.formatEncryptionKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to decrypt repository config")
+	}
+
+	return repoConfig.UpgradeLock, nil
+}

--- a/repo/upgrade_lock_test.go
+++ b/repo/upgrade_lock_test.go
@@ -190,7 +190,7 @@ func TestFormatUpgradeMultipleLocksRollback(t *testing.T) {
 	env.MustReopen(t, func(opts *repo.Options) {
 		opts.UpgradeOwnerID = "another-upgrade-owner"
 	})
-	require.Equal(t, content.FormatVersion2,
+	require.Equal(t, content.FormatVersion3,
 		env.RepositoryWriter.ContentManager().ContentFormat().MutableParameters.Version)
 
 	require.NoError(t, env.RepositoryWriter.RollbackUpgrade(ctx))

--- a/snapshot/snapshotmaintenance/suite_test.go
+++ b/snapshot/snapshotmaintenance/suite_test.go
@@ -18,3 +18,7 @@ func TestFormatV1(t *testing.T) {
 func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion2})
 }
+
+func TestFormatV3(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{content.FormatVersion3})
+}

--- a/tests/compat_test/compat_test.go
+++ b/tests/compat_test/compat_test.go
@@ -41,7 +41,7 @@ func TestRepoCreatedWith08CanBeOpenedWithCurrent(t *testing.T) {
 	// upgrade
 	e2.RunAndExpectSuccess(t, "repository", "upgrade",
 		"--upgrade-owner-id", "owner",
-		"--io-drain-timeout", "1s", "--force",
+		"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 		"--status-poll-interval", "1s")
 
 	// now 0.8 can't open it anymore

--- a/tests/compat_test/compat_test.go
+++ b/tests/compat_test/compat_test.go
@@ -3,7 +3,9 @@ package compat_test
 import (
 	"os"
 	"testing"
+	"time"
 
+	"github.com/kopia/kopia/cli"
 	"github.com/kopia/kopia/tests/testenv"
 )
 
@@ -34,12 +36,13 @@ func TestRepoCreatedWith08CanBeOpenedWithCurrent(t *testing.T) {
 
 	e2.Environment["KOPIA_UPGRADE_LOCK_ENABLED"] = "1"
 
+	cli.MaxPermittedClockDrift = func() time.Duration { return time.Second }
+
 	// upgrade
 	e2.RunAndExpectSuccess(t, "repository", "upgrade",
 		"--upgrade-owner-id", "owner",
 		"--io-drain-timeout", "1s", "--force",
-		"--status-poll-interval", "1s",
-		"--max-clock-drift", "1s")
+		"--status-poll-interval", "1s")
 
 	// now 0.8 can't open it anymore
 	e3 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner08)

--- a/tests/compat_test/compat_test.go
+++ b/tests/compat_test/compat_test.go
@@ -32,6 +32,8 @@ func TestRepoCreatedWith08CanBeOpenedWithCurrent(t *testing.T) {
 	e2.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", e1.RepoDir)
 	e2.RunAndExpectSuccess(t, "snap", "ls")
 
+	e2.Environment["KOPIA_UPGRADE_LOCK_ENABLED"] = "1"
+
 	// upgrade
 	e2.RunAndExpectSuccess(t, "repository", "upgrade",
 		"--upgrade-owner-id", "owner",

--- a/tests/compat_test/compat_test.go
+++ b/tests/compat_test/compat_test.go
@@ -33,7 +33,11 @@ func TestRepoCreatedWith08CanBeOpenedWithCurrent(t *testing.T) {
 	e2.RunAndExpectSuccess(t, "snap", "ls")
 
 	// upgrade
-	e2.RunAndExpectSuccess(t, "repo", "set-parameters", "--upgrade")
+	e2.RunAndExpectSuccess(t, "repository", "upgrade",
+		"--upgrade-owner-id", "owner",
+		"--io-drain-timeout", "1s",
+		"--status-poll-interval", "1s",
+		"--max-clock-drift", "1s")
 
 	// now 0.8 can't open it anymore
 	e3 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner08)

--- a/tests/compat_test/compat_test.go
+++ b/tests/compat_test/compat_test.go
@@ -35,7 +35,7 @@ func TestRepoCreatedWith08CanBeOpenedWithCurrent(t *testing.T) {
 	// upgrade
 	e2.RunAndExpectSuccess(t, "repository", "upgrade",
 		"--upgrade-owner-id", "owner",
-		"--io-drain-timeout", "1s",
+		"--io-drain-timeout", "1s", "--force",
 		"--status-poll-interval", "1s",
 		"--max-clock-drift", "1s")
 

--- a/tests/end_to_end_test/suite_test.go
+++ b/tests/end_to_end_test/suite_test.go
@@ -19,3 +19,7 @@ func TestFormatV1(t *testing.T) {
 func TestFormatV2(t *testing.T) {
 	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=2"}, content.FormatVersion2})
 }
+
+func TestFormatV3(t *testing.T) {
+	testutil.RunAllTestsWithParam(t, &formatSpecificTestSuite{[]string{"--format-version=3"}, content.FormatVersion3})
+}


### PR DESCRIPTION
This change lets any Kopia repository owner set an upgrade intent on the repository to enable the draining protocol based upgrade coordination between multiple clients of Kopia and help gain an upgrade quorum before actually upgrading the repository.

- A dedicated upgrade CLI with the ability to set a new upgrade lock, update an existing lock and also revoke a previous orphaned lock.
- The change maintains backwards compatibility with existing `set-parameters --upgrade` based upgrade mechanism. However, it is encouraged to use the new CLI with new projects.
- Adding a new upgrade status section to the Kopia repository status CLI to allow any user to check for an ongoing upgrade status.
- Increments the max supported format version from 2 to 3. Version 3 repository format is not a data format change but has the draining protocol support which helps coordinate an upgrade quorum between all Kopia clients.

https://docs.google.com/document/d/1zIghQc4i4vJSANjSDBOvjzMiqnZSEp1cCasxSUkltSk/edit#heading=h.khston2oxmxy

PRs that introduced the upgrade-lock:

- https://github.com/kopia/kopia/pull/1742
- https://github.com/kopia/kopia/pull/1727
- https://github.com/kopia/kopia/pull/1758

Upgrading from format 1 to 3:
```sh
$ kopia repository upgrade --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id owner --io-drain-timeout 1s --status-poll-interval 1s --max-clock-drift 1s
Repository upgrade lock intent has been placed.
Waiting for 2s to allow all other kopia clients to drain ...
Waiting for 1s to allow all other kopia clients to drain ...
Waiting for 0s to allow all other kopia clients to drain ...
Successfully drained all repository clients, the lock has been fully-established now.
migrating current indexes to epoch format
Repository indices have been upgraded.
Repository has been successfully upgraded
```

Upgrading from format 3 to 3:
```sh
$ kopia repository upgrade --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id owner --io-drain-timeout 1s --status-poll-interval 1s --max-clock-drift 1s
ERROR error setting the upgrade lock intent: repository is already upgraded to 3, we can only upgrade till 3
```

Upgrading from format 2 to format 3:
```sh
$ kopia repository upgrade --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id owner --io-drain-timeout 1s --status-poll-interval 1s --max-clock-drift 1s
Repository upgrade lock intent has been placed.
repository indices have already been migrated to the epoch format
Repository has been successfully upgraded
```

Non-owner upgraders during an upgrade:
```sh
$ kopia repository upgrade --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id ownerx --io-drain-timeout 10s --status-poll-interval 5s --max-clock-drift 1s
ERROR failed to open repository: repository upgrade in progress
ERROR open repository: unable to open repository: repository upgrade in progress
```

Connections to repository during an upgrade:
```sh
$ kopia repository connect filesystem --password 12345678 --config-file /tmp/kopia/repository.config --path /tmp/kopia/repo/
ERROR failed to open repository: repository upgrade in progress
deleted repository password for /tmp/kopia/repository.config.
kopia: error: error connecting to repository: repository upgrade in progress, try --help
```

Upgrade status with advance notice:
```sh
$ kopia repository status --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id owner
Config file:         /tmp/kopia/repository.config

Description:         Repository in Filesystem: /tmp/kopia/repo
Hostname:            c02fq0ttmd6r
Username:            shikhar.mall
Read-only:           false
Format blob cache:   15m0s

Storage type:        filesystem
Storage config:      {
                       "path": "/tmp/kopia/repo",
                       "fileMode": 384,
                       "dirMode": 448,
                       "dirShards": [
                         3,
                         3
                       ]
                     }

Unique ID:           83e7ec60180d56181c979213b22b9401c3709d1fcac1a2b2d9d8b921940e0c7e
Hash:                BLAKE2B-256-128
Encryption:          AES256-GCM-HMAC-SHA256
Splitter:            DYNAMIC-4M-BUZHASH
Format version:      3
Content compression: false
Password changes:    false
Max pack length:     20 MiB
Index Format:        v1
Epoch Manager:       disabled
Ongoing upgrade:     Format Version 3 -> 3
Upgrade Time:        2021-12-22 17:05:27.98409 -0800 PST
Upgrade lock:        Unlocked
Lock status:         Draining
```

Upgrade status with immediate lock:
```sh
$ kopia repository status --password 12345678 --config-file /tmp/kopia/repository.config --upgrade-owner-id owner
Config file:         /tmp/kopia/repository.config

Description:         Repository in Filesystem: /tmp/kopia/repo
Hostname:            c02fq0ttmd6r
Username:            shikhar.mall
Read-only:           false
Format blob cache:   15m0s

Storage type:        filesystem
Storage config:      {
                       "path": "/tmp/kopia/repo",
                       "fileMode": 384,
                       "dirMode": 448,
                       "dirShards": [
                         3,
                         3
                       ]                                                                                                                                                                                                                                                                             }

Unique ID:           83e7ec60180d56181c979213b22b9401c3709d1fcac1a2b2d9d8b921940e0c7e
Hash:                BLAKE2B-256-128
Encryption:          AES256-GCM-HMAC-SHA256
Splitter:            DYNAMIC-4M-BUZHASH
Format version:      3
Content compression: false
Password changes:    false
Max pack length:     20 MiB
Index Format:        v1
Epoch Manager:       disabled
Ongoing upgrade:     Format Version 1 -> 3
Upgrade Time:        2021-12-22 16:55:49.98409 -0800 PST
Upgrade lock:        Locked
Lock status:         Fully Established
```