### PR TITLE
feat(snapshots): support restoring sparse files

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -126,7 +126,7 @@ func (c *commandRestore) setup(svc appServices, parent commandParent) {
 	cmd.Flag("overwrite-files", "Specifies whether or not to overwrite already existing files").Default("true").BoolVar(&c.restoreOverwriteFiles)
 	cmd.Flag("overwrite-symlinks", "Specifies whether or not to overwrite already existing symlinks").Default("true").BoolVar(&c.restoreOverwriteSymlinks)
 	cmd.Flag("consistent-attributes", "When multiple snapshots match, fail if they have inconsistent attributes").Envar("KOPIA_RESTORE_CONSISTENT_ATTRIBUTES").BoolVar(&c.restoreConsistentAttributes)
-	cmd.Flag("mode", "Override restore mode").Default(restoreModeAuto).EnumVar(&c.restoreMode, restoreModeAuto, restoreModeLocal, restoreModeZip, restoreModeZipNoCompress, restoreModeTar, restoreModeTgz)
+	cmd.Flag("mode", "Override restore mode").Default(restoreModeAuto).EnumVar(&c.restoreMode, restoreModeAuto, restoreModeLocal, restoreModeSparse, restoreModeZip, restoreModeZipNoCompress, restoreModeTar, restoreModeTgz)
 	cmd.Flag("parallel", "Restore parallelism (1=disable)").Default("8").IntVar(&c.restoreParallel)
 	cmd.Flag("skip-owners", "Skip owners during restore").BoolVar(&c.restoreSkipOwners)
 	cmd.Flag("skip-permissions", "Skip permissions during restore").BoolVar(&c.restoreSkipPermissions)
@@ -142,6 +142,7 @@ func (c *commandRestore) setup(svc appServices, parent commandParent) {
 
 const (
 	restoreModeLocal         = "local"
+	restoreModeSparse        = "sparse"
 	restoreModeAuto          = "auto"
 	restoreModeZip           = "zip"
 	restoreModeZipNoCompress = "zip-nocompress"
@@ -209,7 +210,7 @@ func (c *commandRestore) restoreOutput(ctx context.Context) (restore.Output, err
 
 	m := c.detectRestoreMode(ctx, c.restoreMode, targetpath)
 	switch m {
-	case restoreModeLocal:
+	case restoreModeLocal, restoreModeSparse:
 		return &restore.FilesystemOutput{
 			TargetPath:             targetpath,
 			OverwriteDirectories:   c.restoreOverwriteDirectories,
@@ -220,6 +221,7 @@ func (c *commandRestore) restoreOutput(ctx context.Context) (restore.Output, err
 			SkipOwners:             c.restoreSkipOwners,
 			SkipPermissions:        c.restoreSkipPermissions,
 			SkipTimes:              c.restoreSkipTimes,
+			Sparse:                 m == restoreModeSparse,
 		}, nil
 
 	case restoreModeZip, restoreModeZipNoCompress:

--- a/internal/iocopy/copy.go
+++ b/internal/iocopy/copy.go
@@ -6,7 +6,8 @@ import (
 	"sync"
 )
 
-const bufSize = 65536
+// BufSize is the size (in bytes) of the shared copy buffers Kopia uses to copy data.
+const BufSize = 65536
 
 var (
 	mu sync.Mutex //nolint:gochecknoglobals
@@ -21,7 +22,7 @@ func GetBuffer() []byte {
 	defer mu.Unlock()
 
 	if len(buffers) == 0 {
-		return make([]byte, bufSize)
+		return make([]byte, BufSize)
 	}
 
 	var b []byte

--- a/internal/sparsefile/sparsefile.go
+++ b/internal/sparsefile/sparsefile.go
@@ -1,0 +1,107 @@
+// Package sparsefile provides wrappers for handling the writing of sparse files (files with holes).
+package sparsefile
+
+import (
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/iocopy"
+	"github.com/kopia/kopia/internal/stat"
+)
+
+// Write writes the contents of src to the given targetPath, omitting any holes.
+func Write(targetPath string, src io.Reader, size int64) error {
+	dst, err := os.OpenFile(targetPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec,gomnd
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	// ensure we always close f. Note that this does not conflict with the
+	// close below, as close is idempotent.
+	defer dst.Close() //nolint:errcheck,gosec
+
+	if err = dst.Truncate(size); err != nil {
+		return errors.Wrap(err, "error writing sparse file")
+	}
+
+	s, err := stat.GetBlockSize(targetPath)
+	if err != nil {
+		return errors.Wrap(err, "error writing sparse file")
+	}
+
+	buf := iocopy.GetBuffer()
+	defer iocopy.ReleaseBuffer(buf)
+
+	w, err := copySparse(dst, src, buf[0:s])
+	if err != nil {
+		return errors.Wrap(err, "error writing sparse file")
+	}
+
+	if w != size {
+		return errors.Errorf("")
+	}
+
+	if err := dst.Close(); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	return nil
+}
+
+func copySparse(dst io.WriteSeeker, src io.Reader, buf []byte) (written int64, err error) {
+	for {
+		nr, er := src.Read(buf)
+		if nr > 0 { // nolint:nestif
+			// If non-zero data is read, write it. Otherwise, skip forwards.
+			if isAllZero(buf) {
+				dst.Seek(int64(nr), os.SEEK_CUR) // nolint:errcheck
+				written += int64(nr)
+
+				continue
+			}
+
+			nw, ew := dst.Write(buf[0:nr])
+			if nw < 0 || nr < nw {
+				nw = 0
+
+				if ew == nil {
+					ew = errors.New("invalid write result")
+				}
+			}
+
+			written += int64(nw)
+
+			if ew != nil {
+				err = ew
+				break
+			}
+
+			if nr != nw {
+				err = io.ErrShortWrite
+				break
+			}
+		}
+
+		if er != nil {
+			if er != io.EOF {
+				err = er
+			}
+
+			break
+		}
+	}
+
+	return written, err
+}
+
+func isAllZero(buf []byte) bool {
+	for _, b := range buf {
+		if b != 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/sparsefile/sparsefile_test.go
+++ b/internal/sparsefile/sparsefile_test.go
@@ -1,0 +1,98 @@
+package sparsefile
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/kopia/kopia/internal/stat"
+)
+
+func TestSparseWrite(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("sparse files are not supported on windows")
+	}
+
+	dir := t.TempDir()
+
+	blk, err := stat.GetBlockSize(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type chunk struct {
+		slice []byte
+		off   uint64
+		rep   uint64
+	}
+
+	cases := []struct {
+		name string
+		size uint64
+		data []chunk
+	}{
+		{
+			name: "null",
+			size: 0,
+		},
+		{
+			name: "empty",
+			size: blk,
+			data: []chunk{
+				{slice: []byte{0}, off: 0, rep: blk},
+			},
+		},
+		{
+			name: "hole",
+			size: 2 * blk,
+			data: []chunk{
+				{slice: []byte{1}, off: blk, rep: blk},
+			},
+		},
+		{
+			name: "mix",
+			size: 2 * blk,
+			data: []chunk{
+				{slice: []byte{1}, off: 3, rep: blk - 10},
+				{slice: []byte{1}, off: 2*blk - 10, rep: 10},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		src := filepath.Join(dir, "src"+c.name)
+		dst := filepath.Join(dir, "dst"+c.name)
+
+		fd, err := os.Create(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, d := range c.data {
+			fd.WriteAt(bytes.Repeat(d.slice, int(d.rep)), int64(d.off))
+		}
+
+		err = Write(dst, fd, int64(c.size))
+		if err != nil {
+			t.Fatalf("error writing %s: %v", dst, err)
+		}
+
+		s, err := os.ReadFile(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		d, err := os.ReadFile(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(s, d) {
+			t.Fatalf("contents of %s and %s are not identical", src, dst)
+		}
+	}
+}

--- a/internal/stat/stat_bsd.go
+++ b/internal/stat/stat_bsd.go
@@ -1,0 +1,37 @@
+//go:build openbsd
+// +build openbsd
+
+// Package stat provides a cross-platform abstraction for
+// common stat commands.
+package stat
+
+import "syscall"
+
+const (
+	diskBlockSize uint64 = 512
+)
+
+// GetFileAllocSize gets the space allocated on disk for the file.
+// 'fname' in bytes.
+func GetFileAllocSize(fname string) (uint64, error) {
+	var st syscall.Stat_t
+
+	err := syscall.Stat(fname, &st)
+	if err != nil {
+		return 0, err // nolint:wrapcheck
+	}
+
+	return uint64(st.Blocks) * diskBlockSize, nil
+}
+
+// GetBlockSize gets the disk block size of the underlying system.
+func GetBlockSize(path string) (uint64, error) {
+	var st syscall.Statfs_t
+
+	err := syscall.Statfs(path, &st)
+	if err != nil {
+		return 0, err // nolint:wrapcheck
+	}
+
+	return uint64(st.F_bsize), nil
+}

--- a/internal/stat/stat_test.go
+++ b/internal/stat/stat_test.go
@@ -1,0 +1,44 @@
+//go:build !windows
+// +build !windows
+
+package stat
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetBlockSize(t *testing.T) {
+	s, err := GetBlockSize(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s <= 0 {
+		t.Fatalf("invalid disk block size: %d, must be greater than 0", s)
+	}
+}
+
+func TestGetFileAllocSize(t *testing.T) {
+	const size = 4096
+
+	d := t.TempDir()
+	f := filepath.Join(d, "test")
+	data := bytes.Repeat([]byte{1}, size)
+
+	err := os.WriteFile(f, data, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := GetFileAllocSize(f)
+	if err != nil {
+		t.Fatalf("error getting file alloc size for %s: %v", f, err)
+	}
+
+	if s < size {
+		t.Fatalf("invalid allocated file size %d, expected at least %d", s, size)
+	}
+}

--- a/internal/stat/stat_unix.go
+++ b/internal/stat/stat_unix.go
@@ -1,0 +1,37 @@
+//go:build linux || freebsd || darwin
+// +build linux freebsd darwin
+
+// Package stat provides a cross-platform abstraction for
+// common stat commands.
+package stat
+
+import "syscall"
+
+const (
+	diskBlockSize uint64 = 512
+)
+
+// GetFileAllocSize gets the space allocated on disk for the file
+// 'fname' in bytes.
+func GetFileAllocSize(fname string) (uint64, error) {
+	var st syscall.Stat_t
+
+	err := syscall.Stat(fname, &st)
+	if err != nil {
+		return 0, err // nolint:wrapcheck
+	}
+
+	return uint64(st.Blocks) * diskBlockSize, nil
+}
+
+// GetBlockSize gets the disk block size of the underlying system.
+func GetBlockSize(path string) (uint64, error) {
+	var st syscall.Statfs_t
+
+	err := syscall.Statfs(path, &st)
+	if err != nil {
+		return 0, err // nolint:wrapcheck
+	}
+
+	return uint64(st.Bsize), nil // nolint:unconvert,nolintlint
+}

--- a/internal/stat/stat_windows.go
+++ b/internal/stat/stat_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+// +build windows
+
+// Package stat provides a cross-platform abstraction for
+// common stat commands.
+package stat
+
+import (
+	"errors"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// GetFileAllocSize gets the space allocated on disk for the file
+// 'fname' in bytes.
+// nolint:gosec
+func GetFileAllocSize(fname string) (uint64, error) {
+	pathPtr, err := windows.UTF16PtrFromString(fname)
+	if !errors.Is(err, syscall.Errno(0)) {
+		return 0, err // nolint:wrapcheck
+	}
+
+	var size uint64
+
+	GetCompressedFileSizeA := syscall.MustLoadDLL("kernel32.dll").MustFindProc("GetCompressedFileSizeA")
+
+	_, _, err = GetCompressedFileSizeA.Call(
+		uintptr(*pathPtr),
+		uintptr(unsafe.Pointer(&size)))
+	if !errors.Is(err, syscall.Errno(0)) {
+		return 0, err //nolint:wrapcheck
+	}
+
+	return size, nil
+}
+
+// GetBlockSize gets the disk block size of the underlying system.
+// nolint:gosec
+func GetBlockSize(path string) (uint64, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if !errors.Is(err, syscall.Errno(0)) {
+		return 0, err // nolint:wrapcheck
+	}
+
+	var sectorSize, clusterSize uint64
+
+	GetDiskFreeSpaceW := syscall.MustLoadDLL("kernel32.dll").MustFindProc("GetDiskFreeSpaceW")
+
+	_, _, err = GetDiskFreeSpaceW.Call(
+		uintptr(*pathPtr),
+		uintptr(unsafe.Pointer(&sectorSize)),
+		uintptr(unsafe.Pointer(&clusterSize)))
+	if !errors.Is(err, syscall.Errno(0)) {
+		return 0, err // nolint:wrapcheck
+	}
+
+	return sectorSize * clusterSize, nil
+}

--- a/internal/stat/stat_windows.go
+++ b/internal/stat/stat_windows.go
@@ -5,56 +5,17 @@
 // common stat commands.
 package stat
 
-import (
-	"errors"
-	"syscall"
-	"unsafe"
+import "errors"
 
-	"golang.org/x/sys/windows"
-)
+var errNotImplemented = errors.New("not implemented")
 
 // GetFileAllocSize gets the space allocated on disk for the file
 // 'fname' in bytes.
-// nolint:gosec
 func GetFileAllocSize(fname string) (uint64, error) {
-	pathPtr, err := windows.UTF16PtrFromString(fname)
-	if !errors.Is(err, syscall.Errno(0)) {
-		return 0, err // nolint:wrapcheck
-	}
-
-	var size uint64
-
-	GetCompressedFileSizeA := syscall.MustLoadDLL("kernel32.dll").MustFindProc("GetCompressedFileSizeA")
-
-	_, _, err = GetCompressedFileSizeA.Call(
-		uintptr(*pathPtr),
-		uintptr(unsafe.Pointer(&size)))
-	if !errors.Is(err, syscall.Errno(0)) {
-		return 0, err //nolint:wrapcheck
-	}
-
-	return size, nil
+	return 0, errNotImplemented
 }
 
 // GetBlockSize gets the disk block size of the underlying system.
-// nolint:gosec
 func GetBlockSize(path string) (uint64, error) {
-	pathPtr, err := windows.UTF16PtrFromString(path)
-	if !errors.Is(err, syscall.Errno(0)) {
-		return 0, err // nolint:wrapcheck
-	}
-
-	var sectorSize, clusterSize uint64
-
-	GetDiskFreeSpaceW := syscall.MustLoadDLL("kernel32.dll").MustFindProc("GetDiskFreeSpaceW")
-
-	_, _, err = GetDiskFreeSpaceW.Call(
-		uintptr(*pathPtr),
-		uintptr(unsafe.Pointer(&sectorSize)),
-		uintptr(unsafe.Pointer(&clusterSize)))
-	if !errors.Is(err, syscall.Errno(0)) {
-		return 0, err // nolint:wrapcheck
-	}
-
-	return sectorSize * clusterSize, nil
+	return 0, errNotImplemented
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -48,6 +48,15 @@ func TestSkipUnlessCI(tb testing.TB, msg string, args ...interface{}) {
 	}
 }
 
+// TestSkipUnlessLinux skips the current test if the test environment is not Linux.
+func TestSkipUnlessLinux(tb testing.TB) {
+	tb.Helper()
+
+	if runtime.GOOS != "linux" {
+		tb.Skip("test not supported in this environment.")
+	}
+}
+
 // TestSkipOnCIUnlessLinuxAMD64 skips the current test if running on CI unless the environment is Linux/AMD64.
 func TestSkipOnCIUnlessLinuxAMD64(tb testing.TB) {
 	tb.Helper()


### PR DESCRIPTION
Implements support for restoring sparse files from snapshots.

When specifying `--mode=sparse` in a `snapshot restore`
command, Kopia will make a best effort to make sure the underlying
filesystem allocates the minimum amount of blocks needed to persist
restored files. In other words, enabling this feature will "force"
all restored files to be sparse-blocks of zero bytes in the source
file should not be allocated. This feature will only be enabled if:

- the OS is not Windows
- `--write-files-atomically` is not also selected

Otherwise, the flag will be silently ignored. Partially addresses the
concern in #540.