### PR TITLE
refactor(repository): major server code refactoring

### DIFF
--- a/internal/server/api_cli.go
+++ b/internal/server/api_cli.go
@@ -2,21 +2,20 @@ package server
 
 import (
 	"context"
-	"net/http"
 	"os"
 	"strings"
 
 	"github.com/kopia/kopia/internal/serverapi"
 )
 
-func (s *Server) handleCLIInfo(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
+func handleCLIInfo(ctx context.Context, rc requestContext) (interface{}, *apiError) {
 	executable, err := os.Executable()
 	if err != nil {
 		executable = "kopia"
 	}
 
 	return &serverapi.CLIInfo{
-		Executable: maybeQuote(executable) + " --config-file=" + maybeQuote(s.options.ConfigFile) + "",
+		Executable: maybeQuote(executable) + " --config-file=" + maybeQuote(rc.srv.getOptions().ConfigFile) + "",
 	}, nil
 }
 

--- a/internal/server/api_paths.go
+++ b/internal/server/api_paths.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"net/http"
 	"path/filepath"
 
 	"github.com/kopia/kopia/internal/ospath"
@@ -11,18 +10,18 @@ import (
 	"github.com/kopia/kopia/snapshot"
 )
 
-func (s *Server) handlePathResolve(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
+func handlePathResolve(ctx context.Context, rc requestContext) (interface{}, *apiError) {
 	var req serverapi.ResolvePathRequest
 
-	if err := json.Unmarshal(body, &req); err != nil {
+	if err := json.Unmarshal(rc.body, &req); err != nil {
 		return nil, requestError(serverapi.ErrorMalformedRequest, "malformed request body")
 	}
 
 	return &serverapi.ResolvePathResponse{
 		SourceInfo: snapshot.SourceInfo{
 			Path:     filepath.Clean(ospath.ResolveUserFriendlyPath(req.Path, true)),
-			Host:     s.rep.ClientOptions().Hostname,
-			UserName: s.rep.ClientOptions().Username,
+			Host:     rc.rep.ClientOptions().Hostname,
+			UserName: rc.rep.ClientOptions().Username,
 		},
 	}, nil
 }

--- a/internal/server/api_tasks.go
+++ b/internal/server/api_tasks.go
@@ -2,16 +2,13 @@ package server
 
 import (
 	"context"
-	"net/http"
-
-	"github.com/gorilla/mux"
 
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/internal/uitask"
 )
 
-func (s *Server) handleTaskList(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
-	tasks := s.taskmgr.ListTasks()
+func handleTaskList(ctx context.Context, rc requestContext) (interface{}, *apiError) {
+	tasks := rc.srv.taskManager().ListTasks()
 	if tasks == nil {
 		tasks = []uitask.Info{}
 	}
@@ -21,10 +18,10 @@ func (s *Server) handleTaskList(ctx context.Context, r *http.Request, body []byt
 	}, nil
 }
 
-func (s *Server) handleTaskInfo(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
-	taskID := mux.Vars(r)["taskID"]
+func handleTaskInfo(ctx context.Context, rc requestContext) (interface{}, *apiError) {
+	taskID := rc.muxVar("taskID")
 
-	t, ok := s.taskmgr.GetTask(taskID)
+	t, ok := rc.srv.taskManager().GetTask(taskID)
 	if !ok {
 		return nil, notFoundError("task not found")
 	}
@@ -32,20 +29,20 @@ func (s *Server) handleTaskInfo(ctx context.Context, r *http.Request, body []byt
 	return t, nil
 }
 
-func (s *Server) handleTaskSummary(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
-	return s.taskmgr.TaskSummary(), nil
+func handleTaskSummary(ctx context.Context, rc requestContext) (interface{}, *apiError) {
+	return rc.srv.taskManager().TaskSummary(), nil
 }
 
-func (s *Server) handleTaskLogs(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
-	taskID := mux.Vars(r)["taskID"]
+func handleTaskLogs(ctx context.Context, rc requestContext) (interface{}, *apiError) {
+	taskID := rc.muxVar("taskID")
 
 	return serverapi.TaskLogResponse{
-		Logs: s.taskmgr.TaskLog(taskID),
+		Logs: rc.srv.taskManager().TaskLog(taskID),
 	}, nil
 }
 
-func (s *Server) handleTaskCancel(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
-	s.taskmgr.CancelTask(mux.Vars(r)["taskID"])
+func handleTaskCancel(ctx context.Context, rc requestContext) (interface{}, *apiError) {
+	rc.srv.taskManager().CancelTask(rc.muxVar("taskID"))
 
 	return &serverapi.Empty{}, nil
 }

--- a/internal/server/api_user.go
+++ b/internal/server/api_user.go
@@ -2,13 +2,12 @@ package server
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/repo"
 )
 
-func (s *Server) handleCurrentUser(ctx context.Context, r *http.Request, body []byte) (interface{}, *apiError) {
+func handleCurrentUser(ctx context.Context, rc requestContext) (interface{}, *apiError) {
 	return serverapi.CurrentUserResponse{
 		Username: repo.GetDefaultUserName(ctx),
 		Hostname: repo.GetDefaultHostName(ctx),

--- a/internal/server/request_context.go
+++ b/internal/server/request_context.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/kopia/kopia/internal/auth"
+	"github.com/kopia/kopia/internal/mount"
+	"github.com/kopia/kopia/internal/uitask"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/object"
+	"github.com/kopia/kopia/snapshot"
+)
+
+type serverInterface interface {
+	deleteSourceManager(ctx context.Context, src snapshot.SourceInfo) bool
+	generateShortTermAuthCookie(username string, now time.Time) (string, error)
+	isAuthCookieValid(username, cookieValue string) bool
+	getAuthorizer() auth.Authorizer
+	getAuthenticator() auth.Authenticator
+	getOptions() *Options
+	allSourceManagers() map[snapshot.SourceInfo]*sourceManager
+	taskManager() *uitask.Manager
+	Refresh(ctx context.Context) error
+	getMountController(ctx context.Context, rep repo.Repository, oid object.ID, createIfNotFound bool) (mount.Controller, error)
+	deleteMount(oid object.ID)
+	listMounts() map[object.ID]mount.Controller
+	triggerRefreshSource(src snapshot.SourceInfo)
+	disconnect(ctx context.Context) error
+	requestShutdown(ctx context.Context)
+	getOrCreateSourceManager(ctx context.Context, src snapshot.SourceInfo) *sourceManager
+	getInitRepositoryTaskID() string
+	getConnectOptions(cliOpts repo.ClientOptions) *repo.ConnectOptions
+	SetRepository(ctx context.Context, rep repo.Repository) error
+	InitRepositoryAsync(ctx context.Context, mode string, initializer InitRepositoryFunc, wait bool) (string, error)
+}
+
+type requestContext struct {
+	w    http.ResponseWriter
+	req  *http.Request
+	body []byte
+	rep  repo.Repository
+	srv  serverInterface
+}
+
+func (r *requestContext) muxVar(s string) string {
+	return mux.Vars(r.req)[s]
+}
+
+func (r *requestContext) queryParam(s string) string {
+	return r.req.URL.Query().Get(s)
+}

--- a/internal/server/server_authz_checks.go
+++ b/internal/server/server_authz_checks.go
@@ -59,50 +59,50 @@ func (s *Server) validateCSRFToken(r *http.Request) bool {
 	return false
 }
 
-func requireUIUser(s *Server, r *http.Request) bool {
-	if s.authenticator == nil {
+func requireUIUser(ctx context.Context, rc requestContext) bool {
+	if rc.srv.getAuthenticator() == nil {
 		return true
 	}
 
-	if s.options.UIUser == "" {
+	if rc.srv.getOptions().UIUser == "" {
 		return false
 	}
 
-	user, _, _ := r.BasicAuth()
+	user, _, _ := rc.req.BasicAuth()
 
-	return user == s.options.UIUser
+	return user == rc.srv.getOptions().UIUser
 }
 
-func requireServerControlUser(s *Server, r *http.Request) bool {
-	if s.authenticator == nil {
+func requireServerControlUser(ctx context.Context, rc requestContext) bool {
+	if rc.srv.getAuthenticator() == nil {
 		return true
 	}
 
-	if s.options.ServerControlUser == "" {
+	if rc.srv.getOptions().ServerControlUser == "" {
 		return false
 	}
 
-	user, _, _ := r.BasicAuth()
+	user, _, _ := rc.req.BasicAuth()
 
-	return user == s.options.ServerControlUser
+	return user == rc.srv.getOptions().ServerControlUser
 }
 
-func anyAuthenticatedUser(s *Server, r *http.Request) bool {
+func anyAuthenticatedUser(ctx context.Context, rc requestContext) bool {
 	return true
 }
 
-func handlerWillCheckAuthorization(s *Server, r *http.Request) bool {
+func handlerWillCheckAuthorization(ctx context.Context, rc requestContext) bool {
 	return true
 }
 
 func requireContentAccess(level auth.AccessLevel) isAuthorizedFunc {
-	return func(s *Server, r *http.Request) bool {
-		return s.httpAuthorizationInfo(r.Context(), r).ContentAccessLevel() >= level
+	return func(ctx context.Context, rc requestContext) bool {
+		return httpAuthorizationInfo(ctx, rc).ContentAccessLevel() >= level
 	}
 }
 
-func hasManifestAccess(ctx context.Context, s *Server, r *http.Request, labels map[string]string, level auth.AccessLevel) bool {
-	return s.httpAuthorizationInfo(ctx, r).ManifestAccessLevel(labels) >= level
+func hasManifestAccess(ctx context.Context, rc requestContext, labels map[string]string, level auth.AccessLevel) bool {
+	return httpAuthorizationInfo(ctx, rc).ManifestAccessLevel(labels) >= level
 }
 
 var (

--- a/internal/server/server_mount_manager.go
+++ b/internal/server/server_mount_manager.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/mount"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/object"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+)
+
+func (s *Server) getMountController(ctx context.Context, rep repo.Repository, oid object.ID, createIfNotFound bool) (mount.Controller, error) {
+	s.serverMutex.Lock()
+	defer s.serverMutex.Unlock()
+
+	c := s.mounts[oid]
+	if c != nil {
+		return c, nil
+	}
+
+	if !createIfNotFound {
+		return nil, nil
+	}
+
+	log(ctx).Debugf("mount controller for %v not found, starting", oid)
+
+	c, err := mount.Directory(ctx, snapshotfs.DirectoryEntry(rep, oid, nil), "*", mount.Options{})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to mount")
+	}
+
+	s.mounts[oid] = c
+
+	return c, nil
+}
+
+func (s *Server) listMounts() map[object.ID]mount.Controller {
+	s.serverMutex.RLock()
+	defer s.serverMutex.RUnlock()
+
+	result := map[object.ID]mount.Controller{}
+
+	for oid, c := range s.mounts {
+		result[oid] = c
+	}
+
+	return result
+}
+
+func (s *Server) deleteMount(oid object.ID) {
+	s.serverMutex.Lock()
+	defer s.serverMutex.Unlock()
+
+	delete(s.mounts, oid)
+}
+
+// +checklocks:s.serverMutex
+func (s *Server) unmountAllLocked(ctx context.Context) {
+	for oid, c := range s.mounts {
+		if err := c.Unmount(ctx); err != nil {
+			log(ctx).Errorf("unable to unmount %v", oid)
+		}
+
+		delete(s.mounts, oid)
+	}
+}

--- a/snapshot/stats.go
+++ b/snapshot/stats.go
@@ -9,21 +9,31 @@ import (
 // Stats keeps track of snapshot generation statistics.
 type Stats struct {
 	// keep all int64 aligned because they will be atomically updated
-	TotalFileSize         int64 `json:"totalSize"`
+	// +checkatomic
+	TotalFileSize int64 `json:"totalSize"`
+	// +checkatomic
 	ExcludedTotalFileSize int64 `json:"excludedTotalSize"`
 
 	// keep all int32 aligned because they will be atomically updated
+	// +checkatomic
 	TotalFileCount int32 `json:"fileCount"`
-	CachedFiles    int32 `json:"cachedFiles"`
+	// +checkatomic
+	CachedFiles int32 `json:"cachedFiles"`
+	// +checkatomic
 	NonCachedFiles int32 `json:"nonCachedFiles"`
 
+	// +checkatomic
 	TotalDirectoryCount int32 `json:"dirCount"`
 
+	// +checkatomic
 	ExcludedFileCount int32 `json:"excludedFileCount"`
-	ExcludedDirCount  int32 `json:"excludedDirCount"`
+	// +checkatomic
+	ExcludedDirCount int32 `json:"excludedDirCount"`
 
+	// +checkatomic
 	IgnoredErrorCount int32 `json:"ignoredErrorCount"`
-	ErrorCount        int32 `json:"errorCount"`
+	// +checkatomic
+	ErrorCount int32 `json:"errorCount"`
 }
 
 // AddExcluded adds the information about excluded file to the statistics.


### PR DESCRIPTION
This removes big shared lock held for for the duration of each request
and replaces it with trivially short lock to capture the current
state of the server/repository before passing it to handlers.

Handlers are now limited to only accessing a small subset of Server
functionality to be able to better reason about them.