### PR TITLE
chore(ci): added checklocks static analyzer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,14 @@ install-noui: install
 install-race:
 	go install -race $(KOPIA_BUILD_FLAGS) -tags "$(KOPIA_BUILD_TAGS)"
 
-lint: $(linter)
+check-locks: $(checklocks)
+ifneq ($(GOOS)/$(GOARCH),linux/arm64)
+ifneq ($(GOOS)/$(GOARCH),linux/arm)
+	go vet -vettool=$(checklocks) ./...
+endif
+endif
+
+lint: $(linter) check-locks
 ifneq ($(GOOS)/$(GOARCH),linux/arm64)
 ifneq ($(GOOS)/$(GOARCH),linux/arm)
 	$(linter) --deadline $(LINTER_DEADLINE) run $(linter_flags)
@@ -171,7 +178,7 @@ download-rclone:
 	go run ./tools/gettool --tool rclone:$(RCLONE_VERSION) --output-dir dist/kopia_linux_arm_6/ --goos=linux --goarch=arm
 
 
-ci-tests: lint vet test
+ci-tests: lint vet test 
 
 ci-integration-tests:
 	$(MAKE) integration-tests

--- a/cli/command_content_stats.go
+++ b/cli/command_content_stats.go
@@ -27,7 +27,9 @@ func (c *commandContentStats) setup(svc appServices, parent commandParent) {
 }
 
 type contentStatsTotals struct {
-	originalSize, packedSize, count int64
+	originalSize int64
+	packedSize   int64
+	count        int64
 }
 
 func (c *commandContentStats) run(ctx context.Context, rep repo.DirectRepository) error {

--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/fatih/color"
@@ -276,7 +277,7 @@ func (c *commandSnapshotList) outputManifestFromSingleSource(ctx context.Context
 		})
 
 		if m.IncompleteReason == "" {
-			lastTotalFileSize = m.Stats.TotalFileSize
+			lastTotalFileSize = atomic.LoadInt64(&m.Stats.TotalFileSize)
 		}
 
 		return nil
@@ -390,10 +391,10 @@ func (c *commandSnapshotList) entryBits(ctx context.Context, m *snapshot.Manifes
 
 	if u := m.StorageStats; u != nil {
 		bits = append(bits,
-			fmt.Sprintf("new-data:%v", units.BytesStringBase10(u.NewData.PackedContentBytes)),
-			fmt.Sprintf("new-files:%v", int64(u.NewData.FileObjectCount)),
-			fmt.Sprintf("new-dirs:%v", int64(u.NewData.DirObjectCount)),
-			fmt.Sprintf("compression:%v", formatCompressionPercentage(u.NewData.OriginalContentBytes, u.NewData.PackedContentBytes)),
+			fmt.Sprintf("new-data:%v", units.BytesStringBase10(atomic.LoadInt64(&u.NewData.PackedContentBytes))),
+			fmt.Sprintf("new-files:%v", atomic.LoadInt32(&u.NewData.FileObjectCount)),
+			fmt.Sprintf("new-dirs:%v", atomic.LoadInt32(&u.NewData.DirObjectCount)),
+			fmt.Sprintf("compression:%v", formatCompressionPercentage(atomic.LoadInt64(&u.NewData.OriginalContentBytes), atomic.LoadInt64(&u.NewData.PackedContentBytes))),
 		)
 	}
 

--- a/fs/cachefs/cache_test.go
+++ b/fs/cachefs/cache_test.go
@@ -141,15 +141,18 @@ func (cv *cacheVerifier) reset() {
 }
 
 type lockState struct {
-	l      sync.Locker
+	l sync.Locker
+	// +checkatomic
 	locked int32
 }
 
+// +checklocksacquire:ls.l
 func (ls *lockState) Lock() {
 	ls.l.Lock()
 	atomic.AddInt32(&ls.locked, 1)
 }
 
+// +checklocksrelease:ls.l
 func (ls *lockState) Unlock() {
 	atomic.AddInt32(&ls.locked, -1)
 	ls.l.Unlock()

--- a/internal/auth/authn_repo.go
+++ b/internal/auth/authn_repo.go
@@ -13,11 +13,14 @@ import (
 const defaultProfileRefreshFrequency = 10 * time.Second
 
 type repositoryUserAuthenticator struct {
+	mu sync.Mutex
+	// +checklocks:mu
 	lastRep repo.Repository
-
-	mu                          sync.Mutex
-	nextRefreshTime             time.Time
-	userProfiles                map[string]*user.Profile
+	// +checklocks:mu
+	nextRefreshTime time.Time
+	// +checklocks:mu
+	userProfiles map[string]*user.Profile
+	// +checklocks:mu
 	userProfileRefreshFrequency time.Duration
 }
 

--- a/internal/auth/authz_acl.go
+++ b/internal/auth/authz_acl.go
@@ -86,12 +86,15 @@ var DefaultACLs = []*acl.Entry{
 }
 
 type aclCache struct {
-	aclRefreshFrequency time.Duration
+	aclRefreshFrequency time.Duration // +checklocksignore
 
-	mu              sync.Mutex
-	lastRep         repo.Repository
+	mu sync.Mutex
+	// +checklocks:mu
+	lastRep repo.Repository
+	// +checklocks:mu
 	nextRefreshTime time.Time
-	aclEntries      []*acl.Entry
+	// +checklocks:mu
+	aclEntries []*acl.Entry
 }
 
 // Authorize returns authorization info based on ACLs stored in the repository falling back to legacy authorizer

--- a/internal/blobtesting/eventually_consistent.go
+++ b/internal/blobtesting/eventually_consistent.go
@@ -88,6 +88,7 @@ type eventuallyConsistentStorage struct {
 	recentlyDeleted sync.Map
 	listSettleTime  time.Duration
 
+	// +checklocks:mu
 	caches      []*ecFrontendCache
 	realStorage blob.Storage
 	timeNow     func() time.Time

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -18,8 +18,11 @@ import (
 type DataMap map[blob.ID][]byte
 
 type mapStorage struct {
-	data    DataMap
+	// +checklocks:mutex
+	data DataMap
+	// +checklocks:mutex
 	keyTime map[blob.ID]time.Time
+	// +checklocks:mutex
 	timeNow func() time.Time
 	mutex   sync.RWMutex
 }

--- a/internal/blobtesting/object_locking_map.go
+++ b/internal/blobtesting/object_locking_map.go
@@ -29,11 +29,13 @@ type versionedEntries map[blob.ID][]*entry
 // marker. This struct manages the retention time of each blob throug hte
 // PutBlob options.
 type objectLockingMap struct {
+	// +checklocks:mutex
 	data    versionedEntries
-	timeNow func() time.Time
+	timeNow func() time.Time // +checklocksignore
 	mutex   sync.RWMutex
 }
 
+// +checklocksread:s.mutex
 func (s *objectLockingMap) getLatestByID(id blob.ID) (*entry, error) {
 	versions, ok := s.data[id]
 	if !ok {
@@ -50,6 +52,7 @@ func (s *objectLockingMap) getLatestByID(id blob.ID) (*entry, error) {
 	return e, nil
 }
 
+// +checklocksread:s.mutex
 func (s *objectLockingMap) getLatestForMutationLocked(id blob.ID) (*entry, error) {
 	e, err := s.getLatestByID(id)
 	if err != nil {

--- a/internal/cache/content_cache_concurrency_test.go
+++ b/internal/cache/content_cache_concurrency_test.go
@@ -279,8 +279,10 @@ func testGetContentRaceFetchesOnce(t *testing.T, newCache newContentCacheFunc) {
 type concurrencyTester struct {
 	mu sync.Mutex
 
-	concurrencyLevel    int
-	maxConcurrencyLevel int
+	// +checklocks:mu
+	concurrencyLevel int
+
+	maxConcurrencyLevel int // +checklocksignore
 }
 
 func (c *concurrencyTester) enter() {

--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -37,6 +37,7 @@ const (
 
 // PersistentCache provides persistent on-disk cache.
 type PersistentCache struct {
+	// +checkatomic
 	anyChange int32
 
 	cacheStorage      Storage

--- a/internal/connection/reconnector.go
+++ b/internal/connection/reconnector.go
@@ -31,7 +31,8 @@ type ConnectorImpl interface {
 type Reconnector struct {
 	connector ConnectorImpl
 
-	mu               sync.Mutex
+	mu sync.Mutex
+	// +checklocks:mu
 	activeConnection Connection
 }
 

--- a/internal/connection/reconnector_test.go
+++ b/internal/connection/reconnector_test.go
@@ -21,7 +21,9 @@ var (
 )
 
 type fakeConnector struct {
-	nextConnectionID      int32
+	// +checkatomic
+	nextConnectionID int32
+
 	maxConnections        int
 	connectionConcurrency int
 	nextError             error

--- a/internal/faketime/faketime.go
+++ b/internal/faketime/faketime.go
@@ -27,6 +27,7 @@ func AutoAdvance(t time.Time, dt time.Duration) func() time.Time {
 // TimeAdvance allows controlling the passage of time. Intended to be used in
 // tests.
 type TimeAdvance struct {
+	// +checkatomic
 	delta  int64
 	autoDt int64
 	base   time.Time
@@ -60,7 +61,8 @@ func (t *TimeAdvance) Advance(dt time.Duration) time.Time {
 // ClockTimeWithOffset allows controlling the passage of time. Intended to be used in
 // tests.
 type ClockTimeWithOffset struct {
-	mu     sync.Mutex
+	mu sync.Mutex
+	// +checklocks:mu
 	offset time.Duration
 }
 

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.Module("gather")
+var log = logging.Module("gather") // +checklocksignore
 
 // WriteBuffer is a write buffer for content of unknown size that manages
 // data in a series of byte slices of uniform size.

--- a/internal/gather/gather_write_buffer_chunk.go
+++ b/internal/gather/gather_write_buffer_chunk.go
@@ -45,17 +45,28 @@ type chunkAllocator struct {
 	name      string
 	chunkSize int
 
-	mu                    sync.Mutex
-	freeList              [][]byte
-	maxFreeListSize       int
+	mu sync.Mutex
+	// +checklocks:mu
+	freeList [][]byte
+	// +checklocks:mu
+	maxFreeListSize int
+	// +checklocks:mu
 	freeListHighWaterMark int
-	allocHighWaterMark    int
-	allocated             int
-	slicesAllocated       int
-	freed                 int
-	activeChunks          map[uintptr]string
+	// +checklocks:mu
+	allocHighWaterMark int
+	// +checklocks:mu
+	allocated int
+	// +checklocks:mu
+	slicesAllocated int
+
+	// +checklocks:mu
+	freed int
+
+	// +checklocks:mu
+	activeChunks map[uintptr]string
 }
 
+// +checklocks:a.mu
 func (a *chunkAllocator) trackAlloc(v []byte) []byte {
 	if trackChunkAllocations {
 		var (

--- a/internal/iocopy/copy.go
+++ b/internal/iocopy/copy.go
@@ -9,8 +9,10 @@ import (
 const bufSize = 65536
 
 var (
-	mu      sync.Mutex //nolint:gochecknoglobals
-	buffers [][]byte   //nolint:gochecknoglobals
+	mu sync.Mutex //nolint:gochecknoglobals
+
+	// +checklocks:mu
+	buffers [][]byte //nolint:gochecknoglobals
 )
 
 // GetBuffer allocates new temporary buffer suitable for copying data.

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -373,14 +373,26 @@ func logLevelFromFlag(levelString string) zapcore.LevelEnabler {
 }
 
 type onDemandFile struct {
-	segmentCounter         int // number of segments written
-	currentSegmentSize     int // number of bytes written to current segment
-	maxSegmentSize         int
+	// +checklocks:mu
+	segmentCounter int // number of segments written
+
+	// +checklocks:mu
+	currentSegmentSize int // number of bytes written to current segment
+
+	// +checklocks:mu
+	maxSegmentSize int
+
+	// +checklocks:mu
 	currentSegmentFilename string
 
-	logDir          string
+	// +checklocks:mu
+	logDir string
+
+	// +checklocks:mu
 	logFileBaseName string
-	symlinkName     string
+
+	// +checklocks:mu
+	symlinkName string
 
 	startSweep func()
 

--- a/internal/memtrack/memtrack.go
+++ b/internal/memtrack/memtrack.go
@@ -10,14 +10,27 @@ import (
 	"github.com/kopia/kopia/repo/logging"
 )
 
-var log = logging.Module("memtrack")
+var log = logging.Module("memtrack") // +checklocksignore
 
 type tracker struct {
-	name                                  string
-	memoryTrackerMutex                    sync.Mutex
-	initialMemStats                       runtime.MemStats
-	previousMemStats                      runtime.MemStats
-	maxAlloc, maxHeapUsage, maxStackInUse uint64
+	name string
+
+	memoryTrackerMutex sync.Mutex
+
+	// +checklocks:memoryTrackerMutex
+	initialMemStats runtime.MemStats
+
+	// +checklocks:memoryTrackerMutex
+	previousMemStats runtime.MemStats
+
+	// +checklocks:memoryTrackerMutex
+	maxAlloc uint64
+
+	// +checklocks:memoryTrackerMutex
+	maxHeapUsage uint64
+
+	// +checklocks:memoryTrackerMutex
+	maxStackInUse uint64
 }
 
 func (c *tracker) dump(ctx context.Context, desc string) {

--- a/internal/ownwrites/ownwrites.go
+++ b/internal/ownwrites/ownwrites.go
@@ -39,7 +39,9 @@ type CacheStorage struct {
 	prefixes      []blob.ID
 	cacheDuration time.Duration
 
-	mu            sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	nextSweepTime time.Time
 }
 

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -221,9 +221,12 @@ type concurrencyTest struct {
 	prefix   blob.ID
 	deadline time.Time
 
-	mu          sync.Mutex
-	blobData    map[blob.ID][]byte
-	blobIDs     []blob.ID
+	mu sync.Mutex
+	// +checklocks:mu
+	blobData map[blob.ID][]byte
+	// +checklocks:mu
+	blobIDs []blob.ID
+	// +checklocks:mu
 	blobWritten map[blob.ID]bool
 }
 

--- a/internal/stats/countsum.go
+++ b/internal/stats/countsum.go
@@ -9,7 +9,9 @@ import "sync/atomic"
 
 // CountSum holds sum and count values.
 type CountSum struct {
-	sum   int64
+	// +checkatomic
+	sum int64
+	// +checkatomic
 	count uint32
 }
 

--- a/internal/stats/countsum_mutex.go
+++ b/internal/stats/countsum_mutex.go
@@ -11,8 +11,10 @@ import (
 
 // CountSum holds sum and count values.
 type CountSum struct {
-	mu    sync.Mutex
-	sum   int64
+	mu sync.Mutex
+	// +checklocks:mu
+	sum int64
+	// +checklocks:mu
 	count uint32
 }
 

--- a/internal/uitask/uitask.go
+++ b/internal/uitask/uitask.go
@@ -73,9 +73,11 @@ type Info struct {
 type runningTaskInfo struct {
 	Info
 
-	mu             sync.Mutex
-	maxLogMessages int
-	taskCancel     []context.CancelFunc
+	maxLogMessages int // +checklocksignore
+
+	mu sync.Mutex
+	// +checklocks:mu
+	taskCancel []context.CancelFunc
 }
 
 // CurrentTaskID implements the Controller interface.

--- a/internal/uitask/uitask_manager.go
+++ b/internal/uitask/uitask_manager.go
@@ -21,13 +21,16 @@ const (
 
 // Manager manages UI tasks.
 type Manager struct {
-	mu         sync.Mutex
+	mu sync.Mutex
+	// +checklocks:mu
 	nextTaskID int
-	running    map[string]*runningTaskInfo
-	finished   map[string]*Info
+	// +checklocks:mu
+	running map[string]*runningTaskInfo
+	// +checklocks:mu
+	finished map[string]*Info
 
-	MaxFinishedTasks      int
-	MaxLogMessagesPerTask int
+	MaxFinishedTasks      int // +checklocksignore
+	MaxLogMessagesPerTask int // +checklocksignore
 }
 
 // Controller allows the task to communicate with task manager and receive signals.

--- a/internal/webdavmount/webdavmount.go
+++ b/internal/webdavmount/webdavmount.go
@@ -25,12 +25,15 @@ var (
 
 type webdavFile struct {
 	// webdavFile implements webdav.File but needs context
-	ctx context.Context //nolint:containedctx
+	// +checklocks:mu
+	ctx context.Context // nolint:containedctx
 
 	entry fs.File
 
 	mu sync.Mutex
-	r  fs.Reader
+
+	// +checklocks:mu
+	r fs.Reader
 }
 
 func (f *webdavFile) Readdir(n int) ([]os.FileInfo, error) {

--- a/internal/workshare/workshare_pool.go
+++ b/internal/workshare/workshare_pool.go
@@ -19,6 +19,7 @@ type workItem struct {
 
 // Pool manages a pool of generic workers that can process workItem.
 type Pool struct {
+	// +checkatomic
 	activeWorkers int32
 
 	semaphore chan struct{}

--- a/repo/blob/filesystem/osinterface_mock_test.go
+++ b/repo/blob/filesystem/osinterface_mock_test.go
@@ -13,21 +13,36 @@ import (
 var errNonRetriable = errors.Errorf("some non-retriable error")
 
 type mockOS struct {
-	readFileRemainingErrors             int32
-	writeFileRemainingErrors            int32
-	writeFileCloseRemainingErrors       int32
-	createNewFileRemainingErrors        int32
-	mkdirAllRemainingErrors             int32
-	renameRemainingErrors               int32
-	removeRemainingRetriableErrors      int32
-	removeRemainingNonRetriableErrors   int32
-	chownRemainingErrors                int32
-	readDirRemainingErrors              int32
-	readDirRemainingNonRetriableErrors  int32
+	// +checkatomic
+	readFileRemainingErrors int32
+	// +checkatomic
+	writeFileRemainingErrors int32
+	// +checkatomic
+	writeFileCloseRemainingErrors int32
+	// +checkatomic
+	createNewFileRemainingErrors int32
+	// +checkatomic
+	mkdirAllRemainingErrors int32
+	// +checkatomic
+	renameRemainingErrors int32
+	// +checkatomic
+	removeRemainingRetriableErrors int32
+	// +checkatomic
+	removeRemainingNonRetriableErrors int32
+	// +checkatomic
+	chownRemainingErrors int32
+	// +checkatomic
+	readDirRemainingErrors int32
+	// +checkatomic
+	readDirRemainingNonRetriableErrors int32
+	// +checkatomic
 	readDirRemainingFileDeletedDirEntry int32
-	readDirRemainingFatalDirEntry       int32
-	statRemainingErrors                 int32
-	chtimesRemainingErrors              int32
+	// +checkatomic
+	readDirRemainingFatalDirEntry int32
+	// +checkatomic
+	statRemainingErrors int32
+	// +checkatomic
+	chtimesRemainingErrors int32
 
 	effectiveUID int
 

--- a/repo/blob/logging/logging_storage.go
+++ b/repo/blob/logging/logging_storage.go
@@ -11,7 +11,9 @@ import (
 )
 
 type loggingStorage struct {
-	concurrency    int32
+	// +checkatomic
+	concurrency int32
+	// +checkatomic
 	maxConcurrency int32
 
 	base   blob.Storage

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -736,6 +736,7 @@ func createMinioSessionToken(t *testing.T, minioEndpoint, kopiaUserName, kopiaUs
 // provider to force expiration of the credentials. This causes
 // the next call to Retrieve to return expired credentials.
 type customProvider struct {
+	// +checkatomic
 	forceExpired atomic.Value
 	stsProvider  miniocreds.STSAssumeRole
 }

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -20,7 +20,7 @@ import (
 // CompleteBlobSuffix is the extension for sharded blobs that have completed writing.
 const CompleteBlobSuffix = ".f"
 
-var log = logging.Module("sharded")
+var log = logging.Module("sharded") // +checklocksignore
 
 // Impl must be implemented by underlying provided.
 type Impl interface {
@@ -39,7 +39,9 @@ type Storage struct {
 	Options
 
 	parametersMutex sync.Mutex
-	parameters      *Parameters
+
+	// +checklocks:parametersMutex
+	parameters *Parameters
 }
 
 // GetBlob implements blob.Storage.

--- a/repo/blob/throttling/throttler.go
+++ b/repo/blob/throttling/throttler.go
@@ -17,7 +17,8 @@ type SettableThrottler interface {
 }
 
 type tokenBucketBasedThrottler struct {
-	mu     sync.Mutex
+	mu sync.Mutex
+	// +checklocks:mu
 	limits Limits
 
 	readOps  *tokenBucket
@@ -25,7 +26,7 @@ type tokenBucketBasedThrottler struct {
 	listOps  *tokenBucket
 	upload   *tokenBucket
 	download *tokenBucket
-	window   time.Duration
+	window   time.Duration // +checklocksignore
 }
 
 func (t *tokenBucketBasedThrottler) BeforeOperation(ctx context.Context, op string) {

--- a/repo/content/committed_content_index_mem_cache.go
+++ b/repo/content/committed_content_index_mem_cache.go
@@ -12,9 +12,12 @@ import (
 )
 
 type memoryCommittedContentIndexCache struct {
-	mu                   sync.Mutex
-	contents             map[blob.ID]packIndex
-	v1PerContentOverhead uint32
+	mu sync.Mutex
+
+	// +checklocks:mu
+	contents map[blob.ID]packIndex
+
+	v1PerContentOverhead uint32 // +checklocksignore
 }
 
 func (m *memoryCommittedContentIndexCache) hasIndexBlobID(ctx context.Context, indexBlobID blob.ID) (bool, error) {

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -24,7 +24,7 @@ const (
 	manifestIDLength        = 16
 )
 
-var log = logging.Module("kopia/manifest")
+var log = logging.Module("kopia/manifest") // +checklocksignore
 
 // ErrNotFound is returned when the metadata item is not found.
 var ErrNotFound = errors.New("not found")
@@ -57,6 +57,7 @@ type Manager struct {
 	mu sync.Mutex
 	b  contentManager
 
+	// +checklocks:mu
 	pendingEntries map[ID]*manifestEntry
 
 	committed *committedManifestManager

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -32,9 +32,13 @@ import (
 var errSomeError = errors.Errorf("some error")
 
 type fakeContentManager struct {
-	mu                         sync.Mutex
-	data                       map[content.ID][]byte
-	compresionIDs              map[content.ID]compression.HeaderID
+	mu sync.Mutex
+
+	// +checklocks:mu
+	data map[content.ID][]byte
+	// +checklocks:mu
+	compresionIDs map[content.ID]compression.HeaderID
+
 	supportsContentCompression bool
 	writeContentError          error
 }

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -34,7 +34,8 @@ type Writer interface {
 }
 
 type contentIDTracker struct {
-	mu       sync.Mutex
+	mu sync.Mutex
+	// +checklocks:mu
 	contents map[content.ID]bool
 }
 

--- a/repo/recently_read.go
+++ b/repo/recently_read.go
@@ -7,10 +7,13 @@ import (
 )
 
 type recentlyRead struct {
-	mu          sync.Mutex
+	mu sync.Mutex
+	// +checklocks:mu
 	contentList []content.ID
-	next        int
-	contentSet  map[content.ID]struct{}
+	// +checklocks:mu
+	next int
+	// +checklocks:mu
+	contentSet map[content.ID]struct{}
 }
 
 func (r *recentlyRead) add(contentID content.ID) {

--- a/snapshot/manifest.go
+++ b/snapshot/manifest.go
@@ -172,21 +172,27 @@ type StorageStats struct {
 // StorageUsageDetails provides details about snapshot storage usage.
 type StorageUsageDetails struct {
 	// number of bytes in all objects (ignoring content-level deduplication).
+	// +checkatomic
 	ObjectBytes int64 `json:"objectBytes"`
 
 	// number of bytes in all unique contents (original).
+	// +checkatomic
 	OriginalContentBytes int64 `json:"originalContentBytes"`
 
 	// number of bytes in all unique contents as stored in the repository.
+	// +checkatomic
 	PackedContentBytes int64 `json:"packedContentBytes"`
 
 	// number of unique file objects.
+	// +checkatomic
 	FileObjectCount int32 `json:"fileObjects"`
 
 	// number of unique objects.
+	// +checkatomic
 	DirObjectCount int32 `json:"dirObjects"`
 
 	// number of unique contents.
+	// +checkatomic
 	ContentCount int32 `json:"contents"`
 }
 

--- a/snapshot/restore/restore.go
+++ b/snapshot/restore/restore.go
@@ -32,18 +32,29 @@ type Output interface {
 
 // Stats represents restore statistics.
 type Stats struct {
+	// +checkatomic
 	RestoredTotalFileSize int64
+	// +checkatomic
 	EnqueuedTotalFileSize int64
-	SkippedTotalFileSize  int64
+	// +checkatomic
+	SkippedTotalFileSize int64
 
-	RestoredFileCount    int32
-	RestoredDirCount     int32
+	// +checkatomic
+	RestoredFileCount int32
+	// +checkatomic
+	RestoredDirCount int32
+	// +checkatomic
 	RestoredSymlinkCount int32
-	EnqueuedFileCount    int32
-	EnqueuedDirCount     int32
+	// +checkatomic
+	EnqueuedFileCount int32
+	// +checkatomic
+	EnqueuedDirCount int32
+	// +checkatomic
 	EnqueuedSymlinkCount int32
-	SkippedCount         int32
-	IgnoredErrorCount    int32
+	// +checkatomic
+	SkippedCount int32
+	// +checkatomic
+	IgnoredErrorCount int32
 }
 
 func (s *Stats) clone() Stats {

--- a/snapshot/snapshotfs/checkpoint_registry.go
+++ b/snapshot/snapshotfs/checkpoint_registry.go
@@ -17,6 +17,7 @@ type checkpointFunc func() (*snapshot.DirEntry, error)
 type checkpointRegistry struct {
 	mu sync.Mutex
 
+	// +checklocks:mu
 	checkpoints map[string]checkpointFunc
 }
 

--- a/snapshot/snapshotfs/snapshot_tree_walker.go
+++ b/snapshot/snapshotfs/snapshot_tree_walker.go
@@ -26,9 +26,11 @@ type TreeWalker struct {
 	enqueued sync.Map
 	wp       *workshare.Pool
 
-	mu        sync.Mutex
+	mu sync.Mutex
+	// +checklocks:mu
 	numErrors int
-	errors    []error
+	// +checklocks:mu
+	errors []error
 }
 
 func oidOf(e fs.Entry) object.ID {

--- a/snapshot/snapshotfs/upload_progress.go
+++ b/snapshot/snapshotfs/upload_progress.go
@@ -95,21 +95,32 @@ var _ UploadProgress = (*NullUploadProgress)(nil)
 
 // UploadCounters represents a snapshot of upload counters.
 type UploadCounters struct {
-	TotalCachedBytes   int64 `json:"cachedBytes"`
-	TotalHashedBytes   int64 `json:"hashedBytes"`
+	// +checkatomic
+	TotalCachedBytes int64 `json:"cachedBytes"`
+	// +checkatomic
+	TotalHashedBytes int64 `json:"hashedBytes"`
+	// +checkatomic
 	TotalUploadedBytes int64 `json:"uploadedBytes"`
 
+	// +checkatomic
 	EstimatedBytes int64 `json:"estimatedBytes"`
 
+	// +checkatomic
 	TotalCachedFiles int32 `json:"cachedFiles"`
+	// +checkatomic
 	TotalHashedFiles int32 `json:"hashedFiles"`
 
+	// +checkatomic
 	TotalExcludedFiles int32 `json:"excludedFiles"`
-	TotalExcludedDirs  int32 `json:"excludedDirs"`
+	// +checkatomic
+	TotalExcludedDirs int32 `json:"excludedDirs"`
 
-	FatalErrorCount   int32 `json:"errors"`
+	// +checkatomic
+	FatalErrorCount int32 `json:"errors"`
+	// +checkatomic
 	IgnoredErrorCount int32 `json:"ignoredErrors"`
-	EstimatedFiles    int32 `json:"estimatedFiles"`
+	// +checkatomic
+	EstimatedFiles int32 `json:"estimatedFiles"`
 
 	CurrentDirectory string `json:"directory"`
 
@@ -175,9 +186,9 @@ func (p *CountingUploadProgress) Error(path string, err error, isIgnored bool) {
 	defer p.mu.Unlock()
 
 	if isIgnored {
-		p.counters.IgnoredErrorCount++
+		atomic.AddInt32(&p.counters.IgnoredErrorCount, 1)
 	} else {
-		p.counters.FatalErrorCount++
+		atomic.AddInt32(&p.counters.FatalErrorCount, 1)
 	}
 
 	p.counters.LastErrorPath = path

--- a/snapshot/snapshotfs/upload_scan.go
+++ b/snapshot/snapshotfs/upload_scan.go
@@ -2,6 +2,7 @@ package snapshotfs
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/snapshot"
@@ -19,8 +20,8 @@ func (e *scanResults) Processing(ctx context.Context, pathname string) {}
 
 func (e *scanResults) Stats(ctx context.Context, s *snapshot.Stats, includedFiles, excludedFiles SampleBuckets, excludedDirs []string, final bool) {
 	if final {
-		e.numFiles = int(s.TotalFileCount)
-		e.totalFileSize = s.TotalFileSize
+		e.numFiles = int(atomic.LoadInt32(&s.TotalFileCount))
+		e.totalFileSize = atomic.LoadInt64(&s.TotalFileSize)
 	}
 }
 

--- a/tests/robustness/checker/checker.go
+++ b/tests/robustness/checker/checker.go
@@ -38,7 +38,7 @@ type Checker struct {
 	DeleteLimit           int
 
 	mu          sync.RWMutex
-	SnapIDIndex snapmeta.Index
+	SnapIDIndex snapmeta.Index // +checklocksignore
 }
 
 // NewChecker instantiates a new Checker, returning its pointer. A temporary

--- a/tests/robustness/multiclient_test/framework/filewriter.go
+++ b/tests/robustness/multiclient_test/framework/filewriter.go
@@ -17,8 +17,10 @@ import (
 // delegate to a specific client FileWriter.
 type MultiClientFileWriter struct {
 	// Map of client ID to FileWriter and associated mutex
+	mu sync.RWMutex
+
+	// +checklocks:mu
 	fileWriters map[string]FileWriter
-	mu          sync.RWMutex
 
 	// Function used to generate new FileWriters
 	newFileWriter newFileWriterFn

--- a/tests/robustness/pathlock/path_lock.go
+++ b/tests/robustness/pathlock/path_lock.go
@@ -36,7 +36,9 @@ var _ Locker = (*pathLock)(nil)
 // that has already been Locked. The thread will be blocked until the holder
 // of the lock calls Unlock.
 type pathLock struct {
-	mu          sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	lockedPaths map[string]chan struct{}
 }
 

--- a/tests/tools/kopiaclient/kopiaclient.go
+++ b/tests/tools/kopiaclient/kopiaclient.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 
@@ -99,7 +100,7 @@ func (kc *KopiaClient) SnapshotCreate(ctx context.Context, key string, val []byt
 		return errors.Wrap(err, "cannot get manifest")
 	}
 
-	log.Printf("snapshotting %v", units.BytesStringBase10(man.Stats.TotalFileSize))
+	log.Printf("snapshotting %v", units.BytesStringBase10(atomic.LoadInt64(&man.Stats.TotalFileSize)))
 
 	if _, err := snapshot.SaveSnapshot(ctx, rw, man); err != nil {
 		return errors.Wrap(err, "cannot save snapshot")

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -103,6 +103,7 @@ endif
 
 # tool versions
 GOLANGCI_LINT_VERSION=1.45.0
+CHECKLOCKS_VERSION=release-20220314.0
 NODE_VERSION=16.13.0
 HUGO_VERSION=0.89.2
 GOTESTSUM_VERSION=1.7.0
@@ -148,6 +149,14 @@ endif
 
 $(linter):
 	go run github.com/kopia/kopia/tools/gettool --tool linter:$(GOLANGCI_LINT_VERSION) --output-dir $(linter_dir)
+
+# checklocks
+checklocks_dir=$(TOOLS_DIR)$(slash)checklocks-$(CHECKLOCKS_VERSION)
+checklocks=$(checklocks_dir)$(slash)bin$(slash)checklocks$(exe_suffix)
+
+$(checklocks): export GOPATH=$(checklocks_dir)
+$(checklocks):
+	go install gvisor.dev/gvisor/tools/checklocks/cmd/checklocks@$(CHECKLOCKS_VERSION)
 
 # hugo
 hugo_dir=$(TOOLS_DIR)$(slash)hugo-$(HUGO_VERSION)


### PR DESCRIPTION
From https://github.com/google/gvisor/tree/master/tools/checklocks

This will perform static verification that we're using
`sync.Mutex`, `sync.RWMutex` and `atomic` correctly to guard access
to certain fields.

Implementing this was mostly just a matter of adding annotations to indicate which
fields are guarded by which mutex.

In a handful of places the code had to be refactored to allow static
analyzer to do its job better or to not be confused by some
constructs.

In one place this actually uncovered a bug where a function was not
releasing a lock properly in an error case.

The check is part of `make lint` but can also be invoked by
`make check-locks`.