### PR TITLE
fix(repository): fixed 'unable to get content data and info'

### DIFF
--- a/internal/cache/content_cache_data.go
+++ b/internal/cache/content_cache_data.go
@@ -16,9 +16,8 @@ type contentCacheForData struct {
 
 // ContentIDCacheKey computes the cache key for the provided content ID.
 func ContentIDCacheKey(contentID string) string {
-	// content IDs with odd length have a single-byte prefix.
 	// move the prefix to the end of cache key to make sure the top level shard is spread 256 ways.
-	if len(contentID)%2 == 1 {
+	if contentID[0] >= 'g' && contentID[0] <= 'z' {
 		return contentID[1:] + contentID[0:1]
 	}
 


### PR DESCRIPTION
We were incorrectly assigning the same content cache key regardless of
the storage format of the content (compression format, etc.)

This means that if a content has both compressed and non-compressed
entry in the index, it would sometimes get cached incorrectly
and the subsequent reads would fail.

Clearing the cache would fix the issue - this change appends
format-specific suffix to cache keys, so that clearing the cache is not
needed.

Huge thanks to Mark Derricutt who helped get to the bottom of this
on Slack.

Fix #1843