### PR TITLE
feat(cli): show storage capacity in repo status

### DIFF
--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -112,8 +112,8 @@ func (c *commandRepositoryStatus) run(ctx context.Context, rep repo.Repository) 
 
 	switch cp, err := dr.BlobVolume().GetCapacity(ctx); {
 	case err == nil:
-		c.out.printStdout("Storage capacity:    %v\n", units.BytesStringBase2(int64(cp.SizeB)))
-		c.out.printStdout("Storage available:   %v\n", units.BytesStringBase2(int64(cp.FreeB)))
+		c.out.printStdout("Storage capacity:    %v\n", units.BytesStringBase10(int64(cp.SizeB)))
+		c.out.printStdout("Storage available:   %v\n", units.BytesStringBase10(int64(cp.FreeB)))
 	case errors.Is(err, blob.ErrNotAVolume):
 		c.out.printStdout("Storage capacity:    unbounded\n")
 	default:

--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -34,7 +34,7 @@ type RepositoryStatus struct {
 
 	ClientOptions repo.ClientOptions        `json:"clientOptions"`
 	Storage       blob.ConnectionInfo       `json:"storage"`
-	Capacity      blob.Capacity             `json:"volume"`
+	Capacity      *blob.Capacity            `json:"volume,omitempty"`
 	ContentFormat content.FormattingOptions `json:"contentFormat"`
 	ObjectFormat  object.Format             `json:"objectFormat"`
 	BlobRetention content.BlobCfgBlob       `json:"blobRetention"`
@@ -68,7 +68,7 @@ func (c *commandRepositoryStatus) outputJSON(ctx context.Context, r repo.Reposit
 
 		switch cp, err := dr.BlobVolume().GetCapacity(ctx); {
 		case err == nil:
-			s.Capacity = cp
+			s.Capacity = &cp
 		case errors.Is(err, blob.ErrNotAVolume):
 			// This is okay, we will just not populate the result.
 		default:

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -56,9 +56,9 @@ type OutputBuffer interface {
 // Capacity describes the storage capacity and usage of a Volume.
 type Capacity struct {
 	// Size of volume in bytes.
-	SizeB uint64
+	SizeB uint64 `json:"capacity"`
 	// Available (writeable) space in bytes.
-	FreeB uint64
+	FreeB uint64 `json:"available"`
 }
 
 // Volume defines disk/volume access API to blob storage.

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -56,9 +56,9 @@ type OutputBuffer interface {
 // Capacity describes the storage capacity and usage of a Volume.
 type Capacity struct {
 	// Size of volume in bytes.
-	SizeB uint64 `json:"capacity"`
+	SizeB uint64 `json:"capacity,omitempty"`
 	// Available (writeable) space in bytes.
-	FreeB uint64 `json:"available"`
+	FreeB uint64 `json:"available,omitempty"`
 }
 
 // Volume defines disk/volume access API to blob storage.

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -58,7 +58,7 @@ type Capacity struct {
 	// Size of volume in bytes.
 	SizeB uint64 `json:"capacity,omitempty"`
 	// Available (writeable) space in bytes.
-	FreeB uint64 `json:"available,omitempty"`
+	FreeB uint64 `json:"available"`
 }
 
 // Volume defines disk/volume access API to blob storage.

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -50,6 +50,7 @@ type DirectRepository interface {
 	ObjectFormat() object.Format
 	BlobCfg() content.BlobCfgBlob
 	BlobReader() blob.Reader
+	BlobVolume() blob.Volume
 	ContentReader() content.Reader
 	IndexBlobs(ctx context.Context, includeInactive bool) ([]content.IndexBlobInfo, error)
 	Crypter() *content.Crypter
@@ -305,6 +306,11 @@ func (r *directRepository) UniqueID() []byte {
 
 // BlobReader returns the blob reader.
 func (r *directRepository) BlobReader() blob.Reader {
+	return r.blobs
+}
+
+// BlobVolume returns the blob volume interface.
+func (r *directRepository) BlobVolume() blob.Volume {
 	return r.blobs
 }
 


### PR DESCRIPTION
The connected repository's backing storage capacity and available
space can be now retrieved from `kopia repository status`. In text
format, these fields are printed in a human friendly form (MB, GB).
In JSON mode (`--json`), they are output as bytes.