### PR TITLE
test(general): Ignore directory size check before and after restore

### DIFF
--- a/tests/tools/fswalker/fswalker.go
+++ b/tests/tools/fswalker/fswalker.go
@@ -35,7 +35,7 @@ func NewWalkCompare() *WalkCompare {
 		GlobalFilterFuncs: []func(string, fswalker.ActionData) bool{
 			filterFileTimeDiffs,
 			isRootDirectoryRename,
-			dirSizeMightBeOffByBlockSizeMultiple,
+			filterDirSizeCheck,
 			ignoreGIDIfZero,
 			ignoreUIDIfZero,
 		},
@@ -186,18 +186,8 @@ func isRootDirectoryRename(diffItem string, mod fswalker.ActionData) bool {
 	return mod.Before.Info.IsDir && filepath.Clean(mod.Before.Path) == "."
 }
 
-func dirSizeMightBeOffByBlockSizeMultiple(str string, mod fswalker.ActionData) bool {
-	if !mod.Before.Info.IsDir {
-		return false
-	}
-
-	if !strings.Contains(str, "size: ") {
-		return false
-	}
-
-	const blockSize = 4096
-
-	return (mod.Before.Stat.Size-mod.After.Stat.Size)%blockSize == 0
+func filterDirSizeCheck(str string, mod fswalker.ActionData) bool {
+	return mod.Before.Info.IsDir && strings.Contains(str, "size: ")
 }
 
 func filterFileTimeDiffs(str string, mod fswalker.ActionData) bool {

--- a/tests/tools/fswalker/fswalker.go
+++ b/tests/tools/fswalker/fswalker.go
@@ -186,6 +186,8 @@ func isRootDirectoryRename(diffItem string, mod fswalker.ActionData) bool {
 	return mod.Before.Info.IsDir && filepath.Clean(mod.Before.Path) == "."
 }
 
+// Directory size changes with underlying file system setups. Ignote the dir size during data consistency check to make it robust.
+// Remove this filter from GlobalFilterFuncs to detect the size difference in a directory.
 func filterDirSizeCheck(str string, mod fswalker.ActionData) bool {
 	return mod.Before.Info.IsDir && strings.Contains(str, "size: ")
 }


### PR DESCRIPTION
The directory size is affected by the underlying filesystem. Filter directory size check to make the tests more robust.