### PR TITLE
feat(cli): Allow customizing S3 upload part size (#1909)

### DIFF
--- a/cli/storage_s3.go
+++ b/cli/storage_s3.go
@@ -25,6 +25,7 @@ func (c *storageS3Flags) Setup(_ StorageProviderServices, cmd *kingpin.CmdClause
 	cmd.Flag("prefix", "Prefix to use for objects in the bucket").StringVar(&c.s3options.Prefix)
 	cmd.Flag("disable-tls", "Disable TLS security (HTTPS)").BoolVar(&c.s3options.DoNotUseTLS)
 	cmd.Flag("disable-tls-verification", "Disable TLS (HTTPS) certificate verification").BoolVar(&c.s3options.DoNotVerifyTLS)
+	cmd.Flag("upload-part-size-bytes", "Custom part size used for uploading the object").Default("0").Uint64Var(&c.s3options.UploadPartSize)
 
 	commonThrottlingFlags(cmd, &c.s3options.Limits)
 

--- a/repo/blob/s3/s3_options.go
+++ b/repo/blob/s3/s3_options.go
@@ -29,4 +29,7 @@ type Options struct {
 
 	// PointInTime specifies a view of the (versioned) store at that time
 	PointInTime *time.Time `json:"pointInTime,omitempty"`
+
+	// UploadPartSize specifies a custom part size used for uploading the object
+	UploadPartSize uint64 `json:"uploadPartSize,omitempty"`
 }

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -181,6 +181,7 @@ func (s *s3Storage) putBlob(ctx context.Context, b blob.ID, data blob.Bytes, opt
 		StorageClass:    storageClass,
 		RetainUntilDate: retainUntilDate,
 		Mode:            retentionMode,
+		PartSize:        s.Options.UploadPartSize,
 	})
 
 	if isInvalidCredentials(err) {


### PR DESCRIPTION
Add a new UploadPartSize JSON uint64 field for S3 storage config and "upload-part-size-bytes" cli flag.
Part size is specified in bytes, 0 means using the default minio client value (currently 16MiB).

Closes #1909.