### PR TITLE
feat(cli): added 'content delete --forget' flag

### DIFF
--- a/cli/command_content_delete.go
+++ b/cli/command_content_delete.go
@@ -9,7 +9,8 @@ import (
 )
 
 type commandContentDelete struct {
-	ids []string
+	ids    []string
+	forget bool
 
 	svc appServices
 }
@@ -17,6 +18,7 @@ type commandContentDelete struct {
 func (c *commandContentDelete) setup(svc appServices, parent commandParent) {
 	cmd := parent.Command("delete", "Remove content").Alias("remove").Alias("rm")
 	cmd.Arg("id", "IDs of content to remove").Required().StringsVar(&c.ids)
+	cmd.Flag("forget", "Forget the content instead of marking as deleted - USE WITH EXTREME CAUTION").Hidden().BoolVar(&c.forget)
 	cmd.Action(svc.directRepositoryWriteAction(c.run))
 
 	c.svc = svc
@@ -26,8 +28,14 @@ func (c *commandContentDelete) run(ctx context.Context, rep repo.DirectRepositor
 	c.svc.advancedCommand(ctx)
 
 	for _, contentID := range toContentIDs(c.ids) {
-		if err := rep.ContentManager().DeleteContent(ctx, contentID); err != nil {
-			return errors.Wrapf(err, "error deleting content %v", contentID)
+		if c.forget {
+			if err := rep.ContentManager().ForgetContent(ctx, contentID); err != nil {
+				return errors.Wrapf(err, "error forgetting content %v", contentID)
+			}
+		} else {
+			if err := rep.ContentManager().DeleteContent(ctx, contentID); err != nil {
+				return errors.Wrapf(err, "error deleting content %v", contentID)
+			}
 		}
 	}
 

--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -77,12 +77,20 @@ func (c *committedContentIndex) getContent(contentID ID) (Info, error) {
 	return nil, errors.Wrap(err, "error getting content info from index")
 }
 
-func shouldIgnore(id Info, deletionWatermark time.Time) bool {
-	if !id.GetDeleted() {
+func shouldIgnore(ci Info, deletionWatermark time.Time) bool {
+	if !ci.GetDeleted() {
 		return false
 	}
 
-	return !id.Timestamp().After(deletionWatermark)
+	if isForgotten(ci) {
+		return true
+	}
+
+	return !ci.Timestamp().After(deletionWatermark)
+}
+
+func isForgotten(ci Info) bool {
+	return ci.GetPackBlobID() == PackBlobIDForgotten
 }
 
 func (c *committedContentIndex) addIndexBlob(ctx context.Context, indexBlobID blob.ID, data gather.Bytes, use bool) error {

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -193,10 +193,6 @@ func (bm *WriteManager) ForgetContent(ctx context.Context, contentID ID) error {
 
 	bm.log.Debugf("forget-content %v", contentID)
 
-	if err := bm.maybeRefreshIndexes(ctx); err != nil {
-		return err
-	}
-
 	bi, err := bm.committedContents.getContent(contentID)
 	if err != nil {
 		return err

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -218,14 +218,8 @@ func (bm *WriteManager) maybeRefreshIndexes(ctx context.Context) error {
 // Intentionally passing ci by value.
 // +checklocks:bm.mu
 func (bm *WriteManager) deletePreexistingContent(ctx context.Context, ci Info, isForget bool) error {
-	if isForget {
-		if isForgotten(ci) {
-			return nil
-		}
-	} else {
-		if ci.GetDeleted() {
-			return nil
-		}
+	if !isForget && ci.GetDeleted() {
+		return nil
 	}
 
 	pp, err := bm.getOrCreatePendingPackInfoLocked(ctx, packPrefixForContentID(ci.GetContentID()))

--- a/tests/end_to_end_test/content_info_test.go
+++ b/tests/end_to_end_test/content_info_test.go
@@ -55,4 +55,18 @@ func (s *formatSpecificTestSuite) TestContentListAndStats(t *testing.T) {
 	require.True(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "--deleted"), contentID))
 	require.True(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "--deleted", "-l"), contentID))
 	require.True(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "--deleted", "-c"), contentID))
+
+	// sleep a bit to ensure at least one second passes, otherwise forget may end up happen on the same second.
+	time.Sleep(2 * time.Second)
+	e.RunAndExpectSuccess(t, "content", "delete", "--forget", contentID)
+	time.Sleep(2 * time.Second)
+
+	require.False(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list"), contentID))
+	require.False(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "-l"), contentID))
+	require.False(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "-c"), contentID))
+
+	lines := e.RunAndExpectSuccess(t, "content", "list", "-l", "--deleted")
+	require.False(t, containsLineStartingWith(lines, contentID), lines)
+	require.False(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "--deleted", "-l"), contentID))
+	require.False(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "--deleted", "-c"), contentID))
 }


### PR DESCRIPTION
This allows low-level hiding of entries in the index, which makes them completely invisible instead of just marking for deletion.

For #1906