### PR TITLE
feat(cli): REVERT added 'content delete --forget' flag (#1932)

### DIFF
--- a/cli/command_content_delete.go
+++ b/cli/command_content_delete.go
@@ -9,8 +9,7 @@ import (
 )
 
 type commandContentDelete struct {
-	ids    []string
-	forget bool
+	ids []string
 
 	svc appServices
 }
@@ -18,7 +17,6 @@ type commandContentDelete struct {
 func (c *commandContentDelete) setup(svc appServices, parent commandParent) {
 	cmd := parent.Command("delete", "Remove content").Alias("remove").Alias("rm")
 	cmd.Arg("id", "IDs of content to remove").Required().StringsVar(&c.ids)
-	cmd.Flag("forget", "Forget the content instead of marking as deleted - USE WITH EXTREME CAUTION").Hidden().BoolVar(&c.forget)
 	cmd.Action(svc.directRepositoryWriteAction(c.run))
 
 	c.svc = svc
@@ -28,14 +26,8 @@ func (c *commandContentDelete) run(ctx context.Context, rep repo.DirectRepositor
 	c.svc.advancedCommand(ctx)
 
 	for _, contentID := range toContentIDs(c.ids) {
-		if c.forget {
-			if err := rep.ContentManager().ForgetContent(ctx, contentID); err != nil {
-				return errors.Wrapf(err, "error forgetting content %v", contentID)
-			}
-		} else {
-			if err := rep.ContentManager().DeleteContent(ctx, contentID); err != nil {
-				return errors.Wrapf(err, "error deleting content %v", contentID)
-			}
+		if err := rep.ContentManager().DeleteContent(ctx, contentID); err != nil {
+			return errors.Wrapf(err, "error deleting content %v", contentID)
 		}
 	}
 

--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -77,20 +77,12 @@ func (c *committedContentIndex) getContent(contentID ID) (Info, error) {
 	return nil, errors.Wrap(err, "error getting content info from index")
 }
 
-func shouldIgnore(ci Info, deletionWatermark time.Time) bool {
-	if !ci.GetDeleted() {
+func shouldIgnore(id Info, deletionWatermark time.Time) bool {
+	if !id.GetDeleted() {
 		return false
 	}
 
-	if isForgotten(ci) {
-		return true
-	}
-
-	return !ci.Timestamp().After(deletionWatermark)
-}
-
-func isForgotten(ci Info) bool {
-	return ci.GetPackBlobID() == PackBlobIDForgotten
+	return !id.Timestamp().After(deletionWatermark)
 }
 
 func (c *committedContentIndex) addIndexBlob(ctx context.Context, indexBlobID blob.ID, data gather.Bytes, use bool) error {

--- a/tests/end_to_end_test/content_info_test.go
+++ b/tests/end_to_end_test/content_info_test.go
@@ -55,18 +55,4 @@ func (s *formatSpecificTestSuite) TestContentListAndStats(t *testing.T) {
 	require.True(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "--deleted"), contentID))
 	require.True(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "--deleted", "-l"), contentID))
 	require.True(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "--deleted", "-c"), contentID))
-
-	// sleep a bit to ensure at least one second passes, otherwise forget may end up happen on the same second.
-	time.Sleep(2 * time.Second)
-	e.RunAndExpectSuccess(t, "content", "delete", "--forget", contentID)
-	time.Sleep(2 * time.Second)
-
-	require.False(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list"), contentID))
-	require.False(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "-l"), contentID))
-	require.False(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "-c"), contentID))
-
-	lines := e.RunAndExpectSuccess(t, "content", "list", "-l", "--deleted")
-	require.False(t, containsLineStartingWith(lines, contentID), lines)
-	require.False(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "--deleted", "-l"), contentID))
-	require.False(t, containsLineStartingWith(e.RunAndExpectSuccess(t, "content", "list", "--deleted", "-c"), contentID))
 }


### PR DESCRIPTION
This reverts commit d990af4dc21687867f07b990fdc6119a9b2f7a40.

Discussed with @julio-lopez, we don't need this concept after all.