### PR TITLE
chore(providers): Add comment explaining disabling multipart upload

### DIFF
--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -172,7 +172,10 @@ func (s *s3Storage) putBlob(ctx context.Context, b blob.ID, data blob.Bytes, opt
 	}
 
 	uploadInfo, err := s.cli.PutObject(ctx, s.BucketName, s.getObjectNameString(b), data.Reader(), int64(data.Length()), minio.PutObjectOptions{
-		ContentType:      "application/x-kopia",
+		ContentType: "application/x-kopia",
+		// Kopia already splits snapshot contents into small blobs to improve
+		// upload throughput. There is no need for further splitting
+		// through multipart uploads.
 		DisableMultipart: true,
 		// The Content-MD5 header is required for any request to upload an object
 		// with a retention period configured using Amazon S3 Object Lock.


### PR DESCRIPTION
Recently #1942 was merged disabling minio multipart
uploads for S3 storage backend. This commit adds
a comment explaining the reasoning for that change.

Since Kopia already splits snapshot content into
(small) blobs for upload, there is no need to further
split those for multipart uploading.