### PR TITLE
feat(providers): ensure Ctrl-C is not passed to rclone

### DIFF
--- a/internal/osexec/osexec.go
+++ b/internal/osexec/osexec.go
@@ -1,0 +1,2 @@
+// Package osexec provides OS-dependent utilities for running child processes.
+package osexec

--- a/internal/osexec/osexec_test.go
+++ b/internal/osexec/osexec_test.go
@@ -1,0 +1,17 @@
+package osexec_test
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/osexec"
+)
+
+func TestDisableInterruptSignal(t *testing.T) {
+	c := &exec.Cmd{}
+
+	osexec.DisableInterruptSignal(c)
+	require.NotNil(t, c.SysProcAttr)
+}

--- a/internal/osexec/osexec_unix.go
+++ b/internal/osexec/osexec_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+// +build !windows
+
+package osexec
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// DisableInterruptSignal modifies child process attributes so that parent Ctrl-C is not propagated to a child.
+func DisableInterruptSignal(c *exec.Cmd) {
+	c.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/internal/osexec/osexec_windows.go
+++ b/internal/osexec/osexec_windows.go
@@ -1,0 +1,13 @@
+package osexec
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// DisableInterruptSignal modifies child process attributes so that parent Ctrl-C is not propagated to a child.
+func DisableInterruptSignal(c *exec.Cmd) {
+	c.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/osexec"
 	"github.com/kopia/kopia/internal/tlsutil"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/webdav"
@@ -271,6 +272,9 @@ func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error)
 
 	r.cmd = exec.Command(rcloneExe, arguments...) //nolint:gosec
 	r.cmd.Env = append(r.cmd.Env, opt.RCloneEnv...)
+
+	// https://github.com/kopia/kopia/issues/1934
+	osexec.DisableInterruptSignal(r.cmd)
 
 	startupTimeout := rcloneStartupTimeout
 	if opt.StartupTimeout != 0 {


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/33165530/prevent-ctrlc-from-interrupting-exec-command-in-golang

Fixes #1934