### PR TITLE
feat(snapshots): Add callback-based iteration function to Directory interface

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,3 +131,6 @@ issues:
     - text: "Errors unhandled"
       linters:
         - gosec
+    - text: "unwrapped: sig: func github.com/kopia/kopia/fs.ReaddirToIterate"
+      linters:
+        - wrapcheck

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -79,6 +79,21 @@ type ErrorEntry interface {
 // ErrEntryNotFound is returned when an entry is not found.
 var ErrEntryNotFound = errors.New("entry not found")
 
+// Adapter for a naive Readdir -> IterateEntries implementation.
+func ReaddirToIterate(ctx context.Context, d Directory, cb func(context.Context, Entry) error) error {
+	entries, err := d.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := cb(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ReadDirAndFindChild reads all entries from a directory and returns one by name.
 // This is a convenience function that may be helpful in implementations of Directory.Child().
 func ReadDirAndFindChild(ctx context.Context, d Directory, name string) (Entry, error) {

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -79,11 +79,11 @@ type ErrorEntry interface {
 // ErrEntryNotFound is returned when an entry is not found.
 var ErrEntryNotFound = errors.New("entry not found")
 
-// Adapter for a naive Readdir -> IterateEntries implementation.
+// ReaddirToIterate is an adapter for a naive Readdir -> IterateEntries implementation.
 func ReaddirToIterate(ctx context.Context, d Directory, cb func(context.Context, Entry) error) error {
 	entries, err := d.Readdir(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error reading directory")
 	}
 
 	for _, e := range entries {
@@ -91,6 +91,7 @@ func ReaddirToIterate(ctx context.Context, d Directory, cb func(context.Context,
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -61,6 +61,7 @@ type Directory interface {
 	Entry
 	Child(ctx context.Context, name string) (Entry, error)
 	Readdir(ctx context.Context) (Entries, error)
+	IterateEntries(ctx context.Context, cb func(context.Context, Entry) error) error
 }
 
 // DirectoryWithSummary is optionally implemented by Directory that provide summary.

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -142,7 +142,11 @@ func toDirEntryOrNil(dirEntry os.DirEntry, prefix string) (fs.Entry, error) {
 }
 
 func (fsd *filesystemDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	return fs.ReaddirToIterate(ctx, fsd, cb)
+	if err := fs.ReaddirToIterate(ctx, fsd, cb); err != nil {
+		return errors.Wrap(err, "error iterating through directory entries")
+	}
+
+	return nil
 }
 
 func (fsd *filesystemDirectory) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -142,11 +142,7 @@ func toDirEntryOrNil(dirEntry os.DirEntry, prefix string) (fs.Entry, error) {
 }
 
 func (fsd *filesystemDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	if err := fs.ReaddirToIterate(ctx, fsd, cb); err != nil {
-		return errors.Wrap(err, "error iterating through directory entries")
-	}
-
-	return nil
+	return fs.ReaddirToIterate(ctx, fsd, cb)
 }
 
 func (fsd *filesystemDirectory) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -142,17 +142,7 @@ func toDirEntryOrNil(dirEntry os.DirEntry, prefix string) (fs.Entry, error) {
 }
 
 func (fsd *filesystemDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	entries, err := fsd.Readdir(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, e := range entries {
-		if err := cb(ctx, e); err != nil {
-			return err
-		}
-	}
-	return nil
+	return fs.ReaddirToIterate(ctx, fsd, cb)
 }
 
 func (fsd *filesystemDirectory) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -141,6 +141,20 @@ func toDirEntryOrNil(dirEntry os.DirEntry, prefix string) (fs.Entry, error) {
 	return entryFromDirEntry(fi, prefix), nil
 }
 
+func (fsd *filesystemDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
+	entries, err := fsd.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := cb(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (fsd *filesystemDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
 	fullPath := fsd.fullPath()
 

--- a/fs/localfs/shallow_fs.go
+++ b/fs/localfs/shallow_fs.go
@@ -123,6 +123,10 @@ func (fsd *shallowFilesystemDirectory) Readdir(ctx context.Context) (fs.Entries,
 	return nil, errors.New("shallowFilesystemDirectory.Readdir not supported")
 }
 
+func (fsd *shallowFilesystemDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
+	return errors.New("shallowFilesystemDirectory.IterateEntries not supported")
+}
+
 var (
 	_ snapshot.HasDirEntryOrNil = &shallowFilesystemFile{}
 	_ snapshot.HasDirEntryOrNil = &shallowFilesystemDirectory{}

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -78,6 +78,20 @@ func (sd *staticDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
 	return append(fs.Entries(nil), sd.entries...), nil
 }
 
+func (sd *staticDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
+	entries, err := sd.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := cb(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // NewStaticDirectory returns a virtual static directory.
 func NewStaticDirectory(name string, entries fs.Entries) fs.Directory {
 	return &staticDirectory{

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -79,15 +79,7 @@ func (sd *staticDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
 }
 
 func (sd *staticDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	entries := append(fs.Entries(nil), sd.entries...)
-
-	for _, e := range entries {
-		if err := cb(ctx, e); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return fs.ReaddirToIterate(ctx, sd, cb)
 }
 
 // NewStaticDirectory returns a virtual static directory.

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -79,10 +79,7 @@ func (sd *staticDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
 }
 
 func (sd *staticDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	entries, err := sd.Readdir(ctx)
-	if err != nil {
-		return err
-	}
+	entries := append(fs.Entries(nil), sd.entries...)
 
 	for _, e := range entries {
 		if err := cb(ctx, e); err != nil {

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -86,6 +86,7 @@ func (sd *staticDirectory) IterateEntries(ctx context.Context, cb func(context.C
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/kopia/kopia/fs"
 )
 
@@ -273,7 +275,11 @@ func (imd *Directory) Child(ctx context.Context, name string) (fs.Entry, error) 
 
 // IterateEntries calls the given callback on each entry in the directory.
 func (imd *Directory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	return fs.ReaddirToIterate(ctx, imd, cb)
+	if err := fs.ReaddirToIterate(ctx, imd, cb); err != nil {
+		return errors.Wrap(err, "error iterating through directory entries")
+	}
+
+	return nil
 }
 
 // Readdir gets the contents of a directory.

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -271,6 +271,21 @@ func (imd *Directory) Child(ctx context.Context, name string) (fs.Entry, error) 
 	return fs.ReadDirAndFindChild(ctx, imd, name)
 }
 
+func (imd *Directory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
+	entries, err := imd.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := cb(ctx, e); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Readdir gets the contents of a directory.
 func (imd *Directory) Readdir(ctx context.Context) (fs.Entries, error) {
 	if imd.readdirError != nil {

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -271,19 +271,9 @@ func (imd *Directory) Child(ctx context.Context, name string) (fs.Entry, error) 
 	return fs.ReadDirAndFindChild(ctx, imd, name)
 }
 
+// IterateEntries calls the given callback on each entry in the directory.
 func (imd *Directory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	entries, err := imd.Readdir(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, e := range entries {
-		if err := cb(ctx, e); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return fs.ReaddirToIterate(ctx, imd, cb)
 }
 
 // Readdir gets the contents of a directory.

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/kopia/kopia/fs"
 )
 
@@ -275,11 +273,7 @@ func (imd *Directory) Child(ctx context.Context, name string) (fs.Entry, error) 
 
 // IterateEntries calls the given callback on each entry in the directory.
 func (imd *Directory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	if err := fs.ReaddirToIterate(ctx, imd, cb); err != nil {
-		return errors.Wrap(err, "error iterating through directory entries")
-	}
-
-	return nil
+	return fs.ReaddirToIterate(ctx, imd, cb)
 }
 
 // Readdir gets the contents of a directory.

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -58,6 +58,20 @@ func (s *repositoryAllSources) Child(ctx context.Context, name string) (fs.Entry
 	return fs.ReadDirAndFindChild(ctx, s, name)
 }
 
+func (s *repositoryAllSources) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
+	entries, err := s.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := cb(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *repositoryAllSources) Readdir(ctx context.Context) (fs.Entries, error) {
 	srcs, err := snapshot.ListSources(ctx, s.rep)
 	if err != nil {

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -59,17 +59,7 @@ func (s *repositoryAllSources) Child(ctx context.Context, name string) (fs.Entry
 }
 
 func (s *repositoryAllSources) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	entries, err := s.Readdir(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, e := range entries {
-		if err := cb(ctx, e); err != nil {
-			return err
-		}
-	}
-	return nil
+	return fs.ReaddirToIterate(ctx, s, cb)
 }
 
 func (s *repositoryAllSources) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -59,11 +59,7 @@ func (s *repositoryAllSources) Child(ctx context.Context, name string) (fs.Entry
 }
 
 func (s *repositoryAllSources) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	if err := fs.ReaddirToIterate(ctx, s, cb); err != nil {
-		return errors.Wrap(err, "error iterating through directory entries")
-	}
-
-	return nil
+	return fs.ReaddirToIterate(ctx, s, cb)
 }
 
 func (s *repositoryAllSources) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -59,7 +59,11 @@ func (s *repositoryAllSources) Child(ctx context.Context, name string) (fs.Entry
 }
 
 func (s *repositoryAllSources) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	return fs.ReaddirToIterate(ctx, s, cb)
+	if err := fs.ReaddirToIterate(ctx, s, cb); err != nil {
+		return errors.Wrap(err, "error iterating through directory entries")
+	}
+
+	return nil
 }
 
 func (s *repositoryAllSources) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -126,7 +126,11 @@ func (rd *repositoryDirectory) Child(ctx context.Context, name string) (fs.Entry
 }
 
 func (rd *repositoryDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	return fs.ReaddirToIterate(ctx, rd, cb)
+	if err := fs.ReaddirToIterate(ctx, rd, cb); err != nil {
+		return errors.Wrap(err, "error iterating through directory entries")
+	}
+
+	return nil
 }
 
 func (rd *repositoryDirectory) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -125,6 +125,20 @@ func (rd *repositoryDirectory) Child(ctx context.Context, name string) (fs.Entry
 	return fs.ReadDirAndFindChild(ctx, rd, name)
 }
 
+func (rd *repositoryDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
+	entries, err := rd.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := cb(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (rd *repositoryDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
 	r, err := rd.repo.OpenObject(ctx, rd.metadata.ObjectID)
 	if err != nil {

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -126,17 +126,7 @@ func (rd *repositoryDirectory) Child(ctx context.Context, name string) (fs.Entry
 }
 
 func (rd *repositoryDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	entries, err := rd.Readdir(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, e := range entries {
-		if err := cb(ctx, e); err != nil {
-			return err
-		}
-	}
-	return nil
+	return fs.ReaddirToIterate(ctx, rd, cb)
 }
 
 func (rd *repositoryDirectory) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -126,11 +126,7 @@ func (rd *repositoryDirectory) Child(ctx context.Context, name string) (fs.Entry
 }
 
 func (rd *repositoryDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	if err := fs.ReaddirToIterate(ctx, rd, cb); err != nil {
-		return errors.Wrap(err, "error iterating through directory entries")
-	}
-
-	return nil
+	return fs.ReaddirToIterate(ctx, rd, cb)
 }
 
 func (rd *repositoryDirectory) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -62,6 +62,20 @@ func (s *sourceDirectories) Child(ctx context.Context, name string) (fs.Entry, e
 	return fs.ReadDirAndFindChild(ctx, s, name)
 }
 
+func (s *sourceDirectories) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
+	entries, err := s.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := cb(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *sourceDirectories) Readdir(ctx context.Context) (fs.Entries, error) {
 	sources0, err := snapshot.ListSources(ctx, s.rep)
 	if err != nil {

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -63,7 +63,11 @@ func (s *sourceDirectories) Child(ctx context.Context, name string) (fs.Entry, e
 }
 
 func (s *sourceDirectories) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	return fs.ReaddirToIterate(ctx, s, cb)
+	if err := fs.ReaddirToIterate(ctx, s, cb); err != nil {
+		return errors.Wrap(err, "error iterating through directory entries")
+	}
+
+	return nil
 }
 
 func (s *sourceDirectories) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -63,11 +63,7 @@ func (s *sourceDirectories) Child(ctx context.Context, name string) (fs.Entry, e
 }
 
 func (s *sourceDirectories) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	if err := fs.ReaddirToIterate(ctx, s, cb); err != nil {
-		return errors.Wrap(err, "error iterating through directory entries")
-	}
-
-	return nil
+	return fs.ReaddirToIterate(ctx, s, cb)
 }
 
 func (s *sourceDirectories) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -63,17 +63,7 @@ func (s *sourceDirectories) Child(ctx context.Context, name string) (fs.Entry, e
 }
 
 func (s *sourceDirectories) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	entries, err := s.Readdir(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, e := range entries {
-		if err := cb(ctx, e); err != nil {
-			return err
-		}
-	}
-	return nil
+	return fs.ReaddirToIterate(ctx, s, cb)
 }
 
 func (s *sourceDirectories) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -61,17 +61,7 @@ func (s *sourceSnapshots) Child(ctx context.Context, name string) (fs.Entry, err
 }
 
 func (s *sourceSnapshots) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	entries, err := s.Readdir(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, e := range entries {
-		if err := cb(ctx, e); err != nil {
-			return err
-		}
-	}
-	return nil
+	return fs.ReaddirToIterate(ctx, s, cb)
 }
 
 func (s *sourceSnapshots) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -60,6 +60,20 @@ func (s *sourceSnapshots) Child(ctx context.Context, name string) (fs.Entry, err
 	return fs.ReadDirAndFindChild(ctx, s, name)
 }
 
+func (s *sourceSnapshots) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
+	entries, err := s.Readdir(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if err := cb(ctx, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *sourceSnapshots) Readdir(ctx context.Context) (fs.Entries, error) {
 	manifests, err := snapshot.ListSnapshots(ctx, s.rep, s.src)
 	if err != nil {

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -61,11 +61,7 @@ func (s *sourceSnapshots) Child(ctx context.Context, name string) (fs.Entry, err
 }
 
 func (s *sourceSnapshots) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	if err := fs.ReaddirToIterate(ctx, s, cb); err != nil {
-		return errors.Wrap(err, "error iterating through directory entries")
-	}
-
-	return nil
+	return fs.ReaddirToIterate(ctx, s, cb)
 }
 
 func (s *sourceSnapshots) Readdir(ctx context.Context) (fs.Entries, error) {

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -61,7 +61,11 @@ func (s *sourceSnapshots) Child(ctx context.Context, name string) (fs.Entry, err
 }
 
 func (s *sourceSnapshots) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	return fs.ReaddirToIterate(ctx, s, cb)
+	if err := fs.ReaddirToIterate(ctx, s, cb); err != nil {
+		return errors.Wrap(err, "error iterating through directory entries")
+	}
+
+	return nil
 }
 
 func (s *sourceSnapshots) Readdir(ctx context.Context) (fs.Entries, error) {


### PR DESCRIPTION
As the first part of #1955 add an interface method that uses callbacks to process directory entries. Right now it defaults to calling the underlying `Readdir` implementation and then iterating over that result internally