### PR TITLE
feat(repository): switched to using go-mmap for indexes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,7 @@ require (
 	cloud.google.com/go/iam v0.3.0 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
+	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
+github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -248,7 +248,7 @@ func (c *committedContentIndex) combineSmallIndexes(m index.Merged) (index.Merge
 		return nil, errors.Wrap(err, "error building combined in-memory index")
 	}
 
-	combined, err := index.Open(bytes.NewReader(buf.Bytes()), c.v1PerContentOverhead)
+	combined, err := index.Open(buf.Bytes(), nil, c.v1PerContentOverhead)
 	if err != nil {
 		return nil, errors.Wrap(err, "error opening combined in-memory index")
 	}

--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -74,6 +74,8 @@ func (c *diskCommittedContentIndexCache) mmapOpenWithRetry(path string) (mmap.MM
 
 	mm, err := mmap.Map(f, mmap.RDONLY, 0)
 	if err != nil {
+		f.Close() // nolint:errcheck
+
 		return nil, nil, errors.Wrap(err, "mmap error")
 	}
 

--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/edsrzf/mmap-go"
 	"github.com/pkg/errors"
-	"golang.org/x/exp/mmap"
 
 	"github.com/kopia/kopia/internal/cache"
 	"github.com/kopia/kopia/internal/gather"
@@ -36,14 +36,14 @@ func (c *diskCommittedContentIndexCache) indexBlobPath(indexBlobID blob.ID) stri
 func (c *diskCommittedContentIndexCache) openIndex(ctx context.Context, indexBlobID blob.ID) (index.Index, error) {
 	fullpath := c.indexBlobPath(indexBlobID)
 
-	f, err := c.mmapOpenWithRetry(fullpath)
+	f, closeMmap, err := c.mmapOpenWithRetry(fullpath)
 	if err != nil {
 		return nil, err
 	}
 
-	ndx, err := index.Open(f, c.v1PerContentOverhead)
+	ndx, err := index.Open(f, closeMmap, c.v1PerContentOverhead)
 	if err != nil {
-		f.Close() // nolint:errcheck
+		closeMmap() // nolint:errcheck
 		return nil, errors.Wrapf(err, "error openind index from %v", indexBlobID)
 	}
 
@@ -52,14 +52,14 @@ func (c *diskCommittedContentIndexCache) openIndex(ctx context.Context, indexBlo
 
 // mmapOpenWithRetry attempts mmap.Open() with exponential back-off to work around rare issue specific to Windows where
 // we can't open the file right after it has been written.
-func (c *diskCommittedContentIndexCache) mmapOpenWithRetry(path string) (*mmap.ReaderAt, error) {
+func (c *diskCommittedContentIndexCache) mmapOpenWithRetry(path string) (mmap.MMap, func() error, error) {
 	const (
 		maxRetries    = 8
 		startingDelay = 10 * time.Millisecond
 	)
 
 	// retry milliseconds: 10, 20, 40, 80, 160, 320, 640, 1280, total ~2.5s
-	f, err := mmap.Open(path)
+	f, err := os.Open(path) // nolint:gosec
 	nextDelay := startingDelay
 
 	retryCount := 0
@@ -68,10 +68,26 @@ func (c *diskCommittedContentIndexCache) mmapOpenWithRetry(path string) (*mmap.R
 		c.log.Debugf("retry #%v unable to mmap.Open(): %v", retryCount, err)
 		time.Sleep(nextDelay)
 		nextDelay *= 2
-		f, err = mmap.Open(path)
+
+		f, err = os.Open(path) // nolint:gosec
 	}
 
-	return f, errors.Wrap(err, "mmap() error")
+	mm, err := mmap.Map(f, mmap.RDONLY, 0)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "mmap error")
+	}
+
+	return mm, func() error {
+		if err2 := mm.Unmap(); err2 != nil {
+			return errors.Wrapf(err2, "error unmapping index %v", path)
+		}
+
+		if err2 := f.Close(); err2 != nil {
+			return errors.Wrapf(err2, "error closing index %v", path)
+		}
+
+		return nil
+	}, errors.Wrap(err, "mmap() error")
 }
 
 func (c *diskCommittedContentIndexCache) hasIndexBlobID(ctx context.Context, indexBlobID blob.ID) (bool, error) {

--- a/repo/content/committed_content_index_mem_cache.go
+++ b/repo/content/committed_content_index_mem_cache.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"bytes"
 	"context"
 	"sync"
 
@@ -32,7 +31,7 @@ func (m *memoryCommittedContentIndexCache) addContentToCache(ctx context.Context
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	ndx, err := index.Open(bytes.NewReader(data.ToByteSlice()), m.v1PerContentOverhead)
+	ndx, err := index.Open(data.ToByteSlice(), nil, m.v1PerContentOverhead)
 	if err != nil {
 		return errors.Wrapf(err, "error opening index blob %v", indexBlobID)
 	}

--- a/repo/content/content_index_recovery.go
+++ b/repo/content/content_index_recovery.go
@@ -22,11 +22,10 @@ func (bm *WriteManager) RecoverIndexFromPackBlob(ctx context.Context, packFile b
 		return nil, err
 	}
 
-	ndx, err := index.Open(localIndexBytes.Bytes(), uint32(bm.crypter.Encryptor.Overhead()))
+	ndx, err := index.Open(localIndexBytes.Bytes().ToByteSlice(), nil, uint32(bm.crypter.Encryptor.Overhead()))
 	if err != nil {
 		return nil, errors.Errorf("unable to open index in file %v", packFile)
 	}
-	defer ndx.Close() //nolint:errcheck
 
 	var recovered []Info
 

--- a/repo/content/content_manager_indexes.go
+++ b/repo/content/content_manager_indexes.go
@@ -78,7 +78,7 @@ func ParseIndexBlob(ctx context.Context, blobID blob.ID, encrypted gather.Bytes,
 		return nil, errors.Wrap(err, "unable to decrypt index blob")
 	}
 
-	ndx, err := index.Open(data.Bytes(), uint32(crypter.Encryptor.Overhead()))
+	ndx, err := index.Open(data.Bytes().ToByteSlice(), nil, uint32(crypter.Encryptor.Overhead()))
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to open index blob")
 	}

--- a/repo/content/index/index.go
+++ b/repo/content/index/index.go
@@ -43,35 +43,22 @@ func Open(data []byte, closer func() error, v1PerContentOverhead uint32) (Index,
 	}
 }
 
-func safeSlice(data []byte, offset int64, length int) ([]byte, error) {
-	if offset < 0 {
-		return nil,
-			errors.Errorf("invalid offset")
-	}
-
-	if length < 0 {
-		return nil, errors.Errorf("invalid length")
-	}
-
-	if offset+int64(length) > int64(len(data)) {
-		return nil, errors.Errorf("invalid length")
-	}
+func safeSlice(data []byte, offset int64, length int) (v []byte, err error) {
+	defer func() {
+		if recover() != nil {
+			err = errors.Errorf("invalid slice offset=%v, length=%v, data=%v bytes", offset, length, len(data))
+		}
+	}()
 
 	return data[offset : offset+int64(length)], nil
 }
 
-func safeSliceString(data []byte, offset int64, length int) (string, error) {
-	if offset < 0 {
-		return "", errors.Errorf("invalid offset")
-	}
-
-	if length < 0 {
-		return "", errors.Errorf("invalid length")
-	}
-
-	if offset+int64(length) > int64(len(data)) {
-		return "", errors.Errorf("invalid length")
-	}
+func safeSliceString(data []byte, offset int64, length int) (s string, err error) {
+	defer func() {
+		if recover() != nil {
+			err = errors.Errorf("invalid slice offset=%v, length=%v, data=%v bytes", offset, length, len(data))
+		}
+	}()
 
 	return string(data[offset : offset+int64(length)]), nil
 }

--- a/repo/content/index/index.go
+++ b/repo/content/index/index.go
@@ -17,7 +17,6 @@ const (
 // Index is a read-only index of packed contents.
 type Index interface {
 	io.Closer
-
 	ApproximateCount() int
 	GetInfo(contentID ID) (Info, error)
 
@@ -26,33 +25,53 @@ type Index interface {
 }
 
 // Open reads an Index from a given reader. The caller must call Close() when the index is no longer used.
-func Open(readerAt io.ReaderAt, v1PerContentOverhead uint32) (Index, error) {
-	h, err := v1ReadHeader(readerAt)
+func Open(data []byte, closer func() error, v1PerContentOverhead uint32) (Index, error) {
+	h, err := v1ReadHeader(data)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid header")
 	}
 
 	switch h.version {
 	case Version1:
-		return openV1PackIndex(h, readerAt, v1PerContentOverhead)
+		return openV1PackIndex(h, data, closer, v1PerContentOverhead)
 
 	case Version2:
-		return openV2PackIndex(readerAt)
+		return openV2PackIndex(data, closer)
 
 	default:
 		return nil, errors.Errorf("invalid header format: %v", h.version)
 	}
 }
 
-func readAtAll(ra io.ReaderAt, p []byte, offset int64) error {
-	n, err := ra.ReadAt(p, offset)
-	if n != len(p) {
-		return errors.Errorf("incomplete read at offset %v, got %v bytes, expected %v", offset, n, len(p))
+func safeSlice(data []byte, offset int64, length int) ([]byte, error) {
+	if offset < 0 {
+		return nil,
+			errors.Errorf("invalid offset")
 	}
 
-	if err == nil || errors.Is(err, io.EOF) {
-		return nil
+	if length < 0 {
+		return nil, errors.Errorf("invalid length")
 	}
 
-	return errors.Wrapf(err, "invalid read at offset %v (%v bytes)", offset, len(p))
+	if offset+int64(length) > int64(len(data)) {
+		return nil, errors.Errorf("invalid length")
+	}
+
+	return data[offset : offset+int64(length)], nil
+}
+
+func safeSliceString(data []byte, offset int64, length int) (string, error) {
+	if offset < 0 {
+		return "", errors.Errorf("invalid offset")
+	}
+
+	if length < 0 {
+		return "", errors.Errorf("invalid length")
+	}
+
+	if offset+int64(length) > int64(len(data)) {
+		return "", errors.Errorf("invalid length")
+	}
+
+	return string(data[offset : offset+int64(length)]), nil
 }

--- a/repo/content/index/index.go
+++ b/repo/content/index/index.go
@@ -46,6 +46,7 @@ func Open(data []byte, closer func() error, v1PerContentOverhead uint32) (Index,
 func safeSlice(data []byte, offset int64, length int) (v []byte, err error) {
 	defer func() {
 		if recover() != nil {
+			v = nil
 			err = errors.Errorf("invalid slice offset=%v, length=%v, data=%v bytes", offset, length, len(data))
 		}
 	}()
@@ -56,6 +57,7 @@ func safeSlice(data []byte, offset int64, length int) (v []byte, err error) {
 func safeSliceString(data []byte, offset int64, length int) (s string, err error) {
 	defer func() {
 		if recover() != nil {
+			s = ""
 			err = errors.Errorf("invalid slice offset=%v, length=%v, data=%v bytes", offset, length, len(data))
 		}
 	}()

--- a/repo/content/index/index_encode_util.go
+++ b/repo/content/index/index_encode_util.go
@@ -1,21 +1,21 @@
 package index
 
-func decodeBigEndianUint48(d string) int64 {
+func decodeBigEndianUint48(d []byte) int64 {
 	_ = d[5] // early bounds check
 	return int64(d[0])<<40 | int64(d[1])<<32 | int64(d[2])<<24 | int64(d[3])<<16 | int64(d[4])<<8 | int64(d[5])
 }
 
-func decodeBigEndianUint32(d string) uint32 {
+func decodeBigEndianUint32(d []byte) uint32 {
 	_ = d[3] // early bounds check
 	return uint32(d[0])<<24 | uint32(d[1])<<16 | uint32(d[2])<<8 | uint32(d[3])
 }
 
-func decodeBigEndianUint24(d string) uint32 {
+func decodeBigEndianUint24(d []byte) uint32 {
 	_ = d[2] // early bounds check
 	return uint32(d[0])<<16 | uint32(d[1])<<8 | uint32(d[2])
 }
 
-func decodeBigEndianUint16(d string) uint16 {
+func decodeBigEndianUint16(d []byte) uint16 {
 	_ = d[1] // early bounds check
 	return uint16(d[0])<<8 | uint16(d[1])
 }

--- a/repo/content/index/index_v2.go
+++ b/repo/content/index/index_v2.go
@@ -136,7 +136,7 @@ type indexV2FormatInfo struct {
 }
 
 type indexV2EntryInfo struct {
-	data      string // basically a byte array, but immutable
+	data      []byte
 	contentID ID
 	b         *indexV2
 }
@@ -242,9 +242,10 @@ type v2HeaderInfo struct {
 }
 
 type indexV2 struct {
-	hdr      v2HeaderInfo
-	readerAt io.ReaderAt
-	formats  []indexV2FormatInfo
+	hdr     v2HeaderInfo
+	data    []byte
+	closer  func() error
+	formats []indexV2FormatInfo
 }
 
 func (b *indexV2) getPackBlobIDByIndex(ndx uint32) blob.ID {
@@ -252,22 +253,20 @@ func (b *indexV2) getPackBlobIDByIndex(ndx uint32) blob.ID {
 		return invalidBlobID
 	}
 
-	var buf [v2PackInfoSize]byte
-
-	if err := readAtAll(b.readerAt, buf[:], b.hdr.packsOffset+int64(v2PackInfoSize*ndx)); err != nil {
+	buf, err := safeSlice(b.data, b.hdr.packsOffset+int64(v2PackInfoSize*ndx), v2PackInfoSize)
+	if err != nil {
 		return invalidBlobID
 	}
 
 	nameLength := int(buf[0])
 	nameOffset := binary.BigEndian.Uint32(buf[1:])
 
-	var nameBuf [256]byte
-
-	if err := readAtAll(b.readerAt, nameBuf[0:nameLength], int64(nameOffset)); err != nil {
+	nameBuf, err := safeSliceString(b.data, int64(nameOffset), nameLength)
+	if err != nil {
 		return invalidBlobID
 	}
 
-	return blob.ID(nameBuf[0:nameLength])
+	return blob.ID(nameBuf)
 }
 
 func (b *indexV2) ApproximateCount() int {
@@ -283,11 +282,9 @@ func (b *indexV2) Iterate(r IDRange, cb func(Info) error) error {
 		return errors.Wrap(err, "could not find starting position")
 	}
 
-	var entryBuf [v2MaxEntrySize]byte
-	entry := entryBuf[0:b.hdr.entryStride]
-
 	for i := startPos; i < b.hdr.entryCount; i++ {
-		if err := readAtAll(b.readerAt, entry, b.entryOffset(i)); err != nil {
+		entry, err := safeSlice(b.data, b.entryOffset(i), int(b.hdr.entryStride))
+		if err != nil {
 			return errors.Wrap(err, "unable to read from index")
 		}
 
@@ -316,9 +313,6 @@ func (b *indexV2) entryOffset(p int) int64 {
 }
 
 func (b *indexV2) findEntryPosition(contentID IDPrefix) (int, error) {
-	var entryArr [v2MaxEntrySize]byte
-	entryBuf := entryArr[0:b.hdr.entryStride]
-
 	var readErr error
 
 	pos := sort.Search(b.hdr.entryCount, func(p int) bool {
@@ -326,18 +320,19 @@ func (b *indexV2) findEntryPosition(contentID IDPrefix) (int, error) {
 			return false
 		}
 
-		if err := readAtAll(b.readerAt, entryBuf, b.entryOffset(p)); err != nil {
+		entryBuf, err := safeSlice(b.data, b.entryOffset(p), b.hdr.keySize)
+		if err != nil {
 			readErr = err
 			return false
 		}
 
-		return bytesToContentID(entryBuf[0:b.hdr.keySize]).comparePrefix(contentID) >= 0
+		return bytesToContentID(entryBuf).comparePrefix(contentID) >= 0
 	})
 
 	return pos, readErr
 }
 
-func (b *indexV2) findEntryPositionExact(idBytes, entryBuf []byte) (int, error) {
+func (b *indexV2) findEntryPositionExact(idBytes []byte) (int, error) {
 	var readErr error
 
 	pos := sort.Search(b.hdr.entryCount, func(p int) bool {
@@ -345,7 +340,8 @@ func (b *indexV2) findEntryPositionExact(idBytes, entryBuf []byte) (int, error) 
 			return false
 		}
 
-		if err := readAtAll(b.readerAt, entryBuf, b.entryOffset(p)); err != nil {
+		entryBuf, err := safeSlice(b.data, b.entryOffset(p), b.hdr.keySize)
+		if err != nil {
 			readErr = err
 			return false
 		}
@@ -370,10 +366,7 @@ func (b *indexV2) findEntry(output []byte, contentID ID) ([]byte, error) {
 		return nil, errors.Errorf("invalid content ID: %q (%v vs %v)", contentID, len(key), b.hdr.keySize)
 	}
 
-	var entryArr [v2MaxEntrySize]byte
-	entryBuf := entryArr[0:b.hdr.entryStride]
-
-	position, err := b.findEntryPositionExact(key, entryBuf)
+	position, err := b.findEntryPositionExact(key)
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +375,8 @@ func (b *indexV2) findEntry(output []byte, contentID ID) ([]byte, error) {
 		return nil, nil
 	}
 
-	if err := readAtAll(b.readerAt, entryBuf, b.entryOffset(position)); err != nil {
+	entryBuf, err := safeSlice(b.data, b.entryOffset(position), int(b.hdr.entryStride))
+	if err != nil {
 		return nil, errors.Wrap(err, "error reading header")
 	}
 
@@ -414,14 +408,13 @@ func (b *indexV2) entryToInfo(contentID ID, entryData []byte) (Info, error) {
 		return nil, errors.Errorf("invalid entry length: %v", len(entryData))
 	}
 
-	// convert to 'entryData' string to make it read-only
-	return indexV2EntryInfo{string(entryData), contentID, b}, nil
+	return indexV2EntryInfo{entryData, contentID, b}, nil
 }
 
-// Close closes the index and the underlying reader.
+// Close closes the index.
 func (b *indexV2) Close() error {
-	if closer, ok := b.readerAt.(io.Closer); ok {
-		return errors.Wrap(closer.Close(), "error closing index file")
+	if closer := b.closer; closer != nil {
+		return errors.Wrap(closer(), "error closing index file")
 	}
 
 	return nil
@@ -750,10 +743,9 @@ func (b *indexBuilderV2) writeIndexValueEntry(w io.Writer, it Info) error {
 	return errors.Wrap(err, "error writing index value entry")
 }
 
-func openV2PackIndex(readerAt io.ReaderAt) (Index, error) {
-	var header [v2IndexHeaderSize]byte
-
-	if err := readAtAll(readerAt, header[:], 0); err != nil {
+func openV2PackIndex(data []byte, closer func() error) (Index, error) {
+	header, err := safeSlice(data, 0, v2IndexHeaderSize)
+	if err != nil {
 		return nil, errors.Wrap(err, "invalid header")
 	}
 
@@ -781,15 +773,16 @@ func openV2PackIndex(readerAt io.ReaderAt) (Index, error) {
 	hi.formatsOffset = hi.packsOffset + int64(hi.packCount*v2PackInfoSize)
 
 	// pre-read formats section
-	formatsBuf := make([]byte, int(hi.formatCount)*v2FormatInfoSize)
-	if err := readAtAll(readerAt, formatsBuf, hi.formatsOffset); err != nil {
+	formatsBuf, err := safeSlice(data, hi.formatsOffset, int(hi.formatCount)*v2FormatInfoSize)
+	if err != nil {
 		return nil, errors.Errorf("unable to read formats section")
 	}
 
 	return &indexV2{
-		hdr:      hi,
-		readerAt: readerAt,
-		formats:  parseFormatsBuffer(formatsBuf, int(hi.formatCount)),
+		hdr:     hi,
+		data:    data,
+		closer:  closer,
+		formats: parseFormatsBuffer(formatsBuf, int(hi.formatCount)),
 	}, nil
 }
 

--- a/repo/content/index/index_v2.go
+++ b/repo/content/index/index_v2.go
@@ -352,7 +352,7 @@ func (b *indexV2) findEntryPositionExact(idBytes []byte) (int, error) {
 	return pos, readErr
 }
 
-func (b *indexV2) findEntry(output []byte, contentID ID) ([]byte, error) {
+func (b *indexV2) findEntry(contentID ID) ([]byte, error) {
 	var hashBuf [maxContentIDSize]byte
 
 	key := contentIDToBytes(hashBuf[:0], contentID)
@@ -381,7 +381,7 @@ func (b *indexV2) findEntry(output []byte, contentID ID) ([]byte, error) {
 	}
 
 	if bytes.Equal(entryBuf[0:len(key)], key) {
-		return append(output, entryBuf[len(key):]...), nil
+		return entryBuf[len(key):], nil
 	}
 
 	return nil, nil
@@ -389,9 +389,7 @@ func (b *indexV2) findEntry(output []byte, contentID ID) ([]byte, error) {
 
 // GetInfo returns information about a given content. If a content is not found, nil is returned.
 func (b *indexV2) GetInfo(contentID ID) (Info, error) {
-	var entryBuf [v2MaxEntrySize]byte
-
-	e, err := b.findEntry(entryBuf[:0], contentID)
+	e, err := b.findEntry(contentID)
 	if err != nil {
 		return nil, err
 	}

--- a/repo/content/index/merged_test.go
+++ b/repo/content/index/merged_test.go
@@ -249,5 +249,5 @@ func indexWithItems(items ...Info) (Index, error) {
 		return nil, errors.Wrap(err, "build error")
 	}
 
-	return Open(bytes.NewReader(buf.Bytes()), fakeEncryptionOverhead)
+	return Open(buf.Bytes(), nil, fakeEncryptionOverhead)
 }

--- a/repo/content/index/packindex_test.go
+++ b/repo/content/index/packindex_test.go
@@ -188,11 +188,10 @@ func testPackIndex(t *testing.T, version int) {
 		fuzzTestIndexOpen(data1)
 	})
 
-	ndx, err := Open(bytes.NewReader(data1), fakeEncryptionOverhead)
+	ndx, err := Open(data1, nil, fakeEncryptionOverhead)
 	if err != nil {
 		t.Fatalf("can't open index: %v", err)
 	}
-	defer ndx.Close()
 
 	for _, want := range infos {
 		info2, err := ndx.GetInfo(want.GetContentID())
@@ -282,7 +281,7 @@ func TestPackIndexPerContentLimits(t *testing.T) {
 		if tc.errMsg == "" {
 			require.NoError(t, b.buildV2(&result))
 
-			pi, err := Open(bytes.NewReader(result.Bytes()), fakeEncryptionOverhead)
+			pi, err := Open(result.Bytes(), nil, fakeEncryptionOverhead)
 			require.NoError(t, err)
 
 			got, err := pi.GetInfo(cid)
@@ -400,11 +399,10 @@ func fuzzTestIndexOpen(originalData []byte) {
 	rnd := rand.New(rand.NewSource(12345))
 
 	fuzzTest(rnd, originalData, 50000, func(d []byte) {
-		ndx, err := Open(bytes.NewReader(d), 0)
+		ndx, err := Open(d, nil, 0)
 		if err != nil {
 			return
 		}
-		defer ndx.Close()
 		cnt := 0
 		_ = ndx.Iterate(AllIDs, func(cb Info) error {
 			if cnt < 10 {

--- a/repo/content/index_blob_manager_v0.go
+++ b/repo/content/index_blob_manager_v0.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"time"
@@ -521,7 +520,7 @@ func addIndexBlobsToBuilder(ctx context.Context, enc *encryptedBlobMgr, bld inde
 		return errors.Wrapf(err, "error getting index %q", indexBlobID)
 	}
 
-	ndx, err := index.Open(bytes.NewReader(data.ToByteSlice()), uint32(enc.crypter.Encryptor.Overhead()))
+	ndx, err := index.Open(data.ToByteSlice(), nil, uint32(enc.crypter.Encryptor.Overhead()))
 	if err != nil {
 		return errors.Wrapf(err, "unable to open index blob %q", indexBlobID)
 	}


### PR DESCRIPTION
Previous mmap implementation only allowed io.ReaderAt API
this one allows direct access to the underlying bytes which helps
remove a bunch of buffers, copying and allocation in index parsing.