### PR TITLE
feat(cli): added flags for pushing kopia metrics

### DIFF
--- a/cli/command_repository.go
+++ b/cli/command_repository.go
@@ -17,14 +17,14 @@ type commandRepository struct {
 func (c *commandRepository) setup(svc advancedAppServices, parent commandParent) {
 	cmd := parent.Command("repository", "Commands to manipulate repository.").Alias("repo")
 
-	c.connect.setup(svc, cmd) // nolint:contextcheck
-	c.create.setup(svc, cmd)  // nolint:contextcheck
+	c.connect.setup(svc, cmd)
+	c.create.setup(svc, cmd)
 	c.disconnect.setup(svc, cmd)
-	c.repair.setup(svc, cmd) // nolint:contextcheck
+	c.repair.setup(svc, cmd)
 	c.setClient.setup(svc, cmd)
 	c.setParameters.setup(svc, cmd)
 	c.status.setup(svc, cmd)
-	c.syncTo.setup(svc, cmd) // nolint:contextcheck
+	c.syncTo.setup(svc, cmd)
 	c.throttle.setup(svc, cmd)
 	c.changePassword.setup(svc, cmd)
 	c.validateProvider.setup(svc, cmd)

--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -31,14 +31,16 @@ func (c *commandRepositoryConnect) setup(svc advancedAppServices, parent command
 		cc := cmd.Command(prov.Name, "Connect to repository in "+prov.Description)
 		f.Setup(svc, cc)
 		cc.Action(func(_ *kingpin.ParseContext) error {
-			ctx := svc.rootContext()
-			st, err := f.Connect(ctx, false, 0)
-			if err != nil {
-				return errors.Wrap(err, "can't connect to storage")
-			}
-
 			// nolint:wrapcheck
-			return svc.runConnectCommandWithStorage(ctx, &c.co, st)
+			return svc.runAppWithContext(func(ctx context.Context) error {
+				st, err := f.Connect(ctx, false, 0)
+				if err != nil {
+					return errors.Wrap(err, "can't connect to storage")
+				}
+
+				// nolint:wrapcheck
+				return svc.runConnectCommandWithStorage(ctx, &c.co, st)
+			})
 		})
 	}
 }

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -62,13 +62,15 @@ func (c *commandRepositoryCreate) setup(svc advancedAppServices, parent commandP
 		cc := cmd.Command(prov.Name, "Create repository in "+prov.Description)
 		f.Setup(svc, cc)
 		cc.Action(func(_ *kingpin.ParseContext) error {
-			ctx := svc.rootContext()
-			st, err := f.Connect(ctx, true, c.createFormatVersion)
-			if err != nil {
-				return errors.Wrap(err, "can't connect to storage")
-			}
+			// nolint:wrapcheck
+			return svc.runAppWithContext(func(ctx context.Context) error {
+				st, err := f.Connect(ctx, true, c.createFormatVersion)
+				if err != nil {
+					return errors.Wrap(err, "can't connect to storage")
+				}
 
-			return c.runCreateCommandWithStorage(ctx, st)
+				return c.runCreateCommandWithStorage(ctx, st)
+			})
 		})
 	}
 }

--- a/cli/command_repository_repair.go
+++ b/cli/command_repository_repair.go
@@ -30,13 +30,15 @@ func (c *commandRepositoryRepair) setup(svc advancedAppServices, parent commandP
 		cc := cmd.Command(prov.Name, "Repair repository in "+prov.Description)
 		f.Setup(svc, cc)
 		cc.Action(func(_ *kingpin.ParseContext) error {
-			ctx := svc.rootContext()
-			st, err := f.Connect(ctx, false, 0)
-			if err != nil {
-				return errors.Wrap(err, "can't connect to storage")
-			}
+			// nolint:wrapcheck
+			return svc.runAppWithContext(func(ctx context.Context) error {
+				st, err := f.Connect(ctx, false, 0)
+				if err != nil {
+					return errors.Wrap(err, "can't connect to storage")
+				}
 
-			return c.runRepairCommandWithStorage(ctx, st)
+				return c.runRepairCommandWithStorage(ctx, st)
+			})
 		})
 	}
 }

--- a/cli/command_repository_sync.go
+++ b/cli/command_repository_sync.go
@@ -56,25 +56,27 @@ func (c *commandRepositorySyncTo) setup(svc advancedAppServices, parent commandP
 		cc := cmd.Command(prov.Name, "Synchronize repository data to another repository in "+prov.Description)
 		f.Setup(svc, cc)
 		cc.Action(func(_ *kingpin.ParseContext) error {
-			ctx := svc.rootContext()
-			st, err := f.Connect(ctx, false, 0)
-			if err != nil {
-				return errors.Wrap(err, "can't connect to storage")
-			}
+			// nolint:wrapcheck
+			return svc.runAppWithContext(func(ctx context.Context) error {
+				st, err := f.Connect(ctx, false, 0)
+				if err != nil {
+					return errors.Wrap(err, "can't connect to storage")
+				}
 
-			rep, err := svc.openRepository(ctx, true)
-			if err != nil {
-				return errors.Wrap(err, "open repository")
-			}
+				rep, err := svc.openRepository(ctx, true)
+				if err != nil {
+					return errors.Wrap(err, "open repository")
+				}
 
-			defer rep.Close(ctx) // nolint:errcheck
+				defer rep.Close(ctx) // nolint:errcheck
 
-			dr, ok := rep.(repo.DirectRepository)
-			if !ok {
-				return errors.Errorf("sync only supports directly-connected repositories")
-			}
+				dr, ok := rep.(repo.DirectRepository)
+				if !ok {
+					return errors.Errorf("sync only supports directly-connected repositories")
+				}
 
-			return c.runSyncWithStorage(ctx, dr.BlobReader(), st)
+				return c.runSyncWithStorage(ctx, dr.BlobReader(), st)
+			})
 		})
 	}
 }

--- a/cli/inproc.go
+++ b/cli/inproc.go
@@ -20,7 +20,7 @@ func (c *App) RunSubcommand(ctx context.Context, kpapp *kingpin.Application, arg
 	c.stderrWriter = stderrWriter
 	c.rootctx = logging.WithLogger(ctx, logging.Writer(stderrWriter))
 
-	c.Attach(kpapp) // nolint:contextcheck
+	c.Attach(kpapp)
 
 	var exitCode int
 

--- a/cli/observability_flags_test.go
+++ b/cli/observability_flags_test.go
@@ -1,0 +1,78 @@
+package cli_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestMetricsPushFlags(t *testing.T) {
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+	mux := http.NewServeMux()
+
+	var (
+		mu     sync.Mutex
+		urls   []string
+		bodies []string
+		auths  []string
+	)
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		urls = append(urls, r.RequestURI)
+		d, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, r.Method+":"+string(d))
+		u, p, _ := r.BasicAuth()
+
+		auths = append(auths, u+":"+p)
+	})
+
+	tmp1 := testutil.TempDirectory(t)
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", tmp1,
+		"--metrics-push-addr="+server.URL,
+		"--metrics-push-interval=30s",
+		"--metrics-push-format=text",
+	)
+
+	env.RunAndExpectSuccess(t, "repo", "status",
+		"--metrics-push-addr="+server.URL,
+		"--metrics-push-interval=30s",
+		"--metrics-push-grouping=a:b",
+		"--metrics-push-username=user1",
+		"--metrics-push-password=pass1",
+		"--metrics-push-format=proto-text",
+	)
+
+	require.Equal(t, []string{
+		"/metrics/job/kopia",     // initial
+		"/metrics/job/kopia",     // final
+		"/metrics/job/kopia/a/b", // initial
+		"/metrics/job/kopia/a/b", // final
+	}, urls)
+
+	require.Equal(t, "user1:pass1", auths[len(auths)-1])
+
+	for _, b := range bodies {
+		// make sure bodies include some kopia metrics, don't need more
+		require.Contains(t, b, "kopia_content_cache_hit_bytes")
+	}
+
+	env.RunAndExpectFailure(t, "repo", "status",
+		"--metrics-push-addr="+server.URL,
+		"--metrics-push-grouping=a=s",
+	)
+}

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -52,6 +52,9 @@ func NewCLITest(t *testing.T, repoCreateFlags []string, runner CLIRunner) *CLITe
 	t.Helper()
 	configDir := testutil.TempDirectory(t)
 
+	// unset global environment variable that may interfere with the test
+	os.Unsetenv("KOPIA_METRICS_PUSH_ADDR")
+
 	fixedArgs := []string{
 		// use per-test config file, to avoid clobbering current user's setup.
 		"--config-file", filepath.Join(configDir, ".kopia.config"),


### PR DESCRIPTION
When enabled, metrics are pushed to the provided Prometheus Push
Gateway at the start and end of each command and periodically every
few seconds.

```
--metrics-push-addr=http://address:port
--metrics-push-interval=5s
--metrics-push-job=kopia
--metrics-push-grouping=a:b --metrics-push-grouping=c:d
--metrics-push-username=user
--metrics-push-password=pass
```