### PR TITLE
feat(repository): implement shared async writer pool for object manager

### DIFF
--- a/repo/api_server_repository.go
+++ b/repo/api_server_repository.go
@@ -68,6 +68,11 @@ func (r *apiServerRepository) NewObjectWriter(ctx context.Context, opt object.Wr
 	return r.omgr.NewWriter(ctx, opt)
 }
 
+func (r *apiServerRepository) SetObjectManagerOptions(ctx context.Context, opt ...object.ManagerOption) error {
+	// nolint:wrapcheck
+	return r.omgr.SetOptions(opt...)
+}
+
 func (r *apiServerRepository) VerifyObject(ctx context.Context, id object.ID) ([]content.ID, error) {
 	// nolint:wrapcheck
 	return object.VerifyObject(ctx, r, id)
@@ -236,6 +241,11 @@ func (r *apiServerRepository) UpdateDescription(d string) {
 }
 
 func (r *apiServerRepository) Close(ctx context.Context) error {
+	if r.omgr != nil {
+		r.omgr.Close()
+		r.omgr = nil
+	}
+
 	if r.isSharedReadOnlySession && r.contentCache != nil {
 		r.contentCache.Close(ctx)
 		r.contentCache = nil

--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -208,6 +208,11 @@ func (r *grpcRepositoryClient) NewObjectWriter(ctx context.Context, opt object.W
 	return r.omgr.NewWriter(ctx, opt)
 }
 
+func (r *grpcRepositoryClient) SetObjectManagerOptions(ctx context.Context, opt ...object.ManagerOption) error {
+	// nolint:wrapcheck
+	return r.omgr.SetOptions(opt...)
+}
+
 func (r *grpcRepositoryClient) VerifyObject(ctx context.Context, id object.ID) ([]content.ID, error) {
 	// nolint:wrapcheck
 	return object.VerifyObject(ctx, r, id)
@@ -734,6 +739,8 @@ func (r *grpcRepositoryClient) Close(ctx context.Context) error {
 		// already closed
 		return nil
 	}
+
+	r.omgr.Close()
 
 	r.omgr = nil
 

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -41,6 +41,7 @@ type RepositoryWriter interface {
 	Repository
 
 	NewObjectWriter(ctx context.Context, opt object.WriterOptions) object.Writer
+	SetObjectManagerOptions(ctx context.Context, opt ...object.ManagerOption) error
 	PutManifest(ctx context.Context, labels map[string]string, payload interface{}) (manifest.ID, error)
 	DeleteManifest(ctx context.Context, id manifest.ID) error
 	Flush(ctx context.Context) error
@@ -151,6 +152,11 @@ func (r *directRepository) Crypter() *content.Crypter {
 // NewObjectWriter creates an object writer.
 func (r *directRepository) NewObjectWriter(ctx context.Context, opt object.WriterOptions) object.Writer {
 	return r.omgr.NewWriter(ctx, opt)
+}
+
+func (r *directRepository) SetObjectManagerOptions(ctx context.Context, opt ...object.ManagerOption) error {
+	// nolint:wrapcheck
+	return r.omgr.SetOptions(opt...)
 }
 
 // DisableIndexRefresh disables index refresh for the duration of the write session.
@@ -281,6 +287,8 @@ func (r *directRepository) Close(ctx context.Context) error {
 	if err := r.cmgr.Close(ctx); err != nil {
 		return errors.Wrap(err, "error closing content-addressable storage manager")
 	}
+
+	r.omgr.Close()
 
 	close(r.closed)
 


### PR DESCRIPTION
This gets rid of managing asynchronous upload parallelism from the
uploader on a per-file basis.

The effect is slight speed up of snapshots (around 10%), but the
trade-off is slight increase in memory usage (because more memory is
needed for in-flight buffers). Memory usage be improved in #1963 for
overall reduced usage compared to 0.10.7.