### PR TITLE
chore(ci): restrict GH actions for provider and stress tests to upstream repository.

### DIFF
--- a/.github/workflows/endurance-test.yml
+++ b/.github/workflows/endurance-test.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       KOPIA_KEEP_LOGS: true
     name: Endurance Test
+    if: ${{ github.repository == 'kopia/kopia' }}
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go.

--- a/.github/workflows/provider-tests.yml
+++ b/.github/workflows/provider-tests.yml
@@ -11,8 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  endurance-test:
+  provider-test:
     name: Provider Test
+    if: ${{ github.repository == 'kopia/kopia' }}
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go.

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -12,7 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  endurance-test:
+  stress-test:
     name: Stress Test
     if: ${{ github.repository == 'kopia/kopia' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
There's a lot of CI spam in my email because some of these tests occasionally fail. This limits these flows to run only on the upstream repository since they have a schedule. This also potentially saves some GH action cycles on everyone's respective accounts.