### PR TITLE
fix(general): use a fixed time for protecting newly created content

### DIFF
--- a/snapshot/snapshotgc/gc.go
+++ b/snapshot/snapshotgc/gc.go
@@ -74,6 +74,13 @@ func Run(ctx context.Context, rep repo.DirectRepositoryWriter, gcDelete bool, sa
 			return err
 		}
 
+		l := log(ctx)
+
+		l.Infof("GC found %v unused contents (%v bytes)", st.UnusedCount, units.BytesStringBase2(st.UnusedBytes))
+		l.Infof("GC found %v unused contents that are too recent to delete (%v bytes)", st.TooRecentCount, units.BytesStringBase2(st.TooRecentBytes))
+		l.Infof("GC found %v in-use contents (%v bytes)", st.InUseCount, units.BytesStringBase2(st.InUseBytes))
+		l.Infof("GC found %v in-use system-contents (%v bytes)", st.SystemCount, units.BytesStringBase2(st.SystemBytes))
+
 		if st.UnusedCount > 0 && !gcDelete {
 			return errors.Errorf("Not deleting because 'gcDelete' was not set")
 		}

--- a/snapshot/snapshotgc/gc.go
+++ b/snapshot/snapshotgc/gc.go
@@ -114,12 +114,14 @@ func runInternal(ctx context.Context, rep repo.DirectRepositoryWriter, gcDelete 
 			}
 
 			inUse.Add(int64(ci.GetPackedLength()))
+
 			return nil
 		}
 
 		if rep.Time().Sub(ci.Timestamp()) < safety.MinContentAgeSubjectToGC {
 			log(ctx).Debugf("recent unreferenced content %v (%v bytes, modified %v)", ci.GetContentID(), ci.GetPackedLength(), ci.Timestamp())
 			tooRecent.Add(int64(ci.GetPackedLength()))
+
 			return nil
 		}
 

--- a/snapshot/snapshotmaintenance/snapshotmaintenance.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance.go
@@ -18,7 +18,7 @@ func Run(ctx context.Context, dr repo.DirectRepositoryWriter, mode maintenance.M
 		func(ctx context.Context, runParams maintenance.RunParameters) error {
 			// run snapshot GC before full maintenance
 			if runParams.Mode == maintenance.ModeFull {
-				if _, err := snapshotgc.Run(ctx, dr, true, safety); err != nil {
+				if _, err := snapshotgc.Run(ctx, dr, true, safety, runParams.MaintenanceStartTime); err != nil {
 					return errors.Wrap(err, "snapshot GC failure")
 				}
 			}

--- a/snapshot/snapshotmaintenance/snapshotmaintenance_test.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance_test.go
@@ -169,12 +169,6 @@ func (s *formatSpecificTestSuite) TestMaintenanceReuseDirManifest(t *testing.T) 
 	t.Log("root info:", pretty.Sprint(info))
 }
 
-func TestSnapshotGCMinContentAgeSafety(t *testing.T) {
-	s := formatSpecificTestSuite{formatVersion: content.FormatVersion2}
-
-	s.TestSnapshotGCMinContentAgeSafety(t)
-}
-
 func (s *formatSpecificTestSuite) TestSnapshotGCMinContentAgeSafety(t *testing.T) {
 	ctx := testlogging.Context(t)
 	th := newTestHarness(t, s.formatVersion)


### PR DESCRIPTION
Previously, the reference time used to determine whether a content had been recently created would change throughout a snapshot GC execution. For long-running GC tasks, this non-deterministically shrank the safety window specified in `MinContentAgeSubjectToGC`.

Now, the maintenance starting time is used as a fix reference for the safety check.
