### PR TITLE
fix(snapshots): fixed random deadlock when Uploader results in a failure

### DIFF
--- a/internal/workshare/workshare_test.go
+++ b/internal/workshare/workshare_test.go
@@ -102,6 +102,24 @@ func TestComputeTreeSumNegative(t *testing.T) {
 	testComputeTreeSum(t, -1)
 }
 
+func TestDisallowedUse(t *testing.T) {
+	w := workshare.NewPool(1)
+
+	var ag workshare.AsyncGroup
+
+	w.Close()
+
+	require.Panics(t, func() {
+		ag.CanShareWork(w)
+	})
+
+	require.Panics(t, func() {
+		ag.RunAsync(w, func(c *workshare.Pool, request interface{}) {
+			t.Fatal("should not be called")
+		}, nil)
+	})
+}
+
 // nolint:thelper
 func testComputeTreeSum(t *testing.T, numWorkers int) {
 	w := workshare.NewPool(numWorkers)

--- a/internal/workshare/workshare_test.go
+++ b/internal/workshare/workshare_test.go
@@ -102,7 +102,27 @@ func TestComputeTreeSumNegative(t *testing.T) {
 	testComputeTreeSum(t, -1)
 }
 
-func TestDisallowedUse(t *testing.T) {
+func TestDisallowed_DoubleWait(t *testing.T) {
+	var ag workshare.AsyncGroup
+
+	ag.Wait()
+	require.Panics(t, func() {
+		ag.Wait()
+	})
+}
+
+func TestDisallowed_WaitAfterClose(t *testing.T) {
+	var ag workshare.AsyncGroup
+
+	ag.Close()
+	require.Panics(t, func() {
+		ag.Wait()
+	})
+
+	ag.Close() // no-op
+}
+
+func TestDisallowed_UseAfterPoolClose(t *testing.T) {
 	w := workshare.NewPool(1)
 
 	var ag workshare.AsyncGroup

--- a/internal/workshare/workshare_waitgroup.go
+++ b/internal/workshare/workshare_waitgroup.go
@@ -108,7 +108,14 @@ func (g *AsyncGroup) CanShareWork(w *Pool) bool {
 		// we successfully added token to the channel, because we have exactly the same number
 		// of workers as the capacity of the channel, one worker will wake up to process
 		// item from w.work, which will be added by RunAsync().
-		return true
+
+		// double check we're not closed
+		select {
+		case <-w.closed:
+			panic("invalid usage - CanShareWork() after workshare.AsyncGroup has been closed")
+		default:
+			return true
+		}
 
 	case <-w.closed:
 		panic("invalid usage - CanShareWork() after workshare.AsyncGroup has been closed")

--- a/internal/workshare/workshare_waitgroup.go
+++ b/internal/workshare/workshare_waitgroup.go
@@ -108,9 +108,8 @@ func (g *AsyncGroup) CanShareWork(w *Pool) bool {
 		// we successfully added token to the channel, because we have exactly the same number
 		// of workers as the capacity of the channel, one worker will wake up to process
 		// item from w.work, which will be added by RunAsync().
-
-		// double check we're not closed
 		select {
+		// double check we're not closed
 		case <-w.closed:
 			panic("invalid usage - CanShareWork() after workshare.AsyncGroup has been closed")
 		default:

--- a/snapshot/snapshotfs/dir_rewriter.go
+++ b/snapshot/snapshotfs/dir_rewriter.go
@@ -143,6 +143,9 @@ func (rw *DirRewriter) processDirectoryEntries(ctx context.Context, parentPath s
 		wg      workshare.AsyncGroup
 	)
 
+	// ensure we wait for all work items before returning
+	defer wg.Close()
+
 	for _, child := range entries {
 		if wg.CanShareWork(rw.ws) {
 			// see if we can run this child in a goroutine

--- a/snapshot/snapshotfs/snapshot_tree_walker.go
+++ b/snapshot/snapshotfs/snapshot_tree_walker.go
@@ -110,7 +110,7 @@ func (w *TreeWalker) processDirEntry(ctx context.Context, dir fs.Directory, entr
 	}
 
 	var ag workshare.AsyncGroup
-	defer ag.Wait()
+	defer ag.Close()
 
 	err := dir.IterateEntries(ctx, func(c context.Context, ent fs.Entry) error {
 		if w.TooManyErrors() {

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -538,6 +538,9 @@ func (u *Uploader) processChildren(
 ) error {
 	var wg workshare.AsyncGroup
 
+	// ensure we wait for all work items before returning
+	defer wg.Close()
+
 	// ignore errCancel because a more serious error may be reported in wg.Wait()
 	// we'll check for cancelation later.
 


### PR DESCRIPTION
The deadlock was caused by not properly waiting for all asynchronous
work to complete before closing the worker pool.

Introduced `workshare.AsyncGroup.Close()` and some assertions.

Fixes #2019 