### PR TITLE
fix(repository): fixed stress test caused by index leaking file handles

### DIFF
--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -153,36 +153,43 @@ func (c *committedContentIndex) indexFilesChanged(indexFiles []blob.ID) bool {
 	return false
 }
 
-func (c *committedContentIndex) merge(ctx context.Context, indexFiles []blob.ID) (merged index.Merged, used map[blob.ID]index.Index, finalErr error) {
-	used = map[blob.ID]index.Index{}
-
-	defer func() {
-		// we failed along the way, close the merged index.
-		if finalErr != nil {
-			merged.Close() //nolint:errcheck
-		}
-	}()
+// +checklocks:c.mu
+func (c *committedContentIndex) merge(ctx context.Context, indexFiles []blob.ID) (index.Merged, map[blob.ID]index.Index, error) {
+	var (
+		newMerged   index.Merged
+		newlyOpened index.Merged // new indexes that were not in c.inUse before
+		newUsedMap  = map[blob.ID]index.Index{}
+	)
 
 	for _, e := range indexFiles {
-		ndx, err := c.cache.openIndex(ctx, e)
-		if err != nil {
-			return nil, nil, errors.Wrapf(err, "unable to open pack index %q", e)
+		ndx := c.inUse[e]
+		if ndx == nil {
+			var err error
+
+			ndx, err = c.cache.openIndex(ctx, e)
+			if err != nil {
+				newlyOpened.Close() // nolint:errcheck
+
+				return nil, nil, errors.Wrapf(err, "unable to open pack index %q", e)
+			}
+
+			newlyOpened = append(newlyOpened, ndx)
 		}
 
-		merged = append(merged, ndx)
-		used[e] = ndx
+		newMerged = append(newMerged, ndx)
+		newUsedMap[e] = ndx
 	}
 
-	mergedAndCombined, err := c.combineSmallIndexes(merged)
+	mergedAndCombined, err := c.combineSmallIndexes(newMerged)
 	if err != nil {
+		newlyOpened.Close() // nolint:errcheck
+
 		return nil, nil, errors.Wrap(err, "unable to combine small indexes")
 	}
 
-	c.log.Debugf("combined %v into %v index segments", len(merged), len(mergedAndCombined))
+	c.log.Debugf("combined %v into %v index segments", len(newMerged), len(mergedAndCombined))
 
-	merged = mergedAndCombined
-
-	return
+	return mergedAndCombined, newUsedMap, nil
 }
 
 // Uses indexFiles for indexing. An error is returned if the
@@ -205,9 +212,19 @@ func (c *committedContentIndex) use(ctx context.Context, indexFiles []blob.ID, i
 	}
 
 	atomic.AddInt64(&c.rev, 1)
-
 	c.merged = mergedAndCombined
+
+	oldInUse := c.inUse
 	c.inUse = newInUse
+
+	// close indices that were previously in use but are no longer.
+	for k, old := range oldInUse {
+		if newInUse[k] == nil {
+			if err := old.Close(); err != nil {
+				c.log.Errorf("unable to close unused index file: %v", err)
+			}
+		}
+	}
 
 	if err := c.cache.expireUnused(ctx, indexFiles); err != nil {
 		c.log.Errorf("unable to expire unused index files: %v", err)

--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -72,6 +72,10 @@ func (c *diskCommittedContentIndexCache) mmapOpenWithRetry(path string) (mmap.MM
 		f, err = os.Open(path) // nolint:gosec
 	}
 
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "unable to open file despite retries")
+	}
+
 	mm, err := mmap.Map(f, mmap.RDONLY, 0)
 	if err != nil {
 		f.Close() // nolint:errcheck


### PR DESCRIPTION
Fixed regression caused by #1980

Switching to new mmap library uncovered a bug where we were not properly
closing indices that are no longer in use, since previous mmap had
a finalizer defined to do so.