### PR TITLE
chore(deps): update dependabot frequency for go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,14 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: "/"
+    open-pull-requests-limit: 1
     schedule:
-      interval: monthly
+      interval: daily
   - package-ecosystem: github-actions
     directory: "/"
+    open-pull-requests-limit: 3
     schedule:
-      interval: monthly
+      interval: weekly
   - package-ecosystem: npm
     directory: "/app"
     schedule:


### PR DESCRIPTION
Allow more frequent update while limiting the number of open PRs to 1.
Similarly, for GHA deps.