### PR TITLE
docs(site): update instructions on creating issues

### DIFF
--- a/site/content/docs/Contribution guidelines/_index.md
+++ b/site/content/docs/Contribution guidelines/_index.md
@@ -12,7 +12,8 @@ weight: 100
 
 ## Submitting issues
 
-* If you find a bug or have a feature request, please submit an issue at https://github.com/kopia/kopia/issues
+* If you find a bug or have a feature request, please submit an issue in the main Kopia project at https://github.com/kopia/kopia/issues.
+* To keep all issues in one central location, please do not create issues directly in the `kopia/htmlui` (or other auxiliary) project.
 
 ## Security issues
 


### PR DESCRIPTION
New issues should all be created in the main (`kopia/kopia`) project,
as that project is the most watched. Keeping all issues in one
central location will help us track and address them more
efficiently. We can use issue labels to indicate that an issue
relates to the UI or other auxiliary project.