### PR TITLE
chore(ci): fix golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters-settings:
     statements: 60
   forbidigo:
     forbid:
+    - filepath.IsAbs # use ospath.IsAbs which supports windows UNC paths
     - ioutil.Discard # use io.Discard
     - ioutil.NopCloser # use io.NopCloser
     - ioutil.ReadAll # use io.ReadAll
@@ -22,7 +23,6 @@ linters-settings:
     - time.Now # do not use outside of 'clock' and 'timetrack' packages use clock.Now or timetrack.StartTimer
     - time.Since # use timetrack.Timer.Elapsed()
     - time.Until # never use this
-    - filepath.IsAbs # use ospath.IsAbs which supports windows UNC paths
   gocognit:
     min-complexity: 40
   gci:
@@ -58,54 +58,54 @@ linters-settings:
         sizeThreshold: 160
     enabled-tags:
       - diagnostic
+      - experimental
+      - opinionated
       - performance
       - style
-      - opinionated
-      - experimental
     disabled-checks:
-      - wrapperFunc
       - whyNoLint
+      - wrapperFunc
+
 linters:
   enable-all: true
   disable:
-    - maligned
-    - tagliatelle
-    - golint
-    - interfacer
-    - scopelint
-    - prealloc
-    - gochecknoinits
-    - whitespace
-    - exhaustruct
-    - nonamedreturns
-    - nilnil
-    - ireturn # this one may be interesting to control allocations
-    - varnamelen # this one may be interesting, but too much churn
-    - nlreturn
-    - testpackage
-    - ifshort
     - exhaustivestruct
+    - exhaustruct
+    - gochecknoinits
+    - golint
+    - ifshort
+    - interfacer
+    - ireturn # this one may be interesting to control allocations
+    - maligned
+    - nilnil
+    - nlreturn
+    - nonamedreturns
     - paralleltest
+    - prealloc
+    - scopelint
+    - tagliatelle
+    - testpackage
     - tparallel
-
+    - varnamelen # this one may be interesting, but too much churn
+    - whitespace
 
 issues:
   exclude-use-default: false
   exclude-rules:
     - path: _test\.go|testing|tests|test_env|fshasher|fault
       linters:
-      - gomnd
-      - gocognit
-      - funlen
+      - contextcheck
       - errcheck
-      - gosec
-      - gochecknoglobals
-      - nestif
-      - wrapcheck
-      - nolintlint
       - errchkjson
       - forcetypeassert
-      - contextcheck
+      - funlen
+      - gochecknoglobals
+      - gocognit
+      - gomnd
+      - gosec
+      - nestif
+      - nolintlint
+      - wrapcheck
     - text: "log is a global variable"
       linters:
       - gochecknoglobals

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,11 +4,14 @@ run:
     - test/testdata_etc
 
 linters-settings:
-  govet:
-    check-shadowing: true
-  funlen:
-    lines: 100
-    statements: 60
+  cyclop:
+    max-complexity: 20
+    skip-tests: true
+  exhaustive:
+    # indicates that switch statements are to be considered exhaustive if a
+    # 'default' case is present, even if all enum members aren't listed in the
+    # switch
+    default-signifies-exhaustive: true
   forbidigo:
     forbid:
     - filepath.IsAbs # use ospath.IsAbs which supports windows UNC paths
@@ -23,34 +26,19 @@ linters-settings:
     - time.Now # do not use outside of 'clock' and 'timetrack' packages use clock.Now or timetrack.StartTimer
     - time.Since # use timetrack.Timer.Elapsed()
     - time.Until # never use this
-  gocognit:
-    min-complexity: 40
+  funlen:
+    lines: 100
+    statements: 60
   gci:
     sections:
     - standard
     - default
     - prefix(github.com/kopia/kopia)
-  gocyclo:
-    min-complexity: 15
-  cyclop:
-    max-complexity: 20
-    skip-tests: true
-  maligned:
-    suggest-new: true
+  gocognit:
+    min-complexity: 40
   goconst:
     min-len: 5
     min-occurrences: 3
-  exhaustive:
-    # indicates that switch statements are to be considered exhaustive if a
-    # 'default' case is present, even if all enum members aren't listed in the
-    # switch
-    default-signifies-exhaustive: true
-  misspell:
-    locale: US
-  lll:
-    line-length: 256
-  goimports:
-    local-prefixes: github.com/kopia/kopia
   gocritic:
     settings:
       hugeParam:
@@ -65,6 +53,18 @@ linters-settings:
     disabled-checks:
       - whyNoLint
       - wrapperFunc
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/kopia/kopia
+  govet:
+    check-shadowing: true
+  lll:
+    line-length: 256
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
 
 linters:
   enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,8 @@
 run:
-    go: 1.17
+  go: '1.17'
+  skip-dirs:
+    - test/testdata_etc
+
 linters-settings:
   govet:
     check-shadowing: true
@@ -85,9 +88,6 @@ linters:
     - paralleltest
     - tparallel
 
-run:
-  skip-dirs:
-    - test/testdata_etc
 
 issues:
   exclude-use-default: false


### PR DESCRIPTION
The `run` section was repeated.
`run.go` should be a string.

nits:
- alphabetically sort filters and checks
- alphabetically sort stanzas in `linters-settings` section
