### PR TITLE
feat(ui): Save page size

### DIFF
--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -274,6 +274,6 @@ type CLIInfo struct {
 
 // UIPreferences represents JSON object storing UI preferences.
 type UIPreferences struct {
-	Theme string `json:"theme"`    // 'dark', 'light' or ''
-	PageSize int `json:"pageSize"` // A page size; the actual possible values will only be provided by the frontend
+	Theme    string `json:"theme"`    // 'dark', 'light' or ''
+	PageSize int    `json:"pageSize"` // A page size; the actual possible values will only be provided by the frontend
 }

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -275,4 +275,5 @@ type CLIInfo struct {
 // UIPreferences represents JSON object storing UI preferences.
 type UIPreferences struct {
 	Theme string `json:"theme"` // 'dark', 'light' or ''
+	PageSize string `json:"pageSize"` // 'dark', 'light' or ''
 }

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -275,5 +275,5 @@ type CLIInfo struct {
 // UIPreferences represents JSON object storing UI preferences.
 type UIPreferences struct {
 	Theme string `json:"theme"` // 'dark', 'light' or ''
-	PageSize string `json:"pageSize"` // 'dark', 'light' or ''
+	PageSize int `json:"pageSize"` // A page size; the actual possible values will only be provided by the frontend
 }

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -274,6 +274,6 @@ type CLIInfo struct {
 
 // UIPreferences represents JSON object storing UI preferences.
 type UIPreferences struct {
-	Theme string `json:"theme"` // 'dark', 'light' or ''
+	Theme string `json:"theme"`    // 'dark', 'light' or ''
 	PageSize int `json:"pageSize"` // A page size; the actual possible values will only be provided by the frontend
 }


### PR DESCRIPTION
Also fixes #2060.

In general, this PR provides a server API to save the pageSize as UI preference. 
Other changes will be made in kopia/htmlui.