### PR TITLE
style(cli): rename restore `--sparse` to `--write-sparse-files`

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -101,7 +101,7 @@ type commandRestore struct {
 	restoreOverwriteDirectories   bool
 	restoreOverwriteFiles         bool
 	restoreOverwriteSymlinks      bool
-	restoreSparse                 bool
+	restoreWriteSparseFiles       bool
 	restoreConsistentAttributes   bool
 	restoreMode                   string
 	restoreParallel               int
@@ -126,7 +126,7 @@ func (c *commandRestore) setup(svc appServices, parent commandParent) {
 	cmd.Flag("overwrite-directories", "Overwrite existing directories").Default("true").BoolVar(&c.restoreOverwriteDirectories)
 	cmd.Flag("overwrite-files", "Specifies whether or not to overwrite already existing files").Default("true").BoolVar(&c.restoreOverwriteFiles)
 	cmd.Flag("overwrite-symlinks", "Specifies whether or not to overwrite already existing symlinks").Default("true").BoolVar(&c.restoreOverwriteSymlinks)
-	cmd.Flag("sparse", "When doing a restore, attempt to write files sparsely-allocating the minimum amount of disk space needed.").Default("false").BoolVar(&c.restoreSparse)
+	cmd.Flag("write-sparse-files", "When doing a restore, attempt to write files sparsely-allocating the minimum amount of disk space needed.").Default("false").BoolVar(&c.restoreWriteSparseFiles)
 	cmd.Flag("consistent-attributes", "When multiple snapshots match, fail if they have inconsistent attributes").Envar("KOPIA_RESTORE_CONSISTENT_ATTRIBUTES").BoolVar(&c.restoreConsistentAttributes)
 	cmd.Flag("mode", "Override restore mode").Default(restoreModeAuto).EnumVar(&c.restoreMode, restoreModeAuto, restoreModeLocal, restoreModeZip, restoreModeZipNoCompress, restoreModeTar, restoreModeTgz)
 	cmd.Flag("parallel", "Restore parallelism (1=disable)").Default("8").IntVar(&c.restoreParallel)
@@ -222,7 +222,7 @@ func (c *commandRestore) restoreOutput(ctx context.Context) (restore.Output, err
 			SkipOwners:             c.restoreSkipOwners,
 			SkipPermissions:        c.restoreSkipPermissions,
 			SkipTimes:              c.restoreSkipTimes,
-			Sparse:                 c.restoreSparse,
+			WriteSparseFiles:       c.restoreWriteSparseFiles,
 		}
 
 		if err := o.Init(); err != nil {

--- a/snapshot/restore/local_fs_output.go
+++ b/snapshot/restore/local_fs_output.go
@@ -88,8 +88,8 @@ type FilesystemOutput struct {
 	// SkipTimes when set to true causes restore to skip restoring modification times.
 	SkipTimes bool `json:"skipTimes"`
 
-	// Sparse when set to true causes the restored files to be sparse.
-	Sparse bool `json:"sparse"`
+	// WriteSparseFiles when set to true, write contents as sparse files, minimizing allocated disk space.
+	WriteSparseFiles bool `json:"writeSparseFiles"`
 
 	// copier is the StreamCopier to use for copying the actual bit stream to output.
 	// It is assigned at runtime based on the target filesystem and restore options.
@@ -99,7 +99,7 @@ type FilesystemOutput struct {
 // Init initializes the internal members of the filesystem writer output.
 // This method must be called before FilesystemOutput can be used.
 func (o *FilesystemOutput) Init() error {
-	c, err := getStreamCopier(context.TODO(), o.TargetPath, o.Sparse)
+	c, err := getStreamCopier(context.TODO(), o.TargetPath, o.WriteSparseFiles)
 	if err != nil {
 		return errors.Wrap(err, "unable to get stream copier")
 	}

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -722,7 +722,7 @@ func TestSnapshotSparseRestore(t *testing.T) {
 		snapID := si[0].Snapshots[0].SnapshotID
 		restoreFile := filepath.Join(restoreDir, c.name+"_restore")
 
-		e.RunAndExpectSuccess(t, "snapshot", "restore", snapID, "--sparse", restoreFile)
+		e.RunAndExpectSuccess(t, "snapshot", "restore", snapID, "--write-sparse-files", restoreFile)
 		verifyFileSize(t, restoreFile, c.rLog, c.rPhys)
 	}
 }


### PR DESCRIPTION
This breaking commit renames the sparse restore flag (used in
`kopia restore` and `kopia snapshot restore`) to conform more
with the naming precedents in the Kopia code.

The original motivation can be found here:
https://github.com/kopia/htmlui/pull/61#discussion_r899155054