### PR TITLE
feat(snapshots): added fs.Entry.Close which can be used to release any resources

### DIFF
--- a/fs/entry.go
+++ b/fs/entry.go
@@ -19,6 +19,7 @@ type Entry interface {
 	Owner() OwnerInfo
 	Device() DeviceInfo
 	LocalFilesystemPath() string // returns full local filesystem path or "" if not a local filesystem
+	Close()                      // closes or recycles any resources associated with the entry, must be idempotent
 }
 
 // OwnerInfo describes owner of a filesystem entry.

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -71,6 +71,9 @@ func (e *filesystemEntry) LocalFilesystemPath() string {
 	return e.fullPath()
 }
 
+func (e *filesystemEntry) Close() {
+}
+
 var _ os.FileInfo = (*filesystemEntry)(nil)
 
 func newEntry(fi os.FileInfo, prefix string) filesystemEntry {

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -62,6 +62,9 @@ func (e *virtualEntry) LocalFilesystemPath() string {
 	return ""
 }
 
+func (e *virtualEntry) Close() {
+}
+
 // staticDirectory is an in-memory implementation of fs.Directory.
 type staticDirectory struct {
 	virtualEntry

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -77,6 +77,9 @@ func (e *entry) LocalFilesystemPath() string {
 	return ""
 }
 
+func (e *entry) Close() {
+}
+
 // Directory is mock in-memory implementation of fs.Directory.
 type Directory struct {
 	entry

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -57,6 +57,9 @@ func (s *repositoryAllSources) SupportsMultipleIterations() bool {
 	return true
 }
 
+func (s *repositoryAllSources) Close() {
+}
+
 func (s *repositoryAllSources) Child(ctx context.Context, name string) (fs.Entry, error) {
 	// nolint:wrapcheck
 	return fs.IterateEntriesAndFindChild(ctx, s, name)

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -84,6 +84,9 @@ func (e *repositoryEntry) LocalFilesystemPath() string {
 	return ""
 }
 
+func (e *repositoryEntry) Close() {
+}
+
 type repositoryDirectory struct {
 	repositoryEntry
 
@@ -193,6 +196,13 @@ func (rd *repositoryDirectory) loadLocked(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (rd *repositoryDirectory) Close() {
+	rd.mu.Lock()
+	defer rd.mu.Unlock()
+
+	rd.dirEntries = nil
 }
 
 func (rf *repositoryFile) Open(ctx context.Context) (fs.Reader, error) {

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -61,6 +61,9 @@ func (s *sourceDirectories) SupportsMultipleIterations() bool {
 	return true
 }
 
+func (s *sourceDirectories) Close() {
+}
+
 func (s *sourceDirectories) Child(ctx context.Context, name string) (fs.Entry, error) {
 	// nolint:wrapcheck
 	return fs.IterateEntriesAndFindChild(ctx, s, name)

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -59,6 +59,9 @@ func (s *sourceSnapshots) SupportsMultipleIterations() bool {
 	return true
 }
 
+func (s *sourceSnapshots) Close() {
+}
+
 func (s *sourceSnapshots) Child(ctx context.Context, name string) (fs.Entry, error) {
 	// nolint:wrapcheck
 	return fs.IterateEntriesAndFindChild(ctx, s, name)


### PR DESCRIPTION
This is not used yet, but will be used to avoid allocation in performance-critical portions of the upload.
