### PR TITLE
feat(general): implemented custom log encoder for ZAP

### DIFF
--- a/internal/gather/gather_write_buffer_chunk_test.go
+++ b/internal/gather/gather_write_buffer_chunk_test.go
@@ -95,19 +95,19 @@ func TestTrackAllocation(t *testing.T) {
 
 	ctx := logging.WithLogger(context.Background(), logging.ToWriter(&log))
 	DumpStats(ctx)
-	require.Contains(t, log.String(), `"chunksAlive": 0`)
+	require.Contains(t, log.String(), `"chunksAlive":0`)
 	require.NotContains(t, log.String(), "leaked chunk")
 
 	tmp.Append([]byte{1, 2, 3})
 
 	log.Reset()
 	DumpStats(ctx)
-	require.Contains(t, log.String(), `"chunksAlive": 1`)
+	require.Contains(t, log.String(), `"chunksAlive":1`)
 	require.Contains(t, log.String(), "leaked chunk")
 
 	log.Reset()
 	tmp.Close()
 	DumpStats(ctx)
-	require.Contains(t, log.String(), `"chunksAlive": 0`)
+	require.Contains(t, log.String(), `"chunksAlive":0`)
 	require.NotContains(t, log.String(), "leaked chunk")
 }

--- a/internal/logfile/logfile_test.go
+++ b/internal/logfile/logfile_test.go
@@ -200,7 +200,7 @@ func verifyFileLogFormat(t *testing.T, fname string, re *regexp.Regexp) {
 	s := bufio.NewScanner(f)
 
 	for s.Scan() {
-		require.True(t, re.MatchString(s.Text()), "log line does not match the format: %v", s.Text())
+		require.True(t, re.MatchString(s.Text()), "log line does not match the format: %v (re %v)", s.Text(), re.String())
 	}
 }
 

--- a/internal/testlogging/printf.go
+++ b/internal/testlogging/printf.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/kopia/kopia/internal/zaplogutil"
 	"github.com/kopia/kopia/repo/logging"
 )
 
@@ -20,21 +21,7 @@ func PrintfLevel(printf func(msg string, args ...interface{}), prefix string, le
 
 	return zap.New(
 		zapcore.NewCore(
-			zapcore.NewConsoleEncoder(zapcore.EncoderConfig{
-				// Keys can be anything except the empty string.
-				TimeKey:        zapcore.OmitKey,
-				LevelKey:       zapcore.OmitKey,
-				NameKey:        zapcore.OmitKey,
-				CallerKey:      zapcore.OmitKey,
-				FunctionKey:    zapcore.OmitKey,
-				MessageKey:     "M",
-				StacktraceKey:  "S",
-				LineEnding:     zapcore.DefaultLineEnding,
-				EncodeLevel:    zapcore.CapitalLevelEncoder,
-				EncodeTime:     zapcore.ISO8601TimeEncoder,
-				EncodeDuration: zapcore.StringDurationEncoder,
-				EncodeCaller:   zapcore.ShortCallerEncoder,
-			}),
+			zaplogutil.NewStdConsoleEncoder(zaplogutil.StdConsoleEncoderConfig{}),
 			writer,
 			level,
 		),

--- a/internal/zaplogutil/zaplogutil.go
+++ b/internal/zaplogutil/zaplogutil.go
@@ -4,14 +4,19 @@ package zaplogutil
 import (
 	"time"
 
+	"go.uber.org/zap/buffer"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/kopia/kopia/internal/clock"
 )
 
+// PreciseLayout is a variant of time.RFC3339Nano but with microsecond precision
+// and trailing zeroes.
+const PreciseLayout = "2006-01-02T15:04:05.000000Z07:00"
+
 // PreciseTimeEncoder encodes the time as RFC3389 with 6 digits of sub-second precision.
 func PreciseTimeEncoder() zapcore.TimeEncoder {
-	return zapcore.TimeEncoderOfLayout("2006-01-02T15:04:05.000000Z07:00")
+	return zapcore.TimeEncoderOfLayout(PreciseLayout)
 }
 
 type theClock struct{}
@@ -35,4 +40,103 @@ func TimezoneAdjust(inner zapcore.TimeEncoder, isLocal bool) zapcore.TimeEncoder
 	return func(t time.Time, pae zapcore.PrimitiveArrayEncoder) {
 		inner(t.UTC(), pae)
 	}
+}
+
+// NewStdConsoleEncoder returns standardized console encoder which is optimized
+// for performance.
+func NewStdConsoleEncoder(ec StdConsoleEncoderConfig) zapcore.Encoder {
+	return &stdConsoleEncoder{zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		SkipLineEnding: true,
+	}), ec}
+}
+
+// StdConsoleEncoderConfig provides configurationfor NewStdConsoleEncoder.
+type StdConsoleEncoderConfig struct {
+	TimeLayout         string
+	LocalTime          bool
+	EmitLoggerName     bool
+	EmitLogLevel       bool
+	DoNotEmitInfoLevel bool
+	ColoredLogLevel    bool
+}
+
+// nolint:gochecknoglobals
+var bufPool = buffer.NewPool()
+
+type stdConsoleEncoder struct {
+	zapcore.Encoder // inherit JSON encoder
+
+	StdConsoleEncoderConfig
+}
+
+func (c *stdConsoleEncoder) Clone() zapcore.Encoder {
+	return &stdConsoleEncoder{
+		c.Encoder.Clone(),
+		c.StdConsoleEncoderConfig,
+	}
+}
+
+func (c *stdConsoleEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	line := bufPool.Get()
+
+	separator := ""
+
+	if c.TimeLayout != "" {
+		if c.LocalTime {
+			line.AppendTime(ent.Time.Local(), c.TimeLayout)
+		} else {
+			line.AppendTime(ent.Time.UTC(), c.TimeLayout)
+		}
+
+		separator = " "
+	}
+
+	if c.EmitLogLevel {
+		line.AppendString(separator)
+
+		if ent.Level != zapcore.InfoLevel || !c.DoNotEmitInfoLevel {
+			if c.ColoredLogLevel {
+				switch ent.Level {
+				case zapcore.DebugLevel:
+					line.AppendString("\x1b[35m") // magenta
+				case zapcore.WarnLevel:
+					line.AppendString("\x1b[33m") // yellow
+				default:
+					line.AppendString("\x1b[31m") // red
+				}
+
+				line.AppendString(ent.Level.CapitalString())
+				line.AppendString("\x1b[0m")
+			} else {
+				line.AppendString(ent.Level.CapitalString())
+			}
+
+			separator = " "
+		}
+	}
+
+	if ent.LoggerName != "" && c.EmitLoggerName {
+		line.AppendString(separator)
+		line.AppendString(ent.LoggerName)
+
+		separator = " "
+	}
+
+	line.AppendString(separator)
+	line.AppendString(ent.Message)
+
+	if line2, err := c.Encoder.EncodeEntry(ent, fields); err == nil {
+		if line2.Len() > 2 { // nolint:gomnd
+			line.AppendString("\t")
+			line.AppendString(line2.String())
+		}
+
+		line2.Free()
+	}
+
+	line.AppendString("\n")
+
+	return line, nil
 }

--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -187,7 +187,7 @@ func (c *committedContentIndex) merge(ctx context.Context, indexFiles []blob.ID)
 		return nil, nil, errors.Wrap(err, "unable to combine small indexes")
 	}
 
-	c.log.Debugf("combined %v into %v index segments", len(newMerged), len(mergedAndCombined))
+	c.log.Debugw("combined index segments", "original", len(newMerged), "merged", len(mergedAndCombined))
 
 	return mergedAndCombined, newUsedMap, nil
 }

--- a/repo/content/internal_logger.go
+++ b/repo/content/internal_logger.go
@@ -84,13 +84,9 @@ func (m *internalLogManager) NewLogger() *zap.SugaredLogger {
 	}
 
 	return zap.New(zapcore.NewCore(
-		zapcore.NewConsoleEncoder(zapcore.EncoderConfig{
-			TimeKey:          "t",
-			MessageKey:       "m",
-			NameKey:          "n",
-			EncodeTime:       zaplogutil.TimezoneAdjust(zaplogutil.PreciseTimeEncoder(), false),
-			EncodeDuration:   zapcore.StringDurationEncoder,
-			ConsoleSeparator: " ",
+		zaplogutil.NewStdConsoleEncoder(zaplogutil.StdConsoleEncoderConfig{
+			TimeLayout: zaplogutil.PreciseLayout,
+			LocalTime:  false,
 		}),
 		w, zap.DebugLevel), zap.WithClock(zaplogutil.Clock())).Sugar()
 }

--- a/repo/logging/logging.go
+++ b/repo/logging/logging.go
@@ -31,10 +31,6 @@ func Module(module string) func(ctx context.Context) Logger {
 // ToWriter returns LoggerFactory that uses given writer for log output (unadorned).
 func ToWriter(w io.Writer) LoggerFactory {
 	return zap.New(zapcore.NewCore(
-		zapcore.NewConsoleEncoder(zapcore.EncoderConfig{
-			MessageKey:     "m",
-			EncodeTime:     zaplogutil.TimezoneAdjust(zaplogutil.PreciseTimeEncoder(), false),
-			EncodeDuration: zapcore.StringDurationEncoder,
-		}),
+		zaplogutil.NewStdConsoleEncoder(zaplogutil.StdConsoleEncoderConfig{}),
 		zapcore.AddSync(w), zap.DebugLevel), zap.WithClock(zaplogutil.Clock())).Sugar().Named
 }

--- a/repo/logging/logging_test.go
+++ b/repo/logging/logging_test.go
@@ -33,8 +33,8 @@ func TestBroadcast(t *testing.T) {
 	require.Equal(t, []string{
 		"[first] A",
 		"[second] A",
-		"[first] S\t{\"b\": 123}",
-		"[second] S\t{\"b\": 123}",
+		"[first] S\t{\"b\":123}",
+		"[second] S\t{\"b\":123}",
 		"[first] B",
 		"[second] B",
 		"[first] C",
@@ -54,7 +54,7 @@ func TestWriter(t *testing.T) {
 	l.Errorf("C")
 	l.Warnf("W")
 
-	require.Equal(t, "A\nS\t{\"b\": 123}\nB\nC\nW\n", buf.String())
+	require.Equal(t, "A\nS\t{\"b\":123}\nB\nC\nW\n", buf.String())
 }
 
 func TestNullWriterModule(t *testing.T) {
@@ -79,7 +79,7 @@ func TestNonNullWriterModule(t *testing.T) {
 	l.Errorf("C")
 	l.Warnf("W")
 
-	require.Equal(t, "A\nS\t{\"b\": 123}\nB\nC\nW\n", buf.String())
+	require.Equal(t, "A\nS\t{\"b\":123}\nB\nC\nW\n", buf.String())
 }
 
 func BenchmarkLogger(b *testing.B) {


### PR DESCRIPTION
Turns out standard ConsoleEncoder is not optimized at all and we're
emitting up to 8 log entries per file. This change avoids massive
amount of allocations and brings in some latency reduction.

Backing up 100k files in a flat directory:

```
duration: current:7.8 baseline:7.9 change:-1.0 %
repo_size: current:1019954521.4 baseline:1019976318.9 change:-0.0 %
num_files: current:58.0 baseline:58.0 change:0%
avg_heap_objects: current:6682141.0 baseline:7508631.3 change:-11.0 %
avg_heap_bytes: current:845404672.0 baseline:867325413.9 change:-2.5 %
avg_ram: current:156.5 baseline:159.1 change:-1.7 %
max_ram: current:278.3 baseline:287.2 change:-3.1 %
avg_cpu: current:153.8 baseline:156.4 change:-1.7 %
max_cpu: current:298.4 baseline:297.1 change:+0.4 %
```

Backing up Linux 5.18.4:

```
duration: current:3.6 baseline:4.2 change:-14.2 %
repo_size: current:1081624213.7 baseline:1081635886.8 change:-0.0 %
num_files: current:60.0 baseline:60.0 change:0%
avg_heap_objects: current:5180192.3 baseline:5831270.7 change:-11.2 %
avg_heap_bytes: current:783468754.2 baseline:804350042.1 change:-2.6 %
avg_ram: current:239.0 baseline:240.6 change:-0.6 %
max_ram: current:384.8 baseline:368.0 change:+4.6 %
avg_cpu: current:259.8 baseline:230.8 change:+12.6 %
max_cpu: current:321.6 baseline:303.9 change:+5.9 %
```