### PR TITLE
docs(site): Changing Page Title from Installation to Download & Installation

### DIFF
--- a/site/content/docs/Installation/_index.md
+++ b/site/content/docs/Installation/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Installation"
-linkTitle: "Installation"
+title: "Download & Installation"
+linkTitle: "Download & Installation"
 weight: 20
 ---
 


### PR DESCRIPTION
We link to this page when telling people to download Kopia (see the download button at https://kopia.io), so it will be less confusing if we rename the page to "Download & Installation". We don't need to change the URL, just the title.