### PR TITLE
fix(ui): "Kopia UI" to "KopiaUI"

### DIFF
--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -28,7 +28,7 @@ function showRepoWindow(repoID) {
   let rw = new BrowserWindow({
     width: 1000,
     height: 700,
-    title: 'Kopia UI Loading...',
+    title: 'KopiaUI is Loading...',
     autoHideMenuBar: true,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),


### PR DESCRIPTION
Just removing the extra space

Related: https://github.com/kopia/htmlui/pull/84