### PR TITLE
fix(cli): fixed 'cache set' CLI regression due to kingpin change

### DIFF
--- a/cli/command_cache_set.go
+++ b/cli/command_cache_set.go
@@ -29,6 +29,7 @@ func (c *commandCacheSetParams) setup(svc appServices, parent commandParent) {
 	c.contentMinSweepAge = -1
 	c.metadataMinSweepAge = -1
 	c.indexMinSweepAge = -1
+	c.maxListCacheDuration = -1
 
 	cmd.Flag("cache-directory", "Directory where to store cache files").StringVar(&c.directory)
 	cmd.Flag("content-cache-size-mb", "Size of local content cache").PlaceHolder("MB").Default("-1").Int64Var(&c.contentCacheSizeMB)
@@ -36,7 +37,7 @@ func (c *commandCacheSetParams) setup(svc appServices, parent commandParent) {
 	cmd.Flag("metadata-cache-size-mb", "Size of local metadata cache").PlaceHolder("MB").Default("-1").Int64Var(&c.maxMetadataCacheSizeMB)
 	cmd.Flag("metadata-min-sweep-age", "Minimal age of metadata cache item to be subject to sweeping").DurationVar(&c.metadataMinSweepAge)
 	cmd.Flag("index-min-sweep-age", "Minimal age of index cache item to be subject to sweeping").DurationVar(&c.indexMinSweepAge)
-	cmd.Flag("max-list-cache-duration", "Duration of index cache").Default("-1ns").DurationVar(&c.maxListCacheDuration)
+	cmd.Flag("max-list-cache-duration", "Duration of index cache").DurationVar(&c.maxListCacheDuration)
 	cmd.Action(svc.repositoryWriterAction(c.run))
 	c.svc = svc
 }

--- a/cli/command_cache_set_test.go
+++ b/cli/command_cache_set_test.go
@@ -19,12 +19,18 @@ func TestCacheSet(t *testing.T) {
 	env.RunAndExpectFailure(t, "cache", "set")
 
 	ncd := testutil.TempDirectory(t)
+
+	env.RunAndExpectSuccess(t,
+		"cache", "set",
+		"--cache-directory", ncd,
+		"--max-list-cache-duration=55s",
+	)
+
 	env.RunAndExpectSuccess(t,
 		"cache", "set",
 		"--cache-directory", ncd,
 		"--content-cache-size-mb=33",
 		"--metadata-cache-size-mb=44",
-		"--max-list-cache-duration=55s",
 	)
 
 	out := env.RunAndExpectSuccess(t, "cache", "info")


### PR DESCRIPTION
This was caused by a default `-1ns` which is no longer supported in latest Kingpin.

The effect was that `kopia cache set` without `--max-list-cache-duration` would fail. Unforutnately test was passing that flag so it was missed during the upgrade of dependency.

This was likely caused by https://github.com/alecthomas/kingpin/pull/329