### PR TITLE
feat(cli): BREAKING CHANGE ensure `--checkpoint-interval` is <=45min

### DIFF
--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -55,7 +55,7 @@ func (c *commandSnapshotCreate) setup(svc appServices, parent commandParent) {
 	cmd.Arg("source", "Files or directories to create snapshot(s) of.").StringsVar(&c.snapshotCreateSources)
 	cmd.Flag("all", "Create snapshots for files or directories previously backed up by this user on this computer").BoolVar(&c.snapshotCreateAll)
 	cmd.Flag("upload-limit-mb", "Stop the backup process after the specified amount of data (in MB) has been uploaded.").PlaceHolder("MB").Default("0").Int64Var(&c.snapshotCreateCheckpointUploadLimitMB)
-	cmd.Flag("checkpoint-interval", "Frequency for creating periodic checkpoint.").DurationVar(&c.snapshotCreateCheckpointInterval)
+	cmd.Flag("checkpoint-interval", "Interval between periodic checkpoints (must be <= 45 minutes).").Hidden().DurationVar(&c.snapshotCreateCheckpointInterval)
 	cmd.Flag("description", "Free-form snapshot description.").StringVar(&c.snapshotCreateDescription)
 	cmd.Flag("fail-fast", "Fail fast when creating snapshot.").Envar(svc.EnvName("KOPIA_SNAPSHOT_FAIL_FAST")).BoolVar(&c.snapshotCreateFailFast)
 	cmd.Flag("force-hash", "Force hashing of source files for a given percentage of files [0.0 .. 100.0]").Default("0").Float64Var(&c.snapshotCreateForceHash)

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -1185,6 +1185,10 @@ func (u *Uploader) Upload(
 	u.Progress.UploadStarted()
 	defer u.Progress.UploadFinished()
 
+	if u.CheckpointInterval > DefaultCheckpointInterval {
+		return nil, errors.Errorf("checkpoint interval cannot be greater than %v", DefaultCheckpointInterval)
+	}
+
 	parallel := u.effectiveParallelFileReads(policyTree.EffectivePolicy())
 
 	uploadLog(ctx).Debugw("uploading", "source", sourceInfo, "previousManifests", len(previousManifests), "parallel", parallel)

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -110,6 +110,22 @@ func TestTagging(t *testing.T) {
 	}
 }
 
+func TestSnapshotInterval(t *testing.T) {
+	t.Parallel()
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	e.RunAndExpectFailure(t, "snapshot", "create", "--checkpoint-interval=1h", sharedTestDataDir1)
+	e.RunAndExpectFailure(t, "snapshot", "create", "--checkpoint-interval=46m", sharedTestDataDir1)
+	e.RunAndExpectFailure(t, "snapshot", "create", "--checkpoint-interval=45m1s", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "snapshot", "create", "--checkpoint-interval=45m", sharedTestDataDir1)
+}
+
 func TestTaggingBadTags(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Also hide the flag, since it's not recommended to be tweaked anyway.

The value of <=45m is very important for safety of the garbage collection algorithms - too long an interval between checkpoints could mean that GC treats contents in the middle of being uploaded as unused, because they are not reachable from any snapshots or checkpoints.

Fixes #2193