### PR TITLE
refactor(repository): moved upgrade lock intent from content to repo

### DIFF
--- a/repo/content/content_formatting_options.go
+++ b/repo/content/content_formatting_options.go
@@ -35,8 +35,6 @@ type FormattingOptions struct {
 	MasterKey  []byte `json:"masterKey,omitempty" kopia:"sensitive"` // master encryption key (SIV-mode encryption only)
 	MutableParameters
 
-	UpgradeLock *UpgradeLock `json:"upgradeLock,omitempty"` // declares the intent to lock the repository for exclusive access during upgrade
-
 	EnablePasswordChange bool `json:"enablePasswordChange"` // disables replication of kopia.repository blob in packs
 }
 

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -101,6 +101,8 @@ type LocalConfig struct {
 type repositoryObjectFormat struct {
 	content.FormattingOptions
 	object.Format
+
+	UpgradeLock *UpgradeLockIntent `json:"upgradeLock,omitempty"`
 }
 
 // writeToFile writes the config to a given file.

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -76,7 +76,7 @@ type DirectRepositoryWriter interface {
 	ContentManager() *content.WriteManager
 	SetParameters(ctx context.Context, m content.MutableParameters, blobcfg content.BlobCfgBlob) error
 	ChangePassword(ctx context.Context, newPassword string) error
-	SetUpgradeLockIntent(ctx context.Context, l content.UpgradeLock) (*content.UpgradeLock, error)
+	SetUpgradeLockIntent(ctx context.Context, l UpgradeLockIntent) (*UpgradeLockIntent, error)
 	CommitUpgrade(ctx context.Context) error
 	RollbackUpgrade(ctx context.Context) error
 }

--- a/repo/upgrade_lock_intent_test.go
+++ b/repo/upgrade_lock_intent_test.go
@@ -1,4 +1,4 @@
-package content_test
+package repo_test
 
 import (
 	"fmt"
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/clock"
-	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/repo"
 )
 
 func TestUpgradeLockIntentUpdatesWithAdvanceNotice(t *testing.T) {
-	oldLock := content.UpgradeLock{
+	oldLock := repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           clock.Now(),
 		AdvanceNoticeDuration:  time.Hour,
@@ -57,7 +57,7 @@ func TestUpgradeLockIntentUpdatesWithAdvanceNotice(t *testing.T) {
 }
 
 func TestUpgradeLockIntentUpdatesWithoutAdvanceNotice(t *testing.T) {
-	oldLock := content.UpgradeLock{
+	oldLock := repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           clock.Now(),
 		AdvanceNoticeDuration:  0, /* no advance notice */
@@ -77,7 +77,7 @@ func TestUpgradeLockIntentUpdatesWithoutAdvanceNotice(t *testing.T) {
 }
 
 func TestUpgradeLockIntentValidation(t *testing.T) {
-	var l content.UpgradeLock
+	var l repo.UpgradeLockIntent
 
 	require.EqualError(t, l.Validate(), "no owner-id set, it is required to set a unique owner-id")
 	l.OwnerID = "new-owner"
@@ -116,7 +116,7 @@ func TestUpgradeLockIntentValidation(t *testing.T) {
 func TestUpgradeLockIntentImmediateLock(t *testing.T) {
 	now := clock.Now()
 
-	var l *content.UpgradeLock
+	var l *repo.UpgradeLockIntent
 
 	// checking lock status on nil lock
 	locked, writersDrained := l.IsLocked(now)
@@ -127,7 +127,7 @@ func TestUpgradeLockIntentImmediateLock(t *testing.T) {
 	require.PanicsWithValue(t,
 		"writers have drained but we are not locked, this is not possible until the upgrade-lock intent is invalid",
 		func() {
-			tmp := content.UpgradeLock{
+			tmp := repo.UpgradeLockIntent{
 				OwnerID:                "",
 				CreationTime:           now,
 				AdvanceNoticeDuration:  1 * time.Hour,
@@ -139,7 +139,7 @@ func TestUpgradeLockIntentImmediateLock(t *testing.T) {
 			tmp.IsLocked(now.Add(2 * time.Hour))
 		})
 
-	l = &content.UpgradeLock{
+	l = &repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           now,
 		AdvanceNoticeDuration:  0, /* no advance notice */
@@ -182,7 +182,7 @@ func TestUpgradeLockIntentImmediateLock(t *testing.T) {
 
 func TestUpgradeLockIntentSufficientAdvanceLock(t *testing.T) {
 	now := clock.Now()
-	l := content.UpgradeLock{
+	l := repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           now,
 		AdvanceNoticeDuration:  6 * time.Hour,
@@ -249,7 +249,7 @@ func TestUpgradeLockIntentSufficientAdvanceLock(t *testing.T) {
 
 func TestUpgradeLockIntentInSufficientAdvanceLock(t *testing.T) {
 	now := clock.Now()
-	l := content.UpgradeLock{
+	l := repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           now,
 		AdvanceNoticeDuration:  20 * time.Minute, /* insufficient time to drain the writers */
@@ -288,12 +288,12 @@ func TestUpgradeLockIntentInSufficientAdvanceLock(t *testing.T) {
 func TestUpgradeLockIntentUpgradeTime(t *testing.T) {
 	now := clock.Now()
 
-	var l content.UpgradeLock
+	var l repo.UpgradeLockIntent
 
 	// checking time on nil lock
 	require.Equal(t, time.Time{}, l.UpgradeTime())
 
-	l = content.UpgradeLock{
+	l = repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           now,
 		AdvanceNoticeDuration:  20 * time.Minute, /* insufficient time to drain the writers */
@@ -304,7 +304,7 @@ func TestUpgradeLockIntentUpgradeTime(t *testing.T) {
 	}
 	require.Equal(t, now.Add(l.MaxPermittedClockDrift+2*l.IODrainTimeout), l.UpgradeTime())
 
-	l = content.UpgradeLock{
+	l = repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           now,
 		AdvanceNoticeDuration:  20 * time.Hour, /* sufficient time to drain the writers */
@@ -315,7 +315,7 @@ func TestUpgradeLockIntentUpgradeTime(t *testing.T) {
 	}
 	require.Equal(t, now.Add(l.AdvanceNoticeDuration), l.UpgradeTime())
 
-	l = content.UpgradeLock{
+	l = repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           now,
 		AdvanceNoticeDuration:  0, /* immediate lock */
@@ -328,7 +328,7 @@ func TestUpgradeLockIntentUpgradeTime(t *testing.T) {
 }
 
 func TestUpgradeLockIntentClone(t *testing.T) {
-	l := &content.UpgradeLock{
+	l := &repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           clock.Now(),
 		AdvanceNoticeDuration:  20 * time.Minute,

--- a/repo/upgrade_lock_test.go
+++ b/repo/upgrade_lock_test.go
@@ -33,7 +33,7 @@ func TestFormatUpgradeSetLock(t *testing.T) {
 	}})
 	formatBlockCacheDuration := env.Repository.ClientOptions().FormatBlobCacheDuration
 
-	l := &content.UpgradeLock{
+	l := &repo.UpgradeLockIntent{
 		CreationTime:           env.Repository.Time(),
 		AdvanceNoticeDuration:  15 * time.Hour,
 		IODrainTimeout:         formatBlockCacheDuration * 2,
@@ -73,7 +73,7 @@ func TestFormatUpgradeAlreadyUpgraded(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, content.MaxFormatVersion)
 	formatBlockCacheDuration := env.Repository.ClientOptions().FormatBlobCacheDuration
 
-	l := &content.UpgradeLock{
+	l := &repo.UpgradeLockIntent{
 		OwnerID:                "new-upgrade-owner",
 		CreationTime:           env.Repository.Time(),
 		AdvanceNoticeDuration:  0,
@@ -94,7 +94,7 @@ func TestFormatUpgradeCommit(t *testing.T) {
 	}})
 	formatBlockCacheDuration := env.Repository.ClientOptions().FormatBlobCacheDuration
 
-	l := &content.UpgradeLock{
+	l := &repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           env.Repository.Time(),
 		AdvanceNoticeDuration:  0,
@@ -121,7 +121,7 @@ func TestFormatUpgradeRollback(t *testing.T) {
 	}})
 	formatBlockCacheDuration := env.Repository.ClientOptions().FormatBlobCacheDuration
 
-	l := &content.UpgradeLock{
+	l := &repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           env.Repository.Time(),
 		AdvanceNoticeDuration:  0,
@@ -149,7 +149,7 @@ func TestFormatUpgradeMultipleLocksRollback(t *testing.T) {
 	}})
 	formatBlockCacheDuration := env.Repository.ClientOptions().FormatBlobCacheDuration
 
-	l := &content.UpgradeLock{
+	l := &repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           env.Repository.Time(),
 		AdvanceNoticeDuration:  0,
@@ -216,7 +216,7 @@ func TestFormatUpgradeMultipleLocksRollback(t *testing.T) {
 
 func TestFormatUpgradeFailureToBackupFormatBlobOnLock(t *testing.T) {
 	// this lock will be allowed by the backend to create backups
-	allowedLock := content.UpgradeLock{
+	allowedLock := repo.UpgradeLockIntent{
 		OwnerID:                "allowed-upgrade-owner",
 		CreationTime:           clock.Now(),
 		AdvanceNoticeDuration:  0,
@@ -351,7 +351,7 @@ func TestFormatUpgradeDuringOngoingWriteSessions(t *testing.T) {
 	writeObject(ctx, t, lw, o4Data, "o4")
 
 	formatBlockCacheDuration := env.Repository.ClientOptions().FormatBlobCacheDuration
-	l := content.UpgradeLock{
+	l := repo.UpgradeLockIntent{
 		OwnerID:                "upgrade-owner",
 		CreationTime:           env.Repository.Time(),
 		AdvanceNoticeDuration:  0,


### PR DESCRIPTION
There are no real `content` dependencies here and JSON at the repo level can store the upgrade lock in exactly the same way.