### PR TITLE
fix(cli): content sizes are already suffixed, so 'bytes' in the string is redundant.

### DIFF
--- a/snapshot/snapshotgc/gc.go
+++ b/snapshot/snapshotgc/gc.go
@@ -77,10 +77,10 @@ func Run(ctx context.Context, rep repo.DirectRepositoryWriter, gcDelete bool, sa
 
 		l := log(ctx)
 
-		l.Infof("GC found %v unused contents (%v bytes)", st.UnusedCount, units.BytesStringBase2(st.UnusedBytes))
-		l.Infof("GC found %v unused contents that are too recent to delete (%v bytes)", st.TooRecentCount, units.BytesStringBase2(st.TooRecentBytes))
-		l.Infof("GC found %v in-use contents (%v bytes)", st.InUseCount, units.BytesStringBase2(st.InUseBytes))
-		l.Infof("GC found %v in-use system-contents (%v bytes)", st.SystemCount, units.BytesStringBase2(st.SystemBytes))
+		l.Infof("GC found %v unused contents (%v)", st.UnusedCount, units.BytesStringBase2(st.UnusedBytes))
+		l.Infof("GC found %v unused contents that are too recent to delete (%v)", st.TooRecentCount, units.BytesStringBase2(st.TooRecentBytes))
+		l.Infof("GC found %v in-use contents (%v)", st.InUseCount, units.BytesStringBase2(st.InUseBytes))
+		l.Infof("GC found %v in-use system-contents (%v)", st.SystemCount, units.BytesStringBase2(st.SystemBytes))
 
 		if st.UnusedCount > 0 && !gcDelete {
 			return errors.Errorf("Not deleting because 'gcDelete' was not set")


### PR DESCRIPTION
Noticed that running maintenance produces logs like:
```text
...

GC found 32773 unused contents (12.7 GiB bytes)

...
```
Seems like the units are already suffixed appropriately, so the 'bytes' in the string is not required.