### PR TITLE
feat(providers): add AWS IAM as a credential provider for s3 storage

### DIFF
--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -334,6 +334,7 @@ func newStorage(ctx context.Context, opt *Options) (*s3Storage, error) {
 			},
 		},
 	)
+	
 	return newStorageWithCredentials(ctx, creds, opt)
 }
 


### PR DESCRIPTION
When kopia is used as a SDK for applications running inside AWS, IAM credentials cannot be directly leveraged. This PR addresses that need. Now, when running inside AWS environment, if instance role allows access to s3, then kopia will by default have s3 access (only via SDK). 

In the future, this can be done via CLI too. 