### PR TITLE
feat(repository): added `required features` to the repository

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -88,6 +88,8 @@ type appServices interface {
 	Stderr() io.Writer
 	stdin() io.Reader
 	onCtrlC(callback func())
+	onRepositoryFatalError(callback func(err error))
+	enableTestOnlyFlags() bool
 	EnvName(s string) string
 }
 
@@ -130,8 +132,9 @@ type App struct {
 	upgradeOwnerID      string
 	doNotWaitForUpgrade bool
 
-	currentAction   string
-	onExitCallbacks []func()
+	currentAction         string
+	onExitCallbacks       []func()
+	onFatalErrorCallbacks []func(err error)
 
 	// subcommands
 	blob        commandBlob
@@ -154,14 +157,21 @@ type App struct {
 	logs        commandLogs
 
 	// testability hooks
-	osExit         func(int) // allows replacing os.Exit() with custom code
-	stdinReader    io.Reader
-	stdoutWriter   io.Writer
-	stderrWriter   io.Writer
-	rootctx        context.Context // nolint:containedctx
-	loggerFactory  logging.LoggerFactory
-	simulatedCtrlC chan bool
-	envNamePrefix  string
+	testonlyIgnoreMissingRequiredFeatures bool
+
+	isInProcessTest bool
+	exitWithError   func(err error) // os.Exit() with 1 or 0 based on err
+	stdinReader     io.Reader
+	stdoutWriter    io.Writer
+	stderrWriter    io.Writer
+	rootctx         context.Context // nolint:containedctx
+	loggerFactory   logging.LoggerFactory
+	simulatedCtrlC  chan bool
+	envNamePrefix   string
+}
+
+func (c *App) enableTestOnlyFlags() bool {
+	return c.isInProcessTest || os.Getenv("KOPIA_TESTONLY_FLAGS") != ""
 }
 
 func (c *App) getProgress() *cliProgress {
@@ -226,7 +236,7 @@ func (c *App) setup(app *kingpin.Application) {
 
 	_ = app.Flag("help-full", "Show help for all commands, including hidden").Action(func(pc *kingpin.ParseContext) error {
 		_ = app.UsageForContextWithTemplate(pc, 0, kingpin.DefaultUsageTemplate)
-		os.Exit(0)
+		c.exitWithError(nil)
 		return nil
 	}).Bool()
 
@@ -247,6 +257,8 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("dump-allocator-stats", "Dump allocator stats at the end of execution.").Hidden().Envar(c.EnvName("KOPIA_DUMP_ALLOCATOR_STATS")).BoolVar(&c.dumpAllocatorStats)
 	app.Flag("upgrade-owner-id", "Repository format upgrade owner-id.").Hidden().Envar(c.EnvName("KOPIA_REPO_UPGRADE_OWNER_ID")).StringVar(&c.upgradeOwnerID)
 	app.Flag("upgrade-no-block", "Do not block when repository format upgrade is in progress, instead exit with a message.").Hidden().Default("false").Envar(c.EnvName("KOPIA_REPO_UPGRADE_NO_BLOCK")).BoolVar(&c.doNotWaitForUpgrade)
+
+	app.Flag("ignore-missing-required-features", "Open repository despite missing features (VERY DANGEROUS, ONLY FOR TESTING)").Hidden().BoolVar(&c.testonlyIgnoreMissingRequiredFeatures)
 
 	c.observability.setup(c, app)
 
@@ -308,7 +320,13 @@ func NewApp() *App {
 		},
 
 		// testability hooks
-		osExit:       os.Exit,
+		exitWithError: func(err error) {
+			if err != nil {
+				os.Exit(1)
+			} else {
+				os.Exit(0)
+			}
+		},
 		stdoutWriter: colorable.NewColorableStdout(),
 		stderrWriter: colorable.NewColorableStderr(),
 		stdinReader:  os.Stdin,
@@ -474,13 +492,13 @@ func (c *App) runAppWithContext(command *kingpin.CmdClause, cb func(ctx context.
 	if err != nil {
 		// print error in red
 		log(ctx).Errorf("%v", err.Error())
-		c.osExit(1)
+		c.exitWithError(err)
 	}
 
 	if len(c.trackReleasable) > 0 {
 		if err := releasable.Verify(); err != nil {
 			log(ctx).Warnf("%v", err.Error())
-			c.osExit(1)
+			c.exitWithError(err)
 		}
 	}
 
@@ -573,7 +591,7 @@ To run this command despite the warning, set --advanced-commands=enabled
 
 `)
 
-		c.osExit(1)
+		c.exitWithError(errors.Errorf("advanced commands are disabled"))
 	}
 }
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -258,7 +258,9 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("upgrade-owner-id", "Repository format upgrade owner-id.").Hidden().Envar(c.EnvName("KOPIA_REPO_UPGRADE_OWNER_ID")).StringVar(&c.upgradeOwnerID)
 	app.Flag("upgrade-no-block", "Do not block when repository format upgrade is in progress, instead exit with a message.").Hidden().Default("false").Envar(c.EnvName("KOPIA_REPO_UPGRADE_NO_BLOCK")).BoolVar(&c.doNotWaitForUpgrade)
 
-	app.Flag("ignore-missing-required-features", "Open repository despite missing features (VERY DANGEROUS, ONLY FOR TESTING)").Hidden().BoolVar(&c.testonlyIgnoreMissingRequiredFeatures)
+	if c.enableTestOnlyFlags() {
+		app.Flag("ignore-missing-required-features", "Open repository despite missing features (VERY DANGEROUS, ONLY FOR TESTING)").Hidden().BoolVar(&c.testonlyIgnoreMissingRequiredFeatures)
+	}
 
 	c.observability.setup(c, app)
 

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kopia/kopia/cli"
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/tests/testenv"
@@ -182,4 +183,49 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 	require.Contains(t, out, "Epoch checkpoint every:  9 epochs")
 
 	env.RunAndExpectSuccess(t, "index", "epoch", "list")
+}
+
+func (s *formatSpecificTestSuite) TestRepositorySetParametersRequiredFeatures(t *testing.T) {
+	env := s.setupInMemoryRepo(t)
+
+	env.RunAndExpectSuccess(t, "repository", "status")
+	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--add-required-feature", "no-such-feature")
+	env.RunAndExpectFailure(t, "repository", "status")
+	env.RunAndExpectSuccess(t, "repository", "status", "--ignore-missing-required-features")
+	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--remove-required-feature", "no-such-feature", "--ignore-missing-required-features")
+	env.RunAndExpectSuccess(t, "repository", "status")
+
+	// now require a feature but with a warning
+	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--add-required-feature", "no-such-feature", "--warn-on-missing-required-feature")
+	env.RunAndExpectSuccess(t, "repository", "status")
+	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--remove-required-feature", "no-such-feature")
+}
+
+func (s *formatSpecificTestSuite) TestRepositorySetParametersRequiredFeatures_ServerMode(t *testing.T) {
+	env := s.setupInMemoryRepo(t)
+
+	env.RunAndExpectSuccess(t, "repo", "set-client", "--repository-format-cache-duration=1s")
+
+	var sp testutil.ServerParameters
+
+	snapDir := testutil.TempDirectory(t)
+
+	// create a snapshot that will be created every second
+	env.RunAndExpectSuccess(t, "snapshot", "create", snapDir)
+	env.RunAndExpectSuccess(t, "policy", "set", "--snapshot-interval=1s", snapDir)
+
+	wait, _ := env.RunAndProcessStderr(t, sp.ProcessOutput,
+		"server", "start",
+		"--address=localhost:0",
+		"--server-control-password=admin-pwd",
+		"--tls-generate-cert",
+		"--tls-generate-rsa-key-size=2048", // use shorter key size to speed up generation
+	)
+
+	// now introduce required parameters while the server is running
+	env.RunAndExpectSuccess(t, "repository", "set-parameters", "--add-required-feature", "no-such-feature")
+
+	// we are aggressively creating snapshots every second,
+	// the server will soon notice the new required feature and shut down.
+	require.ErrorContains(t, wait(), "no-such-feature")
 }

--- a/cli/command_repository_status.go
+++ b/cli/command_repository_status.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -181,6 +182,8 @@ func (c *commandRepositoryStatus) run(ctx context.Context, rep repo.Repository) 
 	c.out.printStdout("Content compression: %v\n", dr.ContentReader().SupportsContentCompression())
 	c.out.printStdout("Password changes:    %v\n", contentFormat.SupportsPasswordChange())
 
+	c.outputRequiredFeatures(dr)
+
 	c.out.printStdout("Max pack length:     %v\n", units.BytesStringBase2(int64(contentFormat.MaxPackBlobSize())))
 	c.out.printStdout("Index Format:        v%v\n", contentFormat.WriteIndexVersion())
 
@@ -235,6 +238,18 @@ func (c *commandRepositoryStatus) run(ctx context.Context, rep repo.Repository) 
 	}
 
 	return nil
+}
+
+func (c *commandRepositoryStatus) outputRequiredFeatures(dr repo.DirectRepository) {
+	if req, _ := dr.RequiredFeatures(); len(req) > 0 {
+		var featureIDs []string
+
+		for _, r := range req {
+			featureIDs = append(featureIDs, string(r.Feature))
+		}
+
+		c.out.printStdout("Required Features:   %v\n", strings.Join(featureIDs, " "))
+	}
 }
 
 func scanCacheDir(dirname string) (fileCount int, totalFileLength int64, err error) {

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -251,6 +251,12 @@ func (c *commandRepositoryUpgrade) drainAllClients(ctx context.Context, rep repo
 // prior phases.
 func (c *commandRepositoryUpgrade) upgrade(ctx context.Context, rep repo.DirectRepositoryWriter) error {
 	mp := rep.ContentReader().ContentFormat().GetMutableParameters()
+
+	rf, err := rep.RequiredFeatures()
+	if err != nil {
+		return errors.Wrap(err, "error getting repository features")
+	}
+
 	if mp.EpochParameters.Enabled {
 		// nothing to upgrade on format, so let the next action commit the upgraded format blob
 		return nil
@@ -266,7 +272,7 @@ func (c *commandRepositoryUpgrade) upgrade(ctx context.Context, rep repo.DirectR
 	}
 
 	// update format-blob and clear the cache
-	if err := rep.SetParameters(ctx, mp, rep.BlobCfg()); err != nil {
+	if err := rep.SetParameters(ctx, mp, rep.BlobCfg(), rf); err != nil {
 		return errors.Wrap(err, "error setting parameters")
 	}
 

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -196,8 +196,14 @@ func (c *commandServerStart) run(ctx context.Context) error {
 	c.svc.onCtrlC(func() {
 		log(ctx).Infof("Shutting down...")
 
-		if err = httpServer.Shutdown(ctx); err != nil {
-			log(ctx).Debugf("unable to shut down: %v", err)
+		if serr := httpServer.Shutdown(ctx); serr != nil {
+			log(ctx).Debugf("unable to shut down: %v", serr)
+		}
+	})
+
+	c.svc.onRepositoryFatalError(func(_ error) {
+		if serr := httpServer.Shutdown(ctx); serr != nil {
+			log(ctx).Debugf("unable to shut down: %v", serr)
 		}
 	})
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -81,6 +81,8 @@ func (c *App) optionsFromFlags(ctx context.Context) *repo.Options {
 		// when a fatal error is encountered in the repository, run all registered callbacks
 		// and exit the program.
 		OnFatalError: func(err error) {
+			log(ctx).Debugf("onFatalError: %v", err)
+
 			for _, cb := range c.onFatalErrorCallbacks {
 				cb(err)
 			}

--- a/cli/config.go
+++ b/cli/config.go
@@ -25,6 +25,10 @@ func deprecatedFlag(w io.Writer, help string) func(_ *kingpin.ParseContext) erro
 	}
 }
 
+func (c *App) onRepositoryFatalError(f func(err error)) {
+	c.onFatalErrorCallbacks = append(c.onFatalErrorCallbacks, f)
+}
+
 func (c *App) onCtrlC(f func()) {
 	s := make(chan os.Signal, 1)
 	signal.Notify(s, os.Interrupt)
@@ -73,6 +77,18 @@ func (c *App) optionsFromFlags(ctx context.Context) *repo.Options {
 		DisableInternalLog:  c.disableInternalLog,
 		UpgradeOwnerID:      c.upgradeOwnerID,
 		DoNotWaitForUpgrade: c.doNotWaitForUpgrade,
+
+		// when a fatal error is encountered in the repository, run all registered callbacks
+		// and exit the program.
+		OnFatalError: func(err error) {
+			for _, cb := range c.onFatalErrorCallbacks {
+				cb(err)
+			}
+
+			c.exitWithError(err)
+		},
+
+		TestOnlyIgnoreMissingRequiredFeatures: c.testonlyIgnoreMissingRequiredFeatures,
 	}
 }
 

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -1,0 +1,71 @@
+// Package feature tracks features that are supported by Kopia client to ensure forwards and backwards
+// compatibility.
+package feature
+
+import (
+	"fmt"
+)
+
+// Behavior specifies how kopia should behave if it encounters a Feature it does not understand.
+type Behavior string
+
+// IfNotUnderstood describes the behavior of Kopia when a required feature is not understood.
+type IfNotUnderstood struct {
+	Warn             bool   `json:"warn"`                       // warn instead of failing
+	Message          string `json:"message,omitempty"`          // message to show to users
+	URL              string `json:"url,omitempty"`              // URL to show to users
+	UpgradeToVersion string `json:"upgradeToVersion,omitempty"` // suggest upgrading to a particular version
+}
+
+// Feature identifies a feature that particular Kopia client must understand.
+type Feature string
+
+// Required describes a single required feature that a client must understand
+// along with desired behavior when not understood.
+type Required struct {
+	Feature         Feature         `json:"feature"`
+	IfNotUnderstood IfNotUnderstood `json:"ifNotUnderstood"`
+}
+
+// UnsupportedMessage returns a message to display to users if the feature is unsupported.
+func (r Required) UnsupportedMessage() string {
+	msg := fmt.Sprintf("This version of Kopia does not support feature '%v'.", r.Feature)
+
+	if r.IfNotUnderstood.Message != "" {
+		msg += "\n" + r.IfNotUnderstood.Message
+	}
+
+	if r.IfNotUnderstood.URL != "" {
+		msg += "\nSee: " + r.IfNotUnderstood.URL
+	}
+
+	if r.IfNotUnderstood.UpgradeToVersion != "" {
+		msg += "\nPlease upgrade to version " + r.IfNotUnderstood.UpgradeToVersion + " or newer."
+	}
+
+	return msg
+}
+
+// GetUnsupportedFeatures compares the provided list of required features to the list of supported features
+// and returns the list of []RequireFeature that are not supported.
+func GetUnsupportedFeatures(required []Required, supported []Feature) []Required {
+	var result []Required
+
+	for _, req := range required {
+		if !isSupported(req, supported) {
+			result = append(result, req)
+		}
+	}
+
+	return result
+}
+
+func isSupported(req Required, supported []Feature) bool {
+	for _, s := range supported {
+		if req.Feature == s {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -1,0 +1,77 @@
+package feature_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/feature"
+)
+
+func TestFeature(t *testing.T) {
+	rf1 := feature.Required{
+		Feature: "f1",
+	}
+
+	rf2 := feature.Required{
+		Feature: "f2",
+	}
+
+	rf3 := feature.Required{
+		Feature: "f3",
+	}
+
+	cases := []struct {
+		required  []feature.Required
+		supported []feature.Feature
+		want      []feature.Required
+	}{
+		{nil, nil, nil},
+		{
+			[]feature.Required{rf1, rf2, rf3},
+			[]feature.Feature{"f1", "f2"},
+			[]feature.Required{rf3},
+		},
+		{
+			[]feature.Required{rf1},
+			[]feature.Feature{"f1", "f2"},
+			nil,
+		},
+		{
+			[]feature.Required{rf1, rf2, rf3},
+			[]feature.Feature{"f1", "f2", "f3"},
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, feature.GetUnsupportedFeatures(tc.required, tc.supported))
+	}
+}
+
+func TestFeatureUnsupportedMessage(t *testing.T) {
+	cases := map[feature.Required]string{
+		{
+			Feature:         "f1",
+			IfNotUnderstood: feature.IfNotUnderstood{},
+		}: "This version of Kopia does not support feature 'f1'.",
+		{
+			Feature: "f2",
+			IfNotUnderstood: feature.IfNotUnderstood{
+				URL: "http://some-url",
+			},
+		}: "This version of Kopia does not support feature 'f2'.\nSee: http://some-url",
+		{
+			Feature: "f3",
+			IfNotUnderstood: feature.IfNotUnderstood{
+				Message:          "Upgrade is required for better performance.",
+				URL:              "http://some-url",
+				UpgradeToVersion: "2.3.4",
+			},
+		}: "This version of Kopia does not support feature 'f3'.\nUpgrade is required for better performance.\nSee: http://some-url\nPlease upgrade to version 2.3.4 or newer.",
+	}
+
+	for input, want := range cases {
+		require.Equal(t, want, input.UnsupportedMessage())
+	}
+}

--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/atomicfile"
+	"github.com/kopia/kopia/internal/feature"
 	"github.com/kopia/kopia/internal/ospath"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/throttling"
@@ -102,7 +103,8 @@ type repositoryObjectFormat struct {
 	content.FormattingOptions
 	object.Format
 
-	UpgradeLock *UpgradeLockIntent `json:"upgradeLock,omitempty"`
+	UpgradeLock      *UpgradeLockIntent `json:"upgradeLock,omitempty"`
+	RequiredFeatures []feature.Required `json:"requiredFeatures,omitempty"`
 }
 
 // writeToFile writes the config to a given file.

--- a/repo/open.go
+++ b/repo/open.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kopia/kopia/internal/cache"
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/epoch"
+	"github.com/kopia/kopia/internal/feature"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/repo/blob"
@@ -28,6 +29,22 @@ import (
 	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/repo/object"
 )
+
+// The list below keeps track of features this version of Kopia supports for forwards compatibility.
+//
+// Repository can specify which features are required to open it and clients will refuse to open the
+// repository if they don't have all required features.
+//
+// In the future we'll be removing features from the list to deprecate them and this will ensure newer
+// versions of kopia won't be able to work with old, unmigrated repositories.
+//
+// The strings are arbitrary, but should be short, human-readable and immutable once a version
+// that starts requiring them is released.
+// nolint:gochecknoglobals
+var supportedFeatures = []feature.Feature{
+	"index-v1",
+	"index-v2",
+}
 
 // CacheDirMarkerFile is the name of the marker file indicating a directory contains Kopia caches.
 // See https://bford.info/cachedir/
@@ -73,6 +90,11 @@ type Options struct {
 	DisableInternalLog  bool             // Disable internal log
 	UpgradeOwnerID      string           // Owner-ID of any upgrade in progress, when this is not set the access may be restricted
 	DoNotWaitForUpgrade bool             // Disable the exponential forever backoff on an upgrade lock.
+
+	OnFatalError func(err error) // function to invoke when repository encounters a fatal error, usually invokes os.Exit
+
+	// test-only flags
+	TestOnlyIgnoreMissingRequiredFeatures bool // ignore missing features
 }
 
 // ErrInvalidPassword is returned when repository password is invalid.
@@ -95,6 +117,13 @@ func Open(ctx context.Context, configFile, password string, options *Options) (r
 
 	if options == nil {
 		options = &Options{}
+	}
+
+	if options.OnFatalError == nil {
+		options.OnFatalError = func(err error) {
+			log(ctx).Errorf("FATAL: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	configFile, err = filepath.Abs(configFile)
@@ -241,7 +270,7 @@ func ReadAndCacheRepoUpgradeLock(ctx context.Context, st blob.Storage, password 
 }
 
 // openWithConfig opens the repository with a given configuration, avoiding the need for a config file.
-// nolint:funlen,gocyclo
+// nolint:funlen,gocyclo,cyclop
 func openWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, password string, options *Options, cacheOpts *content.CachingOptions, configFile string) (DirectRepository, error) {
 	cacheOpts = cacheOpts.CloneOrDefault()
 	cmOpts := &content.ManagerOptions{
@@ -269,6 +298,10 @@ func openWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 		return !options.DoNotWaitForUpgrade && errors.Is(internalErr, ErrRepositoryUnavailableDueToUpgrageInProgress)
 	}); err != nil {
 		// nolint:wrapcheck
+		return nil, err
+	}
+
+	if err := handleMissingRequiredFeatures(ctx, ufb.repoConfig, options.TestOnlyIgnoreMissingRequiredFeatures); err != nil {
 		return nil, err
 	}
 
@@ -331,7 +364,7 @@ func openWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 
 	// background/interleaving upgrade lock storage monitor
 	st = upgradeLockMonitor(options.UpgradeOwnerID, st, password, cacheOpts, lc.FormatBlobCacheDuration,
-		ufb.cacheMTime, cmOpts.TimeNow)
+		ufb.cacheMTime, cmOpts.TimeNow, options.OnFatalError)
 
 	fop, err := content.NewFormattingOptionsProvider(fo, cmOpts.RepositoryFormatBytes)
 	if err != nil {
@@ -382,6 +415,23 @@ func openWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 	return dr, nil
 }
 
+func handleMissingRequiredFeatures(ctx context.Context, repoConfig *repositoryObjectFormat, ignoreErrors bool) error {
+	// See if the current version of Kopia supports all features required by the repository format.
+	// so we can safely fail to start in case repository has been upgraded to a new, incompatible version.
+	if missingFeatures := feature.GetUnsupportedFeatures(repoConfig.RequiredFeatures, supportedFeatures); len(missingFeatures) > 0 {
+		for _, mf := range missingFeatures {
+			if ignoreErrors || mf.IfNotUnderstood.Warn {
+				log(ctx).Warnf("%s", mf.UnsupportedMessage())
+			} else {
+				// by default, fail hard
+				return errors.Errorf("%s", mf.UnsupportedMessage())
+			}
+		}
+	}
+
+	return nil
+}
+
 func wrapLockingStorage(st blob.Storage, r content.BlobCfgBlob) blob.Storage {
 	// collect prefixes that need to be locked on put
 	var prefixes []string
@@ -421,6 +471,7 @@ func upgradeLockMonitor(
 	lockRefreshInterval time.Duration,
 	lastSync time.Time,
 	now func() time.Time,
+	onFatalError func(err error),
 ) blob.Storage {
 	var (
 		m        sync.RWMutex
@@ -447,6 +498,11 @@ func upgradeLockMonitor(
 
 		ufb, err := readAndCacheRepoConfig(ctx, st, password, cacheOpts, lockRefreshInterval)
 		if err != nil {
+			return err
+		}
+
+		if err := handleMissingRequiredFeatures(ctx, ufb.repoConfig, false); err != nil {
+			onFatalError(err)
 			return err
 		}
 

--- a/repo/open.go
+++ b/repo/open.go
@@ -364,7 +364,7 @@ func openWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 
 	// background/interleaving upgrade lock storage monitor
 	st = upgradeLockMonitor(options.UpgradeOwnerID, st, password, cacheOpts, lc.FormatBlobCacheDuration,
-		ufb.cacheMTime, cmOpts.TimeNow, options.OnFatalError)
+		ufb.cacheMTime, cmOpts.TimeNow, options.OnFatalError, options.TestOnlyIgnoreMissingRequiredFeatures)
 
 	fop, err := content.NewFormattingOptionsProvider(fo, cmOpts.RepositoryFormatBytes)
 	if err != nil {
@@ -472,6 +472,7 @@ func upgradeLockMonitor(
 	lastSync time.Time,
 	now func() time.Time,
 	onFatalError func(err error),
+	ignoreMissingRequiredFeatures bool,
 ) blob.Storage {
 	var (
 		m        sync.RWMutex
@@ -501,7 +502,7 @@ func upgradeLockMonitor(
 			return err
 		}
 
-		if err := handleMissingRequiredFeatures(ctx, ufb.repoConfig, false); err != nil {
+		if err := handleMissingRequiredFeatures(ctx, ufb.repoConfig, ignoreMissingRequiredFeatures); err != nil {
 			onFatalError(err)
 			return err
 		}

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/feature"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/throttling"
 	"github.com/kopia/kopia/repo/content"
@@ -65,6 +66,7 @@ type DirectRepository interface {
 	DeriveKey(purpose []byte, keyLength int) []byte
 	Token(password string) (string, error)
 	Throttler() throttling.SettableThrottler
+	RequiredFeatures() ([]feature.Required, error)
 	DisableIndexRefresh()
 }
 
@@ -74,7 +76,7 @@ type DirectRepositoryWriter interface {
 	DirectRepository
 	BlobStorage() blob.Storage
 	ContentManager() *content.WriteManager
-	SetParameters(ctx context.Context, m content.MutableParameters, blobcfg content.BlobCfgBlob) error
+	SetParameters(ctx context.Context, m content.MutableParameters, blobcfg content.BlobCfgBlob, requiredFeatures []feature.Required) error
 	ChangePassword(ctx context.Context, newPassword string) error
 	GetUpgradeLockIntent(ctx context.Context) (*UpgradeLockIntent, error)
 	SetUpgradeLockIntent(ctx context.Context, l UpgradeLockIntent) (*UpgradeLockIntent, error)

--- a/site/cli2md/cli2md.go
+++ b/site/cli2md/cli2md.go
@@ -45,6 +45,7 @@ func emitFlags(w io.Writer, flags []*kingpin.FlagModel) {
 
 	for _, f := range sortFlags(flags) {
 		maybeAdvanced := ""
+
 		if f.Hidden {
 			maybeAdvanced = "[ADV] "
 		}


### PR DESCRIPTION
This is intended for future compatibility to be able to reliably
stop old kopia client from being able to open a repository when
the old code does not understand new `required feature`.

Required features are checked on startup and periodically using the
same method as upgrade lock, where they will return errors during blob
operations.