### PR TITLE
test(general): Add a stress test for snapshot fix command

### DIFF
--- a/tests/recovery/blobmanipulator/blobmanipulator.go
+++ b/tests/recovery/blobmanipulator/blobmanipulator.go
@@ -1,0 +1,360 @@
+//go:build darwin || (linux && amd64)
+// +build darwin linux,amd64
+
+// Package blobmanipulator provides the framework for snapshot fix testing.
+package blobmanipulator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"math/rand"
+	"strconv"
+	"strings"
+
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/tests/robustness"
+	"github.com/kopia/kopia/tests/robustness/fiofilewriter"
+	"github.com/kopia/kopia/tests/robustness/snapmeta"
+	"github.com/kopia/kopia/tests/tools/fio"
+	"github.com/kopia/kopia/tests/tools/kopiarunner"
+)
+
+var (
+	errKopiaRepoNotFound  = errors.New("kopia repository does not exist")
+	errCreatingFileWriter = errors.New("could not create file writer")
+)
+
+// BlobManipulator provides a way to run a kopia command.
+type BlobManipulator struct {
+	KopiaCommandRunner *kopiarunner.KopiaSnapshotter
+	DirCreater         *snapmeta.KopiaSnapshotter
+	fileWriter         *fiofilewriter.FileWriter
+
+	DataRepoPath       string
+	CanRunMaintenance  bool
+	PathToTakeSnapshot string
+}
+
+// NewBlobManipulator instantiates a new BlobManipulator and returns its pointer.
+func NewBlobManipulator(baseDirPath string, dataRepoPath string) (*BlobManipulator, error) {
+	ks := getSnapshotter(baseDirPath, dataRepoPath)
+	if ks == nil {
+		return nil, nil
+	}
+
+	runner, err := kopiarunner.NewKopiaSnapshotter(baseDirPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BlobManipulator{
+		KopiaCommandRunner: runner,
+		DirCreater:         ks,
+	}, nil
+}
+
+func getSnapshotter(baseDirPath string, dataRepoPath string) *snapmeta.KopiaSnapshotter {
+	ks, err := snapmeta.NewSnapshotter(baseDirPath)
+	if err != nil {
+		if errors.Is(err, kopiarunner.ErrExeVariableNotSet) {
+			log.Println("Skipping recovery tests because KOPIA_EXE is not set")
+		} else {
+			log.Println("Error creating kopia Snapshotter:", err)
+		}
+
+		return nil
+	}
+
+	log.Println("Created snapmeta.KopiaSnapshotter")
+
+	if err = ks.ConnectOrCreateRepo(dataRepoPath); err != nil {
+		log.Println("Error initializing kopia Snapshotter:", err)
+		return nil
+	}
+
+	return ks
+}
+
+// ConnectOrCreateRepo connects to an existing repository if possible or creates a new one.
+func (bm *BlobManipulator) ConnectOrCreateRepo(dataRepoPath string) error {
+	if bm.KopiaCommandRunner == nil {
+		return errKopiaRepoNotFound
+	}
+
+	// return err
+	return bm.DirCreater.ConnectOrCreateRepo(bm.DataRepoPath)
+}
+
+// DeleteBlob deletes the provided blob or a random blob, in kopia repo.
+func (bm *BlobManipulator) DeleteBlob(blobID string) error {
+	if blobID == "" {
+		randomBlobID, err := bm.getBlobIDRand()
+		blobID = randomBlobID
+
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Printf("Deleting BLOB %s", blobID)
+
+	_, _, err := bm.KopiaCommandRunner.Run("blob", "delete", blobID, "--advanced-commands=enabled")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (bm *BlobManipulator) getBlobIDRand() (string, error) {
+	var b []blob.Metadata
+
+	// assumption: the repo under test is in filesystem
+	err := bm.KopiaCommandRunner.ConnectRepo("filesystem", "--path="+bm.DataRepoPath)
+	// err := bm.ConnectOrCreateRepo(bm.DataRepoPath)
+	if err != nil {
+		return "", err
+	}
+
+	blobIDList, _, err := bm.KopiaCommandRunner.Run("blob", "list", "--json")
+	if blobIDList == "" {
+		return "", robustness.ErrNoOp
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	err = json.Unmarshal([]byte(blobIDList), &b)
+	if err != nil {
+		return "", err
+	}
+
+	blobToBeDeleted := ""
+	// Select the first pack blob in the list
+	for _, s := range b {
+		temp := string(s.BlobID)
+		if strings.HasPrefix(temp, "p") {
+			blobToBeDeleted = temp
+			break
+		}
+	}
+
+	return blobToBeDeleted, nil
+}
+
+func (bm *BlobManipulator) getFileWriter() bool {
+	fw, err := fiofilewriter.New()
+	if err != nil {
+		if errors.Is(err, fio.ErrEnvNotSet) {
+			log.Println("Skipping recovery tests because FIO environment is not set")
+		} else {
+			log.Println("Error creating fio FileWriter:", err)
+		}
+
+		return false
+	}
+
+	bm.fileWriter = fw
+
+	return true
+}
+
+func (bm *BlobManipulator) writeRandomFiles(ctx context.Context, fileSize int, numFiles int) error {
+	// create random data
+	gotFileWriter := bm.getFileWriter()
+	if !gotFileWriter {
+		return errCreatingFileWriter
+	}
+
+	fileWriteOpts := map[string]string{
+		fiofilewriter.MaxDirDepthField:         strconv.Itoa(1),
+		fiofilewriter.MaxFileSizeField:         strconv.Itoa(fileSize),
+		fiofilewriter.MinFileSizeField:         strconv.Itoa(fileSize),
+		fiofilewriter.MaxNumFilesPerWriteField: strconv.Itoa(numFiles),
+		fiofilewriter.MinNumFilesPerWriteField: strconv.Itoa(numFiles),
+	}
+
+	_, err := bm.fileWriter.WriteRandomFiles(ctx, fileWriteOpts)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RestoreGivenOrRandomSnapshot restores a given or a random snapshot from kopia repository into the provided target directory.
+func (bm *BlobManipulator) RestoreGivenOrRandomSnapshot(snapID, restoreDir string) (string, error) {
+	err := bm.ConnectOrCreateRepo(bm.DataRepoPath)
+	if err != nil {
+		return "", err
+	}
+
+	if snapID == "" {
+		// list available snaphsots
+		stdout, _, snapshotListErr := bm.KopiaCommandRunner.Run("snapshot", "list", "--json")
+		if snapshotListErr != nil {
+			return stdout, snapshotListErr
+		}
+
+		var s []snapshot.Manifest
+
+		err = json.Unmarshal([]byte(stdout), &s)
+		if err != nil {
+			return "", err
+		}
+
+		// Select a random snapshot to restore
+		snapID = string(s[rand.Intn(len(s))].ID)
+	}
+
+	_, msg, err := bm.KopiaCommandRunner.Run("snapshot", "restore", snapID, restoreDir)
+	if err != nil {
+		// return the error message to parse the object ID to be used in snapshot fix command
+		return msg, err
+	}
+
+	return "", nil
+}
+
+// SetUpSystemUnderTest connects or creates a kopia repo, writes random data in source directory,
+// creates snapshots of the source directory.
+func (bm *BlobManipulator) SetUpSystemUnderTest() error {
+	fileSize := 100
+	numFiles := 100
+	ctx := context.Background()
+
+	err := bm.writeRandomFiles(ctx, fileSize, numFiles)
+	if err != nil {
+		return err
+	}
+
+	// create snapshot of the data
+	bm.PathToTakeSnapshot = bm.fileWriter.DataDirectory(ctx)
+	log.Printf("Creating snapshot of directory %s", bm.PathToTakeSnapshot)
+
+	_, _, err = bm.TakeSnapshot(bm.PathToTakeSnapshot)
+	if err != nil {
+		return err
+	}
+
+	numFiles = 50
+	err = bm.writeRandomFiles(ctx, fileSize, numFiles)
+	if err != nil {
+		return err
+	}
+
+	fileSize = 40 * 1024 * 1024
+	numFiles = 1
+
+	err = bm.writeRandomFiles(ctx, fileSize, numFiles)
+	if err != nil {
+		return err
+	}
+
+	// create snapshot of the data
+	log.Printf("Creating snapshot of directory %s", bm.PathToTakeSnapshot)
+
+	_, _, err = bm.TakeSnapshot(bm.PathToTakeSnapshot)
+	if err != nil {
+		return err
+	}
+
+	if bm.CanRunMaintenance {
+		bm.RunMaintenance()
+	}
+
+	return nil
+}
+
+// TakeSnapshot creates snapshot of the provided directory.
+func (bm *BlobManipulator) TakeSnapshot(dir string) (string, string, error) {
+	err := bm.KopiaCommandRunner.ConnectRepo("filesystem", "--path="+bm.DataRepoPath)
+	if err != nil {
+		return "", "", err
+	}
+
+	msg, stdout, err := bm.KopiaCommandRunner.Run("snapshot", "create", dir, "--json")
+	if err != nil {
+		return msg, stdout, err
+	}
+
+	var m snapshot.Manifest
+	err = json.Unmarshal([]byte(msg), &m)
+	if err != nil {
+		return "", "", err
+	}
+
+	return string(m.ID), stdout, nil
+	// return snapshot, "", nil
+}
+
+// DeleteSnapshot deletes provided snapshot.
+func (bm *BlobManipulator) DeleteSnapshot(snapshot string) (string, error) {
+	err := bm.ConnectOrCreateRepo(bm.DataRepoPath)
+	if err != nil {
+		return "", err
+	}
+
+	stdout, snapshot, err := bm.KopiaCommandRunner.Run("snapshot", "delete", snapshot, "--delete")
+	log.Println(snapshot)
+	if err != nil {
+		return stdout, err
+	}
+
+	return "", nil
+}
+
+// SnapshotFixRemoveFilesByBlobID runs snapshot fix remove-files command with a provided blob id.
+func (bm *BlobManipulator) SnapshotFixRemoveFilesByBlobID(blobID string) (string, error) {
+	// Get hold of object ID that can be used in the snapshot fix command
+	output, msg, err := bm.KopiaCommandRunner.Run("snapshot", "fix", "remove-files", "--object-id="+blobID, "--commit")
+	if err != nil {
+		log.Println(output, msg)
+		return output, err
+	}
+
+	return "", nil
+}
+
+// SnapshotFixRemoveFilesByFilename runs snapshot fix remove-files command with a provided file name.
+func (bm *BlobManipulator) SnapshotFixRemoveFilesByFilename(filename string) (string, error) {
+	// Get hold of the filename that can be used to in the snapshot fix command
+	stdout, msg, err := bm.KopiaCommandRunner.Run("snapshot", "fix", "remove-files", "--filename="+filename, "--commit")
+	if err != nil {
+		log.Println(stdout, msg)
+		return stdout, err
+	}
+
+	return "", nil
+}
+
+// SnapshotFixInvalidFiles runs snapshot fix invalid-files command with the provided flags.
+func (bm *BlobManipulator) SnapshotFixInvalidFiles(flags string) (string, error) {
+	stdout, msg, err := bm.KopiaCommandRunner.Run("snapshot", "fix", "invalid-files", flags, "--commit")
+	if err != nil {
+		log.Println(stdout, msg)
+		return stdout, err
+	}
+
+	return "", nil
+}
+
+// RunMaintenance runs repository maintenance.
+func (bm *BlobManipulator) RunMaintenance() (string, error) {
+	stdout, _, err := bm.KopiaCommandRunner.Run("maintenance", "set", "--full-interval", "2s")
+	if err != nil {
+		return stdout, err
+	}
+
+	// Run full maintenance, most likely calls blob gc
+	stdout, _, err = bm.KopiaCommandRunner.Run("maintenance", "run", "--full", "--force", "--safety", "none")
+
+	if err != nil {
+		return stdout, err
+	}
+
+	return "", nil
+}

--- a/tests/recovery/recovery_test/main_test.go
+++ b/tests/recovery/recovery_test/main_test.go
@@ -1,0 +1,37 @@
+//go:build darwin || (linux && amd64)
+// +build darwin linux,amd64
+
+package recovery
+
+import (
+	"flag"
+	"os"
+	"path"
+	"testing"
+)
+
+const (
+	dataSubPath = "recovery-data"
+)
+
+var repoPathPrefix = flag.String("repo-path-prefix", "/Users/chaitali.gondhalekar/Work/Kasten/kopia_dummy_repo/", "Point the robustness tests at this path prefix")
+
+func TestMain(m *testing.M) {
+	dataRepoPath := path.Join(*repoPathPrefix, dataSubPath)
+
+	th := &kopiaRecoveryTestHarness{}
+	th.init(dataRepoPath)
+
+	// run the tests
+	result := m.Run()
+
+	os.Exit(result)
+}
+
+type kopiaRecoveryTestHarness struct {
+	dataRepoPath string
+}
+
+func (th *kopiaRecoveryTestHarness) init(dataRepoPath string) {
+	th.dataRepoPath = dataRepoPath
+}

--- a/tests/recovery/recovery_test/recovery_test.go
+++ b/tests/recovery/recovery_test/recovery_test.go
@@ -1,0 +1,186 @@
+//go:build darwin || (linux && amd64)
+// +build darwin linux,amd64
+
+package recovery
+
+import (
+	"errors"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/tests/recovery/blobmanipulator"
+	"github.com/kopia/kopia/tests/tools/kopiarunner"
+)
+
+func TestSnapshotFix(t *testing.T) {
+	// assumption: the test is run on filesystem & not directly on object store
+	dataRepoPath := path.Join(*repoPathPrefix, dataSubPath)
+
+	baseDir := makeDir("base-dir-")
+	if baseDir == "" {
+		t.FailNow()
+	}
+
+	bm, err := blobmanipulator.NewBlobManipulator(baseDir, dataRepoPath)
+	if err != nil {
+		if errors.Is(err, kopiarunner.ErrExeVariableNotSet) {
+			t.Skip("Skipping recovery tests because KOPIA_EXE is not set")
+		} else {
+			t.Skip("Error creating Blob Manipulator:", err)
+		}
+	}
+
+	bm.DataRepoPath = dataRepoPath
+
+	// populate the kopia repo under test with random snapshots
+	bm.CanRunMaintenance = false
+	err = bm.SetUpSystemUnderTest()
+	if err != nil {
+		t.FailNow()
+	}
+
+	kopiaExe := os.Getenv("KOPIA_EXE")
+	cmd := exec.Command(kopiaExe, "maintenance", "run", "--full", "--force", "--safety", "none")
+	time.AfterFunc(10*time.Millisecond, func() {
+		syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
+	})
+	err = cmd.Start()
+
+	// delete random blob
+	// assumption: the repo contains "p" blobs to delete, else the test will fail
+	err = bm.DeleteBlob("")
+	if err != nil {
+		log.Println("Error deleting kopia blob: ", err)
+		t.FailNow()
+	}
+
+	// Create a temporary dir to restore a snapshot
+	restoreDir := makeDir("restore-data-")
+	if restoreDir == "" {
+		t.FailNow()
+	}
+
+	stdout, err := bm.RunMaintenance()
+	require.NoError(t, err)
+
+	// try to restore a snapshot, this should error out
+	stdout, err = bm.RestoreGivenOrRandomSnapshot("", restoreDir)
+	require.Error(t, err)
+
+	// extract out object ID needed to be used in snapshot fix command
+	blobID := getBlobIDToBeDeleted(stdout)
+
+	stdout, err = bm.SnapshotFixRemoveFilesByBlobID(blobID)
+	if err != nil {
+		log.Println("Error repairing the kopia repository:", stdout, err)
+		t.FailNow()
+	}
+
+	// restore a random snapshot
+	_, err = bm.RestoreGivenOrRandomSnapshot("", restoreDir)
+	require.NoError(t, err)
+}
+
+func TestSnapshotFixInvalidFiles(t *testing.T) {
+	// assumption: the test is run on filesystem & not directly on object store
+	dataRepoPath := path.Join(*repoPathPrefix, dataSubPath)
+
+	baseDir := makeDir("base-dir-")
+	if baseDir == "" {
+		t.FailNow()
+	}
+
+	bm, err := blobmanipulator.NewBlobManipulator(baseDir, dataRepoPath)
+	if err != nil {
+		if errors.Is(err, kopiarunner.ErrExeVariableNotSet) {
+			log.Println("Skipping recovery tests because KOPIA_EXE is not set")
+		} else {
+			log.Println("Error creating Blob Manipulator:", err)
+		}
+
+		t.FailNow()
+	}
+
+	bm.DataRepoPath = dataRepoPath
+
+	// populate the kopia repo under test with random snapshots
+	bm.CanRunMaintenance = false
+	err = bm.SetUpSystemUnderTest()
+	if err != nil {
+		t.FailNow()
+	}
+
+	kopiaExe := os.Getenv("KOPIA_EXE")
+	// cmd := exec.Command(kopiaExe, "snapshot", "create", bm.PathToTakeSnapshot)
+	cmd := exec.Command(kopiaExe, "maintenance", "run", "--full", "--force", "--safety", "none")
+	time.AfterFunc(10*time.Millisecond, func() {
+		syscall.Kill(cmd.Process.Pid, syscall.SIGKILL)
+	})
+	err = cmd.Start()
+
+	// delete random blob
+	// assumption: the repo contains "p" blobs to delete, else the test will fail
+	err = bm.DeleteBlob("")
+	if err != nil {
+		log.Println("Error deleting kopia blob: ", err)
+		t.FailNow()
+	}
+
+	// Create a temporary dir to restore a snapshot
+	restoreDir := makeDir("restore-data-")
+	if restoreDir == "" {
+		t.FailNow()
+	}
+
+	// try to restore a snapshot, this should error out
+	stdout, err := bm.RestoreGivenOrRandomSnapshot("", restoreDir)
+	require.Error(t, err)
+
+	// fix all the invalid files
+	stdout, err = bm.SnapshotFixInvalidFiles("--verify-files-percent=100")
+	if err != nil {
+		log.Println("Error repairing the kopia repository:", stdout, err)
+		t.FailNow()
+	}
+
+	// restore a random snapshot
+	_, err = bm.RestoreGivenOrRandomSnapshot("", restoreDir)
+	require.NoError(t, err)
+}
+
+func makeDir(dirName string) string {
+	baseDir, err := os.MkdirTemp("", dirName)
+	if err != nil {
+		log.Println("Error creating temp dir:", err)
+		return ""
+	}
+
+	return baseDir
+}
+
+func getBlobIDToBeDeleted(stdout string) string {
+	s1 := strings.Split(stdout, ":")
+
+	wantedIndex := -1
+
+	for i, s := range s1 {
+		if strings.Contains(s, "unable to open object") {
+			wantedIndex = i + 1
+			break
+		}
+	}
+
+	if wantedIndex == -1 {
+		return ""
+	}
+
+	return strings.TrimSpace(s1[wantedIndex])
+}


### PR DESCRIPTION
This PR adds a new test package to stress test snapshot fix command. The motivation is to simulate the issue of repository corruption encountered in the field and to verify whether snapshot fix command can successfully repair the repository.

The test
1. creates a kopia repository in file system
2. generates random data to be used as source data for snapshots
3. creates multiple snapshots
4. runs kopia maintenance command and tries to kill it during execution 
5. deletes a random pack blob to simulate repository corruption
6. uses snapshot fix command to repair the repository
7. verifies that the repository is operational after the repair
The orchestration script recovery-job.sh can be used to run the test in a pipeline.

Testing repository in object store is a future task.