### PR TITLE
refactor(repository): introduce interface for reading FormattingOptions

### DIFF
--- a/cli/command_repository_set_parameters.go
+++ b/cli/command_repository_set_parameters.go
@@ -113,7 +113,7 @@ func (c *commandRepositorySetParameters) setRetentionModeParameter(ctx context.C
 func (c *commandRepositorySetParameters) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
 	var anyChange bool
 
-	mp := rep.ContentReader().ContentFormat().MutableParameters
+	mp := rep.ContentReader().ContentFormat().GetMutableParameters()
 	blobcfg := rep.BlobCfg()
 
 	upgradeToEpochManager := false

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -122,7 +122,7 @@ func (c *commandRepositoryUpgrade) setLockIntent(ctx context.Context, rep repo.D
 	}
 
 	now := rep.Time()
-	mp := rep.ContentReader().ContentFormat().MutableParameters
+	mp := rep.ContentReader().ContentFormat().GetMutableParameters()
 	openOpts := c.svc.optionsFromFlags(ctx)
 	l := &repo.UpgradeLockIntent{
 		OwnerID:                openOpts.UpgradeOwnerID,
@@ -163,7 +163,7 @@ func (c *commandRepositoryUpgrade) setLockIntent(ctx context.Context, rep repo.D
 // skipped until the lock is fully established.
 func (c *commandRepositoryUpgrade) drainOrCommit(ctx context.Context, rep repo.DirectRepositoryWriter) error {
 	cf := rep.ContentReader().ContentFormat()
-	if cf.MutableParameters.EpochParameters.Enabled {
+	if cf.GetEpochManagerEnabled() {
 		log(ctx).Infof("Repository indices have already been migrated to the epoch format, no need to drain other clients")
 
 		l, err := rep.GetUpgradeLockIntent(ctx)
@@ -250,7 +250,7 @@ func (c *commandRepositoryUpgrade) drainAllClients(ctx context.Context, rep repo
 // repository. This phase runs after the lock has been acquired in one of the
 // prior phases.
 func (c *commandRepositoryUpgrade) upgrade(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	mp := rep.ContentReader().ContentFormat().MutableParameters
+	mp := rep.ContentReader().ContentFormat().GetMutableParameters()
 	if mp.EpochParameters.Enabled {
 		// nothing to upgrade on format, so let the next action commit the upgraded format blob
 		return nil

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -92,7 +92,7 @@ func newTestEnv(t *testing.T) *epochManagerTestEnv {
 	st = fs
 	st = logging.NewWrapper(st, testlogging.NewTestLogger(t), "[STORAGE] ")
 	te := &epochManagerTestEnv{unloggedst: unloggedst, st: st, ft: ft}
-	m := NewManager(te.st, Parameters{
+	m := NewManager(te.st, &Parameters{
 		Enabled:                 true,
 		EpochRefreshFrequency:   20 * time.Minute,
 		FullCheckpointFrequency: 7,
@@ -121,7 +121,7 @@ func (te *epochManagerTestEnv) another() *epochManagerTestEnv {
 		faultyStorage: te.faultyStorage,
 	}
 
-	te2.mgr = NewManager(te2.st, te.mgr.Params, te2.compact, te.mgr.log, te.mgr.timeFunc)
+	te2.mgr = NewManager(te2.st, te.mgr.Parameters, te2.compact, te.mgr.log, te.mgr.timeFunc)
 
 	return te2
 }
@@ -577,7 +577,7 @@ func verifySequentialWrites(t *testing.T, te *epochManagerTestEnv) {
 func TestIndexEpochManager_Disabled(t *testing.T) {
 	te := newTestEnv(t)
 
-	te.mgr.Params.Enabled = false
+	(te.mgr.Parameters).(*Parameters).Enabled = false
 
 	_, err := te.mgr.Current(testlogging.Context(t))
 	require.Error(t, err)

--- a/internal/server/api_repo.go
+++ b/internal/server/api_repo.go
@@ -34,8 +34,8 @@ func handleRepoParameters(ctx context.Context, rc requestContext) (interface{}, 
 	}
 
 	rp := &remoterepoapi.Parameters{
-		HashFunction:               dr.ContentReader().ContentFormat().Hash,
-		HMACSecret:                 dr.ContentReader().ContentFormat().HMACSecret,
+		HashFunction:               dr.ContentReader().ContentFormat().GetHashFunction(),
+		HMACSecret:                 dr.ContentReader().ContentFormat().GetHmacSecret(),
 		Format:                     dr.ObjectFormat(),
 		SupportsContentCompression: dr.ContentReader().SupportsContentCompression(),
 	}
@@ -56,9 +56,9 @@ func handleRepoStatus(ctx context.Context, rc requestContext) (interface{}, *api
 		return &serverapi.StatusResponse{
 			Connected:                  true,
 			ConfigFile:                 dr.ConfigFilename(),
-			Hash:                       dr.ContentReader().ContentFormat().Hash,
-			Encryption:                 dr.ContentReader().ContentFormat().Encryption,
-			MaxPackSize:                dr.ContentReader().ContentFormat().MaxPackSize,
+			Hash:                       dr.ContentReader().ContentFormat().GetHashFunction(),
+			Encryption:                 dr.ContentReader().ContentFormat().GetEncryptionAlgorithm(),
+			MaxPackSize:                dr.ContentReader().ContentFormat().MaxPackBlobSize(),
 			Splitter:                   dr.ObjectFormat().Splitter,
 			Storage:                    dr.BlobReader().ConnectionInfo().Type,
 			ClientOptions:              dr.ClientOptions(),

--- a/internal/server/grpc_session.go
+++ b/internal/server/grpc_session.go
@@ -459,8 +459,8 @@ func (s *Server) handleInitialSessionHandshake(srv grpcapi.KopiaRepository_Sessi
 		Response: &grpcapi.SessionResponse_InitializeSession{
 			InitializeSession: &grpcapi.InitializeSessionResponse{
 				Parameters: &grpcapi.RepositoryParameters{
-					HashFunction:               dr.ContentReader().ContentFormat().Hash,
-					HmacSecret:                 dr.ContentReader().ContentFormat().HMACSecret,
+					HashFunction:               dr.ContentReader().ContentFormat().GetHashFunction(),
+					HmacSecret:                 dr.ContentReader().ContentFormat().GetHmacSecret(),
 					Splitter:                   dr.ObjectFormat().Splitter,
 					SupportsContentCompression: dr.ContentReader().SupportsContentCompression(),
 				},

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -100,7 +100,7 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 	keyTime := map[blob.ID]time.Time{}
 	st := blobtesting.NewMapStorage(data, keyTime, nil)
 
-	bm, err := NewManagerForTesting(testlogging.Context(t), st, &FormattingOptions{
+	bm, err := NewManagerForTesting(testlogging.Context(t), st, mustCreateFormatProvider(t, &FormattingOptions{
 		Hash:       hashAlgo,
 		Encryption: encryptionAlgo,
 		HMACSecret: hmacSecret,
@@ -109,7 +109,7 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 			MaxPackSize: maxPackSize,
 		},
 		MasterKey: make([]byte, 32), // zero key, does not matter
-	}, nil, nil)
+	}), nil, nil)
 	if err != nil {
 		t.Errorf("can't create content manager with hash %v and encryption %v: %v", hashAlgo, encryptionAlgo, err.Error())
 		return
@@ -158,4 +158,13 @@ func verifyEndToEndFormatter(ctx context.Context, t *testing.T, hashAlgo, encryp
 			return
 		}
 	}
+}
+
+func mustCreateFormatProvider(t *testing.T, f *FormattingOptions) FormattingOptionsProvider {
+	t.Helper()
+
+	fop, err := NewFormattingOptionsProvider(f, nil)
+	require.NoError(t, err)
+
+	return fop
 }

--- a/repo/content/content_index_recovery.go
+++ b/repo/content/content_index_recovery.go
@@ -22,7 +22,7 @@ func (bm *WriteManager) RecoverIndexFromPackBlob(ctx context.Context, packFile b
 		return nil, err
 	}
 
-	ndx, err := index.Open(localIndexBytes.Bytes().ToByteSlice(), nil, uint32(bm.crypter.Encryptor.Overhead()))
+	ndx, err := index.Open(localIndexBytes.Bytes().ToByteSlice(), nil, uint32(bm.format.Crypter().Encryptor.Overhead()))
 	if err != nil {
 		return nil, errors.Errorf("unable to open index in file %v", packFile)
 	}
@@ -171,7 +171,7 @@ func decodePostamble(payload []byte) *packContentPostamble {
 }
 
 func (sm *SharedManager) buildLocalIndex(pending index.Builder, output *gather.WriteBuffer) error {
-	if err := pending.Build(output, sm.indexVersion); err != nil {
+	if err := pending.Build(output, sm.format.WriteIndexVersion()); err != nil {
 		return errors.Wrap(err, "unable to build local index")
 	}
 
@@ -195,7 +195,7 @@ func (sm *SharedManager) appendPackFileIndexRecoveryData(pending index.Builder, 
 	var encryptedLocalIndex gather.WriteBuffer
 	defer encryptedLocalIndex.Close()
 
-	if err := sm.crypter.Encryptor.Encrypt(localIndex.Bytes(), localIndexIV, &encryptedLocalIndex); err != nil {
+	if err := sm.format.Crypter().Encryptor.Encrypt(localIndex.Bytes(), localIndexIV, &encryptedLocalIndex); err != nil {
 		return errors.Wrap(err, "encryption error")
 	}
 

--- a/repo/content/content_manager_indexes.go
+++ b/repo/content/content_manager_indexes.go
@@ -38,7 +38,7 @@ func (sm *SharedManager) Refresh(ctx context.Context) error {
 
 	sm.log.Debugf("Refresh started")
 
-	sm.indexBlobManager.invalidate(ctx)
+	sm.indexBlobManager().invalidate(ctx)
 
 	timer := timetrack.StartTimer()
 
@@ -57,7 +57,7 @@ func (sm *SharedManager) CompactIndexes(ctx context.Context, opt CompactOptions)
 
 	sm.log.Debugf("CompactIndexes(%+v)", opt)
 
-	if err := sm.indexBlobManager.compact(ctx, opt); err != nil {
+	if err := sm.indexBlobManager().compact(ctx, opt); err != nil {
 		return errors.Wrap(err, "error performing compaction")
 	}
 

--- a/repo/content/content_reader.go
+++ b/repo/content/content_reader.go
@@ -9,7 +9,7 @@ import (
 // Reader defines content read API.
 type Reader interface {
 	SupportsContentCompression() bool
-	ContentFormat() FormattingOptions
+	ContentFormat() FormattingOptionsProvider
 	GetContent(ctx context.Context, id ID) ([]byte, error)
 	ContentInfo(ctx context.Context, id ID) (Info, error)
 	IterateContents(ctx context.Context, opts IterateOptions, callback IterateCallback) error

--- a/repo/content/encrypted_blob_mgr.go
+++ b/repo/content/encrypted_blob_mgr.go
@@ -12,10 +12,10 @@ import (
 )
 
 type encryptedBlobMgr struct {
-	st             blob.Storage
-	crypter        *Crypter
-	indexBlobCache *cache.PersistentCache
-	log            logging.Logger
+	st              blob.Storage
+	crypterProvider CrypterProvider
+	indexBlobCache  *cache.PersistentCache
+	log             logging.Logger
 }
 
 func (m *encryptedBlobMgr) getEncryptedBlob(ctx context.Context, blobID blob.ID, output *gather.WriteBuffer) error {
@@ -29,14 +29,14 @@ func (m *encryptedBlobMgr) getEncryptedBlob(ctx context.Context, blobID blob.ID,
 		return errors.Wrap(err, "getContent")
 	}
 
-	return m.crypter.DecryptBLOB(payload.Bytes(), blobID, output)
+	return m.crypterProvider.Crypter().DecryptBLOB(payload.Bytes(), blobID, output)
 }
 
 func (m *encryptedBlobMgr) encryptAndWriteBlob(ctx context.Context, data gather.Bytes, prefix blob.ID, sessionID SessionID) (blob.Metadata, error) {
 	var data2 gather.WriteBuffer
 	defer data2.Close()
 
-	blobID, err := m.crypter.EncryptBLOB(data, prefix, sessionID, &data2)
+	blobID, err := m.crypterProvider.Crypter().EncryptBLOB(data, prefix, sessionID, &data2)
 	if err != nil {
 		return blob.Metadata{}, errors.Wrap(err, "error encrypting")
 	}

--- a/repo/content/encrypted_blob_mgr_test.go
+++ b/repo/content/encrypted_blob_mgr_test.go
@@ -43,10 +43,10 @@ func TestEncryptedBlobManager(t *testing.T) {
 	}
 
 	ebm := encryptedBlobMgr{
-		st:             fs,
-		crypter:        cr,
-		indexBlobCache: nil,
-		log:            logging.NullLogger,
+		st:              fs,
+		crypterProvider: staticCrypterProvider{cr},
+		indexBlobCache:  nil,
+		log:             logging.NullLogger,
 	}
 
 	ctx := testlogging.Context(t)
@@ -84,4 +84,12 @@ func TestEncryptedBlobManager(t *testing.T) {
 
 	_, err = ebm.encryptAndWriteBlob(ctx, gather.FromSlice([]byte{1, 2, 3, 4}), "x", "session1")
 	require.ErrorIs(t, err, someError2)
+}
+
+type staticCrypterProvider struct {
+	theCrypter *Crypter
+}
+
+func (p staticCrypterProvider) Crypter() *Crypter {
+	return p.theCrypter
 }

--- a/repo/content/index_blob_manager_v0_test.go
+++ b/repo/content/index_blob_manager_v0_test.go
@@ -794,16 +794,14 @@ func newIndexBlobManagerForTesting(t *testing.T, st blob.Storage, localTimeNow f
 		enc: &encryptedBlobMgr{
 			st:             st,
 			indexBlobCache: nil,
-			crypter: &Crypter{
+			crypterProvider: staticCrypterProvider{&Crypter{
 				HashFunction: hf,
 				Encryptor:    enc,
-			},
+			}},
 			log: log,
 		},
-		timeNow:      localTimeNow,
-		maxPackSize:  20 << 20,
-		indexVersion: 1,
-		log:          log,
+		timeNow: localTimeNow,
+		log:     log,
 	}
 
 	return m

--- a/repo/content/index_blob_manager_v1.go
+++ b/repo/content/index_blob_manager_v1.go
@@ -16,14 +16,12 @@ import (
 )
 
 type indexBlobManagerV1 struct {
-	st             blob.Storage
-	enc            *encryptedBlobMgr
-	epochMgr       *epoch.Manager
-	timeNow        func() time.Time
-	log            logging.Logger
-	maxPackSize    int
-	indexVersion   int
-	indexShardSize int
+	st                blob.Storage
+	enc               *encryptedBlobMgr
+	epochMgr          *epoch.Manager
+	timeNow           func() time.Time
+	log               logging.Logger
+	formattingOptions IndexFormattingOptions
 }
 
 func (m *indexBlobManagerV1) listActiveIndexBlobs(ctx context.Context) ([]IndexBlobInfo, time.Time, error) {
@@ -70,7 +68,7 @@ func (m *indexBlobManagerV1) compactEpoch(ctx context.Context, blobIDs []blob.ID
 		}
 	}
 
-	dataShards, cleanupShards, err := tmpbld.BuildShards(m.indexVersion, true, m.indexShardSize)
+	dataShards, cleanupShards, err := tmpbld.BuildShards(m.formattingOptions.WriteIndexVersion(), true, m.formattingOptions.IndexShardSize())
 	if err != nil {
 		return errors.Wrap(err, "unable to build index dataShards")
 	}
@@ -91,7 +89,7 @@ func (m *indexBlobManagerV1) compactEpoch(ctx context.Context, blobIDs []blob.ID
 	for _, data := range dataShards {
 		data2.Reset()
 
-		blobID, err := m.enc.crypter.EncryptBLOB(data, outputPrefix, SessionID(sessionID), &data2)
+		blobID, err := m.enc.crypterProvider.Crypter().EncryptBLOB(data, outputPrefix, SessionID(sessionID), &data2)
 		if err != nil {
 			return errors.Wrap(err, "error encrypting")
 		}
@@ -115,7 +113,7 @@ func (m *indexBlobManagerV1) writeIndexBlobs(ctx context.Context, dataShards []g
 		data2 := gather.NewWriteBuffer()
 		defer data2.Close() //nolint:gocritic
 
-		unprefixedBlobID, err := m.enc.crypter.EncryptBLOB(data, "", sessionID, data2)
+		unprefixedBlobID, err := m.enc.crypterProvider.Crypter().EncryptBLOB(data, "", sessionID, data2)
 		if err != nil {
 			return nil, errors.Wrap(err, "error encrypting")
 		}
@@ -131,8 +129,6 @@ var _ indexBlobManager = (*indexBlobManagerV1)(nil)
 
 // PrepareUpgradeToIndexBlobManagerV1 prepares the repository for migrating to IndexBlobManagerV1.
 func (sm *SharedManager) PrepareUpgradeToIndexBlobManagerV1(ctx context.Context, params epoch.Parameters) error {
-	sm.indexBlobManagerV1.epochMgr.Params = params
-
 	ibl, _, err := sm.indexBlobManagerV0.listActiveIndexBlobs(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error listing active index blobs")
@@ -147,8 +143,6 @@ func (sm *SharedManager) PrepareUpgradeToIndexBlobManagerV1(ctx context.Context,
 	if err := sm.indexBlobManagerV1.compactEpoch(ctx, blobIDs, epoch.UncompactedEpochBlobPrefix(epoch.FirstEpoch)); err != nil {
 		return errors.Wrap(err, "unable to generate initial epoch")
 	}
-
-	sm.indexBlobManager = sm.indexBlobManagerV1
 
 	return nil
 }

--- a/repo/content/internal_logger.go
+++ b/repo/content/internal_logger.go
@@ -33,7 +33,7 @@ type internalLogManager struct {
 	ctx context.Context // nolint:containedctx
 
 	st             blob.Storage
-	bc             *Crypter
+	bc             CrypterProvider
 	wg             sync.WaitGroup
 	timeFunc       func() time.Time
 	flushThreshold int
@@ -48,7 +48,7 @@ func (m *internalLogManager) encryptAndWriteLogBlob(prefix blob.ID, data gather.
 	encrypted := gather.NewWriteBuffer()
 	// Close happens in a goroutine
 
-	blobID, err := m.bc.EncryptBLOB(data, prefix, "", encrypted)
+	blobID, err := m.bc.Crypter().EncryptBLOB(data, prefix, "", encrypted)
 	if err != nil {
 		encrypted.Close()
 
@@ -208,7 +208,7 @@ func (l *internalLogger) Sync() error {
 }
 
 // newInternalLogManager creates a new blobLogManager that will emit logs as repository blobs with a given prefix.
-func newInternalLogManager(ctx context.Context, st blob.Storage, bc *Crypter) *internalLogManager {
+func newInternalLogManager(ctx context.Context, st blob.Storage, bc CrypterProvider) *internalLogManager {
 	return &internalLogManager{
 		ctx:            ctx,
 		st:             st,

--- a/repo/content/sessions.go
+++ b/repo/content/sessions.go
@@ -111,7 +111,7 @@ func (bm *WriteManager) writeSessionMarkerLocked(ctx context.Context) error {
 	var encrypted gather.WriteBuffer
 	defer encrypted.Close()
 
-	sessionBlobID, err := bm.crypter.EncryptBLOB(gather.FromSlice(js), BlobIDPrefixSession, bm.currentSessionInfo.ID, &encrypted)
+	sessionBlobID, err := bm.format.Crypter().EncryptBLOB(gather.FromSlice(js), BlobIDPrefixSession, bm.currentSessionInfo.ID, &encrypted)
 	if err != nil {
 		return errors.Wrap(err, "unable to encrypt session marker")
 	}
@@ -178,7 +178,7 @@ func (bm *WriteManager) ListActiveSessions(ctx context.Context) (map[SessionID]*
 			return nil, errors.Wrapf(err, "error loading session: %v", b.BlobID)
 		}
 
-		err = bm.crypter.DecryptBLOB(payload.Bytes(), b.BlobID, &decrypted)
+		err = bm.format.Crypter().DecryptBLOB(payload.Bytes(), b.BlobID, &decrypted)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error decrypting session: %v", b.BlobID)
 		}

--- a/repo/maintenance/content_rewrite.go
+++ b/repo/maintenance/content_rewrite.go
@@ -136,7 +136,7 @@ func getContentToRewrite(ctx context.Context, rep repo.DirectRepository, opt *Re
 
 		// add all content IDs from short packs
 		if opt.ShortPacks {
-			threshold := int64(rep.ContentReader().ContentFormat().MaxPackSize * shortPackThresholdPercent / 100) //nolint:gomnd
+			threshold := int64(rep.ContentReader().ContentFormat().MaxPackBlobSize() * shortPackThresholdPercent / 100) //nolint:gomnd
 			findContentInShortPacks(ctx, rep, ch, threshold, opt)
 		}
 

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -142,20 +142,19 @@ func TestManifestInitCorruptedBlock(t *testing.T) {
 	data := blobtesting.DataMap{}
 	st := blobtesting.NewMapStorage(data, nil, nil)
 
-	f := &content.FormattingOptions{
+	fop, err := content.NewFormattingOptionsProvider(&content.FormattingOptions{
 		Hash:       hashing.DefaultAlgorithm,
 		Encryption: encryption.DefaultAlgorithm,
 		MutableParameters: content.MutableParameters{
 			Version:     1,
 			MaxPackSize: 100000,
 		},
-	}
+	}, nil)
+	require.NoError(t, err)
 
 	// write some data to storage
-	bm, err := content.NewManagerForTesting(ctx, st, f, nil, nil)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	bm, err := content.NewManagerForTesting(ctx, st, fop, nil, nil)
+	require.NoError(t, err)
 
 	bm0 := bm
 
@@ -182,10 +181,8 @@ func TestManifestInitCorruptedBlock(t *testing.T) {
 	}
 
 	// make a new content manager based on corrupted data.
-	bm, err = content.NewManagerForTesting(ctx, st, f, nil, nil)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	bm, err = content.NewManagerForTesting(ctx, st, fop, nil, nil)
+	require.NoError(t, err)
 
 	t.Cleanup(func() { bm.Close(ctx) })
 
@@ -305,24 +302,24 @@ func newManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.Da
 
 	st := blobtesting.NewMapStorage(data, nil, nil)
 
-	bm, err := content.NewManagerForTesting(ctx, st, &content.FormattingOptions{
+	fop, err := content.NewFormattingOptionsProvider(&content.FormattingOptions{
 		Hash:       hashing.DefaultAlgorithm,
 		Encryption: encryption.DefaultAlgorithm,
 		MutableParameters: content.MutableParameters{
 			Version:     1,
 			MaxPackSize: 100000,
 		},
-	}, nil, nil)
-	if err != nil {
-		t.Fatalf("can't create content manager: %v", err)
-	}
+	}, nil)
+
+	require.NoError(t, err)
+
+	bm, err := content.NewManagerForTesting(ctx, st, fop, nil, nil)
+	require.NoError(t, err)
 
 	t.Cleanup(func() { bm.Close(ctx) })
 
 	mm, err := NewManager(ctx, bm, ManagerOptions{})
-	if err != nil {
-		t.Fatalf("can't create manifest manager: %v", err)
-	}
+	require.NoError(t, err)
 
 	return mm
 }

--- a/repo/open.go
+++ b/repo/open.go
@@ -333,7 +333,12 @@ func openWithConfig(ctx context.Context, st blob.Storage, lc *LocalConfig, passw
 	st = upgradeLockMonitor(options.UpgradeOwnerID, st, password, cacheOpts, lc.FormatBlobCacheDuration,
 		ufb.cacheMTime, cmOpts.TimeNow)
 
-	scm, err := content.NewSharedManager(ctx, st, fo, cacheOpts, cmOpts)
+	fop, err := content.NewFormattingOptionsProvider(fo, cmOpts.RepositoryFormatBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create format options provider")
+	}
+
+	scm, err := content.NewSharedManager(ctx, st, fop, cacheOpts, cmOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shared content manager")
 	}

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -110,8 +110,8 @@ type directRepository struct {
 
 // DeriveKey derives encryption key of the provided length from the master key.
 func (r *directRepository) DeriveKey(purpose []byte, keyLength int) []byte {
-	if r.cmgr.ContentFormat().EnablePasswordChange {
-		return deriveKeyFromMasterKey(r.cmgr.ContentFormat().MasterKey, r.uniqueID, purpose, keyLength)
+	if r.cmgr.ContentFormat().SupportsPasswordChange() {
+		return deriveKeyFromMasterKey(r.cmgr.ContentFormat().GetMasterKey(), r.uniqueID, purpose, keyLength)
 	}
 
 	// version of kopia <v0.9 had a bug where certain keys were derived directly from

--- a/repo/upgrade_lock_test.go
+++ b/repo/upgrade_lock_test.go
@@ -191,7 +191,7 @@ func TestFormatUpgradeMultipleLocksRollback(t *testing.T) {
 		opts.UpgradeOwnerID = "another-upgrade-owner"
 	})
 	require.Equal(t, content.FormatVersion3,
-		env.RepositoryWriter.ContentManager().ContentFormat().MutableParameters.Version)
+		env.RepositoryWriter.ContentManager().ContentFormat().FormatVersion())
 
 	require.NoError(t, env.RepositoryWriter.RollbackUpgrade(ctx))
 
@@ -211,7 +211,7 @@ func TestFormatUpgradeMultipleLocksRollback(t *testing.T) {
 
 	// verify that we are back to the original version where we started from
 	require.Equal(t, content.FormatVersion1,
-		env.RepositoryWriter.ContentManager().ContentFormat().MutableParameters.Version)
+		env.RepositoryWriter.ContentManager().ContentFormat().FormatVersion())
 }
 
 func TestFormatUpgradeFailureToBackupFormatBlobOnLock(t *testing.T) {

--- a/tests/stress_test/stress_test.go
+++ b/tests/stress_test/stress_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
@@ -45,16 +47,19 @@ func TestStressBlockManager(t *testing.T) {
 func stressTestWithStorage(t *testing.T, st blob.Storage, duration time.Duration) {
 	ctx := testlogging.Context(t)
 
+	fop, err := content.NewFormattingOptionsProvider(&content.FormattingOptions{
+		Hash:       "HMAC-SHA256-128",
+		Encryption: encryption.DefaultAlgorithm,
+		MutableParameters: content.MutableParameters{
+			Version:     1,
+			MaxPackSize: 20000000,
+		},
+		MasterKey: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+	}, nil)
+	require.NoError(t, err)
+
 	openMgr := func() (*content.WriteManager, error) {
-		return content.NewManagerForTesting(ctx, st, &content.FormattingOptions{
-			Hash:       "HMAC-SHA256-128",
-			Encryption: encryption.DefaultAlgorithm,
-			MutableParameters: content.MutableParameters{
-				Version:     1,
-				MaxPackSize: 20000000,
-			},
-			MasterKey: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
-		}, nil, nil)
+		return content.NewManagerForTesting(ctx, st, fop, nil, nil)
 	}
 
 	seed0 := clock.Now().Nanosecond()


### PR DESCRIPTION
Instead of passing static content.FormattingOptions (and caching it)
we now introduce an interface to provide its values.

This will allow the values to dynamically change at runtime in the
future to support cases like live migration.