### PR TITLE
fix(cli): drop the ability to set advance-notices on upgrade

### DIFF
--- a/cli/command_repository_upgrade_test.go
+++ b/cli/command_repository_upgrade_test.go
@@ -53,7 +53,35 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 	require.Contains(t, out, "Format version:      3")
 }
 
-func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.T) {
+func lockAndKill(t *testing.T, env *testenv.CLITest) {
+	t.Helper()
+
+	t.Log("Placing upgrade lock ...")
+	wait, kill := env.RunAndProcessStderr(t, func(line string) bool { return false }, "repository", "upgrade",
+		"--upgrade-owner-id", "owner",
+		"--io-drain-timeout", "30s", "--allow-unsafe-upgrade",
+		"--status-poll-interval", "1s")
+
+	go func() {
+		for {
+			t.Log("Waiting for the repository to be locked ...")
+
+			out := env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block", "--upgrade-owner-id", "owner")
+			if strings.Contains(strings.Join(out, "\n"), "Lock status:         Draining") {
+				t.Log("Repository is locked, interrupting upgrade drain.")
+				kill()
+
+				break
+			}
+
+			time.Sleep(200 * time.Millisecond)
+		}
+	}()
+
+	require.EqualError(t, wait(), "failed to upgrade the repository, lock is not released: upgrade drain interrupted")
+}
+
+func (s *formatSpecificTestSuite) TestRepositoryUpgradeStatusWhileLocked(t *testing.T) {
 	env := testenv.NewCLITest(t, s.formatFlags, testenv.NewInProcRunner(t))
 
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
@@ -66,46 +94,29 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 	switch s.formatVersion {
 	case format.FormatVersion1:
 		require.Contains(t, out, "Format version:      1")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
-			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
-			"--status-poll-interval", "1s",
-			"--advance-notice", "30s")
-		require.Contains(t, strings.Join(stderr, "\n"),
-			"Repository upgrade advance notice has been set, you must come back and perform the upgrade")
+		lockAndKill(t, env)
 
 		// verify that non-owner clients will fail to connect/upgrade
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "non-owner",
-			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
-			"--status-poll-interval", "1s")
+			"--io-drain-timeout", "15s", "--allow-unsafe-upgrade",
+			"--status-poll-interval", "1s", "--upgrade-no-block")
 
-		// until we drain, we would be able to see the upgrade status
-		out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
+		// until we drain, we would be able to see the upgrade status as
+		// "Draining"
+		out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block", "--upgrade-owner-id", "owner")
 		require.Contains(t, out, "Ongoing upgrade:     Upgrading from format version 1 -> 3")
-		require.Contains(t, out, "Upgrade lock:        Unlocked")
+		require.Contains(t, out, "Upgrade lock:        Locked")
 		require.Contains(t, out, "Lock status:         Draining")
 
 		// attempt to rollback the upgrade and restart
-		env.RunAndExpectSuccess(t, "repository", "upgrade", "rollback", "--force")
-		env.RunAndExpectSuccess(t, "repository", "upgrade",
-			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
-			"--status-poll-interval", "1s",
-			"--advance-notice", "30s")
-
-		// setup advance-notice on upgrade, this will exit immediately
-		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
-			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
-			"--status-poll-interval", "1s",
-			"--advance-notice", "30s")
-		require.Contains(t, strings.Join(stderr, "\n"),
-			"Repository upgrade advance notice has been set, you must come back and perform the upgrade")
+		env.RunAndExpectSuccess(t, "repository", "upgrade", "rollback", "--force", "--upgrade-owner-id", "owner")
+		lockAndKill(t, env)
 
 		// drain all clients
 		t.Log("Waiting to drain all clients ...")
-		time.Sleep(33 * time.Second)
+		// drain time [30 (io-drain-timeout) * 2 + 1(max clock drift)] + buffer [1 sec]
+		time.Sleep(62 * time.Second)
 
 		// verify that access is denied after we drain
 		env.RunAndExpectFailure(t, "repository", "status", "--upgrade-no-block")
@@ -117,68 +128,22 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		require.Contains(t, out, "Lock status:         Fully Established")
 
 		// finalize the upgrade
-		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
-			"--status-poll-interval", "1s",
-			"--advance-notice", "30s")
+			"--io-drain-timeout", "15s", "--allow-unsafe-upgrade",
+			"--status-poll-interval", "1s")
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
 
 		// verify that non-owner clients can resume access
 		env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
 	case format.FormatVersion2:
 		require.Contains(t, out, "Format version:      2")
+
+		// perform the upgrade
 		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
-			"--status-poll-interval", "1s",
-			"--advance-notice", "30s")
-		require.Contains(t, strings.Join(stderr, "\n"),
-			"Repository upgrade advance notice has been set, you must come back and perform the upgrade")
-
-		// verify that non-owner clients will fail to connect/upgrade
-		env.RunAndExpectFailure(t, "repository", "upgrade",
-			"--upgrade-owner-id", "non-owner",
-			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s")
-
-		// until we drain, we would be able to see the upgrade status
-		out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
-		require.Contains(t, out, "Ongoing upgrade:     Upgrading from format version 2 -> 3")
-		require.Contains(t, out, "Upgrade lock:        Unlocked")
-		require.Contains(t, out, "Lock status:         Draining")
-
-		// attempt to rollback the upgrade and restart
-		env.RunAndExpectSuccess(t, "repository", "upgrade", "rollback", "--force")
-
-		// setup advance-notice on upgrade, this will exit immediately
-		env.RunAndExpectSuccess(t, "repository", "upgrade",
-			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
-			"--status-poll-interval", "1s",
-			"--advance-notice", "30s")
-		require.Contains(t, strings.Join(stderr, "\n"),
-			"Repository upgrade advance notice has been set, you must come back and perform the upgrade")
-
-		// drain all clients
-		t.Log("Waiting to drain all clients ...")
-		time.Sleep(33 * time.Second)
-
-		// verify that access is denied after we drain
-		env.RunAndExpectFailure(t, "repository", "status", "--upgrade-no-block")
-
-		// verify that owner clients can check status
-		out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-owner-id", "owner")
-		require.Contains(t, out, "Ongoing upgrade:     Upgrading from format version 2 -> 3")
-		require.Contains(t, out, "Upgrade lock:        Locked")
-		require.Contains(t, out, "Lock status:         Fully Established")
-
-		// finalize the upgrade
-		_, stderr = env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
-			"--upgrade-owner-id", "owner",
-			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
-			"--status-poll-interval", "1s",
-			"--advance-notice", "30s")
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
 
 		// verify that non-owner clients can resume access
@@ -188,8 +153,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeAdvanceNotice(t *testing.
 		env.RunAndExpectFailure(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
-			"--status-poll-interval", "1s",
-			"--advance-notice", "30s")
+			"--status-poll-interval", "1s")
 	}
 
 	out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")


### PR DESCRIPTION
This PR removes the advance-notice setting from the upgrade CLI that was introduced in PR #1818 . This PR also updates some of the existing Advance Notice tests as "upgrade status while locked" style testing, so instead of removing them we change them slightly here to give us additional coverage under lock.