### PR TITLE
feat(snapshots): Allow uploader to find cached `StreamingFile`s

### DIFF
--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/internal/clock"
 )
 
 const (
@@ -188,10 +189,16 @@ func (vf *virtualFile) GetReader(ctx context.Context) (io.Reader, error) {
 
 // StreamingFileFromReader returns a streaming file with given name and reader.
 func StreamingFileFromReader(name string, reader io.Reader) fs.StreamingFile {
+	return StreamingFileWithModTimeFromReader(name, clock.Now(), reader)
+}
+
+// StreamingFileWithModTimeFromReader returns a streaming file with given name, modified time, and reader.
+func StreamingFileWithModTimeFromReader(name string, t time.Time, reader io.Reader) fs.StreamingFile {
 	return &virtualFile{
 		virtualEntry: virtualEntry{
-			name: name,
-			mode: defaultPermissions,
+			name:    name,
+			mode:    defaultPermissions,
+			modTime: t,
 		},
 		reader: reader,
 	}

--- a/fs/virtualfs/virtualfs_test.go
+++ b/fs/virtualfs/virtualfs_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,6 +72,15 @@ func TestStreamingFile(t *testing.T) {
 	if !reflect.DeepEqual(result, content) {
 		t.Fatalf("did not get expected file content: (actual) %v != %v (expected)", result, content)
 	}
+}
+
+func TestStreamingFileModTime(t *testing.T) {
+	data := []byte("data")
+	f1 := StreamingFileFromReader("f1", bytes.NewReader(data))
+	mt := time.Date(2021, 1, 2, 3, 4, 5, 0, time.UTC)
+	f2 := StreamingFileWithModTimeFromReader("f2", mt, bytes.NewReader(data))
+
+	assert.True(t, f1.ModTime().After(f2.ModTime()))
 }
 
 func TestStreamingFileGetReader(t *testing.T) {


### PR DESCRIPTION
Main changes in this PR:
* allow user to set mod time on a `StreamingFile` if they want
* set `StreamingFile` mod time when the struct is created, not in the uploader when the directory manifest entry is added
* relax metadata equality checks for `StreamingFile` in the uploader when looking for cached files

Together these allows the uploader to skip reuploading `StreamingFile` content if the file has the same mod time, mode, and owner. Size is no longer checked as that is only populated after the `StreamingFile` has been completely uploaded

This patch is not expected to change the behavior of backups that don't explicitly set the mod time as `StreamingFile` will default to using the current time. This means that different backups should have different mod times for `StreamingFile`s, resulting in reuploading the content just like it does now. The generated times for the `StreamingFile`s may be slightly earlier than previously observed though because it is set on struct initialization closer to the start of the backup, not when the data upload is completed during the backup