### PR TITLE
feat(snapshots): Callback for when uploader finishes processing a file

### DIFF
--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -115,6 +115,25 @@ func (imd *Directory) AddFile(name string, content []byte, permissions os.FileMo
 	return file
 }
 
+// AddFileWithSource adds a mock file with the specified name, permissions, and
+// given source function for getting a Reader instance.
+func (imd *Directory) AddFileWithSource(name string, permissions os.FileMode, source func() (ReaderSeekerCloser, error)) *File {
+	imd, name = imd.resolveSubdir(name)
+	file := &File{
+		entry: entry{
+			name:    name,
+			mode:    permissions,
+			size:    0,
+			modTime: DefaultModTime,
+		},
+		source: source,
+	}
+
+	imd.addChild(file)
+
+	return file
+}
+
 // AddSymlink adds a mock symlink with the specified name, target and permissions.
 func (imd *Directory) AddSymlink(name, target string, permissions os.FileMode) *Symlink {
 	imd, name = imd.resolveSubdir(name)

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -544,8 +544,8 @@ func (t *uitaskProgress) FinishedHashingFile(fname string, numBytes int64) {
 }
 
 // FinishedFile is emitted when the system is done examining a file.
-func (t *uitaskProgress) FinishedFile(fname string, hadErr bool) {
-	t.p.FinishedFile(fname, hadErr)
+func (t *uitaskProgress) FinishedFile(fname string, err error) {
+	t.p.FinishedFile(fname, err)
 	t.maybeReport()
 }
 

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -543,6 +543,12 @@ func (t *uitaskProgress) FinishedHashingFile(fname string, numBytes int64) {
 	t.maybeReport()
 }
 
+// FinishedFile is emitted when the system is done examining a file.
+func (t *uitaskProgress) FinishedFile(fname string, hadErr bool) {
+	t.p.FinishedFile(fname, hadErr)
+	t.maybeReport()
+}
+
 // HashedBytes is emitted while hashing any blocks of bytes.
 func (t *uitaskProgress) HashedBytes(numBytes int64) {
 	t.p.HashedBytes(numBytes)

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -136,8 +136,12 @@ func (u *Uploader) incompleteReason() string {
 	return ""
 }
 
-func (u *Uploader) uploadFileInternal(ctx context.Context, parentCheckpointRegistry *checkpointRegistry, relativePath string, f fs.File, pol *policy.Policy) (*snapshot.DirEntry, error) {
+func (u *Uploader) uploadFileInternal(ctx context.Context, parentCheckpointRegistry *checkpointRegistry, relativePath string, f fs.File, pol *policy.Policy) (dirEntry *snapshot.DirEntry, ret error) {
 	u.Progress.HashingFile(relativePath)
+
+	defer func() {
+		u.Progress.FinishedFile(relativePath, ret != nil)
+	}()
 	defer u.Progress.FinishedHashingFile(relativePath, f.Size())
 
 	if pf, ok := f.(snapshot.HasDirEntryOrNil); ok {
@@ -294,8 +298,12 @@ func (u *Uploader) uploadFileData(ctx context.Context, parentCheckpointRegistry 
 	return de, nil
 }
 
-func (u *Uploader) uploadSymlinkInternal(ctx context.Context, relativePath string, f fs.Symlink) (*snapshot.DirEntry, error) {
+func (u *Uploader) uploadSymlinkInternal(ctx context.Context, relativePath string, f fs.Symlink) (dirEntry *snapshot.DirEntry, ret error) {
 	u.Progress.HashingFile(relativePath)
+
+	defer func() {
+		u.Progress.FinishedFile(relativePath, ret != nil)
+	}()
 	defer u.Progress.FinishedHashingFile(relativePath, f.Size())
 
 	target, err := f.Readlink(ctx)
@@ -328,7 +336,7 @@ func (u *Uploader) uploadSymlinkInternal(ctx context.Context, relativePath strin
 	return de, nil
 }
 
-func (u *Uploader) uploadStreamingFileInternal(ctx context.Context, relativePath string, f fs.StreamingFile) (*snapshot.DirEntry, error) {
+func (u *Uploader) uploadStreamingFileInternal(ctx context.Context, relativePath string, f fs.StreamingFile) (dirEntry *snapshot.DirEntry, ret error) {
 	reader, err := f.GetReader(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get streaming file reader")
@@ -340,6 +348,7 @@ func (u *Uploader) uploadStreamingFileInternal(ctx context.Context, relativePath
 
 	defer func() {
 		u.Progress.FinishedHashingFile(relativePath, streamSize)
+		u.Progress.FinishedFile(relativePath, ret != nil)
 	}()
 
 	writer := u.repo.NewObjectWriter(ctx, object.WriterOptions{
@@ -806,8 +815,11 @@ func (u *Uploader) processSingle(
 			// compute entryResult now, cachedEntry is short-lived
 			cachedDirEntry, err := newDirEntry(entry, entry.Name(), cachedEntry.(object.HasObjectID).ObjectID())
 			if err != nil {
+				u.Progress.FinishedFile(entryRelativePath, true)
 				return errors.Wrap(err, "unable to create dir entry")
 			}
+
+			u.Progress.FinishedFile(entryRelativePath, false)
 
 			return u.processEntryUploadResult(ctx, cachedDirEntry, nil, entryRelativePath, parentDirBuilder,
 				false,

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -140,7 +140,7 @@ func (u *Uploader) uploadFileInternal(ctx context.Context, parentCheckpointRegis
 	u.Progress.HashingFile(relativePath)
 
 	defer func() {
-		u.Progress.FinishedFile(relativePath, ret != nil)
+		u.Progress.FinishedFile(relativePath, ret)
 	}()
 	defer u.Progress.FinishedHashingFile(relativePath, f.Size())
 
@@ -302,7 +302,7 @@ func (u *Uploader) uploadSymlinkInternal(ctx context.Context, relativePath strin
 	u.Progress.HashingFile(relativePath)
 
 	defer func() {
-		u.Progress.FinishedFile(relativePath, ret != nil)
+		u.Progress.FinishedFile(relativePath, ret)
 	}()
 	defer u.Progress.FinishedHashingFile(relativePath, f.Size())
 
@@ -348,7 +348,7 @@ func (u *Uploader) uploadStreamingFileInternal(ctx context.Context, relativePath
 
 	defer func() {
 		u.Progress.FinishedHashingFile(relativePath, streamSize)
-		u.Progress.FinishedFile(relativePath, ret != nil)
+		u.Progress.FinishedFile(relativePath, ret)
 	}()
 
 	writer := u.repo.NewObjectWriter(ctx, object.WriterOptions{
@@ -814,12 +814,11 @@ func (u *Uploader) processSingle(
 
 			// compute entryResult now, cachedEntry is short-lived
 			cachedDirEntry, err := newDirEntry(entry, entry.Name(), cachedEntry.(object.HasObjectID).ObjectID())
+			u.Progress.FinishedFile(entryRelativePath, err)
+
 			if err != nil {
-				u.Progress.FinishedFile(entryRelativePath, true)
 				return errors.Wrap(err, "unable to create dir entry")
 			}
-
-			u.Progress.FinishedFile(entryRelativePath, false)
 
 			return u.processEntryUploadResult(ctx, cachedDirEntry, nil, entryRelativePath, parentDirBuilder,
 				false,

--- a/snapshot/snapshotfs/upload_progress.go
+++ b/snapshot/snapshotfs/upload_progress.go
@@ -34,7 +34,7 @@ type UploadProgress interface {
 	// or cached. If an error was encountered it reports that too. A call to FinishedFile gives no
 	// information about the reachability of the file in checkpoints that may occur close to the
 	// time this function is called.
-	FinishedFile(fname string, hadErr bool)
+	FinishedFile(fname string, err error)
 
 	// HashedBytes is emitted while hashing any blocks of bytes.
 	HashedBytes(numBytes int64)
@@ -89,7 +89,7 @@ func (p *NullUploadProgress) HashingFile(fname string) {}
 func (p *NullUploadProgress) FinishedHashingFile(fname string, numBytes int64) {}
 
 // FinishedFile implements UploadProgress.
-func (p *NullUploadProgress) FinishedFile(fname string, hadErr bool) {}
+func (p *NullUploadProgress) FinishedFile(fname string, err error) {}
 
 // StartedDirectory implements UploadProgress.
 func (p *NullUploadProgress) StartedDirectory(dirname string) {}
@@ -180,7 +180,7 @@ func (p *CountingUploadProgress) FinishedHashingFile(fname string, numBytes int6
 }
 
 // FinishedFile implements UploadProgress.
-func (p *CountingUploadProgress) FinishedFile(fname string, hadErr bool) {}
+func (p *CountingUploadProgress) FinishedFile(fname string, err error) {}
 
 // ExcludedDir implements UploadProgress.
 func (p *CountingUploadProgress) ExcludedDir(dirname string) {

--- a/snapshot/snapshotfs/upload_progress.go
+++ b/snapshot/snapshotfs/upload_progress.go
@@ -30,6 +30,10 @@ type UploadProgress interface {
 	// FinishedHashingFile is emitted at the end of hashing of a given file.
 	FinishedHashingFile(fname string, numBytes int64)
 
+	// FinishedFile is emitted when the uploader is done with a file, regardless of if it was hashed
+	// or cached. If an error was encountered it reports that too.
+	FinishedFile(fname string, hadErr bool)
+
 	// HashedBytes is emitted while hashing any blocks of bytes.
 	HashedBytes(numBytes int64)
 
@@ -81,6 +85,9 @@ func (p *NullUploadProgress) HashingFile(fname string) {}
 
 // FinishedHashingFile implements UploadProgress.
 func (p *NullUploadProgress) FinishedHashingFile(fname string, numBytes int64) {}
+
+// FinishedFile implements UploadProgress.
+func (p *NullUploadProgress) FinishedFile(fname string, hadErr bool) {}
 
 // StartedDirectory implements UploadProgress.
 func (p *NullUploadProgress) StartedDirectory(dirname string) {}
@@ -169,6 +176,9 @@ func (p *CountingUploadProgress) CachedFile(fname string, numBytes int64) {
 func (p *CountingUploadProgress) FinishedHashingFile(fname string, numBytes int64) {
 	atomic.AddInt32(&p.counters.TotalHashedFiles, 1)
 }
+
+// FinishedFile implements UploadProgress.
+func (p *CountingUploadProgress) FinishedFile(fname string, hadErr bool) {}
 
 // ExcludedDir implements UploadProgress.
 func (p *CountingUploadProgress) ExcludedDir(dirname string) {

--- a/snapshot/snapshotfs/upload_progress.go
+++ b/snapshot/snapshotfs/upload_progress.go
@@ -31,7 +31,9 @@ type UploadProgress interface {
 	FinishedHashingFile(fname string, numBytes int64)
 
 	// FinishedFile is emitted when the uploader is done with a file, regardless of if it was hashed
-	// or cached. If an error was encountered it reports that too.
+	// or cached. If an error was encountered it reports that too. A call to FinishedFile gives no
+	// information about the reachability of the file in checkpoints that may occur close to the
+	// time this function is called.
 	FinishedFile(fname string, hadErr bool)
 
 	// HashedBytes is emitted while hashing any blocks of bytes.

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -525,13 +525,13 @@ func TestUpload_SubDirectoryReadFailureSomeIgnoredNoFailFast(t *testing.T) {
 
 type mockProgress struct {
 	UploadProgress
-	finishedFileCheck func(string, bool)
+	finishedFileCheck func(string, error)
 }
 
-func (mp *mockProgress) FinishedFile(relativePath string, hadErr bool) {
-	defer mp.UploadProgress.FinishedFile(relativePath, hadErr)
+func (mp *mockProgress) FinishedFile(relativePath string, err error) {
+	defer mp.UploadProgress.FinishedFile(relativePath, err)
 
-	mp.finishedFileCheck(relativePath, hadErr)
+	mp.finishedFileCheck(relativePath, err)
 }
 
 func TestUpload_FinishedFileProgress(t *testing.T) {
@@ -553,7 +553,7 @@ func TestUpload_FinishedFileProgress(t *testing.T) {
 	u.ForceHashPercentage = 0
 	u.Progress = &mockProgress{
 		UploadProgress: u.Progress,
-		finishedFileCheck: func(relativePath string, hadErr bool) {
+		finishedFileCheck: func(relativePath string, err error) {
 			defer func() {
 				filesFinished++
 			}()
@@ -561,11 +561,11 @@ func TestUpload_FinishedFileProgress(t *testing.T) {
 			assert.Contains(t, []string{"f1", "f2"}, filepath.Base(relativePath))
 
 			if strings.Contains(relativePath, "f2") {
-				assert.True(t, hadErr)
+				assert.Error(t, err)
 				return
 			}
 
-			assert.False(t, hadErr)
+			assert.NoError(t, err)
 		},
 	}
 

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -13,6 +13,7 @@ import (
 	"runtime/debug"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -537,6 +538,7 @@ func (mp *mockProgress) FinishedFile(relativePath string, err error) {
 func TestUpload_FinishedFileProgress(t *testing.T) {
 	ctx := testlogging.Context(t)
 	th := newUploadTestHarness(ctx, t)
+	mu := sync.Mutex{}
 	filesFinished := 0
 
 	defer th.cleanup()
@@ -555,6 +557,9 @@ func TestUpload_FinishedFileProgress(t *testing.T) {
 		UploadProgress: u.Progress,
 		finishedFileCheck: func(relativePath string, err error) {
 			defer func() {
+				mu.Lock()
+				defer mu.Unlock()
+
 				filesFinished++
 			}()
 


### PR DESCRIPTION
Add a callback that gives implementations of `UploadProgress` insight into the fate of uploaded files. This callback provides a slightly different surface area compared to listening on `FinishedHashingFile` and `Error`. Notably, it combines the completion of a file with whether or not there was an error processing the file. By combining this, listeners do not have to worry about seeing a `FinishedHashingFile` call and then maybe seeing an `Error` call. Instead, they know the outcome right away. This can save listeners from caching all files reported by `FinishedHashingFile` until the end of the upload (at which point `Error` will definitely not be called on them)