### PR TITLE
WIP: Suggestion on how to get information out of "Encryption" process

### DIFF
--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -100,7 +100,7 @@ func (c *commandBenchmarkCrypto) runBenchmark(ctx context.Context) []cryptoBench
 				for i := 0; i < hashCount; i++ {
 					contentID := hf(hashOutput[:0], input)
 
-					if encerr := enc.Encrypt(input, contentID, &encryptOutput); encerr != nil {
+					if encerr := enc.Encrypt(input, contentID, &encryptOutput, &encryption.EncryptInfo{}); encerr != nil {
 						log(ctx).Errorf("encryption failed: %v", encerr)
 						break
 					}

--- a/cli/command_benchmark_ecc.go
+++ b/cli/command_benchmark_ecc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo/ecc"
+	"github.com/kopia/kopia/repo/encryption"
 )
 
 type commandBenchmarkEcc struct {
@@ -128,7 +129,7 @@ func (c *commandBenchmarkEcc) runBenchmark(ctx context.Context) []eccBenchResult
 				defer tmp.Close()
 
 				for i := 0; i < repeat; i++ {
-					if decerr := impl.Decrypt(input, nil, &tmp); decerr != nil {
+					if decerr := impl.Decrypt(input, nil, &tmp, &encryption.DecryptInfo{}); decerr != nil {
 						log(ctx).Errorf("decoding failed: %v", decerr)
 						break
 					}

--- a/cli/command_benchmark_ecc.go
+++ b/cli/command_benchmark_ecc.go
@@ -101,7 +101,7 @@ func (c *commandBenchmarkEcc) runBenchmark(ctx context.Context) []eccBenchResult
 				defer tmp.Close()
 
 				for i := 0; i < repeat; i++ {
-					if encerr := impl.Encrypt(input, nil, &tmp); encerr != nil {
+					if encerr := impl.Encrypt(input, nil, &tmp, &encryption.EncryptInfo{}); encerr != nil {
 						log(ctx).Errorf("encoding failed: %v", encerr)
 						break
 					}
@@ -116,7 +116,7 @@ func (c *commandBenchmarkEcc) runBenchmark(ctx context.Context) []eccBenchResult
 
 			encodedBuffer.Reset()
 
-			if err := impl.Encrypt(gather.FromSlice(data), nil, &encodedBuffer); err != nil {
+			if err := impl.Encrypt(gather.FromSlice(data), nil, &encodedBuffer, &encryption.EncryptInfo{}); err != nil {
 				log(ctx).Errorf("encoding failed: %v", err)
 				break
 			}

--- a/cli/command_benchmark_encryption.go
+++ b/cli/command_benchmark_encryption.go
@@ -90,7 +90,7 @@ func (c *commandBenchmarkEncryption) runBenchmark(ctx context.Context) []cryptoB
 			defer encryptOutput.Close()
 
 			for i := 0; i < hashCount; i++ {
-				if encerr := enc.Encrypt(input, hashOutput[:32], &encryptOutput); encerr != nil {
+				if encerr := enc.Encrypt(input, hashOutput[:32], &encryptOutput, &encryption.EncryptInfo{}); encerr != nil {
 					log(ctx).Errorf("encryption failed: %v", encerr)
 					break
 				}

--- a/cli/command_index_inspect.go
+++ b/cli/command_index_inspect.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/repo/encryption"
 )
 
 type commandIndexInspect struct {
@@ -162,9 +163,15 @@ func (c *commandIndexInspect) inspectSingleIndexBlob(ctx context.Context, rep re
 		return errors.Wrapf(err, "unable to get data for %v", blobID)
 	}
 
-	entries, err := content.ParseIndexBlob(ctx, blobID, data.Bytes(), rep.ContentReader().ContentFormat())
+	info := encryption.DecryptInfo{}
+
+	entries, err := content.ParseIndexBlob(ctx, blobID, data.Bytes(), rep.ContentReader().ContentFormat(), &info)
 	if err != nil {
 		return errors.Wrapf(err, "unable to recover index from %v", blobID)
+	}
+
+	if info.CorrectedBlocksByECC > 0 {
+		// TODO Write corrected data
 	}
 
 	for _, ent := range entries {

--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kopia/kopia/internal/releasable"
 	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/encryption"
 	"github.com/kopia/kopia/repo/logging"
 )
 
@@ -138,7 +139,9 @@ func (c *PersistentCache) GetPartial(ctx context.Context, key string, offset, le
 			prot = nullStorageProtection{}
 		}
 
-		if err := prot.Verify(key, tmp.Bytes(), output); err == nil {
+		info := encryption.DecryptInfo{}
+
+		if err := prot.Verify(key, tmp.Bytes(), output, &info); err == nil {
 			// cache hit
 			reportHitBytes(int64(output.Length()))
 

--- a/internal/cache/storage_protection.go
+++ b/internal/cache/storage_protection.go
@@ -71,7 +71,7 @@ func (p authenticatedEncryptionProtection) deriveIV(id string) []byte {
 func (p authenticatedEncryptionProtection) Protect(id string, input gather.Bytes, output *gather.WriteBuffer) {
 	output.Reset()
 
-	impossible.PanicOnError(p.e.Encrypt(input, p.deriveIV(id), output))
+	impossible.PanicOnError(p.e.Encrypt(input, p.deriveIV(id), output, &encryption.EncryptInfo{}))
 }
 
 func (p authenticatedEncryptionProtection) Verify(id string, input gather.Bytes, output *gather.WriteBuffer, info *encryption.DecryptInfo) error {

--- a/internal/cache/storage_protection_test.go
+++ b/internal/cache/storage_protection_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kopia/kopia/internal/cache"
 	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/repo/encryption"
 )
 
 func TestNoStorageProection(t *testing.T) {
@@ -45,7 +46,7 @@ func testStorageProtection(t *testing.T, sp cache.StorageProtection, protectsFro
 	// append dummy bytes to ensure Reset is called.
 	unprotected.Append([]byte("dummy"))
 
-	require.NoError(t, sp.Verify("x", protected.Bytes(), &unprotected))
+	require.NoError(t, sp.Verify("x", protected.Bytes(), &unprotected, &encryption.DecryptInfo{}))
 
 	if got, want := unprotected.ToByteSlice(), payload; !bytes.Equal(got, want) {
 		t.Fatalf("invalid unprotected payload %x, wanted %x", got, want)
@@ -57,8 +58,8 @@ func testStorageProtection(t *testing.T, sp cache.StorageProtection, protectsFro
 		// flip one bit
 		pb[0] ^= 1
 
-		require.Error(t, sp.Verify("x", gather.FromSlice(pb), &unprotected))
+		require.Error(t, sp.Verify("x", gather.FromSlice(pb), &unprotected, &encryption.DecryptInfo{}))
 	} else {
-		require.NoError(t, sp.Verify("x", gather.FromSlice(pb), &unprotected))
+		require.NoError(t, sp.Verify("x", gather.FromSlice(pb), &unprotected, &encryption.DecryptInfo{}))
 	}
 }

--- a/repo/content/blob_crypto.go
+++ b/repo/content/blob_crypto.go
@@ -65,7 +65,7 @@ func EncryptBLOB(c crypter, payload gather.Bytes, prefix blob.ID, sessionID Sess
 }
 
 // DecryptBLOB decrypts the provided data using provided blobID to derive initialization vector.
-func DecryptBLOB(c crypter, payload gather.Bytes, blobID blob.ID, output *gather.WriteBuffer) error {
+func DecryptBLOB(c crypter, payload gather.Bytes, blobID blob.ID, output *gather.WriteBuffer, info *encryption.DecryptInfo) error {
 	iv, err := getIndexBlobIV(blobID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get index blob IV")
@@ -74,7 +74,7 @@ func DecryptBLOB(c crypter, payload gather.Bytes, blobID blob.ID, output *gather
 	output.Reset()
 
 	// Decrypt will verify the payload.
-	if err := c.Encryptor().Decrypt(payload, iv, output); err != nil {
+	if err := c.Encryptor().Decrypt(payload, iv, output, info); err != nil {
 		return errors.Wrapf(err, "error decrypting BLOB %v", blobID)
 	}
 

--- a/repo/content/blob_crypto.go
+++ b/repo/content/blob_crypto.go
@@ -57,7 +57,7 @@ func EncryptBLOB(c crypter, payload gather.Bytes, prefix blob.ID, sessionID Sess
 
 	output.Reset()
 
-	if err := c.Encryptor().Encrypt(payload, iv, output); err != nil {
+	if err := c.Encryptor().Encrypt(payload, iv, output, &encryption.EncryptInfo{}); err != nil {
 		return "", errors.Wrapf(err, "error encrypting BLOB %v", blobID)
 	}
 

--- a/repo/content/blob_crypto_test.go
+++ b/repo/content/blob_crypto_test.go
@@ -59,7 +59,7 @@ func TestBlobCrypto(t *testing.T) {
 
 type badEncryptor struct{}
 
-func (badEncryptor) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {
+func (badEncryptor) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *encryption.EncryptInfo) error {
 	return errors.Errorf("some error")
 }
 

--- a/repo/content/blob_crypto_test.go
+++ b/repo/content/blob_crypto_test.go
@@ -38,23 +38,23 @@ func TestBlobCrypto(t *testing.T) {
 
 	require.NotEqual(t, id, id2)
 
-	require.NoError(t, DecryptBLOB(cr, tmp.Bytes(), id, &tmp3))
+	require.NoError(t, DecryptBLOB(cr, tmp.Bytes(), id, &tmp3, &encryption.DecryptInfo{}))
 	require.Equal(t, []byte{1, 2, 3}, tmp3.ToByteSlice())
-	require.NoError(t, DecryptBLOB(cr, tmp2.Bytes(), id2, &tmp3))
+	require.NoError(t, DecryptBLOB(cr, tmp2.Bytes(), id2, &tmp3, &encryption.DecryptInfo{}))
 	require.Equal(t, []byte{1, 2, 4}, tmp3.ToByteSlice())
 
 	// decrypting using invalid ID fails
-	require.Error(t, DecryptBLOB(cr, tmp.Bytes(), id2, &tmp3))
-	require.Error(t, DecryptBLOB(cr, tmp2.Bytes(), id, &tmp3))
+	require.Error(t, DecryptBLOB(cr, tmp.Bytes(), id2, &tmp3, &encryption.DecryptInfo{}))
+	require.Error(t, DecryptBLOB(cr, tmp2.Bytes(), id, &tmp3, &encryption.DecryptInfo{}))
 
 	require.True(t, strings.HasPrefix(string(id), "n"))
 	require.True(t, strings.HasSuffix(string(id), "-mysessionid"), id)
 
 	// negative cases
-	require.Error(t, DecryptBLOB(cr, tmp.Bytes(), "invalid-blob-id", &tmp3))
-	require.Error(t, DecryptBLOB(cr, tmp.Bytes(), "zzz0123456789abcdef0123456789abcde-suffix", &tmp3))
-	require.Error(t, DecryptBLOB(cr, tmp.Bytes(), id2, &tmp3))
-	require.Error(t, DecryptBLOB(cr, gather.FromSlice([]byte{2, 3, 4}), id, &tmp2))
+	require.Error(t, DecryptBLOB(cr, tmp.Bytes(), "invalid-blob-id", &tmp3, &encryption.DecryptInfo{}))
+	require.Error(t, DecryptBLOB(cr, tmp.Bytes(), "zzz0123456789abcdef0123456789abcde-suffix", &tmp3, &encryption.DecryptInfo{}))
+	require.Error(t, DecryptBLOB(cr, tmp.Bytes(), id2, &tmp3, &encryption.DecryptInfo{}))
+	require.Error(t, DecryptBLOB(cr, gather.FromSlice([]byte{2, 3, 4}), id, &tmp2, &encryption.DecryptInfo{}))
 }
 
 type badEncryptor struct{}
@@ -63,7 +63,7 @@ func (badEncryptor) Encrypt(input gather.Bytes, contentID []byte, output *gather
 	return errors.Errorf("some error")
 }
 
-func (badEncryptor) Decrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {
+func (badEncryptor) Decrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *encryption.DecryptInfo) error {
 	return errors.Errorf("some error")
 }
 

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -52,7 +52,7 @@ func TestFormatters(t *testing.T) {
 					var cipherText gather.WriteBuffer
 					defer cipherText.Close()
 
-					require.NoError(t, enc.Encrypt(gather.FromSlice(data), contentID, &cipherText))
+					require.NoError(t, enc.Encrypt(gather.FromSlice(data), contentID, &cipherText, &encryption.EncryptInfo{}))
 
 					var plainText gather.WriteBuffer
 					defer plainText.Close()

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -57,7 +57,7 @@ func TestFormatters(t *testing.T) {
 					var plainText gather.WriteBuffer
 					defer plainText.Close()
 
-					require.NoError(t, enc.Decrypt(cipherText.Bytes(), contentID, &plainText))
+					require.NoError(t, enc.Decrypt(cipherText.Bytes(), contentID, &plainText, &encryption.DecryptInfo{}))
 
 					h1 := sha1.Sum(plainText.ToByteSlice())
 

--- a/repo/content/content_index_recovery.go
+++ b/repo/content/content_index_recovery.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content/index"
+	"github.com/kopia/kopia/repo/encryption"
 )
 
 // RecoverIndexFromPackBlob attempts to recover index blob entries from a given pack file.
@@ -200,7 +201,7 @@ func (sm *SharedManager) appendPackFileIndexRecoveryData(pending index.Builder, 
 	var encryptedLocalIndex gather.WriteBuffer
 	defer encryptedLocalIndex.Close()
 
-	if err := sm.format.Encryptor().Encrypt(localIndex.Bytes(), localIndexIV, &encryptedLocalIndex); err != nil {
+	if err := sm.format.Encryptor().Encrypt(localIndex.Bytes(), localIndexIV, &encryptedLocalIndex, &encryption.EncryptInfo{}); err != nil {
 		return errors.Wrap(err, "encryption error")
 	}
 

--- a/repo/content/content_manager_indexes.go
+++ b/repo/content/content_manager_indexes.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/content/index"
+	"github.com/kopia/kopia/repo/encryption"
 )
 
 const verySmallContentFraction = 20 // blobs less than 1/verySmallContentFraction of maxPackSize are considered 'very small'
@@ -80,11 +81,11 @@ func (sm *SharedManager) CompactIndexes(ctx context.Context, opt CompactOptions)
 }
 
 // ParseIndexBlob loads entries in a given index blob and returns them.
-func ParseIndexBlob(ctx context.Context, blobID blob.ID, encrypted gather.Bytes, crypter crypter) ([]Info, error) {
+func ParseIndexBlob(ctx context.Context, blobID blob.ID, encrypted gather.Bytes, crypter crypter, info *encryption.DecryptInfo) ([]Info, error) {
 	var data gather.WriteBuffer
 	defer data.Close()
 
-	if err := DecryptBLOB(crypter, encrypted, blobID, &data); err != nil {
+	if err := DecryptBLOB(crypter, encrypted, blobID, &data, info); err != nil {
 		return nil, errors.Wrap(err, "unable to decrypt index blob")
 	}
 

--- a/repo/content/encrypted_blob_mgr_test.go
+++ b/repo/content/encrypted_blob_mgr_test.go
@@ -21,7 +21,7 @@ type failingEncryptor struct {
 	err error
 }
 
-func (f failingEncryptor) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {
+func (f failingEncryptor) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *encryption.EncryptInfo) error {
 	return f.err
 }
 

--- a/repo/ecc/ecc_rs_crc.go
+++ b/repo/ecc/ecc_rs_crc.go
@@ -163,7 +163,7 @@ func (r *ReedSolomonCrcECC) computeSizesFromStored(length int) sizesInfo {
 // The parity data comes first so we can avoid storing the padding needed for the
 // data shards, and instead compute the padded size based on the input length.
 // All parity shards are always stored.
-func (r *ReedSolomonCrcECC) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {
+func (r *ReedSolomonCrcECC) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *encryption.EncryptInfo) error {
 	sizes := r.computeSizesFromOriginal(input.Length())
 	inputPlusLengthSize := lengthSize + input.Length()
 	dataSizeInBlock := sizes.DataShards * sizes.ShardSize
@@ -241,6 +241,8 @@ func (r *ReedSolomonCrcECC) Encrypt(input gather.Bytes, contentID []byte, output
 		output.Append(crcBytes)
 		output.Append(shard[:left])
 	}
+
+	info.BytesAfterECC = output.Length()
 
 	return nil
 }

--- a/repo/ecc/ecc_utils_test.go
+++ b/repo/ecc/ecc_utils_test.go
@@ -53,7 +53,7 @@ func testPutAndGet(t *testing.T, opts *Options, originalSize,
 
 	output = gather.NewWriteBuffer()
 
-	err = impl.Decrypt(gather.FromSlice(result), nil, output)
+	err = impl.Decrypt(gather.FromSlice(result), nil, output, &encryption.DecryptInfo{})
 
 	if expectedSuccess {
 		require.NoError(t, err)

--- a/repo/ecc/ecc_utils_test.go
+++ b/repo/ecc/ecc_utils_test.go
@@ -43,7 +43,7 @@ func testPutAndGet(t *testing.T, opts *Options, originalSize,
 
 	output := gather.NewWriteBuffer()
 
-	err = impl.Encrypt(gather.FromSlice(original), nil, output)
+	err = impl.Encrypt(gather.FromSlice(original), nil, output, &encryption.EncryptInfo{})
 	require.NoError(t, err)
 
 	result := output.ToByteSlice()

--- a/repo/encryption/aes256_gcm_hmac_sha256_encryptor.go
+++ b/repo/encryption/aes256_gcm_hmac_sha256_encryptor.go
@@ -44,13 +44,20 @@ func (e aes256GCMHmacSha256) aeadForContent(contentID []byte) (cipher.AEAD, erro
 	return cipher.NewGCM(c)
 }
 
-func (e aes256GCMHmacSha256) Decrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {
+func (e aes256GCMHmacSha256) Decrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *DecryptInfo) error {
 	a, err := e.aeadForContent(contentID)
 	if err != nil {
 		return err
 	}
 
-	return aeadOpenPrefixedWithNonce(a, input, contentID, output)
+	err = aeadOpenPrefixedWithNonce(a, input, contentID, output)
+	if err != nil {
+		return err
+	}
+
+	info.BytesAfterDecryption = output.Length()
+
+	return nil
 }
 
 func (e aes256GCMHmacSha256) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {

--- a/repo/encryption/aes256_gcm_hmac_sha256_encryptor.go
+++ b/repo/encryption/aes256_gcm_hmac_sha256_encryptor.go
@@ -60,13 +60,20 @@ func (e aes256GCMHmacSha256) Decrypt(input gather.Bytes, contentID []byte, outpu
 	return nil
 }
 
-func (e aes256GCMHmacSha256) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {
+func (e aes256GCMHmacSha256) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *EncryptInfo) error {
 	a, err := e.aeadForContent(contentID)
 	if err != nil {
 		return err
 	}
 
-	return aeadSealWithRandomNonce(a, input, contentID, output)
+	err = aeadSealWithRandomNonce(a, input, contentID, output)
+	if err != nil {
+		return err
+	}
+
+	info.BytesAfterEncryption = output.Length()
+
+	return nil
 }
 
 func (e aes256GCMHmacSha256) Overhead() int {

--- a/repo/encryption/chacha20_poly1305_hmac_sha256_encryptor.go
+++ b/repo/encryption/chacha20_poly1305_hmac_sha256_encryptor.go
@@ -56,13 +56,20 @@ func (e chacha20poly1305hmacSha256Encryptor) Decrypt(input gather.Bytes, content
 	return nil
 }
 
-func (e chacha20poly1305hmacSha256Encryptor) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {
+func (e chacha20poly1305hmacSha256Encryptor) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *EncryptInfo) error {
 	a, err := e.aeadForContent(contentID)
 	if err != nil {
 		return err
 	}
 
-	return aeadSealWithRandomNonce(a, input, contentID, output)
+	err = aeadSealWithRandomNonce(a, input, contentID, output)
+	if err != nil {
+		return err
+	}
+
+	info.BytesAfterEncryption = output.Length()
+
+	return nil
 }
 
 func (e chacha20poly1305hmacSha256Encryptor) Overhead() int {

--- a/repo/encryption/chacha20_poly1305_hmac_sha256_encryptor.go
+++ b/repo/encryption/chacha20_poly1305_hmac_sha256_encryptor.go
@@ -40,13 +40,20 @@ func (e chacha20poly1305hmacSha256Encryptor) aeadForContent(contentID []byte) (c
 	return chacha20poly1305.New(key)
 }
 
-func (e chacha20poly1305hmacSha256Encryptor) Decrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {
+func (e chacha20poly1305hmacSha256Encryptor) Decrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *DecryptInfo) error {
 	a, err := e.aeadForContent(contentID)
 	if err != nil {
 		return err
 	}
 
-	return aeadOpenPrefixedWithNonce(a, input, contentID, output)
+	err = aeadOpenPrefixedWithNonce(a, input, contentID, output)
+	if err != nil {
+		return err
+	}
+
+	info.BytesAfterDecryption = output.Length()
+
+	return nil
 }
 
 func (e chacha20poly1305hmacSha256Encryptor) Encrypt(input gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {

--- a/repo/encryption/encryption.go
+++ b/repo/encryption/encryption.go
@@ -23,7 +23,7 @@ const (
 type Encryptor interface {
 	// Encrypt appends the encrypted bytes corresponding to the given plaintext to a given slice.
 	// Must not clobber the input slice and return ciphertext with additional padding and checksum.
-	Encrypt(plainText gather.Bytes, contentID []byte, output *gather.WriteBuffer) error
+	Encrypt(plainText gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *EncryptInfo) error
 
 	// Decrypt appends the unencrypted bytes corresponding to the given ciphertext to a given slice.
 	// Must not clobber the input slice. If IsAuthenticated() == true, Decrypt will perform

--- a/repo/encryption/encryption.go
+++ b/repo/encryption/encryption.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/crypto/hkdf"
 
 	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/repo/compression"
 )
 
 const (
@@ -27,10 +28,41 @@ type Encryptor interface {
 	// Decrypt appends the unencrypted bytes corresponding to the given ciphertext to a given slice.
 	// Must not clobber the input slice. If IsAuthenticated() == true, Decrypt will perform
 	// authenticity check before decrypting.
-	Decrypt(cipherText gather.Bytes, contentID []byte, output *gather.WriteBuffer) error
+	Decrypt(cipherText gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *DecryptInfo) error
 
 	// Overhead is the number of bytes of overhead added by Encrypt()
 	Overhead() int
+}
+
+// EncryptInfo stores information about an encryption request an result.
+type EncryptInfo struct {
+	RequestedCompression compression.HeaderID
+	Compression          compression.HeaderID
+
+	// 0 means no compression
+	BytesAfterCompression int
+
+	// 0 means no encryption
+	BytesAfterEncryption int
+
+	// 0 means no ECC
+	BytesAfterECC int
+}
+
+// DecryptInfo stores information about an encryption request an result.
+type DecryptInfo struct {
+	Compression compression.HeaderID
+
+	// 0 means no compression
+	BytesAfterDecompression int
+
+	// 0 means no encryption
+	BytesAfterDecryption int
+
+	// 0 means no ECC
+	BytesAfterECC int
+	// CorrectedBlocksByECC indicates the number of blocks that were corrected by ECC
+	CorrectedBlocksByECC int
 }
 
 // Parameters encapsulates all encryption parameters.

--- a/repo/encryption/encryption_test.go
+++ b/repo/encryption/encryption_test.go
@@ -49,8 +49,8 @@ func TestRoundTrip(t *testing.T) {
 			var cipherText1b gather.WriteBuffer
 			defer cipherText1b.Close()
 
-			require.NoError(t, e.Encrypt(gather.FromSlice(data), contentID1, &cipherText1))
-			require.NoError(t, e.Encrypt(gather.FromSlice(data), contentID1, &cipherText1b))
+			require.NoError(t, e.Encrypt(gather.FromSlice(data), contentID1, &cipherText1, &encryption.EncryptInfo{}))
+			require.NoError(t, e.Encrypt(gather.FromSlice(data), contentID1, &cipherText1b, &encryption.EncryptInfo{}))
 
 			if v := cipherText1.ToByteSlice(); bytes.Equal(v, cipherText1b.ToByteSlice()) {
 				t.Errorf("multiple Encrypt returned the same ciphertext: %x", v)
@@ -68,7 +68,7 @@ func TestRoundTrip(t *testing.T) {
 			var cipherText2 gather.WriteBuffer
 			defer cipherText2.Close()
 
-			require.NoError(t, e.Encrypt(gather.FromSlice(data), contentID2, &cipherText2))
+			require.NoError(t, e.Encrypt(gather.FromSlice(data), contentID2, &cipherText2, &encryption.EncryptInfo{}))
 
 			var plainText2 gather.WriteBuffer
 			defer plainText2.Close()
@@ -145,7 +145,7 @@ func verifyCiphertextSamples(t *testing.T, masterKey, contentID, payload []byte,
 			func() {
 				var v gather.WriteBuffer
 				defer v.Close()
-				require.NoError(t, enc.Encrypt(gather.FromSlice(payload), contentID, &v))
+				require.NoError(t, enc.Encrypt(gather.FromSlice(payload), contentID, &v, &encryption.EncryptInfo{}))
 
 				t.Errorf("missing ciphertext sample for %q: %q,", encryptionAlgo, hex.EncodeToString(payload))
 			}()
@@ -184,7 +184,7 @@ func BenchmarkEncryption(b *testing.B) {
 
 	iv := []byte{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7}
 
-	require.NoError(b, enc.Encrypt(plainText, iv, &warmupOut))
+	require.NoError(b, enc.Encrypt(plainText, iv, &warmupOut, &encryption.EncryptInfo{}))
 	warmupOut.Close()
 
 	b.ResetTimer()
@@ -192,7 +192,7 @@ func BenchmarkEncryption(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var out gather.WriteBuffer
 
-		enc.Encrypt(plainText, iv, &out)
+		enc.Encrypt(plainText, iv, &out, &encryption.EncryptInfo{})
 		out.Close()
 	}
 }

--- a/repo/encryption/encryption_test.go
+++ b/repo/encryption/encryption_test.go
@@ -59,7 +59,7 @@ func TestRoundTrip(t *testing.T) {
 			var plainText1 gather.WriteBuffer
 			defer plainText1.Close()
 
-			require.NoError(t, e.Decrypt(cipherText1.Bytes(), contentID1, &plainText1))
+			require.NoError(t, e.Decrypt(cipherText1.Bytes(), contentID1, &plainText1, &encryption.DecryptInfo{}))
 
 			if v := plainText1.ToByteSlice(); !bytes.Equal(v, data) {
 				t.Errorf("Encrypt()/Decrypt() does not round-trip: %x %x", v, data)
@@ -73,7 +73,7 @@ func TestRoundTrip(t *testing.T) {
 			var plainText2 gather.WriteBuffer
 			defer plainText2.Close()
 
-			require.NoError(t, e.Decrypt(cipherText2.Bytes(), contentID2, &plainText2))
+			require.NoError(t, e.Decrypt(cipherText2.Bytes(), contentID2, &plainText2, &encryption.DecryptInfo{}))
 
 			if v := plainText2.ToByteSlice(); !bytes.Equal(v, data) {
 				t.Errorf("Encrypt()/Decrypt() does not round-trip: %x %x", v, data)
@@ -84,13 +84,13 @@ func TestRoundTrip(t *testing.T) {
 			}
 
 			// decrypt using wrong content ID
-			require.Error(t, e.Decrypt(cipherText2.Bytes(), contentID1, &plainText2))
+			require.Error(t, e.Decrypt(cipherText2.Bytes(), contentID1, &plainText2, &encryption.DecryptInfo{}))
 
 			// flip some bits in the cipherText
 			b := cipherText2.Bytes()
 			b.Slices[0][mathrand.Intn(b.Length())] ^= byte(1 + mathrand.Intn(254))
 
-			require.Error(t, e.Decrypt(b, contentID1, &plainText2))
+			require.Error(t, e.Decrypt(b, contentID1, &plainText2, &encryption.DecryptInfo{}))
 		})
 	}
 }
@@ -160,7 +160,7 @@ func verifyCiphertextSamples(t *testing.T, masterKey, contentID, payload []byte,
 				var plainText gather.WriteBuffer
 				defer plainText.Close()
 
-				require.NoError(t, enc.Decrypt(gather.FromSlice(b), contentID, &plainText))
+				require.NoError(t, enc.Decrypt(gather.FromSlice(b), contentID, &plainText, &encryption.DecryptInfo{}))
 
 				if v := plainText.ToByteSlice(); !bytes.Equal(v, payload) {
 					t.Errorf("invalid plaintext after decryption %x, want %x", v, payload)

--- a/repo/format/encryptorWrapper.go
+++ b/repo/format/encryptorWrapper.go
@@ -10,17 +10,17 @@ type encryptorWrapper struct {
 	next encryption.Encryptor
 }
 
-func (p *encryptorWrapper) Encrypt(plainText gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {
+func (p *encryptorWrapper) Encrypt(plainText gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *encryption.EncryptInfo) error {
 	var tmp gather.WriteBuffer
 	defer tmp.Close()
 
-	if err := p.impl.Encrypt(plainText, contentID, &tmp); err != nil {
+	if err := p.impl.Encrypt(plainText, contentID, &tmp, info); err != nil {
 		//nolint:wrapcheck
 		return err
 	}
 
 	//nolint:wrapcheck
-	return p.next.Encrypt(tmp.Bytes(), contentID, output)
+	return p.next.Encrypt(tmp.Bytes(), contentID, output, info)
 }
 
 func (p *encryptorWrapper) Decrypt(cipherText gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *encryption.DecryptInfo) error {

--- a/repo/format/encryptorWrapper.go
+++ b/repo/format/encryptorWrapper.go
@@ -23,17 +23,17 @@ func (p *encryptorWrapper) Encrypt(plainText gather.Bytes, contentID []byte, out
 	return p.next.Encrypt(tmp.Bytes(), contentID, output)
 }
 
-func (p *encryptorWrapper) Decrypt(cipherText gather.Bytes, contentID []byte, output *gather.WriteBuffer) error {
+func (p *encryptorWrapper) Decrypt(cipherText gather.Bytes, contentID []byte, output *gather.WriteBuffer, info *encryption.DecryptInfo) error {
 	var tmp gather.WriteBuffer
 	defer tmp.Close()
 
-	if err := p.next.Decrypt(cipherText, contentID, &tmp); err != nil {
+	if err := p.next.Decrypt(cipherText, contentID, &tmp, info); err != nil {
 		//nolint:wrapcheck
 		return err
 	}
 
 	//nolint:wrapcheck
-	return p.impl.Decrypt(tmp.Bytes(), contentID, output)
+	return p.impl.Decrypt(tmp.Bytes(), contentID, output, info)
 }
 
 func (p *encryptorWrapper) Overhead() int {

--- a/repo/format/format_provider.go
+++ b/repo/format/format_provider.go
@@ -127,7 +127,7 @@ func NewFormattingOptionsProvider(f0 *ContentFormat, formatBytes []byte) (Provid
 	var tmp gather.WriteBuffer
 	defer tmp.Close()
 
-	err = e.Encrypt(gather.FromSlice(nil), contentID, &tmp)
+	err = e.Encrypt(gather.FromSlice(nil), contentID, &tmp, &encryption.EncryptInfo{})
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid encryptor")
 	}

--- a/repo/maintenance/blob_gc_test.go
+++ b/repo/maintenance/blob_gc_test.go
@@ -212,7 +212,7 @@ func mustPutDummySessionBlob(t *testing.T, st blob.Storage, sessionIDSuffix blob
 	var enc gather.WriteBuffer
 	defer enc.Close()
 
-	require.NoError(t, e.Encrypt(gather.FromSlice(j), iv, &enc))
+	require.NoError(t, e.Encrypt(gather.FromSlice(j), iv, &enc, &encryption.EncryptInfo{}))
 	require.NoError(t, st.PutBlob(testlogging.Context(t), blobID, enc.Bytes(), blob.PutOptions{}))
 
 	return blobID


### PR DESCRIPTION
This is a suggestion on how we could get information out of the Encryption/ECC process. I believe that, with something like this, compression could also became an "`Encryptor`", and that interface could be renamed. Also, there are a few TODOs in the code, because I could not find out how to write data at some points. 

I must confess that I'm a bit out of my depth with this PR, because I believe I don't understand kopia enough to do a change like that. But I hope this can start the conversation.

Also, naming is hard and I really didn't like `EncryptInfo` and `DecryptInfo` but couldn't come up with anything better. They probably should be in the content package or somewhere else - again, not sure.

This would fix https://github.com/kopia/kopia/issues/2328 .