### PR TITLE
feat(cli): Allow restore from snapshoted path

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -502,7 +502,7 @@ func (c *commandRestore) tryToConvertPathToID(ctx context.Context, rep repo.Repo
 		"   Snapshot source: %v\n"+
 		"   Snapshot time: %v\n"+
 		"   Relative path: %v\n"+
-		"   Object ID: %v", m.Source, formatTimestamp(m.StartTime), relPath, ohid)
+		"   Object ID: %v", m.Source, formatTimestamp(m.StartTime.ToTime()), relPath, ohid)
 
 	return ohid.String(), nil
 }
@@ -526,7 +526,7 @@ func createSnapshotTimeFilter(timespec string) (func(*snapshot.Manifest, int, in
 	}
 
 	return func(m *snapshot.Manifest, i, total int) bool {
-		return m.StartTime.Before(t)
+		return m.StartTime.ToTime().Before(t)
 	}, nil
 }
 
@@ -537,21 +537,21 @@ func computeMaxTime(timespec string) (time.Time, error) {
 	now := clock.Now()
 
 	if timespec == "yesterday" {
-		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()), nil
+		return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local), nil
 	}
 
 	if timespec == "last-month" {
-		return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location()), nil
+		return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.Local), nil
 	}
 
 	if timespec == "last-year" {
-		return time.Date(now.Year(), 1, 1, 0, 0, 0, 0, now.Location()), nil
+		return time.Date(now.Year(), 1, 1, 0, 0, 0, 0, time.Local), nil
 	}
 
 	if strings.HasSuffix(timespec, "-ago") {
 		ymd := timeAgoRE.FindStringSubmatch(timespec)
 		if ymd != nil {
-			t := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+			t := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
 
 			years, _ := strconv.Atoi(ymd[1])
 			months, _ := strconv.Atoi(ymd[2])
@@ -601,7 +601,7 @@ func computeMaxTime(timespec string) (time.Time, error) {
 
 		// If no timezone is given, assume local time
 		if !strings.Contains(f.format, "Z") && !strings.Contains(f.format, "MST") {
-			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), now.Location())
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.Local)
 		}
 
 		switch f.precision {

--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -451,10 +451,12 @@ func (c *commandRestore) run(ctx context.Context, rep repo.Repository) error {
 func (c *commandRestore) tryToConvertPathToID(ctx context.Context, rep repo.Repository, source string) (string, error) {
 	pathElements := strings.Split(filepath.ToSlash(source), "/")
 
-	_, err := index.ParseID(pathElements[0])
-	if err == nil {
-		// source is an ID
-		return source, nil
+	if pathElements[0] != "" {
+		_, err := index.ParseID(pathElements[0])
+		if err == nil {
+			// source is an ID
+			return source, nil
+		}
 	}
 
 	// Consider source as a path

--- a/cli/command_restore_test.go
+++ b/cli/command_restore_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/clock"
+)
+
+func TestRestoreSnapshotMaxTime(t *testing.T) {
+	t.Parallel()
+
+	now := clock.Now()
+	ago := func(y, m, d int) time.Time {
+		r := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		return r.AddDate(y, m, d)
+	}
+	at := func(y, mo, d, h, m, s int) time.Time {
+		return time.Date(y, time.Month(mo), d, h, m, s, 0, now.Location())
+	}
+
+	requireTime := func(expected time.Time, timespect string) {
+		mt, err := computeMaxTime(timespect)
+		require.NoError(t, err)
+		require.Equal(t, expected, mt)
+
+	}
+
+	requireTime(ago(0, 0, 0), "yesterday")
+	requireTime(ago(0, 0, 0), "1d-ago")
+	requireTime(ago(0, 0, 0), "1day-ago")
+
+	requireTime(at(now.Year(), int(now.Month()), 1, 0, 0, 0), "last-month")
+	requireTime(at(now.Year(), 1, 1, 0, 0, 0), "last-year")
+
+	requireTime(ago(0, -1, 1), "1month-ago")
+	requireTime(ago(0, -1, 1), "1m-ago")
+	requireTime(ago(-1, 0, 1), "1year-ago")
+	requireTime(ago(-1, 0, 1), "1y-ago")
+	requireTime(ago(-2, -2, -1), "2years-2months-2days-ago")
+	requireTime(ago(-2, -2, -1), "2y-2m-2d-ago")
+
+	requireTime(at(2020, 1, 1, 0, 0, 0), "2019")
+	requireTime(at(2019, 2, 1, 0, 0, 0), "2019-1")
+	requireTime(at(2019, 1, 2, 0, 0, 0), "2019-01-1")
+	requireTime(at(2019, 1, 1, 14, 0, 0), "2019-01-1 13")
+	requireTime(at(2019, 1, 1, 13, 2, 0), "2019-01-1 13:01")
+	requireTime(at(2019, 1, 1, 13, 1, 16), "2019-01-1 13:01:15")
+}
+
+func TestRestoreSnapshotFilter(t *testing.T) {
+	f, err := createSnapshotTimeFilter("latest")
+	require.NoError(t, err)
+	require.Equal(t, true, f(nil, 0, 2))
+	require.Equal(t, false, f(nil, 1, 2))
+
+	f, err = createSnapshotTimeFilter("oldest")
+	require.NoError(t, err)
+	require.Equal(t, false, f(nil, 0, 2))
+	require.Equal(t, true, f(nil, 1, 2))
+}

--- a/cli/command_restore_test.go
+++ b/cli/command_restore_test.go
@@ -25,7 +25,6 @@ func TestRestoreSnapshotMaxTime(t *testing.T) {
 		mt, err := computeMaxTime(timespect)
 		require.NoError(t, err)
 		require.Equal(t, expected, mt)
-
 	}
 
 	requireTime(ago(0, 0, 0), "yesterday")

--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -86,14 +86,14 @@ func findSnapshotsForSource(ctx context.Context, rep repo.Repository, sourceInfo
 	return result, nil
 }
 
-func findRelativePathParts(manifest *snapshot.Manifest, path string) ([]string, error) {
+func findRelativePathParts(m *snapshot.Manifest, path string) ([]string, error) {
 	if path == "" {
 		return nil, nil
 	}
 
-	relPath, err := filepath.Rel(manifest.Source.Path, path)
+	relPath, err := filepath.Rel(m.Source.Path, path)
 	if err != nil {
-		return nil, err
+		return nil, err //nolint:wrapcheck
 	}
 
 	if relPath == "." {

--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -62,24 +62,18 @@ func (c *commandSnapshotList) setup(svc appServices, parent commandParent) {
 	cmd.Action(svc.repositoryReaderAction(c.run))
 }
 
-func findSnapshotsForSource(ctx context.Context, rep repo.Repository, sourceInfo snapshot.SourceInfo, tags map[string]string) (manifestIDs []manifest.ID, relPath string, err error) {
+func findSnapshotsForSource(ctx context.Context, rep repo.Repository, sourceInfo snapshot.SourceInfo, tags map[string]string) (manifestIDs []manifest.ID, err error) {
+	var result []manifest.ID
+
 	for len(sourceInfo.Path) > 0 {
 		list, err := snapshot.ListSnapshotManifests(ctx, rep, &sourceInfo, tags)
 		if err != nil {
-			return nil, "", errors.Wrapf(err, "error listing manifests for %v", sourceInfo)
+			return nil, errors.Wrapf(err, "error listing manifests for %v", sourceInfo)
 		}
 
 		if len(list) > 0 {
-			return list, relPath, nil
+			result = append(result, list...)
 		}
-
-		if len(relPath) > 0 {
-			relPath = filepath.Base(sourceInfo.Path) + "/" + relPath
-		} else {
-			relPath = filepath.Base(sourceInfo.Path)
-		}
-
-		log(ctx).Debugf("No snapshots of %v@%v:%v", sourceInfo.UserName, sourceInfo.Host, sourceInfo.Path)
 
 		parentPath := filepath.Dir(sourceInfo.Path)
 		if parentPath == sourceInfo.Path {
@@ -89,26 +83,40 @@ func findSnapshotsForSource(ctx context.Context, rep repo.Repository, sourceInfo
 		sourceInfo.Path = parentPath
 	}
 
-	return nil, "", nil
+	return result, nil
 }
 
-func findManifestIDs(ctx context.Context, rep repo.Repository, source string, tags map[string]string) ([]manifest.ID, string, error) {
+func findRelativePathParts(manifest *snapshot.Manifest, path string) ([]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	relPath, err := filepath.Rel(manifest.Source.Path, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if relPath == "." {
+		return nil, nil
+	}
+
+	return strings.Split(filepath.ToSlash(relPath), "/"), nil
+}
+
+func findManifestIDs(ctx context.Context, rep repo.Repository, source string, tags map[string]string) ([]manifest.ID, error) {
 	if source == "" {
 		man, err := snapshot.ListSnapshotManifests(ctx, rep, nil, tags)
-		return man, "", errors.Wrap(err, "error listing all snapshot manifests")
+		return man, errors.Wrap(err, "error listing all snapshot manifests")
 	}
 
 	si, err := snapshot.ParseSourceInfo(source, rep.ClientOptions().Hostname, rep.ClientOptions().Username)
 	if err != nil {
-		return nil, "", errors.Errorf("invalid directory: '%s': %s", source, err)
+		return nil, errors.Errorf("invalid directory: '%s': %s", source, err)
 	}
 
-	manifestIDs, relPath, err := findSnapshotsForSource(ctx, rep, si, tags)
-	if relPath != "" {
-		relPath = "/" + relPath
-	}
+	manifestIDs, err := findSnapshotsForSource(ctx, rep, si, tags)
 
-	return manifestIDs, relPath, err
+	return manifestIDs, err
 }
 
 func (c *commandSnapshotList) run(ctx context.Context, rep repo.Repository) error {
@@ -117,7 +125,7 @@ func (c *commandSnapshotList) run(ctx context.Context, rep repo.Repository) erro
 		return err
 	}
 
-	manifestIDs, relPath, err := findManifestIDs(ctx, rep, c.snapshotListPath, tags)
+	manifestIDs, err := findManifestIDs(ctx, rep, c.snapshotListPath, tags)
 	if err != nil {
 		return err
 	}
@@ -131,7 +139,7 @@ func (c *commandSnapshotList) run(ctx context.Context, rep repo.Repository) erro
 		return c.outputJSON(ctx, rep, manifests)
 	}
 
-	return c.outputManifestGroups(ctx, rep, manifests, strings.Split(relPath, "/"))
+	return c.outputManifestGroups(ctx, rep, manifests, c.snapshotListPath)
 }
 
 // SnapshotManifest defines the JSON output for the CLI snapshot commands.
@@ -190,7 +198,7 @@ func (c *commandSnapshotList) shouldOutputSnapshotSource(rep repo.Repository, sr
 	return src.UserName == co.Username
 }
 
-func (c *commandSnapshotList) outputManifestGroups(ctx context.Context, rep repo.Repository, manifests []*snapshot.Manifest, relPathParts []string) error {
+func (c *commandSnapshotList) outputManifestGroups(ctx context.Context, rep repo.Repository, manifests []*snapshot.Manifest, path string) error {
 	separator := ""
 
 	var anyOutput bool
@@ -212,6 +220,11 @@ func (c *commandSnapshotList) outputManifestGroups(ctx context.Context, rep repo
 			log(ctx).Errorf("unable to determine effective policy for %v", src)
 		} else {
 			pol.RetentionPolicy.ComputeRetentionReasons(snapshotGroup)
+		}
+
+		relPathParts, err := findRelativePathParts(snapshotGroup[0], path)
+		if err != nil {
+			return err
 		}
 
 		if err := c.outputManifestFromSingleSource(ctx, rep, snapshotGroup, relPathParts); err != nil {

--- a/cli/command_snapshot_list_test.go
+++ b/cli/command_snapshot_list_test.go
@@ -78,3 +78,47 @@ func TestSnapshotList(t *testing.T) {
 	require.Contains(t, lines[4], " 8 B ")
 	require.Contains(t, lines[4], " files:3 dirs:1 ")
 }
+
+func TestSnapshotListWithSameFileInMultipleSnapshots(t *testing.T) {
+	t.Parallel()
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	srcdir := testutil.TempDirectory(t)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(srcdir, "a", "b", "c", "d"), os.FileMode(0x600)))
+	require.NoError(t, os.WriteFile(filepath.Join(srcdir, "a", "b", "c", "d", "e.txt"), []byte{1, 2, 3}, 0o755))
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", srcdir)
+	e.RunAndExpectSuccess(t, "snapshot", "create", filepath.Join(srcdir, "a"))
+	e.RunAndExpectSuccess(t, "snapshot", "create", filepath.Join(srcdir, "a", "b"))
+	e.RunAndExpectSuccess(t, "snapshot", "create", filepath.Join(srcdir, "a", "b", "c"))
+	e.RunAndExpectSuccess(t, "snapshot", "create", filepath.Join(srcdir, "a", "b", "c", "d"))
+	e.RunAndExpectSuccess(t, "snapshot", "create", filepath.Join(srcdir, "a", "b", "c", "d", "e.txt"))
+
+	var snapshots []*cli.SnapshotManifest
+
+	testutil.MustParseJSONLines(t, e.RunAndExpectSuccess(t, "snapshot", "list",
+		filepath.Join(srcdir, "a", "b", "c", "d", "e.txt"), "--json"), &snapshots)
+
+	require.Len(t, snapshots, 6)
+
+	var sps []string
+
+	for _, s := range snapshots {
+		sps = append(sps, s.Source.Path)
+	}
+
+	require.Equal(t, []string{
+		srcdir,
+		filepath.Join(srcdir, "a"),
+		filepath.Join(srcdir, "a", "b"),
+		filepath.Join(srcdir, "a", "b", "c"),
+		filepath.Join(srcdir, "a", "b", "c", "d"),
+		filepath.Join(srcdir, "a", "b", "c", "d", "e.txt"),
+	}, sps)
+}

--- a/cli/command_snapshot_list_test.go
+++ b/cli/command_snapshot_list_test.go
@@ -90,7 +90,7 @@ func TestSnapshotListWithSameFileInMultipleSnapshots(t *testing.T) {
 
 	srcdir := testutil.TempDirectory(t)
 
-	require.NoError(t, os.MkdirAll(filepath.Join(srcdir, "a", "b", "c", "d"), os.FileMode(0x600)))
+	require.NoError(t, os.MkdirAll(filepath.Join(srcdir, "a", "b", "c", "d"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(srcdir, "a", "b", "c", "d", "e.txt"), []byte{1, 2, 3}, 0o755))
 
 	e.RunAndExpectSuccess(t, "snapshot", "create", srcdir)

--- a/snapshot/snapshotfs/objref.go
+++ b/snapshot/snapshotfs/objref.go
@@ -3,6 +3,7 @@ package snapshotfs
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -143,7 +144,7 @@ func latestManifest(mans []*snapshot.Manifest) *snapshot.Manifest {
 // If multiple snapshots match and they don't agree on root object attributes and consistentAttributes==true
 // the function fails, otherwise it returns the latest of the snapshots.
 func FilesystemEntryFromIDWithPath(ctx context.Context, rep repo.Repository, rootID string, consistentAttributes bool) (fs.Entry, error) {
-	pathElements := strings.Split(rootID, "/")
+	pathElements := strings.Split(filepath.ToSlash(rootID), "/")
 
 	if len(pathElements) > 1 {
 		// if a path is provided, consistentAttributes is meaningless since descending into nested path is


### PR DESCRIPTION
When using a path, it finds the last snapshot that contains that path.

One thing that is somewhat sketchy: the function `findSnapshotsForSource` is being used from another command. But it did not seem like a good idea to duplicate the function.

This also allows to use `\` in windows after a snapshot id.