### PR TITLE
test(general): Use new kopia upgrade cli in robustness upgrade tests

### DIFF
--- a/tests/robustness/robustness_test/main_test.go
+++ b/tests/robustness/robustness_test/main_test.go
@@ -219,9 +219,7 @@ func (th *kopiaRobustnessTestHarness) getEngine() bool {
 }
 
 func (th *kopiaRobustnessTestHarness) cleanup(ctx context.Context) (retErr error) {
-	if os.Getenv("UPGRADE_REPOSITORY_FORMAT_VERSION") == "ON" {
-		os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "")
-	}
+	os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "")
 
 	if th.engine != nil {
 		retErr = th.engine.Shutdown(ctx)

--- a/tests/robustness/robustness_test/main_test.go
+++ b/tests/robustness/robustness_test/main_test.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	randomizedTestDur = flag.Duration("rand-test-duration", defaultTestDur, "Set the duration for the randomized test")
-	repoPathPrefix    = flag.String("repo-path-prefix", "", "Point the robustness tests at this path prefix")
+	repoPathPrefix    = flag.String("repo-path-prefix", "/Users/chaitali.gondhalekar/Work/Kasten/kopia_dummy_repo/", "Point the robustness tests at this path prefix")
 )
 
 func TestMain(m *testing.M) {
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 
 		prev := rs.ContentFormat.MutableParameters.Version
 
+		// This variable is reset in cleanup function.
+		os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "1")
+
 		log.Println("Old repository format:", prev)
 		th.snapshotter.UpgradeRepository()
 
@@ -70,6 +73,9 @@ func TestMain(m *testing.M) {
 
 		curr := rs.ContentFormat.MutableParameters.Version
 		log.Println("Upgraded repository format:", curr)
+
+		//Reset the env variable.
+		os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "")
 	}
 
 	// run the tests
@@ -216,6 +222,9 @@ func (th *kopiaRobustnessTestHarness) getEngine() bool {
 }
 
 func (th *kopiaRobustnessTestHarness) cleanup(ctx context.Context) (retErr error) {
+	if os.Getenv("UPGRADE_REPOSITORY_FORMAT_VERSION") == "ON" {
+		os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "")
+	}
 	if th.engine != nil {
 		retErr = th.engine.Shutdown(ctx)
 	}

--- a/tests/robustness/robustness_test/main_test.go
+++ b/tests/robustness/robustness_test/main_test.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	randomizedTestDur = flag.Duration("rand-test-duration", defaultTestDur, "Set the duration for the randomized test")
-	repoPathPrefix    = flag.String("repo-path-prefix", "/Users/chaitali.gondhalekar/Work/Kasten/kopia_dummy_repo/", "Point the robustness tests at this path prefix")
+	repoPathPrefix    = flag.String("repo-path-prefix", "", "Point the robustness tests at this path prefix")
 )
 
 func TestMain(m *testing.M) {
@@ -61,9 +61,6 @@ func TestMain(m *testing.M) {
 		exitOnError("failed to get repository status before upgrade", err)
 
 		prev := rs.ContentFormat.MutableParameters.Version
-
-		// This variable is reset in cleanup function.
-		os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "1")
 
 		log.Println("Old repository format:", prev)
 		th.snapshotter.UpgradeRepository()

--- a/tests/robustness/robustness_test/main_test.go
+++ b/tests/robustness/robustness_test/main_test.go
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 		curr := rs.ContentFormat.MutableParameters.Version
 		log.Println("Upgraded repository format:", curr)
 
-		//Reset the env variable.
+		// Reset the env variable.
 		os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "")
 	}
 
@@ -222,6 +222,7 @@ func (th *kopiaRobustnessTestHarness) cleanup(ctx context.Context) (retErr error
 	if os.Getenv("UPGRADE_REPOSITORY_FORMAT_VERSION") == "ON" {
 		os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "")
 	}
+
 	if th.engine != nil {
 		retErr = th.engine.Shutdown(ctx)
 	}

--- a/tests/robustness/robustness_test/robustness_test.go
+++ b/tests/robustness/robustness_test/robustness_test.go
@@ -21,7 +21,7 @@ import (
 func TestManySmallFiles(t *testing.T) {
 	const (
 		fileSize = 4096
-		numFiles = 10000
+		numFiles = 100
 	)
 
 	fileWriteOpts := map[string]string{

--- a/tests/robustness/robustness_test/robustness_test.go
+++ b/tests/robustness/robustness_test/robustness_test.go
@@ -21,7 +21,7 @@ import (
 func TestManySmallFiles(t *testing.T) {
 	const (
 		fileSize = 4096
-		numFiles = 100
+		numFiles = 10000
 	)
 
 	fileWriteOpts := map[string]string{

--- a/tests/robustness/snapmeta/kopia_snapshotter.go
+++ b/tests/robustness/snapmeta/kopia_snapshotter.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"io"
 	"log"
-	"os"
 	"os/exec"
 	"strconv"
 
@@ -201,8 +200,6 @@ func (ks *KopiaSnapshotter) GetRepositoryStatus() (cli.RepositoryStatus, error) 
 // UpgradeRepository upgrades the given kopia repository
 // from current format version to latest stable format version.
 func (ks *KopiaSnapshotter) UpgradeRepository() error {
-	os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "1")
-
 	_, _, err := ks.snap.Run("repository", "upgrade",
 		"--upgrade-owner-id", "robustness-tests",
 		"--io-drain-timeout", "30s", "--allow-unsafe-upgrade",

--- a/tests/robustness/snapmeta/kopia_snapshotter.go
+++ b/tests/robustness/snapmeta/kopia_snapshotter.go
@@ -201,7 +201,6 @@ func (ks *KopiaSnapshotter) GetRepositoryStatus() (cli.RepositoryStatus, error) 
 // UpgradeRepository upgrades the given kopia repository
 // from current format version to latest stable format version.
 func (ks *KopiaSnapshotter) UpgradeRepository() error {
-
 	// This variable is also reset in cleanup function
 	// in case the test fails
 	os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "1")

--- a/tests/robustness/snapmeta/kopia_snapshotter.go
+++ b/tests/robustness/snapmeta/kopia_snapshotter.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"os"
 	"os/exec"
 	"strconv"
 
@@ -200,7 +201,12 @@ func (ks *KopiaSnapshotter) GetRepositoryStatus() (cli.RepositoryStatus, error) 
 // UpgradeRepository upgrades the given kopia repository
 // from current format version to latest stable format version.
 func (ks *KopiaSnapshotter) UpgradeRepository() error {
-	_, _, err := ks.snap.Run("repository", "set-parameters", "--upgrade")
+	os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "1")
+
+	_, _, err := ks.snap.Run("repository", "upgrade",
+		"--upgrade-owner-id", "robustness-tests",
+		"--io-drain-timeout", "30s", "--allow-unsafe-upgrade",
+		"--status-poll-interval", "1s")
 
 	return err
 }

--- a/tests/robustness/snapmeta/kopia_snapshotter.go
+++ b/tests/robustness/snapmeta/kopia_snapshotter.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"os"
 	"os/exec"
 	"strconv"
 
@@ -200,10 +201,18 @@ func (ks *KopiaSnapshotter) GetRepositoryStatus() (cli.RepositoryStatus, error) 
 // UpgradeRepository upgrades the given kopia repository
 // from current format version to latest stable format version.
 func (ks *KopiaSnapshotter) UpgradeRepository() error {
+
+	// This variable is also reset in cleanup function
+	// in case the test fails
+	os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "1")
+
 	_, _, err := ks.snap.Run("repository", "upgrade",
 		"--upgrade-owner-id", "robustness-tests",
 		"--io-drain-timeout", "30s", "--allow-unsafe-upgrade",
 		"--status-poll-interval", "1s")
+
+	// cleanup
+	os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "")
 
 	return err
 }


### PR DESCRIPTION
Use `repository upgrade` command in the robustness tests.