### PR TITLE
feat(snapshots): always serialize timestamps in UTC timezone

### DIFF
--- a/fs/utc_timestamp.go
+++ b/fs/utc_timestamp.go
@@ -26,7 +26,7 @@ func (u *UTCTimestamp) UnmarshalJSON(v []byte) error {
 // MarshalJSON implements json.Marshaler.
 func (u UTCTimestamp) MarshalJSON() ([]byte, error) {
 	//nolint:wrapcheck
-	return u.ToTime().MarshalJSON()
+	return u.ToTime().UTC().MarshalJSON()
 }
 
 // ToTime returns time.Time representation of the time.
@@ -61,7 +61,7 @@ func (u UTCTimestamp) Equal(other UTCTimestamp) bool {
 
 // Format formats the timestamp according to the provided layout.
 func (u UTCTimestamp) Format(layout string) string {
-	return u.ToTime().Format(layout)
+	return u.ToTime().UTC().Format(layout)
 }
 
 // UTCTimestampFromTime converts time.Time to UTCTimestamp.

--- a/fs/utc_timestamp_test.go
+++ b/fs/utc_timestamp_test.go
@@ -30,6 +30,10 @@ func TestUTCTimestamp(t *testing.T) {
 	require.NoError(t, json.Unmarshal(v, &y))
 	require.Equal(t, x, y)
 
+	require.NoError(t, json.Unmarshal([]byte(`{"myts":"2022-07-10T11:15:22.656077568-07:00"}`), &y))
+	require.Equal(t, fs.UTCTimestamp(1657476922656077568), y.TS)
+	require.Equal(t, "2022-07-10T18:15:22.656077568Z", y.TS.Format(time.RFC3339Nano))
+
 	require.True(t, fs.UTCTimestampFromTime(t0) < fs.UTCTimestampFromTime(t1))
 	require.True(t, fs.UTCTimestampFromTime(t0).Equal(fs.UTCTimestampFromTime(t0)))
 	require.False(t, fs.UTCTimestampFromTime(t0).Equal(fs.UTCTimestampFromTime(t1)))


### PR DESCRIPTION
This actually fixes test runs on non-UTC timezone which were broken
by #2343.