### PR TITLE
feat(snapshots): implemented support for action webhooks

### DIFF
--- a/cli/command_policy_set_actions.go
+++ b/cli/command_policy_set_actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -24,6 +25,16 @@ type policyActionFlags struct {
 	policySetActionCommandTimeout            time.Duration
 	policySetActionCommandMode               string
 	policySetPersistActionScript             bool
+
+	policySetBeforeFolderActionWebhookURL       string
+	policySetAfterFolderActionWebhookURL        string
+	policySetBeforeSnapshotRootActionWebhookURL string
+	policySetAfterSnapshotRootActionWebhookURL  string
+
+	policySetActionWebhookMode                                string
+	policySetActionWebhookMethod                              string
+	policySetActionWebhookHeaders                             []string
+	policySetActionWebhookTrustedServerCertificateFingerprint string
 }
 
 func (c *policyActionFlags) setup(cmd *kingpin.CmdClause) {
@@ -34,6 +45,16 @@ func (c *policyActionFlags) setup(cmd *kingpin.CmdClause) {
 	cmd.Flag("action-command-timeout", "Max time allowed for an action to run in seconds").Default("5m").DurationVar(&c.policySetActionCommandTimeout)
 	cmd.Flag("action-command-mode", "Action command mode").Default("essential").EnumVar(&c.policySetActionCommandMode, "essential", "optional", "async")
 	cmd.Flag("persist-action-script", "Persist action script").BoolVar(&c.policySetPersistActionScript)
+
+	cmd.Flag("before-folder-webhook-url", "Webhook URL for before-folder action webhook ('none' to remove)").Default("-").PlaceHolder("COMMAND").StringVar(&c.policySetBeforeFolderActionWebhookURL)
+	cmd.Flag("after-folder-webhook-url", "Webhook URL for after-folder action webhook ('none' to remove)").Default("-").PlaceHolder("COMMAND").StringVar(&c.policySetAfterFolderActionWebhookURL)
+	cmd.Flag("before-snapshot-root-webhook-url", "Webhook URL for before-snapshot-root action webhook ('none' to remove or 'inherit')").Default("-").PlaceHolder("COMMAND").StringVar(&c.policySetBeforeSnapshotRootActionWebhookURL)
+	cmd.Flag("after-snapshot-root-webhook-url", "Webhook URL for after-snapshot-root action webhook ('none' to remove or 'inherit')").Default("-").PlaceHolder("COMMAND").StringVar(&c.policySetAfterSnapshotRootActionWebhookURL)
+
+	cmd.Flag("webhook-method", "Webhook method").Default("POST").EnumVar(&c.policySetActionWebhookMethod, "GET", "POST", "PUT", "PATCH", "DELETE")
+	cmd.Flag("webhook-header", "Webhook header").StringsVar(&c.policySetActionWebhookHeaders)
+	cmd.Flag("webhook-mode", "Webhook mode").Default("essential").EnumVar(&c.policySetActionWebhookMode, "essential", "optional")
+	cmd.Flag("webhook-server-certificate-fingerprint", "Webhook server certificate fingerprint").StringVar(&c.policySetActionWebhookTrustedServerCertificateFingerprint)
 }
 
 func (c *policyActionFlags) setActionsFromFlags(ctx context.Context, p *policy.ActionsPolicy, changeCount *int) error {
@@ -51,6 +72,22 @@ func (c *policyActionFlags) setActionsFromFlags(ctx context.Context, p *policy.A
 
 	if err := c.setActionCommandFromFlags(ctx, "after-snapshot-root", &p.AfterSnapshotRoot, c.policySetAfterSnapshotRootActionCommand, changeCount); err != nil {
 		return errors.Wrap(err, "invalid after-snapshot-root-action")
+	}
+
+	if err := c.setActionWebhookURLFromFlags(ctx, "before-folder", &p.BeforeFolder, c.policySetBeforeFolderActionWebhookURL, changeCount); err != nil {
+		return errors.Wrap(err, "invalid before-folder-webhook-url")
+	}
+
+	if err := c.setActionWebhookURLFromFlags(ctx, "after-folder", &p.AfterFolder, c.policySetAfterFolderActionWebhookURL, changeCount); err != nil {
+		return errors.Wrap(err, "invalid after-folder-webhook-url")
+	}
+
+	if err := c.setActionWebhookURLFromFlags(ctx, "before-snapshot-root", &p.BeforeSnapshotRoot, c.policySetBeforeSnapshotRootActionWebhookURL, changeCount); err != nil {
+		return errors.Wrap(err, "invalid before-snapshot-root-webhook-url")
+	}
+
+	if err := c.setActionWebhookURLFromFlags(ctx, "after-snapshot-root", &p.AfterSnapshotRoot, c.policySetAfterSnapshotRootActionWebhookURL, changeCount); err != nil {
+		return errors.Wrap(err, "invalid after-snapshot-root-webhook-url")
 	}
 
 	return nil
@@ -113,6 +150,73 @@ func (c *policyActionFlags) setActionCommandFromFlags(ctx context.Context, actio
 	} else {
 		log(ctx).Infof(" - setting %v (%v) action command to %v with arguments %v and timeout %v", actionName, c.policySetActionCommandMode, quoteArguments((*cmd).Command), quoteArguments((*cmd).Arguments...), c.policySetActionCommandTimeout)
 	}
+
+	return nil
+}
+
+func (c *policyActionFlags) setActionWebhookURLFromFlags(ctx context.Context, actionName string, cmd **policy.ActionCommand, value string, changeCount *int) error {
+	if value == "-" {
+		// not set
+		return nil
+	}
+
+	if value == "" {
+		log(ctx).Infof(" - removing %v webhook URL", actionName)
+
+		*changeCount++
+
+		*cmd = nil
+
+		return nil
+	}
+
+	ac := &policy.ActionCommand{
+		TimeoutSeconds: int(c.policySetActionCommandTimeout.Seconds()),
+		Mode:           c.policySetActionWebhookMode,
+		WebHook: &policy.WebHookInfo{
+			WebhookURL:                          value,
+			Method:                              c.policySetActionWebhookMethod,
+			Headers:                             map[string]string{},
+			TrustedServerCertificateFingerprint: c.policySetActionWebhookTrustedServerCertificateFingerprint,
+		},
+	}
+
+	if !strings.HasPrefix(value, "http://") && !strings.HasPrefix(value, "https://") {
+		return errors.Errorf("webhook URL must be http:// or https://")
+	}
+
+	u, err := url.ParseRequestURI(value)
+	if err != nil || u.Host == "" {
+		return errors.Errorf("invalid URL")
+	}
+
+	if c.policySetActionWebhookMode == "async" {
+		return errors.Errorf("asynchronous webhook invocation is not supported")
+	}
+
+	*cmd = ac
+
+	for _, v := range c.policySetActionWebhookHeaders {
+		const numParts = 2
+
+		parts := strings.SplitN(v, "=", numParts)
+		if len(parts) != numParts || parts[0] == "" {
+			return errors.Errorf("invalid webhook header, must be key=value")
+		}
+
+		ac.WebHook.Headers[parts[0]] = parts[1]
+	}
+
+	log(ctx).Infof(" - setting %v (%v) webhook to %v %v with headers %v and timeout %v",
+		actionName,
+		c.policySetActionWebhookMode,
+		ac.WebHook.Method,
+		ac.WebHook.WebhookURL,
+		ac.WebHook.Headers,
+		ac.TimeoutSeconds,
+	)
+
+	*changeCount++
 
 	return nil
 }

--- a/cli/command_policy_set_logging_test.go
+++ b/cli/command_policy_set_logging_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,7 +16,7 @@ func TestSetLoggingPolicy(t *testing.T) {
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
 	lines := e.RunAndExpectSuccess(t, "policy", "show", "--global")
-	lines = compressSpaces(lines)
+	lines = testutil.CompressSpaces(lines)
 	require.Contains(t, lines, " Directory snapshotted: 5 (defined for this target)")
 	require.Contains(t, lines, " Directory ignored: 5 (defined for this target)")
 	require.Contains(t, lines, " Entry snapshotted: 0 (defined for this target)")
@@ -29,7 +28,7 @@ func TestSetLoggingPolicy(t *testing.T) {
 	td := testutil.TempDirectory(t)
 
 	lines = e.RunAndExpectSuccess(t, "policy", "show", td)
-	lines = compressSpaces(lines)
+	lines = testutil.CompressSpaces(lines)
 	require.Contains(t, lines, " Directory snapshotted: 5 inherited from (global)")
 	require.Contains(t, lines, " Directory ignored: 5 inherited from (global)")
 	require.Contains(t, lines, " Entry snapshotted: 0 inherited from (global)")
@@ -46,7 +45,7 @@ func TestSetLoggingPolicy(t *testing.T) {
 		"--log-entry-cache-miss=6")
 
 	lines = e.RunAndExpectSuccess(t, "policy", "show", td)
-	lines = compressSpaces(lines)
+	lines = testutil.CompressSpaces(lines)
 	require.Contains(t, lines, " Directory snapshotted: 1 (defined for this target)")
 	require.Contains(t, lines, " Directory ignored: 2 (defined for this target)")
 	require.Contains(t, lines, " Entry snapshotted: 3 (defined for this target)")
@@ -57,7 +56,7 @@ func TestSetLoggingPolicy(t *testing.T) {
 	e.RunAndExpectSuccess(t, "policy", "set", td, "--log-entry-ignored=inherit")
 
 	lines = e.RunAndExpectSuccess(t, "policy", "show", td)
-	lines = compressSpaces(lines)
+	lines = testutil.CompressSpaces(lines)
 	require.Contains(t, lines, " Entry ignored: 5 inherited from (global)")
 
 	e.RunAndExpectFailure(t, "policy", "set", td, "--log-dir-snapshotted=-1")
@@ -66,18 +65,4 @@ func TestSetLoggingPolicy(t *testing.T) {
 	e.RunAndExpectFailure(t, "policy", "set", td, "--log-entry-ignored=-1")
 	e.RunAndExpectFailure(t, "policy", "set", td, "--log-entry-cache-hit=-1")
 	e.RunAndExpectFailure(t, "policy", "set", td, "--log-entry-cache-miss=-1")
-}
-
-func compressSpaces(lines []string) []string {
-	var result []string
-
-	for _, l := range lines {
-		for l2 := strings.ReplaceAll(l, "  ", " "); l != l2; l2 = strings.ReplaceAll(l, "  ", " ") {
-			l = l2
-		}
-
-		result = append(result, l)
-	}
-
-	return result
 }

--- a/cli/command_policy_set_upload_test.go
+++ b/cli/command_policy_set_upload_test.go
@@ -16,7 +16,7 @@ func TestSetUploadPolicy(t *testing.T) {
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
 	lines := e.RunAndExpectSuccess(t, "policy", "show", "--global")
-	lines = compressSpaces(lines)
+	lines = testutil.CompressSpaces(lines)
 	require.Contains(t, lines, " Max parallel snapshots (server/UI): 1 (defined for this target)")
 	require.Contains(t, lines, " Max parallel file reads: - (defined for this target)")
 	require.Contains(t, lines, " Parallel upload above size: 2.1 GB (defined for this target)")
@@ -25,7 +25,7 @@ func TestSetUploadPolicy(t *testing.T) {
 	td := testutil.TempDirectory(t)
 
 	lines = e.RunAndExpectSuccess(t, "policy", "show", td)
-	lines = compressSpaces(lines)
+	lines = testutil.CompressSpaces(lines)
 	require.Contains(t, lines, " Max parallel snapshots (server/UI): 1 inherited from (global)")
 	require.Contains(t, lines, " Max parallel file reads: - inherited from (global)")
 	require.Contains(t, lines, " Parallel upload above size: 2.1 GB inherited from (global)")
@@ -33,7 +33,7 @@ func TestSetUploadPolicy(t *testing.T) {
 	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--max-parallel-snapshots=7", "--max-parallel-file-reads=33", "--parallel-upload-above-size-mib=4096")
 
 	lines = e.RunAndExpectSuccess(t, "policy", "show", td)
-	lines = compressSpaces(lines)
+	lines = testutil.CompressSpaces(lines)
 
 	require.Contains(t, lines, " Max parallel snapshots (server/UI): 7 inherited from (global)")
 	require.Contains(t, lines, " Max parallel file reads: 33 inherited from (global)")
@@ -42,7 +42,7 @@ func TestSetUploadPolicy(t *testing.T) {
 	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--max-parallel-snapshots=default", "--max-parallel-file-reads=default", "--parallel-upload-above-size-mib=default")
 
 	lines = e.RunAndExpectSuccess(t, "policy", "show", td)
-	lines = compressSpaces(lines)
+	lines = testutil.CompressSpaces(lines)
 
 	require.Contains(t, lines, " Max parallel snapshots (server/UI): 1 inherited from (global)")
 	require.Contains(t, lines, " Max parallel file reads: - inherited from (global)")

--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	cloud.google.com/go/iam v0.7.0 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
+	github.com/ettle/strcase v0.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/ettle/strcase v0.1.1 h1:htFueZyVeE1XNnMEfbqp5r67qAN/4r6ya1ysq8Q+Zcw=
+github.com/ettle/strcase v0.1.1/go.mod h1:hzDLsPC7/lwKyBOywSHEP89nt2pDgdy+No1NBA9o9VY=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/foomo/htpasswd v0.0.0-20200116085101-e3a90e78da9c h1:DBGU7zCwrrPPDsD6+gqKG8UfMxenWg9BOJE/Nmfph+4=

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -178,3 +178,18 @@ func MustGetTotalDirSize(t *testing.T, dirpath string) int64 {
 
 	return total
 }
+
+// CompressSpaces normalizes all repeated spaces in the given lines with single space.
+func CompressSpaces(lines []string) []string {
+	var result []string
+
+	for _, l := range lines {
+		for l2 := strings.ReplaceAll(l, "  ", " "); l != l2; l2 = strings.ReplaceAll(l, "  ", " ") {
+			l = l2
+		}
+
+		result = append(result, l)
+	}
+
+	return result
+}

--- a/snapshot/policy/actions_policy.go
+++ b/snapshot/policy/actions_policy.go
@@ -19,6 +19,15 @@ type ActionsPolicyDefinition struct {
 	AfterSnapshotRoot  snapshot.SourceInfo `json:"afterSnapshotRoot,omitempty"`
 }
 
+// WebHookInfo encapsulates all parameters for invoking a webhook.
+type WebHookInfo struct {
+	WebhookURL string            `json:"url"`
+	Method     string            `json:"method,omitempty"`  // method, default==POST
+	Headers    map[string]string `json:"headers,omitempty"` // HTTP headers to add
+
+	TrustedServerCertificateFingerprint string `json:"certFingerprint,omitempty"`
+}
+
 // ActionCommand configures a action command.
 type ActionCommand struct {
 	// command + args to run
@@ -27,6 +36,8 @@ type ActionCommand struct {
 
 	// alternatively inline script to run using either Unix shell or cmd.exe on Windows.
 	Script string `json:"script,omitempty"`
+
+	WebHook *WebHookInfo `json:"webhook,omitempty"`
 
 	TimeoutSeconds int    `json:"timeout,omitempty"`
 	Mode           string `json:"mode,omitempty"` // essential,optional,async


### PR DESCRIPTION
The webhook works in exactly the same way as command-line actions, except instead of environment variables we use headers:

* `X-Kopia-Action`
* `X-Kopia-Snapshot-Id`
* `X-Kopia-Source-Path`
* `X-Kopia-Snapshot-Path`
* `X-Kopia-Version`

To redirect snapshot path, webhook must set response header:

* `X-Kopia-Snapshot-Path: <new-path>`

Usage:

```
kopia policy set \
  --before-folder-webhook-url=URL \
  --after-folder-webhook-url=URL \
  --before-snapshot-root-webhook-url=URL \
  --after-snapshot-root-webhook-url=URL \
  --webhook-method=POST|GET|PUT|DELETE|PATCH \
  --webhook-header k=v \
  --webhook-header k=v \
  --webhook-mode=essential|optional \
  --webhook-server-certificate-fingerprint=<sha256>
```
