### PR TITLE
fix(general): resume TestS3Connect() after fixing regression

### DIFF
--- a/tests/robustness/snapmeta/kopia_persister_light_test.go
+++ b/tests/robustness/snapmeta/kopia_persister_light_test.go
@@ -131,8 +131,6 @@ func TestPersistence(t *testing.T) {
 }
 
 func TestS3Connect(t *testing.T) {
-	t.Skip("TODO - fix me")
-
 	repoPath, err := os.MkdirTemp("", "kopia-test-repo-")
 	assertNoError(t, err)
 


### PR DESCRIPTION
Since the fix https://github.com/minio/minio-go/pull/1682 has merged and `go-minio` dependency was bumped to `v7.0.36` in #2378, this reverts commit 7fbf8636079dfe4b51edcadaaff596aa6f1dcea8 from #2246. Resolves #2247.