### PR TITLE
fix(ci): fixed git working directory cleanup issue

### DIFF
--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -157,6 +157,7 @@ checklocks=$(checklocks_dir)$(slash)bin$(slash)checklocks$(exe_suffix)
 $(checklocks): export GOPATH=$(checklocks_dir)
 $(checklocks):
 	go install gvisor.dev/gvisor/tools/checklocks/cmd/checklocks@$(CHECKLOCKS_VERSION)
+	go clean -modcache
 
 # hugo
 hugo_dir=$(TOOLS_DIR)$(slash)hugo-$(HUGO_VERSION)


### PR DESCRIPTION
https://github.com/kopia/kopia/runs/8243012442?check_suite_focus=true

This is caused by weird permissions set on files by `go install` which makes it hard to remove the entire directory using `rm -rf`.

The solution is to clean (local) module cache after `go install` which makes subsequent `rm -rf` work without a problem.