### PR TITLE
fix(snapshots): fixed --parallel flag when snapshotting

### DIFF
--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -727,8 +727,13 @@ func (u *Uploader) maybeIgnoreCachedEntry(ctx context.Context, ent fs.Entry) fs.
 
 func (u *Uploader) effectiveParallelFileReads(pol *policy.Policy) int {
 	p := u.ParallelUploads
-	max := pol.UploadPolicy.MaxParallelFileReads.OrDefault(runtime.NumCPU())
+	if p > 0 {
+		// command-line override takes precedence.
+		return p
+	}
 
+	// use policy setting or number of CPUs.
+	max := pol.UploadPolicy.MaxParallelFileReads.OrDefault(runtime.NumCPU())
 	if p < 1 || p > max {
 		return max
 	}

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -679,7 +679,7 @@ func TestParallelUploadUploadsBlobsInParallel(t *testing.T) {
 	th := newUploadTestHarness(ctx, t)
 
 	u := NewUploader(th.repo)
-	u.ParallelUploads = 10
+	u.ParallelUploads = 13
 
 	// no faults for first blob write - session marker.
 	th.faulty.AddFault(blobtesting.MethodPutBlob)
@@ -704,6 +704,8 @@ func TestParallelUploadUploadsBlobsInParallel(t *testing.T) {
 	u.disableEstimation = true
 
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+
+	require.Equal(t, 13, u.effectiveParallelFileReads(policyTree.EffectivePolicy()))
 
 	si := snapshot.SourceInfo{
 		UserName: "user",


### PR DESCRIPTION
Previously the value of --parallel flag was (unintentionally) capped at max number of CPUs. This PR fixes the logic.