### PR TITLE
feat(snapshots): Added option to ignore file by extended attributes

### DIFF
--- a/cli/command_policy_set_files.go
+++ b/cli/command_policy_set_files.go
@@ -25,6 +25,11 @@ type policyFilesFlags struct {
 	policyOneFileSystem string
 
 	policyIgnoreCacheDirs string
+
+	// Ignore extended attributes rules.
+	policySetAddIgnoreExtendedAttributes    []string
+	policySetRemoveIgnoreExtendedAttributes []string
+	policySetClearIgnoreExtendedAttributes  bool
 }
 
 func (c *policyFilesFlags) setup(cmd *kingpin.CmdClause) {
@@ -43,6 +48,11 @@ func (c *policyFilesFlags) setup(cmd *kingpin.CmdClause) {
 	cmd.Flag("one-file-system", "Stay in parent filesystem when finding files ('true', 'false', 'inherit')").EnumVar(&c.policyOneFileSystem, booleanEnumValues...)
 
 	cmd.Flag("ignore-cache-dirs", "Ignore cache directories ('true', 'false', 'inherit')").EnumVar(&c.policyIgnoreCacheDirs, booleanEnumValues...)
+
+	// Ignore extended attribute rules.
+	cmd.Flag("add-ignore-extended-attribute", "List of extended attribute names to add to the ignore extended attributes list").PlaceHolder("NAME").StringsVar(&c.policySetAddIgnoreExtendedAttributes)
+	cmd.Flag("remove-ignore-extended-attribute", "List of extended attribute names to remove from the ignore extended attributes list").PlaceHolder("NAME").StringsVar(&c.policySetRemoveIgnoreExtendedAttributes)
+	cmd.Flag("clear-ignore-extended-attributes", "Clear list of extended attribute names in the ignore attributes extended list").BoolVar(&c.policySetClearIgnoreExtendedAttributes)
 }
 
 func (c *policyFilesFlags) setFilesPolicyFromFlags(ctx context.Context, fp *policy.FilesPolicy, changeCount *int) error {
@@ -56,6 +66,8 @@ func (c *policyFilesFlags) setFilesPolicyFromFlags(ctx context.Context, fp *poli
 	if err := applyPolicyBoolPtr(ctx, "ignore cache dirs", &fp.IgnoreCacheDirectories, c.policyIgnoreCacheDirs, changeCount); err != nil {
 		return err
 	}
+
+	applyPolicyStringList(ctx, "ignore extended attributes", &fp.IgnoreExtendedAttributes, c.policySetAddIgnoreExtendedAttributes, c.policySetRemoveIgnoreExtendedAttributes, c.policySetClearIgnoreExtendedAttributes, changeCount)
 
 	return applyPolicyBoolPtr(ctx, "one filesystem", &fp.OneFileSystem, c.policyOneFileSystem, changeCount)
 }

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -169,13 +169,19 @@ func appendFilesPolicyValue(items []policyTableRow, p *policy.Policy, def *polic
 
 	if len(p.FilesPolicy.IgnoreRules) > 0 {
 		items = append(items, policyTableRow{
-			"  Ignore rules:", "", definitionPointToString(p.Target(), def.FilesPolicy.IgnoreRules),
+			"  Ignore rules:",
+			"",
+			definitionPointToString(p.Target(), def.FilesPolicy.IgnoreRules),
 		})
 		for _, rule := range p.FilesPolicy.IgnoreRules {
 			items = append(items, policyTableRow{"    " + rule, "", ""})
 		}
 	} else {
-		items = append(items, policyTableRow{"  No ignore rules:", "", ""})
+		items = append(items, policyTableRow{
+			"  No ignore rules:",
+			"",
+			definitionPointToString(p.Target(), def.FilesPolicy.IgnoreRules),
+		})
 	}
 
 	if len(p.FilesPolicy.DotIgnoreFiles) > 0 {
@@ -202,6 +208,23 @@ func appendFilesPolicyValue(items []policyTableRow, p *policy.Policy, def *polic
 		boolToString(p.FilesPolicy.OneFileSystem.OrDefault(false)),
 		definitionPointToString(p.Target(), def.FilesPolicy.OneFileSystem),
 	})
+
+	if len(p.FilesPolicy.IgnoreExtendedAttributes) > 0 {
+		items = append(items, policyTableRow{
+			"  Ignore extended attributes:",
+			"",
+			definitionPointToString(p.Target(), def.FilesPolicy.IgnoreExtendedAttributes),
+		})
+		for _, attrib := range p.FilesPolicy.IgnoreExtendedAttributes {
+			items = append(items, policyTableRow{"    " + attrib, "", ""})
+		}
+	} else {
+		items = append(items, policyTableRow{
+			"  No ignore extended attributes:",
+			"",
+			definitionPointToString(p.Target(), def.FilesPolicy.IgnoreExtendedAttributes),
+		})
+	}
 
 	return items
 }

--- a/fs/ignorefs/ignorefs_test.go
+++ b/fs/ignorefs/ignorefs_test.go
@@ -58,6 +58,9 @@ var defaultPolicy = policy.BuildTree(map[string]*policy.Policy{
 			IgnoreRules: []string{
 				"*-by-rule",
 			},
+			IgnoreExtendedAttributes: []string{
+				"com.apple.metadata:com_apple_backup_excludeItem",
+			},
 		},
 	},
 }, policy.DefaultPolicy)
@@ -491,6 +494,20 @@ var cases = []struct {
 			"./B/AB/file.go",
 		},
 		ignoredFiles: []string{},
+	},
+	{
+		desc:       "default policy, only ignore file by extended attributes",
+		policyTree: defaultPolicy,
+		setup: func(root *mockfs.Directory) {
+			f := root.AddFile("ignored-by-xattr", dummyFileContents, 0)
+			f.AddExtendedAttribute("com.apple.metadata:com_apple_backup_excludeItem")
+		},
+		addedFiles: nil,
+		ignoredFiles: []string{
+			"./ignored-by-xattr",
+			"./ignored-by-rule",
+			"./largefile1",
+		},
 	},
 }
 

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -59,6 +59,10 @@ func (e *virtualEntry) Device() fs.DeviceInfo {
 	return e.device
 }
 
+func (e *virtualEntry) ExtendedAttributes() fs.Attributes {
+	return fs.AttributesNotSupported{}
+}
+
 func (e *virtualEntry) LocalFilesystemPath() string {
 	return ""
 }

--- a/go.mod
+++ b/go.mod
@@ -107,6 +107,7 @@ require (
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/klauspost/reedsolomon v1.11.6
+	github.com/pkg/xattr v0.4.9
 	github.com/prometheus/client_model v0.3.0
 	go.opentelemetry.io/otel v1.13.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=
 github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pkg/sftp v1.13.5 h1:a3RLUqkyjYRtBTZJZ1VRrKbN3zhuPLlUc3sphVz81go=
 github.com/pkg/sftp v1.13.5/go.mod h1:wHDZ0IZX6JcBYRK1TH9bcVq8G7TLpVHYIGJRFnmPfxg=
+github.com/pkg/xattr v0.4.9 h1:5883YPCtkSd8LFbs13nXplj9g9tlrwoJRjgpgMu1/fE=
+github.com/pkg/xattr v0.4.9/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -367,6 +369,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/snapshot/policy/files_policy.go
+++ b/snapshot/policy/files_policy.go
@@ -4,24 +4,26 @@ import "github.com/kopia/kopia/snapshot"
 
 // FilesPolicy describes files to be ignored when taking snapshots.
 type FilesPolicy struct {
-	IgnoreRules            []string      `json:"ignore,omitempty"`
-	NoParentIgnoreRules    bool          `json:"noParentIgnore,omitempty"`
-	DotIgnoreFiles         []string      `json:"ignoreDotFiles,omitempty"`
-	NoParentDotIgnoreFiles bool          `json:"noParentDotFiles,omitempty"`
-	IgnoreCacheDirectories *OptionalBool `json:"ignoreCacheDirs,omitempty"`
-	MaxFileSize            int64         `json:"maxFileSize,omitempty"`
-	OneFileSystem          *OptionalBool `json:"oneFileSystem,omitempty"`
+	IgnoreRules              []string      `json:"ignore,omitempty"`
+	NoParentIgnoreRules      bool          `json:"noParentIgnore,omitempty"`
+	DotIgnoreFiles           []string      `json:"ignoreDotFiles,omitempty"`
+	NoParentDotIgnoreFiles   bool          `json:"noParentDotFiles,omitempty"`
+	IgnoreCacheDirectories   *OptionalBool `json:"ignoreCacheDirs,omitempty"`
+	MaxFileSize              int64         `json:"maxFileSize,omitempty"`
+	OneFileSystem            *OptionalBool `json:"oneFileSystem,omitempty"`
+	IgnoreExtendedAttributes []string      `json:"ignoreExtendedAttributes,omitempty"`
 }
 
 // FilesPolicyDefinition specifies which policy definition provided the value of a particular field.
 type FilesPolicyDefinition struct {
-	IgnoreRules            snapshot.SourceInfo `json:"ignore,omitempty"`
-	NoParentIgnoreRules    snapshot.SourceInfo `json:"noParentIgnore,omitempty"`
-	DotIgnoreFiles         snapshot.SourceInfo `json:"ignoreDotFiles,omitempty"`
-	NoParentDotIgnoreFiles snapshot.SourceInfo `json:"noParentDotFiles,omitempty"`
-	IgnoreCacheDirectories snapshot.SourceInfo `json:"ignoreCacheDirs,omitempty"`
-	MaxFileSize            snapshot.SourceInfo `json:"maxFileSize,omitempty"`
-	OneFileSystem          snapshot.SourceInfo `json:"oneFileSystem,omitempty"`
+	IgnoreRules              snapshot.SourceInfo `json:"ignore,omitempty"`
+	NoParentIgnoreRules      snapshot.SourceInfo `json:"noParentIgnore,omitempty"`
+	DotIgnoreFiles           snapshot.SourceInfo `json:"ignoreDotFiles,omitempty"`
+	NoParentDotIgnoreFiles   snapshot.SourceInfo `json:"noParentDotFiles,omitempty"`
+	IgnoreCacheDirectories   snapshot.SourceInfo `json:"ignoreCacheDirs,omitempty"`
+	MaxFileSize              snapshot.SourceInfo `json:"maxFileSize,omitempty"`
+	OneFileSystem            snapshot.SourceInfo `json:"oneFileSystem,omitempty"`
+	IgnoreExtendedAttributes snapshot.SourceInfo `json:"ignoreExtendedAttributes,omitempty"`
 }
 
 // Merge applies default values from the provided policy.
@@ -33,4 +35,5 @@ func (p *FilesPolicy) Merge(src FilesPolicy, def *FilesPolicyDefinition, si snap
 	mergeOptionalBool(&p.IgnoreCacheDirectories, src.IgnoreCacheDirectories, &def.IgnoreCacheDirectories, si)
 	mergeInt64(&p.MaxFileSize, src.MaxFileSize, &def.MaxFileSize, si)
 	mergeOptionalBool(&p.OneFileSystem, src.OneFileSystem, &def.OneFileSystem, si)
+	mergeStringList(&p.IgnoreExtendedAttributes, src.IgnoreExtendedAttributes, &def.IgnoreExtendedAttributes, si)
 }

--- a/snapshot/policy/policy_tree.go
+++ b/snapshot/policy/policy_tree.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"runtime"
 	"strings"
 )
 
@@ -22,7 +23,8 @@ var (
 
 	// defaultFilesPolicy is the default file ignore policy.
 	defaultFilesPolicy = FilesPolicy{
-		DotIgnoreFiles: []string{".kopiaignore"},
+		DotIgnoreFiles:           []string{".kopiaignore"},
+		IgnoreExtendedAttributes: createDefaultIgnoreExtendedAttributes(),
 	}
 
 	// defaultLoggingPolicy is the default logs policy.
@@ -74,6 +76,15 @@ var (
 	// DefaultDefinition provides the Definition for the default policy.
 	DefaultDefinition = &Definition{}
 )
+
+func createDefaultIgnoreExtendedAttributes() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{"com.apple.metadata:com_apple_backup_excludeItem"}
+	default:
+		return nil
+	}
+}
 
 // Tree represents a node in the policy tree, where a policy can be
 // defined. A nil tree is a valid tree with default policy.

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -49,6 +49,10 @@ func (s *repositoryAllSources) Sys() interface{} {
 	return nil
 }
 
+func (s *repositoryAllSources) ExtendedAttributes() fs.Attributes {
+	return fs.AttributesNotSupported{}
+}
+
 func (s *repositoryAllSources) LocalFilesystemPath() string {
 	return ""
 }

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -80,6 +80,10 @@ func (e *repositoryEntry) DirEntry() *snapshot.DirEntry {
 	return e.metadata
 }
 
+func (e *repositoryEntry) ExtendedAttributes() fs.Attributes {
+	return fs.AttributesNotSupported{}
+}
+
 func (e *repositoryEntry) LocalFilesystemPath() string {
 	return ""
 }

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -53,6 +53,10 @@ func (s *sourceDirectories) Device() fs.DeviceInfo {
 	return fs.DeviceInfo{}
 }
 
+func (s *sourceDirectories) ExtendedAttributes() fs.Attributes {
+	return fs.AttributesNotSupported{}
+}
+
 func (s *sourceDirectories) LocalFilesystemPath() string {
 	return ""
 }

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -51,6 +51,10 @@ func (s *sourceSnapshots) Device() fs.DeviceInfo {
 	return fs.DeviceInfo{}
 }
 
+func (s *sourceSnapshots) ExtendedAttributes() fs.Attributes {
+	return fs.AttributesNotSupported{}
+}
+
 func (s *sourceSnapshots) LocalFilesystemPath() string {
 	return ""
 }


### PR DESCRIPTION
It allows to set any attribute, and use as default the attribute used in MacOS.

This fixes #1539.