### PR TITLE
chore(cli): log bad snapshot tag when parsing fails

### DIFF
--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -173,7 +173,7 @@ func getTags(tagStrings []string) (map[string]string, error) {
 	for _, tagkv := range tagStrings {
 		parts := strings.SplitN(tagkv, ":", numberOfPartsInTagString)
 		if len(parts) != numberOfPartsInTagString {
-			return nil, errors.New("Invalid tag format. Requires <key>:<value>")
+			return nil, errors.Errorf("Invalid tag format (%s). Requires <key>:<value>", tagkv)
 		}
 
 		key := tagKeyPrefix + parts[0]


### PR DESCRIPTION
In the function that parses the tags passed to the create snapshot command, if the tag had an incorrect format, an error message would be returned which did not show the tag itself, making debugging such error difficult. This commit includes the tag in the error message to make debugging easier.