### PR TITLE
fix(server): Respect manual scheduling policy

### DIFF
--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -81,6 +81,10 @@ func (p *SchedulingPolicy) SetInterval(d time.Duration) {
 // NextSnapshotTime computes next snapshot time given previous
 // snapshot time and current wall clock time.
 func (p *SchedulingPolicy) NextSnapshotTime(previousSnapshotTime, now time.Time) (time.Time, bool) {
+	if p.Manual {
+		return time.Time{}, false
+	}
+
 	const oneDay = 24 * time.Hour
 
 	var (

--- a/snapshot/policy/scheduling_policy_test.go
+++ b/snapshot/policy/scheduling_policy_test.go
@@ -162,6 +162,17 @@ func TestNextSnapshotTime(t *testing.T) {
 			wantTime:             time.Date(2020, time.January, 1, 19, 0, 0, 0, time.Local),
 			wantOK:               true,
 		},
+		{
+			pol: policy.SchedulingPolicy{
+				IntervalSeconds: 43200,
+				TimesOfDay:      []policy.TimeOfDay{{19, 0}, {20, 0}},
+				Manual:          true,
+			},
+			previousSnapshotTime: time.Date(2020, time.January, 1, 19, 0, 0, 0, time.Local),
+			now:                  time.Date(2020, time.January, 1, 10, 0, 0, 0, time.Local),
+			wantTime:             time.Time{},
+			wantOK:               false,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
The server was ignoring when "Manual Snapshots Only" was set to true in policy. This fixes that.