### PR TITLE
fix(repository): fixed frequent repository refreshes for older repositories

### DIFF
--- a/tests/compat_test/compat_test.go
+++ b/tests/compat_test/compat_test.go
@@ -2,7 +2,11 @@ package compat_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/tests/testenv"
 )
@@ -48,6 +52,43 @@ func TestRepoCreatedWith08CanBeOpenedWithCurrent(t *testing.T) {
 	// old 0.8 client who has cached the format blob and never disconnected
 	// can't open the repository because of the poison blob
 	e1.RunAndExpectFailure(t, "snap", "ls")
+}
+
+func TestRepoCreatedWith08ProperlyRefreshes(t *testing.T) {
+	t.Parallel()
+
+	if kopiaCurrentExe == "" {
+		t.Skip()
+	}
+
+	runner08 := testenv.NewExeRunnerWithBinary(t, kopia08exe)
+
+	// create repository using v0.8
+	e1 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner08)
+	e1.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e1.RepoDir)
+	e1.RunAndExpectSuccess(t, "snap", "create", ".")
+
+	// switch to using latest runner
+	e1.Runner = testenv.NewExeRunnerWithBinary(t, kopiaCurrentExe)
+
+	// measure time of the cache file and ensure it stays the same
+	cachePath := e1.RunAndExpectSuccess(t, "cache", "info", "--path")[0]
+	cachedBlob := filepath.Join(cachePath, "kopia.repository")
+
+	time.Sleep(1 * time.Second)
+	// 0.12.0 had a bug where we would constantly refresh kopia.repository
+	// this was done all the time instead of every 15 minutes,
+	st1, err := os.Stat(cachedBlob)
+	require.NoError(t, err)
+
+	e1.RunAndExpectSuccess(t, "repo", "status")
+	time.Sleep(1 * time.Second)
+	e1.RunAndExpectSuccess(t, "repo", "status")
+
+	st2, err := os.Stat(cachedBlob)
+	require.NoError(t, err)
+
+	require.Equal(t, st1.ModTime(), st2.ModTime())
 }
 
 func TestRepoCreatedWithCurrentWithFormatVersion1CanBeOpenedWith08(t *testing.T) {


### PR DESCRIPTION
This is a regression in 0.12.0 and was reported on Slack by Amir Zarrinkafsh.

Repository connections made using old version of Kopia did not properly save format blob cache duration so it was defaulting to 0s instead of 15 minutes causing endless format refreshes, slowing things down and causing unnecessary read traffic to blob storage.