### PR TITLE
feat(cli): Support .kopiaignore symlinks

### DIFF
--- a/fs/entry.go
+++ b/fs/entry.go
@@ -158,6 +158,7 @@ func (s *DirectorySummary) Clone() DirectorySummary {
 type Symlink interface {
 	Entry
 	Readlink(ctx context.Context) (string, error)
+	Resolve(ctx context.Context) (Entry, error)
 }
 
 // FindByName returns an entry with a given name, or nil if not found. Assumes

--- a/fs/ignorefs/ignorefs.go
+++ b/fs/ignorefs/ignorefs.go
@@ -222,6 +222,13 @@ func (d *ignoreDirectory) buildContext(ctx context.Context) (*ignoreContext, err
 
 	for _, dotfile := range effectiveDotIgnoreFiles {
 		if e, err := d.Directory.Child(ctx, dotfile); err == nil {
+			if f, ok := e.(fs.Symlink); ok {
+				e, err = f.Resolve(ctx)
+				if err != nil {
+					continue
+				}
+			}
+
 			if f, ok := e.(fs.File); ok {
 				dotIgnoreFiles = append(dotIgnoreFiles, f)
 			}

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -299,6 +299,15 @@ func (fsl *filesystemSymlink) Readlink(ctx context.Context) (string, error) {
 	return os.Readlink(fsl.fullPath())
 }
 
+func (fsl *filesystemSymlink) Resolve(ctx context.Context) (fs.Entry, error) {
+	path, err := fsl.Readlink(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get symlink target")
+	}
+
+	return NewEntry(path)
+}
+
 func (e *filesystemErrorEntry) ErrorInfo() error {
 	return e.err
 }

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -4,6 +4,7 @@ package mockfs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -368,6 +369,11 @@ type Symlink struct {
 // Readlink implements fs.Symlink interface.
 func (imsl *Symlink) Readlink(ctx context.Context) (string, error) {
 	return imsl.target, nil
+}
+
+// Resolve covers for Symlink interface's Resolve. Not implemented currently.
+func (imsl *Symlink) Resolve(ctx context.Context) (fs.Entry, error) {
+	return nil, errors.New("not implemented") //nolint:goerr113
 }
 
 // NewDirectory returns new mock directory.

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -230,6 +230,10 @@ func (rsl *repositorySymlink) Readlink(ctx context.Context) (string, error) {
 	return string(b), nil
 }
 
+func (rsl *repositorySymlink) Resolve(ctx context.Context) (fs.Entry, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (ee *repositoryEntryError) ErrorInfo() error {
 	return ee.err
 }


### PR DESCRIPTION
Implement a feature requested in #2037
- If .kopiaignore is a symlink, follow it exactly one time

Byt the way, end-to-end tests fail on my machine even in a clean master branch, so I wasn't able to run the full suite.