### PR TITLE
feat(validate index): new `repository upgrade` sub-command to validate indices.

### DIFF
--- a/cli/command_index_inspect.go
+++ b/cli/command_index_inspect.go
@@ -162,7 +162,7 @@ func (c *commandIndexInspect) inspectSingleIndexBlob(ctx context.Context, rep re
 		return errors.Wrapf(err, "unable to get data for %v", blobID)
 	}
 
-	entries, err := content.ParseIndexBlob(ctx, blobID, data.Bytes(), rep.ContentReader().ContentFormat())
+	entries, err := content.ParseIndexBlob(blobID, data.Bytes(), rep.ContentReader().ContentFormat())
 	if err != nil {
 		return errors.Wrapf(err, "unable to recover index from %v", blobID)
 	}

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -81,13 +81,8 @@ func (c *commandRepositoryUpgrade) setup(svc advancedAppServices, parent command
 }
 
 func (c *commandRepositoryUpgrade) validateAction(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-
 	_, err := rep.ContentManager().SharedManager.ValidateIndexes(ctx)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (c *commandRepositoryUpgrade) forceRollbackAction(ctx context.Context, rep repo.DirectRepositoryWriter) error {

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -72,7 +72,22 @@ func (c *commandRepositoryUpgrade) setup(svc advancedAppServices, parent command
 
 	rollbackCmd.Action(svc.directRepositoryWriteAction(c.forceRollbackAction))
 
+	validateCmd := parent.Command("validate", "Validate the upgraded indexes.")
+	validateCmd.Flag("force", "Force rollback the repository upgrade, this action can cause repository corruption").BoolVar(&c.forceRollback)
+
+	validateCmd.Action(svc.directRepositoryWriteAction(c.validateAction))
+
 	c.svc = svc
+}
+
+func (c *commandRepositoryUpgrade) validateAction(ctx context.Context, rep repo.DirectRepositoryWriter) error {
+
+	_, err := rep.ContentManager().SharedManager.ValidateIndexes(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *commandRepositoryUpgrade) forceRollbackAction(ctx context.Context, rep repo.DirectRepositoryWriter) error {

--- a/repo/content/content_manager_indexes.go
+++ b/repo/content/content_manager_indexes.go
@@ -79,6 +79,7 @@ func (sm *SharedManager) CompactIndexes(ctx context.Context, opt CompactOptions)
 	return nil
 }
 
+// ParseIndexBlob loads entries in a given index blob and returns them.
 func ParseIndexBlob(blobID blob.ID, encrypted gather.Bytes, crypter crypter) ([]Info, error) {
 	var data gather.WriteBuffer
 	defer data.Close()

--- a/repo/content/content_manager_indexes.go
+++ b/repo/content/content_manager_indexes.go
@@ -79,8 +79,7 @@ func (sm *SharedManager) CompactIndexes(ctx context.Context, opt CompactOptions)
 	return nil
 }
 
-// ParseIndexBlob loads entries in a given index blob and returns them.
-func ParseIndexBlob(ctx context.Context, blobID blob.ID, encrypted gather.Bytes, crypter crypter) ([]Info, error) {
+func ParseIndexBlob(blobID blob.ID, encrypted gather.Bytes, crypter crypter) ([]Info, error) {
 	var data gather.WriteBuffer
 	defer data.Close()
 

--- a/repo/content/index/info.go
+++ b/repo/content/index/info.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/kopia/kopia/repo/blob"
@@ -91,4 +92,33 @@ func ToInfoStruct(i Info) *InfoStruct {
 		CompressionHeaderID: i.GetCompressionHeaderID(),
 		EncryptionKeyID:     i.GetEncryptionKeyID(),
 	}
+}
+
+func DiffInfo(i0, i1 Info) []string {
+	var qs []string
+	if i0.GetFormatVersion() != i1.GetFormatVersion() {
+		qs = append(qs, fmt.Sprintf("mixed FormatVersions: %v %v", i0.GetFormatVersion(), i1.GetFormatVersion()))
+	}
+	if i0.GetOriginalLength() != i1.GetOriginalLength() {
+		qs = append(qs, fmt.Sprintf("mixed OriginalLengths: %v %v", i0.GetOriginalLength(), i1.GetOriginalLength()))
+	}
+	if i0.GetPackBlobID() != i1.GetPackBlobID() {
+		qs = append(qs, fmt.Sprintf("mixed PackBlobIDs: %v %v", i0.GetPackBlobID(), i1.GetPackBlobID()))
+	}
+	if i0.GetPackedLength() != i1.GetPackedLength() {
+		qs = append(qs, fmt.Sprintf("mixed PackedLengths: %v %v", i0.GetPackedLength(), i1.GetPackedLength()))
+	}
+	if i0.GetPackOffset() != i1.GetPackOffset() {
+		qs = append(qs, fmt.Sprintf("mixed PackOffsets: %v %v", i0.GetPackOffset(), i1.GetPackOffset()))
+	}
+	if i0.GetEncryptionKeyID() != i1.GetEncryptionKeyID() {
+		qs = append(qs, fmt.Sprintf("mixed EncryptionKeyIDs: %v %v", i0.GetEncryptionKeyID(), i1.GetEncryptionKeyID()))
+	}
+	if i0.GetDeleted() != i1.GetDeleted() {
+		qs = append(qs, fmt.Sprintf("mixed Deleted flags: %v %v", i0.GetDeleted(), i1.GetDeleted()))
+	}
+	if i0.GetTimestampSeconds() != i1.GetTimestampSeconds() {
+		qs = append(qs, fmt.Sprintf("mixed TimestampSeconds: %v %v", i0.GetTimestampSeconds(), i1.GetTimestampSeconds()))
+	}
+	return qs
 }

--- a/repo/format/upgrade_lock_test.go
+++ b/repo/format/upgrade_lock_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/epoch"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
@@ -114,6 +115,77 @@ func TestFormatUpgradeCommit(t *testing.T) {
 
 	// verify that rollback after commit fails
 	require.EqualError(t, env.RepositoryWriter.FormatManager().RollbackUpgrade(ctx), "no upgrade in progress")
+}
+
+func TestFormatUpgradeValidate(t *testing.T) {
+	upgradeOwnerId := "upgrade-owner"
+	ctx, env := repotesting.NewEnvironment(t, format.FormatVersion1, repotesting.Options{
+		OpenOptions: func(opts *repo.Options) {
+			opts.UpgradeOwnerID = upgradeOwnerId
+		},
+	})
+
+	formatBlockCacheDuration := env.Repository.ClientOptions().FormatBlobCacheDuration
+
+	l := &format.UpgradeLockIntent{
+		OwnerID:                upgradeOwnerId,
+		CreationTime:           env.Repository.Time(),
+		AdvanceNoticeDuration:  0,
+		IODrainTimeout:         formatBlockCacheDuration * 2,
+		StatusPollInterval:     formatBlockCacheDuration,
+		Message:                "upgrading from format version 2 -> 3",
+		MaxPermittedClockDrift: formatBlockCacheDuration / 3,
+	}
+
+	rep := env.RepositoryWriter
+
+	_, err := rep.FormatManager().SetUpgradeLockIntent(ctx, *l)
+	require.NoError(t, err)
+
+	rf, err := rep.FormatManager().RequiredFeatures()
+	require.NoError(t, err)
+
+	mp, err := rep.FormatManager().GetMutableParameters()
+	require.NoError(t, err)
+
+	require.Zero(t, mp.EpochParameters.Enabled)
+
+	mp.EpochParameters = epoch.DefaultParameters()
+	mp.IndexVersion = 2
+
+	err = rep.ContentManager().PrepareUpgradeToIndexBlobManagerV1(ctx, mp.EpochParameters)
+	require.NoError(t, err)
+
+	blobCfg, err := rep.FormatManager().BlobCfgBlob()
+	require.NoError(t, err)
+
+	// update format-blob and clear the cache
+	err = rep.FormatManager().SetParameters(ctx, mp, blobCfg, rf)
+
+	// poison V0 index so that old readers won't be able to open it.
+	err = content.WriteLegacyIndexPoisonBlob(ctx, rep.BlobStorage())
+	require.NoError(t, err)
+
+	mp, err = rep.FormatManager().GetMutableParameters()
+	require.NoError(t, err)
+
+	err = env.RepositoryWriter.FormatManager().CommitUpgrade(ctx)
+	require.NoError(t, err)
+
+	// reopen the repo because we still have the lock in-memory
+	env.MustReopen(t, func(opts *repo.Options) {
+		opts.UpgradeOwnerID = upgradeOwnerId
+	})
+	rep = env.RepositoryWriter
+
+	mp, err = rep.FormatManager().GetMutableParameters()
+	require.NoError(t, err)
+
+	require.True(t, mp.EpochParameters.Enabled)
+
+	msgs, err := rep.ContentManager().ValidateIndexes(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgs, 0)
 }
 
 func TestFormatUpgradeRollback(t *testing.T) {


### PR DESCRIPTION
This PR adds functionality to validate indices.

The full feature will add a validation phase to the current V0 to V1 index upgrade command.  This phase will be run before the `commitUpgrade` phase.  If validation fails, console output will be generated that indicates the failed blobs and the command exited, leaving the repository locked.  The user may then either rollback and re-run the upgrade, or continue the upgrade (by re-executing `repo upgrade begin` with the `--force` flag).  The user may also choose to change the index blob(s) using a Kopia blob-editor tool and then re-validate the index (to check the work) using `repo upgrade validate`.

Re-running `repo upgrade begin` command with the `--force` flag will commit the existing index and unlock the repository, making the V0 index blob available for reclamation.

DO NOT MERGE

This PR is a proof-of-concept, designed to promote discussion.  Maintainers may choose to approve development into a full feature (additional testing, completion of command line invocation, and finalize report output).