### PR TITLE
refactor(repository): refactored Prometheus metrics

### DIFF
--- a/cli/observability_flags_test.go
+++ b/cli/observability_flags_test.go
@@ -69,7 +69,7 @@ func TestMetricsPushFlags(t *testing.T) {
 
 	for _, b := range bodies {
 		// make sure bodies include some kopia metrics, don't need more
-		require.Contains(t, b, "kopia_content_cache_hit_bytes")
+		require.Contains(t, b, "kopia_cache_hit_bytes_total")
 	}
 
 	env.RunAndExpectFailure(t, "repo", "status",

--- a/go.mod
+++ b/go.mod
@@ -49,13 +49,13 @@ require (
 	github.com/zeebo/blake3 v0.2.3
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/zap v1.23.0
-	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
-	golang.org/x/net v0.0.0-20221014081412-f15817d10f9b
+	golang.org/x/crypto v0.1.0
+	golang.org/x/mod v0.6.0
+	golang.org/x/net v0.1.0
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	golang.org/x/sync v0.1.0
-	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	golang.org/x/sys v0.1.0
+	golang.org/x/term v0.1.0
 	golang.org/x/text v0.4.0
 	google.golang.org/api v0.103.0
 	google.golang.org/grpc v1.50.1
@@ -91,7 +91,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rs/xid v1.4.0 // indirect
@@ -108,10 +107,12 @@ require (
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/klauspost/reedsolomon v1.11.1
+	github.com/prometheus/client_model v0.3.0
 	go.opentelemetry.io/otel v1.11.1
 	go.opentelemetry.io/otel/exporters/jaeger v1.11.1
 	go.opentelemetry.io/otel/sdk v1.11.1
 	go.opentelemetry.io/otel/trace v1.11.1
+	golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -448,8 +448,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
-golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -460,6 +460,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f h1:Al51T6tzvuh3oiwX11vex3QgJ2XTedFPGmbEVh8cdoc=
+golang.org/x/exp v0.0.0-20221028150844-83b7d23a625f/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -480,8 +482,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
+golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -519,8 +521,8 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20221014081412-f15817d10f9b h1:tvrvnPFcdzp294diPnrdZZZ8XUt2Tyj7svb7X52iDuU=
-golang.org/x/net v0.0.0-20221014081412-f15817d10f9b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=
+golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -588,11 +590,12 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
-golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/cache/content_cache_concurrency_test.go
+++ b/internal/cache/content_cache_concurrency_test.go
@@ -27,7 +27,7 @@ func newContentDataCache(ctx context.Context, st blob.Storage, cacheStorage cach
 		Sweep: cache.SweepSettings{
 			MaxSizeBytes: 100,
 		},
-	})
+	}, nil)
 }
 
 func newContentMetadataCache(ctx context.Context, st blob.Storage, cacheStorage cache.Storage) (cache.ContentCache, error) {
@@ -38,7 +38,7 @@ func newContentMetadataCache(ctx context.Context, st blob.Storage, cacheStorage 
 		Sweep: cache.SweepSettings{
 			MaxSizeBytes: 100,
 		},
-	})
+	}, nil)
 }
 
 func TestPrefetchBlocksGetContent_DataCache(t *testing.T) {

--- a/internal/cache/content_cache_data_test.go
+++ b/internal/cache/content_cache_data_test.go
@@ -27,7 +27,7 @@ func TestContentCacheForData(t *testing.T) {
 		Sweep: cache.SweepSettings{
 			MaxSizeBytes: 100,
 		},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	var tmp gather.WriteBuffer
@@ -78,7 +78,7 @@ func TestContentCacheForData_Passthrough(t *testing.T) {
 
 	ctx := testlogging.Context(t)
 
-	dataCache, err := cache.NewContentCache(ctx, underlying, cache.Options{})
+	dataCache, err := cache.NewContentCache(ctx, underlying, cache.Options{}, nil)
 
 	require.NoError(t, err)
 	require.NoError(t, underlying.PutBlob(ctx, "blob1", gather.FromSlice([]byte{1, 2, 3, 4, 5, 6}), blob.PutOptions{}))

--- a/internal/cache/content_cache_metadata_test.go
+++ b/internal/cache/content_cache_metadata_test.go
@@ -29,7 +29,7 @@ func TestContentCacheForMetadata(t *testing.T) {
 		Sweep: cache.SweepSettings{
 			MaxSizeBytes: 100,
 		},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	cacheStorage := metadataCache.CacheStorage()
@@ -80,7 +80,7 @@ func TestContentCacheForMetadata_Passthrough(t *testing.T) {
 		Sweep: cache.SweepSettings{
 			MaxSizeBytes: 100,
 		},
-	})
+	}, nil)
 
 	require.NoError(t, err)
 	require.NoError(t, underlying.PutBlob(ctx, "blob1", gather.FromSlice([]byte{1, 2, 3, 4, 5, 6}), blob.PutOptions{}))

--- a/internal/cache/content_cache_test.go
+++ b/internal/cache/content_cache_test.go
@@ -62,7 +62,7 @@ func TestCacheExpiration(t *testing.T) {
 			SweepFrequency: 500 * time.Millisecond,
 			TouchThreshold: -1,
 		},
-	})
+	}, nil)
 
 	require.NoError(t, err)
 
@@ -121,7 +121,7 @@ func TestDiskContentCache(t *testing.T) {
 		Sweep: cache.SweepSettings{
 			MaxSizeBytes: maxBytes,
 		},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	defer cc.Close(ctx)
@@ -208,7 +208,7 @@ func TestCacheFailureToOpen(t *testing.T) {
 	_, err := cache.NewContentCache(testlogging.Context(t), underlyingStorage, cache.Options{
 		Storage: withoutTouchBlob{faultyCache},
 		Sweep:   cache.SweepSettings{MaxSizeBytes: 10000},
-	})
+	}, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, someError.Error())
 
@@ -218,7 +218,7 @@ func TestCacheFailureToOpen(t *testing.T) {
 	cc, err := cache.NewContentCache(ctx, underlyingStorage, cache.Options{
 		Storage: withoutTouchBlob{faultyCache},
 		Sweep:   cache.SweepSettings{MaxSizeBytes: 10000},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	cc.Close(ctx)
@@ -235,7 +235,7 @@ func TestCacheFailureToWrite(t *testing.T) {
 	cc, err := cache.NewContentCache(testlogging.Context(t), underlyingStorage, cache.Options{
 		Storage: withoutTouchBlob{faultyCache},
 		Sweep:   cache.SweepSettings{MaxSizeBytes: 10000},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	ctx := testlogging.Context(t)
@@ -270,7 +270,7 @@ func TestCacheFailureToRead(t *testing.T) {
 	cc, err := cache.NewContentCache(testlogging.Context(t), underlyingStorage, cache.Options{
 		Storage: withoutTouchBlob{faultyCache},
 		Sweep:   cache.SweepSettings{MaxSizeBytes: 10000},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	ctx := testlogging.Context(t)

--- a/internal/cache/persistent_lru_cache_test.go
+++ b/internal/cache/persistent_lru_cache_test.go
@@ -29,7 +29,7 @@ func TestPersistentLRUCache(t *testing.T) {
 		MaxSizeBytes:   maxSizeBytes,
 		TouchThreshold: cache.DefaultTouchThreshold,
 		SweepFrequency: cache.DefaultSweepFrequency,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	var tmp gather.WriteBuffer
@@ -71,7 +71,7 @@ func TestPersistentLRUCache(t *testing.T) {
 		MaxSizeBytes:   maxSizeBytes,
 		TouchThreshold: cache.DefaultTouchThreshold,
 		SweepFrequency: cache.DefaultSweepFrequency,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	verifyCached(ctx, t, pc, "key1", nil)
@@ -85,7 +85,7 @@ func TestPersistentLRUCache(t *testing.T) {
 		MaxSizeBytes:   maxSizeBytes,
 		TouchThreshold: cache.DefaultTouchThreshold,
 		SweepFrequency: cache.DefaultSweepFrequency,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	someError := errors.Errorf("some error")
@@ -135,7 +135,7 @@ func TestPersistentLRUCache_Invalid(t *testing.T) {
 
 	fs.AddFault(blobtesting.MethodGetMetadata).ErrorInstead(someError)
 
-	pc, err := cache.NewPersistentCache(ctx, "test", fc, nil, cache.SweepSettings{})
+	pc, err := cache.NewPersistentCache(ctx, "test", fc, nil, cache.SweepSettings{}, nil)
 	require.ErrorIs(t, err, someError)
 	require.Nil(t, pc)
 }
@@ -153,7 +153,7 @@ func TestPersistentLRUCache_GetDeletesInvalidBlob(t *testing.T) {
 	fs := blobtesting.NewFaultyStorage(st)
 	fc := faultyCache{fs}
 
-	pc, err := cache.NewPersistentCache(ctx, "test", fc, cache.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{})
+	pc, err := cache.NewPersistentCache(ctx, "test", fc, cache.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{}, nil)
 	require.NoError(t, err)
 
 	pc.Put(ctx, "key", gather.FromSlice([]byte{1, 2, 3}))
@@ -183,7 +183,7 @@ func TestPersistentLRUCache_PutIgnoresStorageFailure(t *testing.T) {
 	fs := blobtesting.NewFaultyStorage(st)
 	fc := faultyCache{fs}
 
-	pc, err := cache.NewPersistentCache(ctx, "test", fc, cache.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{})
+	pc, err := cache.NewPersistentCache(ctx, "test", fc, cache.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{}, nil)
 	require.NoError(t, err)
 
 	fs.AddFault(blobtesting.MethodPutBlob).ErrorInstead(someError)
@@ -213,7 +213,7 @@ func TestPersistentLRUCache_SweepMinSweepAge(t *testing.T) {
 		SweepFrequency: 100 * time.Millisecond,
 		MaxSizeBytes:   1000,
 		MinSweepAge:    10 * time.Second,
-	})
+	}, nil)
 	require.NoError(t, err)
 	pc.Put(ctx, "key", gather.FromSlice([]byte{1, 2, 3}))
 	pc.Put(ctx, "key2", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3}, 1e6)))
@@ -241,7 +241,7 @@ func TestPersistentLRUCache_SweepIgnoresErrors(t *testing.T) {
 	pc, err := cache.NewPersistentCache(ctx, "test", fc, cache.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{
 		SweepFrequency: 100 * time.Millisecond,
 		MaxSizeBytes:   1000,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// ignore delete errors forever
@@ -275,7 +275,7 @@ func TestPersistentLRUCache_Sweep1(t *testing.T) {
 		SweepFrequency: 10 * time.Millisecond,
 		MaxSizeBytes:   1,
 		MinSweepAge:    0 * time.Second,
-	})
+	}, nil)
 	require.NoError(t, err)
 	pc.Put(ctx, "key", gather.FromSlice([]byte{1, 2, 3}))
 	pc.Put(ctx, "key", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3}, 1e6)))
@@ -329,7 +329,7 @@ func TestPersistentLRUCache_Defaults(t *testing.T) {
 
 	pc, err := cache.NewPersistentCache(ctx, "testing", cs, nil, cache.SweepSettings{
 		MaxSizeBytes: maxSizeBytes,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	defer pc.Close(ctx)

--- a/internal/metrics/metric_test.go
+++ b/internal/metrics/metric_test.go
@@ -1,0 +1,54 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func mustFindMetric(t *testing.T, wantName string, wantType io_prometheus_client.MetricType, wantLabels map[string]string) *io_prometheus_client.Metric {
+	t.Helper()
+
+	mf, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, f := range mf {
+		if f.GetName() != wantName {
+			continue
+		}
+
+		if f.GetType() != wantType {
+			continue
+		}
+
+		for _, l := range f.Metric {
+			if len(l.Label) != len(wantLabels) {
+				continue
+			}
+
+			found := true
+
+			for _, lab := range l.Label {
+				if wantLabels[lab.GetName()] != lab.GetValue() {
+					found = false
+				}
+			}
+
+			if found {
+				return l
+			}
+		}
+	}
+
+	for _, f := range mf {
+		for _, l := range f.Metric {
+			t.Logf("  %v %v %v", f.GetName(), f.GetType(), l.Label)
+		}
+	}
+
+	require.Failf(t, "metric %v not found", wantName)
+
+	return nil
+}

--- a/internal/metrics/metrics_counter.go
+++ b/internal/metrics/metrics_counter.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"sync/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Counter represents a monotonically increasing int64 counter value.
+type Counter struct {
+	state atomic.Int64
+
+	prom prometheus.Counter
+}
+
+// Add adds a value to a counter.
+func (c *Counter) Add(v int64) {
+	if c == nil {
+		return
+	}
+
+	c.prom.Add(float64(v))
+	c.state.Add(v)
+}
+
+// newState initializes counter state and returns previous state or nil.
+func (c *Counter) newState() int64 {
+	return c.state.Swap(0)
+}
+
+// Snapshot captures the momentary state of a counter.
+func (c *Counter) Snapshot() int64 {
+	if c == nil {
+		return 0
+	}
+
+	return c.state.Load()
+}
+
+// CounterInt64 gets a persistent int64 counter with the provided name.
+func (r *Registry) CounterInt64(name, help string, labels map[string]string) *Counter {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	fullName := name + labelsSuffix(labels)
+
+	c := r.allCounters[fullName]
+	if c == nil {
+		c = &Counter{
+			prom: getPrometheusCounter(prometheus.CounterOpts{
+				Name: prometheusPrefix + name + prometheusCounterSuffix,
+				Help: help,
+			}, labels),
+		}
+
+		c.newState()
+		r.allCounters[fullName] = c
+	}
+
+	return c
+}

--- a/internal/metrics/metrics_counter_test.go
+++ b/internal/metrics/metrics_counter_test.go
@@ -1,0 +1,66 @@
+package metrics_test
+
+import (
+	"testing"
+
+	prommodel "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/metrics"
+)
+
+func TestCounter_Nil(t *testing.T) {
+	var e *metrics.Registry
+	cnt := e.CounterInt64("aaa", "bbb", nil)
+	require.Nil(t, cnt)
+	cnt.Add(33)
+	require.Equal(t, int64(0), cnt.Snapshot())
+}
+
+func TestCounter_NoLabels(t *testing.T) {
+	e := metrics.NewRegistry()
+	cnt := e.CounterInt64("some_gauge", "some-help", nil)
+
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_gauge_total", prommodel.MetricType_COUNTER, nil).
+			GetCounter().GetValue())
+	cnt.Add(33)
+	require.Equal(t, 33.0,
+		mustFindMetric(t, "kopia_some_gauge_total", prommodel.MetricType_COUNTER, nil).
+			GetCounter().GetValue())
+	cnt.Add(100)
+	require.Equal(t, 133.0,
+		mustFindMetric(t, "kopia_some_gauge_total", prommodel.MetricType_COUNTER, nil).
+			GetCounter().GetValue())
+
+	require.Equal(t, int64(133), cnt.Snapshot())
+}
+
+func TestCounter_WithLabels(t *testing.T) {
+	e := metrics.NewRegistry()
+	cnt1 := e.CounterInt64("some_gauge2", "some-help", map[string]string{"key1": "label1"})
+	cnt2 := e.CounterInt64("some_gauge2", "some-help", map[string]string{"key1": "label2"})
+
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_gauge2_total", prommodel.MetricType_COUNTER, map[string]string{"key1": "label1"}).
+			GetCounter().GetValue())
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_gauge2_total", prommodel.MetricType_COUNTER, map[string]string{"key1": "label2"}).
+			GetCounter().GetValue())
+	cnt1.Add(33)
+	cnt2.Add(44)
+	require.Equal(t, 44.0,
+		mustFindMetric(t, "kopia_some_gauge2_total", prommodel.MetricType_COUNTER, map[string]string{"key1": "label2"}).
+			GetCounter().GetValue())
+	require.Equal(t, 33.0,
+		mustFindMetric(t, "kopia_some_gauge2_total", prommodel.MetricType_COUNTER, map[string]string{"key1": "label1"}).
+			GetCounter().GetValue())
+	cnt1.Add(100)
+	cnt2.Add(100)
+	require.Equal(t, 133.0,
+		mustFindMetric(t, "kopia_some_gauge2_total", prommodel.MetricType_COUNTER, map[string]string{"key1": "label1"}).
+			GetCounter().GetValue())
+	require.Equal(t, 144.0,
+		mustFindMetric(t, "kopia_some_gauge2_total", prommodel.MetricType_COUNTER, map[string]string{"key1": "label2"}).
+			GetCounter().GetValue())
+}

--- a/internal/metrics/metrics_distribution.go
+++ b/internal/metrics/metrics_distribution.go
@@ -1,0 +1,186 @@
+package metrics
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/exp/constraints"
+)
+
+// DistributionState captures momentary state of a Distribution.
+type DistributionState[T constraints.Float | constraints.Integer] struct {
+	Min              T
+	Max              T
+	Sum              T
+	Count            int64
+	BucketCounters   []int64
+	BucketThresholds []T
+}
+
+// Mean returns arithmetic mean value captured in the distribution.
+func (s *DistributionState[T]) Mean() T {
+	if s.Count == 0 {
+		return 0
+	}
+
+	return s.Sum / T(s.Count)
+}
+
+// Distribution measures distribution/summary of values.
+type Distribution[T constraints.Integer | constraints.Float] struct {
+	mu               sync.Mutex
+	state            atomic.Pointer[DistributionState[T]]
+	bucketThresholds []T
+
+	prom            prometheus.Observer
+	prometheusScale float64
+}
+
+// Observe adds the provided observation value to the summary.
+func (d *Distribution[T]) Observe(value T) {
+	if d == nil {
+		return
+	}
+
+	st := d.state.Load()
+	b := bucketForThresholds(d.bucketThresholds, value)
+
+	d.prom.Observe(float64(value) / d.prometheusScale)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	st.Sum += value
+	st.Count++
+
+	if st.Count == 1 {
+		st.Max = value
+		st.Min = value
+	} else {
+		if value > st.Max {
+			st.Max = value
+		}
+
+		if value < st.Min {
+			st.Min = value
+		}
+	}
+
+	st.BucketCounters[b]++
+}
+
+// Snapshot returns a snapshot of the distribution state.
+func (d *Distribution[T]) Snapshot() DistributionState[T] {
+	if d == nil {
+		return DistributionState[T]{}
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	s := d.state.Load()
+
+	return DistributionState[T]{
+		Sum:            s.Sum,
+		Count:          s.Count,
+		Min:            s.Min,
+		Max:            s.Max,
+		BucketCounters: append([]int64(nil), s.BucketCounters...),
+	}
+}
+
+func (d *Distribution[T]) newState() *DistributionState[T] {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.state.Swap(&DistributionState[T]{
+		BucketCounters:   make([]int64, len(d.bucketThresholds)+1),
+		BucketThresholds: d.bucketThresholds,
+	})
+}
+
+// DurationDistribution gets a persistent duration distribution with the provided name.
+func (r *Registry) DurationDistribution(name, help string, thresholds *Thresholds[time.Duration], labels map[string]string) *Distribution[time.Duration] {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	fullName := name + labelsSuffix(labels)
+	h := r.allDurationDistributions[fullName]
+
+	if h == nil {
+		var promBuckets []float64
+
+		// convert from nanoseconds to seconds
+		promScale := thresholds.promScale
+		for _, v := range thresholds.values {
+			promBuckets = append(promBuckets, float64(v)/promScale)
+		}
+
+		h = &Distribution[time.Duration]{
+			bucketThresholds: thresholds.values,
+			prometheusScale:  promScale,
+			prom: getPrometheusHistogram(
+				prometheus.HistogramOpts{
+					Name:    prometheusPrefix + name + thresholds.prometheusSuffix,
+					Help:    help,
+					Buckets: promBuckets,
+				},
+				labels,
+			),
+		}
+
+		h.newState()
+
+		r.allDurationDistributions[fullName] = h
+	}
+
+	return h
+}
+
+// SizeDistribution gets a persistent size distribution with the provided name.
+func (r *Registry) SizeDistribution(name, help string, thresholds *Thresholds[int64], labels map[string]string) *Distribution[int64] {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	fullName := name + labelsSuffix(labels)
+	h := r.allSizeDistributions[fullName]
+
+	if h == nil {
+		var promBuckets []float64
+
+		// convert from nanoseconds to seconds
+		promScale := thresholds.promScale
+		for _, v := range thresholds.values {
+			promBuckets = append(promBuckets, float64(v)/promScale)
+		}
+
+		h = &Distribution[int64]{
+			bucketThresholds: thresholds.values,
+			prometheusScale:  promScale,
+			prom: getPrometheusHistogram(
+				prometheus.HistogramOpts{
+					Name:    prometheusPrefix + name + thresholds.prometheusSuffix,
+					Help:    help,
+					Buckets: promBuckets,
+				},
+				labels,
+			),
+		}
+
+		h.newState()
+
+		r.allSizeDistributions[fullName] = h
+	}
+
+	return h
+}

--- a/internal/metrics/metrics_distribution_test.go
+++ b/internal/metrics/metrics_distribution_test.go
@@ -1,0 +1,23 @@
+package metrics
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBucketForThresholds(t *testing.T) {
+	buckets := IOLatencyThresholds.values
+	n := len(buckets)
+
+	assert.Equal(t, 0, bucketForThresholds(buckets, buckets[0]-1))
+
+	for i := 0; i < n; i++ {
+		assert.Equal(t, i, bucketForThresholds(buckets, buckets[i]-1))
+		assert.Equal(t, i, bucketForThresholds(buckets, buckets[i]))
+		assert.Equal(t, i+1, bucketForThresholds(buckets, buckets[i]+1), "looking for %v", buckets[i]+1)
+	}
+
+	assert.Equal(t, n, bucketForThresholds(buckets, math.MaxInt64))
+}

--- a/internal/metrics/metrics_duration_distribution_test.go
+++ b/internal/metrics/metrics_duration_distribution_test.go
@@ -1,0 +1,142 @@
+package metrics_test
+
+import (
+	"testing"
+	"time"
+
+	prommodel "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/metrics"
+)
+
+func TestDurationDistribution_Nil(t *testing.T) {
+	var e *metrics.Registry
+	dist := e.DurationDistribution("aaa", "bbb", metrics.IOLatencyThresholds, nil)
+	require.Nil(t, dist)
+	dist.Observe(time.Second)
+	require.Equal(t, metrics.DistributionState[time.Duration]{}, dist.Snapshot())
+}
+
+func TestSizeDistribution_Nil(t *testing.T) {
+	var e *metrics.Registry
+	cnt := e.SizeDistribution("aaa", "bbb", metrics.ISOBytesThresholds, nil)
+	require.Nil(t, cnt)
+	cnt.Observe(333)
+}
+
+func TestDurationDistribution_NoLabels(t *testing.T) {
+	e := metrics.NewRegistry()
+	cnt := e.DurationDistribution("some_dur_dist", "some-help", metrics.IOLatencyThresholds, nil)
+	cnt.Observe(time.Second)
+
+	h1 := mustFindMetric(t, "kopia_some_dur_dist_ms", prommodel.MetricType_HISTOGRAM, nil)
+	require.Equal(t, uint64(1), h1.GetHistogram().GetSampleCount())
+	require.Equal(t, 1000.0, h1.GetHistogram().GetSampleSum())
+
+	cnt.Observe(30 * time.Second)
+
+	h1 = mustFindMetric(t, "kopia_some_dur_dist_ms", prommodel.MetricType_HISTOGRAM, nil)
+	require.Equal(t, uint64(2), h1.GetHistogram().GetSampleCount())
+	require.Equal(t, 31000.0, h1.GetHistogram().GetSampleSum())
+}
+
+func TestDurationDistribution_WithLabels(t *testing.T) {
+	e := metrics.NewRegistry()
+	cnt1 := e.DurationDistribution("some_dur_dist2", "some-help", metrics.IOLatencyThresholds, map[string]string{"key1": "label1"})
+	cnt2 := e.DurationDistribution("some_dur_dist2", "some-help", metrics.IOLatencyThresholds, map[string]string{"key1": "label2"})
+
+	snap0 := cnt1.Snapshot()
+
+	require.Equal(t, int64(0), snap0.Count)
+	require.Equal(t, 0*time.Second, snap0.Min)
+	require.Equal(t, 0*time.Second, snap0.Max)
+	require.Equal(t, 0*time.Second, snap0.Sum)
+	require.Equal(t, 0*time.Second, snap0.Mean())
+
+	cnt1.Observe(time.Second)
+	cnt2.Observe(time.Hour)
+
+	h1 := mustFindMetric(t, "kopia_some_dur_dist2_ms", prommodel.MetricType_HISTOGRAM, map[string]string{"key1": "label1"})
+	h2 := mustFindMetric(t, "kopia_some_dur_dist2_ms", prommodel.MetricType_HISTOGRAM, map[string]string{"key1": "label2"})
+	require.Equal(t, uint64(1), h1.GetHistogram().GetSampleCount())
+	require.Equal(t, 1000.0, h1.GetHistogram().GetSampleSum())
+	require.Equal(t, uint64(1), h2.GetHistogram().GetSampleCount())
+	require.Equal(t, 3600000.0, h2.GetHistogram().GetSampleSum())
+
+	cnt1.Observe(30 * time.Second)
+	cnt2.Observe(50 * time.Second)
+
+	h1 = mustFindMetric(t, "kopia_some_dur_dist2_ms", prommodel.MetricType_HISTOGRAM, map[string]string{"key1": "label1"})
+	h2 = mustFindMetric(t, "kopia_some_dur_dist2_ms", prommodel.MetricType_HISTOGRAM, map[string]string{"key1": "label2"})
+	require.Equal(t, uint64(2), h1.GetHistogram().GetSampleCount())
+	require.Equal(t, 31000.0, h1.GetHistogram().GetSampleSum())
+	require.Equal(t, uint64(2), h2.GetHistogram().GetSampleCount())
+	require.Equal(t, 3650000.0, h2.GetHistogram().GetSampleSum())
+
+	snap1 := cnt1.Snapshot()
+
+	require.Equal(t, int64(2), snap1.Count)
+	require.Equal(t, time.Second, snap1.Min)
+	require.Equal(t, 30*time.Second, snap1.Max)
+	require.Equal(t, 31*time.Second, snap1.Sum)
+	require.Equal(t, 15500*time.Millisecond, snap1.Mean())
+
+	snap2 := cnt2.Snapshot()
+
+	require.Equal(t, int64(2), snap2.Count)
+	require.Equal(t, 50*time.Second, snap2.Min)
+	require.Equal(t, time.Hour, snap2.Max)
+	require.Equal(t, time.Hour+50*time.Second, snap2.Sum)
+	require.Equal(t, 30*time.Minute+25*time.Second, snap2.Mean())
+}
+
+func TestSizeDistribution_WithLabels(t *testing.T) {
+	e := metrics.NewRegistry()
+	cnt1 := e.SizeDistribution("some_size_dist", "some-help", metrics.ISOBytesThresholds, map[string]string{"key1": "label1"})
+	cnt2 := e.SizeDistribution("some_size_dist", "some-help", metrics.ISOBytesThresholds, map[string]string{"key1": "label2"})
+
+	snap0 := cnt1.Snapshot()
+
+	require.Equal(t, int64(0), snap0.Count)
+	require.Equal(t, int64(0), snap0.Min)
+	require.Equal(t, int64(0), snap0.Max)
+	require.Equal(t, int64(0), snap0.Sum)
+	require.Equal(t, int64(0), snap0.Mean())
+
+	cnt1.Observe(1000)
+	cnt2.Observe(1e6)
+
+	h1 := mustFindMetric(t, "kopia_some_size_dist", prommodel.MetricType_HISTOGRAM, map[string]string{"key1": "label1"})
+	h2 := mustFindMetric(t, "kopia_some_size_dist", prommodel.MetricType_HISTOGRAM, map[string]string{"key1": "label2"})
+	require.Equal(t, uint64(1), h1.GetHistogram().GetSampleCount())
+	require.Equal(t, 1000.0, h1.GetHistogram().GetSampleSum())
+	require.Equal(t, uint64(1), h2.GetHistogram().GetSampleCount())
+	require.Equal(t, 1.0e6, h2.GetHistogram().GetSampleSum())
+
+	cnt1.Observe(300)
+	cnt2.Observe(50e6)
+
+	h1 = mustFindMetric(t, "kopia_some_size_dist", prommodel.MetricType_HISTOGRAM, map[string]string{"key1": "label1"})
+	h2 = mustFindMetric(t, "kopia_some_size_dist", prommodel.MetricType_HISTOGRAM, map[string]string{"key1": "label2"})
+	require.Equal(t, uint64(2), h1.GetHistogram().GetSampleCount())
+	require.Equal(t, 1300.0, h1.GetHistogram().GetSampleSum())
+	require.Equal(t, uint64(2), h2.GetHistogram().GetSampleCount())
+	require.Equal(t, 51.0e6, h2.GetHistogram().GetSampleSum())
+
+	snap1 := cnt1.Snapshot()
+
+	require.Equal(t, int64(2), snap1.Count)
+	require.Equal(t, int64(300), snap1.Min)
+	require.Equal(t, int64(1000), snap1.Max)
+	require.Equal(t, int64(1300), snap1.Sum)
+	require.Equal(t, int64(650), snap1.Mean())
+
+	snap2 := cnt2.Snapshot()
+
+	require.Equal(t, int64(2), snap2.Count)
+	require.Equal(t, int64(1000000), snap2.Min)
+	require.Equal(t, int64(50000000), snap2.Max)
+	require.Equal(t, int64(51000000), snap2.Sum)
+	require.Equal(t, int64(25500000), snap2.Mean())
+}

--- a/internal/metrics/metrics_gauge.go
+++ b/internal/metrics/metrics_gauge.go
@@ -1,0 +1,68 @@
+package metrics
+
+import (
+	"sync/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Gauge is a metric representing momentary state.
+type Gauge struct {
+	state atomic.Int64
+
+	prom prometheus.Gauge
+}
+
+// Set sets the value of a gauge.
+func (c *Gauge) Set(v int64) {
+	if c == nil {
+		return
+	}
+
+	if c.prom != nil {
+		c.prom.Set(float64(v))
+	}
+
+	c.state.Store(v)
+}
+
+// newState initializes counter state and returns previous state or 0.
+func (c *Gauge) newState() int64 {
+	return c.state.Swap(0)
+}
+
+// Snapshot captures a momentary state of the gauge.
+func (c *Gauge) Snapshot() int64 {
+	if c == nil {
+		return 0
+	}
+
+	return c.state.Load()
+}
+
+// Gauge gets a persistent gauge with the provided name.
+func (r *Registry) Gauge(name, help string, labels map[string]string) *Gauge {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	fullName := name + labelsSuffix(labels)
+
+	c := r.allGauges[fullName]
+	if c == nil {
+		c = &Gauge{
+			prom: getPrometheusGauge(prometheus.GaugeOpts{
+				Name: prometheusPrefix + name,
+				Help: help,
+			}, labels),
+		}
+		c.newState()
+
+		r.allGauges[fullName] = c
+	}
+
+	return c
+}

--- a/internal/metrics/metrics_gauge_test.go
+++ b/internal/metrics/metrics_gauge_test.go
@@ -1,0 +1,66 @@
+package metrics_test
+
+import (
+	"testing"
+
+	prommodel "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/metrics"
+)
+
+func TestGauge_Nil(t *testing.T) {
+	var mr *metrics.Registry
+	g := mr.Gauge("aaa", "bbb", nil)
+	require.Nil(t, g)
+	g.Set(33)
+	require.Equal(t, int64(0), g.Snapshot())
+}
+
+func TestGauge_NoLabels(t *testing.T) {
+	mr := metrics.NewRegistry()
+	g := mr.Gauge("some_gauge", "some-help", nil)
+
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, nil).
+			GetGauge().GetValue())
+	g.Set(33)
+	require.Equal(t, 33.0,
+		mustFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, nil).
+			GetGauge().GetValue())
+	g.Set(133)
+	require.Equal(t, 133.0,
+		mustFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, nil).
+			GetGauge().GetValue())
+
+	require.Equal(t, int64(133), g.Snapshot())
+}
+
+func TestGauge_WithLabels(t *testing.T) {
+	mr := metrics.NewRegistry()
+	g1 := mr.Gauge("some_gauge2", "some-help", map[string]string{"key1": "label1"})
+	g2 := mr.Gauge("some_gauge2", "some-help", map[string]string{"key1": "label2"})
+
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"}).
+			GetGauge().GetValue())
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}).
+			GetGauge().GetValue())
+	g1.Set(33)
+	g2.Set(44)
+	require.Equal(t, 44.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}).
+			GetGauge().GetValue())
+	require.Equal(t, 33.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"}).
+			GetGauge().GetValue())
+	g1.Set(133)
+	g2.Set(144)
+	require.Equal(t, 133.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"}).
+			GetGauge().GetValue())
+	require.Equal(t, 144.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}).
+			GetGauge().GetValue())
+}

--- a/internal/metrics/metrics_registry.go
+++ b/internal/metrics/metrics_registry.go
@@ -1,0 +1,119 @@
+// Package metrics provides unified way of emitting metrics inside Kopia.
+package metrics
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kopia/kopia/repo/logging"
+)
+
+var log = logging.Module("metrics")
+
+// Registry groups together all metrics stored in the repository and provides ways of accessing them.
+type Registry struct {
+	mu                       sync.Mutex
+	allCounters              map[string]*Counter
+	allGauges                map[string]*Gauge
+	allThroughput            map[string]*Throughput
+	allDurationDistributions map[string]*Distribution[time.Duration]
+	allSizeDistributions     map[string]*Distribution[int64]
+}
+
+// Snapshot captures the state of all metrics.
+type Snapshot struct {
+	Counters              map[string]int64
+	Gauges                map[string]int64
+	DurationDistributions map[string]DistributionState[time.Duration]
+	SizeDistributions     map[string]DistributionState[int64]
+}
+
+// Snapshot captures the snapshot of all metrics.
+func (r *Registry) Snapshot() Snapshot {
+	s := Snapshot{
+		Counters:              map[string]int64{},
+		Gauges:                map[string]int64{},
+		DurationDistributions: map[string]DistributionState[time.Duration]{},
+		SizeDistributions:     map[string]DistributionState[int64]{},
+	}
+
+	for k, c := range r.allCounters {
+		s.Counters[k] = c.Snapshot()
+	}
+
+	for k, c := range r.allGauges {
+		s.Gauges[k] = c.Snapshot()
+	}
+
+	for k, c := range r.allDurationDistributions {
+		s.DurationDistributions[k] = c.Snapshot()
+	}
+
+	for k, c := range r.allSizeDistributions {
+		s.SizeDistributions[k] = c.Snapshot()
+	}
+
+	return s
+}
+
+// Close closes the metrics registry.
+func (r *Registry) Close(ctx context.Context) error {
+	return nil
+}
+
+// Log logs all metrics in the registry.
+func (r *Registry) Log(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+
+	s := r.Snapshot()
+
+	for n, val := range s.Counters {
+		log(ctx).Debugw("COUNTER", "name", n, "value", val)
+	}
+
+	for n, val := range s.Gauges {
+		log(ctx).Debugw("GAUGE", "name", n, "value", val)
+	}
+
+	for n, st := range s.DurationDistributions {
+		log(ctx).Debugw("DURATION-DISTRIBUTION", "name", n, "counters", st.BucketCounters, "cnt", st.Count, "sum", st.Sum, "min", st.Min, "avg", st.Mean(), "max", st.Max)
+	}
+
+	for n, st := range s.SizeDistributions {
+		if st.Count > 0 {
+			log(ctx).Debugw("SIZE-DISTRIBUTION", "name", n, "counters", st.BucketCounters, "cnt", st.Count, "sum", st.Sum, "min", st.Min, "avg", st.Mean(), "max", st.Max)
+		}
+	}
+
+	return nil
+}
+
+// NewRegistry returns new metrics registry.
+func NewRegistry() *Registry {
+	e := &Registry{
+		allCounters:              map[string]*Counter{},
+		allGauges:                map[string]*Gauge{},
+		allDurationDistributions: map[string]*Distribution[time.Duration]{},
+		allSizeDistributions:     map[string]*Distribution[int64]{},
+		allThroughput:            map[string]*Throughput{},
+	}
+
+	return e
+}
+
+func labelsSuffix(l map[string]string) string {
+	if len(l) == 0 {
+		return ""
+	}
+
+	var params []string
+	for k, v := range l {
+		params = append(params, k+":"+v)
+	}
+
+	return "[" + strings.Join(params, ";") + "]"
+}

--- a/internal/metrics/metrics_registry_test.go
+++ b/internal/metrics/metrics_registry_test.go
@@ -1,0 +1,49 @@
+package metrics_test
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/metrics"
+	"github.com/kopia/kopia/repo/logging"
+)
+
+func TestMetricEmitter_Nil(t *testing.T) {
+	var m *metrics.Registry
+
+	m.Log(context.Background())
+	m.Close(context.Background())
+}
+
+func TestMetricEmitter_NotNil(t *testing.T) {
+	var buf bytes.Buffer
+
+	ctx := logging.WithLogger(context.Background(), logging.ToWriter(&buf))
+
+	r := metrics.NewRegistry()
+	r.CounterInt64("c1", "h1", nil).Add(33)
+	r.Gauge("g1", "h1", nil).Set(44)
+	r.Throughput("t1", "h1", nil).Observe(44, time.Second)
+	r.DurationDistribution("d1", "h1", metrics.IOLatencyThresholds, nil).Observe(33 * time.Second)
+	r.SizeDistribution("s1", "h1", metrics.ISOBytesThresholds, nil).Observe(333)
+	require.NoError(t, r.Log(ctx))
+	require.NoError(t, r.Close(ctx))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	sort.Strings(lines)
+
+	require.Equal(t, []string{
+		"COUNTER\t{\"name\":\"c1\",\"value\":33}",
+		"COUNTER\t{\"name\":\"t1_bytes\",\"value\":44}",
+		"COUNTER\t{\"name\":\"t1_duration_nanos\",\"value\":1000000000}",
+		"DURATION-DISTRIBUTION\t{\"name\":\"d1\",\"counters\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0],\"cnt\":1,\"sum\":\"33s\",\"min\":\"33s\",\"avg\":\"33s\",\"max\":\"33s\"}",
+		"GAUGE\t{\"name\":\"g1\",\"value\":44}",
+		"SIZE-DISTRIBUTION\t{\"name\":\"s1\",\"counters\":[0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],\"cnt\":1,\"sum\":333,\"min\":333,\"avg\":333,\"max\":333}",
+	}, lines)
+}

--- a/internal/metrics/metrics_thresholds.go
+++ b/internal/metrics/metrics_thresholds.go
@@ -1,0 +1,129 @@
+package metrics
+
+import (
+	"time"
+
+	"golang.org/x/exp/constraints"
+)
+
+// Thresholds encapsulates a set of bucket thresholds used in Summary[T].
+type Thresholds[T constraints.Float | constraints.Integer] struct {
+	values           []T
+	promScale        float64
+	prometheusSuffix string
+}
+
+// ISOBytesThresholds is a set of thresholds for sizes.
+//
+//nolint:gochecknoglobals
+var ISOBytesThresholds = &Thresholds[int64]{
+	[]int64{
+		100,
+		250,
+		500,
+		1_000,
+		2_500,
+		5_000,
+		10_000,
+		25_000,
+		50_000,
+		100_000,
+		250_000,
+		500_000,
+		1_000_000,
+		2_500_000,
+		5_000_000,
+		10_000_000,
+		25_000_000,
+		50_000_000,
+		100_000_000,
+		250_000_000,
+		500_000_000,
+	},
+	1,
+	"",
+}
+
+// IOLatencyThresholds is a set of thresholds that can represent IO latencies from 500us to 50s.
+//
+//nolint:gochecknoglobals
+var IOLatencyThresholds = &Thresholds[time.Duration]{
+	[]time.Duration{
+		500 * time.Microsecond,
+
+		1000 * time.Microsecond,
+		2500 * time.Microsecond,
+		5000 * time.Microsecond,
+
+		10 * time.Millisecond,
+		25 * time.Millisecond,
+		50 * time.Millisecond,
+
+		100 * time.Millisecond,
+		250 * time.Millisecond,
+		500 * time.Millisecond,
+
+		1000 * time.Millisecond,
+		2500 * time.Millisecond,
+		5000 * time.Millisecond,
+
+		10 * time.Second,
+		25 * time.Second,
+		50 * time.Second,
+	},
+	1e6, // store as milliseconds
+	"_ms",
+}
+
+// CPULatencyThresholds is a set of thresholds that can represent CPU latencies from 10us to 5s.
+//
+//nolint:gochecknoglobals
+var CPULatencyThresholds = &Thresholds[time.Duration]{
+	[]time.Duration{
+		10 * time.Microsecond,
+		25 * time.Microsecond,
+		50 * time.Microsecond,
+
+		100 * time.Microsecond,
+		250 * time.Microsecond,
+		500 * time.Microsecond,
+
+		1000 * time.Microsecond,
+		2500 * time.Microsecond,
+		5000 * time.Microsecond,
+
+		10 * time.Millisecond,
+		25 * time.Millisecond,
+		50 * time.Millisecond,
+
+		100 * time.Millisecond,
+		250 * time.Millisecond,
+		500 * time.Millisecond,
+
+		1000 * time.Millisecond,
+		2500 * time.Millisecond,
+		5000 * time.Millisecond,
+	},
+	1, // export to Prometheus as nanoseconds
+	"_ns",
+}
+
+func bucketForThresholds[T constraints.Integer | constraints.Float](thresholds []T, d T) int {
+	l, r := 0, len(thresholds)-1
+
+	for l <= r {
+		m := (l + r) >> 1
+		mid := thresholds[m]
+
+		switch {
+		case mid < d:
+			l = m + 1
+		case mid > d:
+			r = m - 1
+		default:
+			return m
+		}
+	}
+
+	return l
+}

--- a/internal/metrics/metrics_throughput.go
+++ b/internal/metrics/metrics_throughput.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+	"time"
+)
+
+// Throughput measures throughput by keeping track of total value and total duration.
+type Throughput struct {
+	totalBytes    *Counter
+	totalDuration *Counter
+}
+
+// Observe increases duration and total value counters based on the amount of time to process particular amount of data.
+func (c *Throughput) Observe(size int64, dt time.Duration) {
+	if c == nil {
+		return
+	}
+
+	c.totalBytes.Add(size)
+	c.totalDuration.Add(dt.Nanoseconds())
+}
+
+// Throughput gets a persistent counter with the provided name.
+func (r *Registry) Throughput(name, help string, labels map[string]string) *Throughput {
+	if r == nil {
+		return nil
+	}
+
+	fullName := name + labelsSuffix(labels)
+
+	c := r.allThroughput[fullName]
+	if c == nil {
+		c = &Throughput{
+			totalBytes:    r.CounterInt64(name+"_bytes", help, labels),
+			totalDuration: r.CounterInt64(name+"_duration_nanos", help, labels),
+		}
+
+		r.allThroughput[fullName] = c
+	}
+
+	return c
+}

--- a/internal/metrics/metrics_throughput_test.go
+++ b/internal/metrics/metrics_throughput_test.go
@@ -1,0 +1,41 @@
+package metrics_test
+
+import (
+	"testing"
+	"time"
+
+	prommodel "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/metrics"
+)
+
+func TestThroughput_Nil(t *testing.T) {
+	var r *metrics.Registry
+
+	th := r.Throughput("some_throughput", "some-help", nil)
+	th.Observe(1, time.Second)
+}
+
+func TestThroughput_NotNil(t *testing.T) {
+	r := metrics.NewRegistry()
+
+	th := r.Throughput("some_throughput2", "some-help", nil)
+
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_throughput2_bytes_total", prommodel.MetricType_COUNTER, nil).
+			GetCounter().GetValue())
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_throughput2_duration_nanos_total", prommodel.MetricType_COUNTER, nil).
+			GetCounter().GetValue())
+
+	th.Observe(500, 500*time.Millisecond)
+	th.Observe(1, time.Second)
+
+	require.Equal(t, 501.0,
+		mustFindMetric(t, "kopia_some_throughput2_bytes_total", prommodel.MetricType_COUNTER, nil).
+			GetCounter().GetValue())
+	require.Equal(t, 1.5e9,
+		mustFindMetric(t, "kopia_some_throughput2_duration_nanos_total", prommodel.MetricType_COUNTER, nil).
+			GetCounter().GetValue())
+}

--- a/internal/metrics/prom_cache.go
+++ b/internal/metrics/prom_cache.go
@@ -1,0 +1,64 @@
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/exp/maps"
+)
+
+const (
+	prometheusCounterSuffix = "_total"
+	prometheusPrefix        = "kopia_"
+)
+
+//nolint:gochecknoglobals
+var (
+	promCacheMutex sync.Mutex
+	promCounters   = map[string]*prometheus.CounterVec{}
+	promGauges     = map[string]*prometheus.GaugeVec{}
+	promHistograms = map[string]*prometheus.HistogramVec{}
+)
+
+func getPrometheusCounter(opts prometheus.CounterOpts, labels map[string]string) prometheus.Counter {
+	promCacheMutex.Lock()
+	defer promCacheMutex.Unlock()
+
+	prom := promCounters[opts.Name]
+	if prom == nil {
+		prom = promauto.NewCounterVec(opts, maps.Keys(labels))
+
+		promCounters[opts.Name] = prom
+	}
+
+	return prom.WithLabelValues(maps.Values(labels)...)
+}
+
+func getPrometheusGauge(opts prometheus.GaugeOpts, labels map[string]string) prometheus.Gauge {
+	promCacheMutex.Lock()
+	defer promCacheMutex.Unlock()
+
+	prom := promGauges[opts.Name]
+	if prom == nil {
+		prom = promauto.NewGaugeVec(opts, maps.Keys(labels))
+
+		promGauges[opts.Name] = prom
+	}
+
+	return prom.WithLabelValues(maps.Values(labels)...)
+}
+
+func getPrometheusHistogram(opts prometheus.HistogramOpts, labels map[string]string) prometheus.Observer {
+	promCacheMutex.Lock()
+	defer promCacheMutex.Unlock()
+
+	prom := promHistograms[opts.Name]
+	if prom == nil {
+		prom = promauto.NewHistogramVec(opts, maps.Keys(labels))
+
+		promHistograms[opts.Name] = prom
+	}
+
+	return prom.WithLabelValues(maps.Values(labels)...)
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -140,7 +140,7 @@ func TestGPRServer_AuthenticationError(t *testing.T) {
 	if _, err := repo.OpenGRPCAPIRepository(ctx, apiServerInfo, repo.ClientOptions{
 		Username: "bad-username",
 		Hostname: "bad-hostname",
-	}, nil, "bad-password"); err == nil {
+	}, nil, "bad-password", nil); err == nil {
 		t.Fatal("unexpected success when connecting with invalid username")
 	}
 }

--- a/repo/blob/storagemetrics/storage_metrics.go
+++ b/repo/blob/storagemetrics/storage_metrics.go
@@ -1,0 +1,228 @@
+// Package storagemetrics implements wrapper around Storage that adds metrics around all activity.
+package storagemetrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/kopia/kopia/internal/metrics"
+	"github.com/kopia/kopia/internal/timetrack"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+type blobMetrics struct {
+	base blob.Storage
+
+	downloadedBytesPartial *metrics.Counter
+	downloadedBytesFull    *metrics.Counter
+	uploadedBytes          *metrics.Counter
+	listBlobItems          *metrics.Counter
+
+	getBlobPartialDuration *metrics.Distribution[time.Duration]
+	getBlobFullDuration    *metrics.Distribution[time.Duration]
+	putBlobDuration        *metrics.Distribution[time.Duration]
+	getCapacityDuration    *metrics.Distribution[time.Duration]
+	getMetadataDuration    *metrics.Distribution[time.Duration]
+	deleteBlobDuration     *metrics.Distribution[time.Duration]
+	listBlobsDuration      *metrics.Distribution[time.Duration]
+	closeDuration          *metrics.Distribution[time.Duration]
+	flushCachesDuration    *metrics.Distribution[time.Duration]
+
+	getBlobErrors     *metrics.Counter
+	getCapacityErrors *metrics.Counter
+	getMetadataErrors *metrics.Counter
+	putBlobErrors     *metrics.Counter
+	deleteBlobErrors  *metrics.Counter
+	listBlobsErrors   *metrics.Counter
+	closeErrors       *metrics.Counter
+	flushCachesErrors *metrics.Counter
+}
+
+func (s *blobMetrics) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
+	timer := timetrack.StartTimer()
+	err := s.base.GetBlob(ctx, id, offset, length, output)
+	dt := timer.Elapsed()
+
+	if length < 0 {
+		s.downloadedBytesFull.Add(int64(output.Length()))
+		s.getBlobFullDuration.Observe(dt)
+	} else {
+		s.downloadedBytesPartial.Add(int64(output.Length()))
+		s.getBlobPartialDuration.Observe(dt)
+	}
+
+	if err != nil {
+		s.getBlobErrors.Add(1)
+	}
+
+	//nolint:wrapcheck
+	return err
+}
+
+func (s *blobMetrics) GetCapacity(ctx context.Context) (blob.Capacity, error) {
+	timer := timetrack.StartTimer()
+	c, err := s.base.GetCapacity(ctx)
+	dt := timer.Elapsed()
+
+	s.getCapacityDuration.Observe(dt)
+
+	if err != nil {
+		s.getCapacityErrors.Add(1)
+	}
+
+	//nolint:wrapcheck
+	return c, err
+}
+
+func (s *blobMetrics) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata, error) {
+	timer := timetrack.StartTimer()
+	result, err := s.base.GetMetadata(ctx, id)
+	dt := timer.Elapsed()
+
+	s.getMetadataDuration.Observe(dt)
+
+	if err != nil {
+		s.getMetadataErrors.Add(1)
+	}
+
+	//nolint:wrapcheck
+	return result, err
+}
+
+func (s *blobMetrics) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
+	timer := timetrack.StartTimer()
+	err := s.base.PutBlob(ctx, id, data, opts)
+	dt := timer.Elapsed()
+
+	s.putBlobDuration.Observe(dt)
+
+	if err != nil {
+		s.putBlobErrors.Add(1)
+	} else {
+		s.uploadedBytes.Add(int64(data.Length()))
+	}
+
+	//nolint:wrapcheck
+	return err
+}
+
+func (s *blobMetrics) DeleteBlob(ctx context.Context, id blob.ID) error {
+	timer := timetrack.StartTimer()
+	err := s.base.DeleteBlob(ctx, id)
+	dt := timer.Elapsed()
+
+	s.deleteBlobDuration.Observe(dt)
+
+	if err != nil {
+		s.deleteBlobErrors.Add(1)
+	}
+
+	//nolint:wrapcheck
+	return err
+}
+
+func (s *blobMetrics) ListBlobs(ctx context.Context, prefix blob.ID, callback func(blob.Metadata) error) error {
+	timer := timetrack.StartTimer()
+	cnt := int64(0)
+	err := s.base.ListBlobs(ctx, prefix, func(bi blob.Metadata) error {
+		cnt++
+		return callback(bi)
+	})
+	dt := timer.Elapsed()
+
+	s.listBlobItems.Add(cnt)
+	s.listBlobsDuration.Observe(dt)
+
+	if err != nil {
+		s.listBlobsErrors.Add(1)
+	}
+
+	//nolint:wrapcheck
+	return err
+}
+
+func (s *blobMetrics) Close(ctx context.Context) error {
+	timer := timetrack.StartTimer()
+	err := s.base.Close(ctx)
+	dt := timer.Elapsed()
+
+	s.closeDuration.Observe(dt)
+
+	if err != nil {
+		s.closeErrors.Add(1)
+	}
+
+	//nolint:wrapcheck
+	return err
+}
+
+func (s *blobMetrics) ConnectionInfo() blob.ConnectionInfo {
+	return s.base.ConnectionInfo()
+}
+
+func (s *blobMetrics) DisplayName() string {
+	return s.base.DisplayName()
+}
+
+func (s *blobMetrics) FlushCaches(ctx context.Context) error {
+	timer := timetrack.StartTimer()
+	err := s.base.FlushCaches(ctx)
+	dt := timer.Elapsed()
+
+	s.flushCachesDuration.Observe(dt)
+
+	if err != nil {
+		s.flushCachesErrors.Add(1)
+	}
+
+	//nolint:wrapcheck
+	return err
+}
+
+// NewWrapper returns a Storage wrapper that logs all storage commands.
+func NewWrapper(wrapped blob.Storage, mr *metrics.Registry) blob.Storage {
+	durationSummaryForMethod := func(m string) *metrics.Distribution[time.Duration] {
+		return mr.DurationDistribution(
+			"blob_storage_latency",
+			"Latency of blob storage operation by method",
+			metrics.IOLatencyThresholds,
+			map[string]string{"method": m},
+		)
+	}
+
+	errorCounterForMethod := func(m string) *metrics.Counter {
+		return mr.CounterInt64(
+			"blob_errors",
+			"Number of storage operation errors by method",
+			map[string]string{"method": m},
+		)
+	}
+
+	return &blobMetrics{
+		base: wrapped,
+
+		downloadedBytesPartial: mr.CounterInt64("blob_download_partial_blob_bytes", "Number of bytes downloaded as partial blobs", nil),
+		downloadedBytesFull:    mr.CounterInt64("blob_download_full_blob_bytes", "Number of bytes downloaded as full blobs", nil),
+		uploadedBytes:          mr.CounterInt64("blob_upload_bytes", "Number of bytes uploaded", nil),
+		listBlobItems:          mr.CounterInt64("blob_list_items", "Number of list items returned", nil),
+
+		getBlobPartialDuration: durationSummaryForMethod("GetBlob-partial"),
+		getBlobFullDuration:    durationSummaryForMethod("GetBlob-full"),
+		getCapacityDuration:    durationSummaryForMethod("GetCapacity"),
+		getMetadataDuration:    durationSummaryForMethod("GetMetadata"),
+		putBlobDuration:        durationSummaryForMethod("PutBlob"),
+		deleteBlobDuration:     durationSummaryForMethod("DeleteBlob"),
+		listBlobsDuration:      durationSummaryForMethod("ListBlobs"),
+		closeDuration:          durationSummaryForMethod("Close"),
+		flushCachesDuration:    durationSummaryForMethod("FlushCaches"),
+
+		getBlobErrors:     errorCounterForMethod("GetBlob"),
+		getCapacityErrors: errorCounterForMethod("GetCapacity"),
+		getMetadataErrors: errorCounterForMethod("GetMetadata"),
+		putBlobErrors:     errorCounterForMethod("PutBlob"),
+		deleteBlobErrors:  errorCounterForMethod("DeleteBlob"),
+		listBlobsErrors:   errorCounterForMethod("ListBlobs"),
+		closeErrors:       errorCounterForMethod("Close"),
+		flushCachesErrors: errorCounterForMethod("FlushCaches"),
+	}
+}

--- a/repo/blob/storagemetrics/storage_metrics_test.go
+++ b/repo/blob/storagemetrics/storage_metrics_test.go
@@ -1,0 +1,288 @@
+package storagemetrics_test
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/metrics"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/storagemetrics"
+)
+
+func TestStorageMetrics_PutBlob(t *testing.T) {
+	ctx := testlogging.Context(t)
+	someError := errors.Errorf("foo")
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+
+	fs := blobtesting.NewFaultyStorage(st)
+	fs.AddFault(blobtesting.MethodPutBlob).ErrorInstead(someError)
+
+	mr := metrics.NewRegistry()
+	ms := storagemetrics.NewWrapper(fs, mr)
+	snap := mr.Snapshot()
+
+	requireCounterValue(t, snap, "blob_upload_bytes", 0)
+	requireCounterValue(t, snap, "blob_errors[method:PutBlob]", 0)
+
+	require.ErrorIs(t, ms.PutBlob(ctx, "someBlob1", gather.FromSlice([]byte{1, 2, 3, 4}), blob.PutOptions{}), someError)
+	require.NoError(t, ms.PutBlob(ctx, "someBlob", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
+
+	snap = mr.Snapshot()
+	requireCounterValue(t, snap, "blob_errors[method:PutBlob]", 1)
+	requireCounterValue(t, snap, "blob_upload_bytes", 3)
+
+	d := snap.DurationDistributions["blob_storage_latency[method:PutBlob]"]
+	require.EqualValues(t, 2, d.Count)
+}
+
+func TestStorageMetrics_GetBlob(t *testing.T) {
+	ctx := testlogging.Context(t)
+	someError := errors.Errorf("foo")
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+
+	require.NoError(t, st.PutBlob(ctx, "someBlob", gather.FromSlice([]byte{1, 2, 3, 4, 5}), blob.PutOptions{}))
+
+	fs := blobtesting.NewFaultyStorage(st)
+	fs.AddFault(blobtesting.MethodGetBlob).ErrorInstead(someError)
+
+	mr := metrics.NewRegistry()
+	ms := storagemetrics.NewWrapper(fs, mr)
+	snap := mr.Snapshot()
+
+	requireCounterValue(t, snap, "blob_download_full_blob_bytes", 0)
+	requireCounterValue(t, snap, "blob_download_partial_blob_bytes", 0)
+	requireCounterValue(t, snap, "blob_errors[method:GetBlob]", 0)
+
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	require.ErrorIs(t, ms.GetBlob(ctx, "someBlob", 0, -1, &tmp), someError)
+	require.NoError(t, ms.GetBlob(ctx, "someBlob", 0, -1, &tmp))
+
+	snap = mr.Snapshot()
+	requireCounterValue(t, snap, "blob_errors[method:GetBlob]", 1)
+	requireCounterValue(t, snap, "blob_download_full_blob_bytes", 5)
+
+	d := snap.DurationDistributions["blob_storage_latency[method:GetBlob-full]"]
+	require.EqualValues(t, 2, d.Count)
+
+	require.NoError(t, ms.GetBlob(ctx, "someBlob", 2, 2, &tmp))
+
+	snap = mr.Snapshot()
+	requireCounterValue(t, snap, "blob_errors[method:GetBlob]", 1)
+	requireCounterValue(t, snap, "blob_download_full_blob_bytes", 5)
+	require.Equal(t, 2, tmp.Length())
+
+	d = snap.DurationDistributions["blob_storage_latency[method:GetBlob-partial]"]
+	require.EqualValues(t, 1, d.Count)
+}
+
+func TestStorageMetrics_GetMetadata(t *testing.T) {
+	ctx := testlogging.Context(t)
+	someError := errors.Errorf("foo")
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+
+	require.NoError(t, st.PutBlob(ctx, "someBlob", gather.FromSlice([]byte{1, 2, 3, 4, 5}), blob.PutOptions{}))
+
+	fs := blobtesting.NewFaultyStorage(st)
+	fs.AddFault(blobtesting.MethodGetMetadata).ErrorInstead(someError)
+
+	mr := metrics.NewRegistry()
+	ms := storagemetrics.NewWrapper(fs, mr)
+	snap := mr.Snapshot()
+
+	requireCounterValue(t, snap, "blob_errors[method:GetMetadata]", 0)
+
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	_, err := ms.GetMetadata(ctx, "someBlob")
+	require.ErrorIs(t, err, someError)
+
+	_, err = ms.GetMetadata(ctx, "someBlob")
+	require.NoError(t, err)
+
+	snap = mr.Snapshot()
+	requireCounterValue(t, snap, "blob_errors[method:GetMetadata]", 1)
+
+	d := snap.DurationDistributions["blob_storage_latency[method:GetMetadata]"]
+	require.EqualValues(t, 2, d.Count)
+}
+
+func TestStorageMetrics_GetCapacity(t *testing.T) {
+	ctx := testlogging.Context(t)
+	someError := errors.Errorf("foo")
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+
+	fs := blobtesting.NewFaultyStorage(st)
+	fs.AddFault(blobtesting.MethodGetCapacity).ErrorInstead(someError)
+
+	mr := metrics.NewRegistry()
+	ms := storagemetrics.NewWrapper(fs, mr)
+	snap := mr.Snapshot()
+
+	requireCounterValue(t, snap, "blob_errors[method:GetCapacity]", 0)
+
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	_, err := ms.GetCapacity(ctx)
+	require.ErrorIs(t, err, someError)
+
+	_, err = ms.GetCapacity(ctx)
+	require.ErrorIs(t, err, blob.ErrNotAVolume)
+
+	snap = mr.Snapshot()
+	requireCounterValue(t, snap, "blob_errors[method:GetCapacity]", 2)
+
+	d := snap.DurationDistributions["blob_storage_latency[method:GetCapacity]"]
+	require.EqualValues(t, 2, d.Count)
+}
+
+func TestStorageMetrics_DeleteBlob(t *testing.T) {
+	ctx := testlogging.Context(t)
+	someError := errors.Errorf("foo")
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+
+	require.NoError(t, st.PutBlob(ctx, "someBlob", gather.FromSlice([]byte{1, 2, 3, 4, 5}), blob.PutOptions{}))
+
+	fs := blobtesting.NewFaultyStorage(st)
+	fs.AddFault(blobtesting.MethodDeleteBlob).ErrorInstead(someError)
+
+	mr := metrics.NewRegistry()
+	ms := storagemetrics.NewWrapper(fs, mr)
+	snap := mr.Snapshot()
+
+	requireCounterValue(t, snap, "blob_errors[method:DeleteBlob]", 0)
+
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	err := ms.DeleteBlob(ctx, "someBlob")
+	require.ErrorIs(t, err, someError)
+
+	err = ms.DeleteBlob(ctx, "someBlob")
+	require.NoError(t, err)
+
+	snap = mr.Snapshot()
+	requireCounterValue(t, snap, "blob_errors[method:DeleteBlob]", 1)
+
+	d := snap.DurationDistributions["blob_storage_latency[method:DeleteBlob]"]
+	require.EqualValues(t, 2, d.Count)
+}
+
+func TestStorageMetrics_Close(t *testing.T) {
+	ctx := testlogging.Context(t)
+	someError := errors.Errorf("foo")
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+
+	fs := blobtesting.NewFaultyStorage(st)
+	fs.AddFault(blobtesting.MethodClose).ErrorInstead(someError)
+
+	mr := metrics.NewRegistry()
+	ms := storagemetrics.NewWrapper(fs, mr)
+	snap := mr.Snapshot()
+
+	requireCounterValue(t, snap, "blob_errors[method:Close]", 0)
+
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	err := ms.Close(ctx)
+	require.ErrorIs(t, err, someError)
+
+	err = ms.Close(ctx)
+	require.NoError(t, err)
+
+	snap = mr.Snapshot()
+	requireCounterValue(t, snap, "blob_errors[method:Close]", 1)
+
+	d := snap.DurationDistributions["blob_storage_latency[method:Close]"]
+	require.EqualValues(t, 2, d.Count)
+}
+
+func TestStorageMetrics_FlushCaches(t *testing.T) {
+	ctx := testlogging.Context(t)
+	someError := errors.Errorf("foo")
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+
+	fs := blobtesting.NewFaultyStorage(st)
+	fs.AddFault(blobtesting.MethodFlushCaches).ErrorInstead(someError)
+
+	mr := metrics.NewRegistry()
+	ms := storagemetrics.NewWrapper(fs, mr)
+	snap := mr.Snapshot()
+
+	requireCounterValue(t, snap, "blob_errors[method:FlushCaches]", 0)
+
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	err := ms.FlushCaches(ctx)
+	require.ErrorIs(t, err, someError)
+
+	err = ms.FlushCaches(ctx)
+	require.NoError(t, err)
+
+	snap = mr.Snapshot()
+	requireCounterValue(t, snap, "blob_errors[method:FlushCaches]", 1)
+
+	d := snap.DurationDistributions["blob_storage_latency[method:FlushCaches]"]
+	require.EqualValues(t, 2, d.Count)
+}
+
+func TestStorageMetrics_ListBlobs(t *testing.T) {
+	ctx := testlogging.Context(t)
+	someError := errors.Errorf("foo")
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+	require.NoError(t, st.PutBlob(ctx, "someBlob1", gather.FromSlice([]byte{1, 2, 3, 4, 5}), blob.PutOptions{}))
+	require.NoError(t, st.PutBlob(ctx, "someBlob2", gather.FromSlice([]byte{1, 2, 3, 4, 5}), blob.PutOptions{}))
+	require.NoError(t, st.PutBlob(ctx, "someBlob3", gather.FromSlice([]byte{1, 2, 3, 4, 5}), blob.PutOptions{}))
+
+	fs := blobtesting.NewFaultyStorage(st)
+	fs.AddFault(blobtesting.MethodListBlobs).ErrorInstead(someError)
+
+	mr := metrics.NewRegistry()
+	ms := storagemetrics.NewWrapper(fs, mr)
+	snap := mr.Snapshot()
+
+	requireCounterValue(t, snap, "blob_errors[method:ListBlobs]", 0)
+	requireCounterValue(t, snap, "blob_list_items", 0)
+
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	err := ms.ListBlobs(ctx, "", func(bm blob.Metadata) error { return nil })
+	require.ErrorIs(t, err, someError)
+
+	err = ms.ListBlobs(ctx, "", func(bm blob.Metadata) error { return nil })
+	require.NoError(t, err)
+
+	snap = mr.Snapshot()
+	requireCounterValue(t, snap, "blob_errors[method:ListBlobs]", 1)
+
+	d := snap.DurationDistributions["blob_storage_latency[method:ListBlobs]"]
+	require.EqualValues(t, 2, d.Count)
+	requireCounterValue(t, snap, "blob_list_items", 3)
+}
+
+func TestStorageMetrics_Misc(t *testing.T) {
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+	mr := metrics.NewRegistry()
+	ms := storagemetrics.NewWrapper(st, mr)
+	require.Equal(t, st.ConnectionInfo(), ms.ConnectionInfo())
+	require.Equal(t, st.DisplayName(), ms.DisplayName())
+}
+
+func requireCounterValue(t *testing.T, snap metrics.Snapshot, key string, want int64) {
+	t.Helper()
+
+	v, ok := snap.Counters[key]
+	require.True(t, ok)
+	require.EqualValues(t, want, v)
+}

--- a/repo/content/caching_options.go
+++ b/repo/content/caching_options.go
@@ -1,6 +1,9 @@
 package content
 
-import "time"
+import (
+	"path/filepath"
+	"time"
+)
 
 // DurationSeconds represents the duration in seconds.
 type DurationSeconds float64
@@ -35,4 +38,17 @@ func (c *CachingOptions) CloneOrDefault() *CachingOptions {
 	c2 := *c
 
 	return &c2
+}
+
+// CacheSubdirOrEmpty returns path to a cache subdirectory or empty string if cache is disabled.
+func (c *CachingOptions) CacheSubdirOrEmpty(subdir string) string {
+	if c == nil {
+		return ""
+	}
+
+	if c.CacheDirectory == "" {
+		return ""
+	}
+
+	return filepath.Join(c.CacheDirectory, subdir)
 }

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -16,7 +16,9 @@ import (
 	"github.com/kopia/kopia/internal/epoch"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/listcache"
+	"github.com/kopia/kopia/internal/metrics"
 	"github.com/kopia/kopia/internal/ownwrites"
+	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/filesystem"
 	"github.com/kopia/kopia/repo/blob/sharded"
@@ -113,6 +115,8 @@ type SharedManager struct {
 	contextLogger      logging.Logger
 	internalLogManager *internalLogManager
 	internalLogger     *zap.SugaredLogger // backing logger for 'sharedBaseLogger'
+
+	metricsStruct
 }
 
 func (sm *SharedManager) readPackFileLocalIndex(ctx context.Context, packFile blob.ID, packFileLength int64, output *gather.WriteBuffer) error {
@@ -284,19 +288,26 @@ func (sm *SharedManager) decryptContentAndVerify(payload gather.Bytes, bi Info, 
 		return errors.Errorf("unsupported compressor %x", h)
 	}
 
+	t0 := timetrack.StartTimer()
+
 	if err := c.Decompress(output, tmp.Bytes().Reader(), true); err != nil {
 		return errors.Wrap(err, "error decompressing")
 	}
+
+	sm.decompressedBytes.Observe(int64(tmp.Length()), t0.Elapsed())
 
 	return nil
 }
 
 func (sm *SharedManager) decryptAndVerify(encrypted gather.Bytes, iv []byte, output *gather.WriteBuffer) error {
+	t0 := timetrack.StartTimer()
+
 	if err := sm.format.Encryptor().Decrypt(encrypted, iv, output); err != nil {
 		sm.Stats.foundInvalidContent()
 		return errors.Wrap(err, "decrypt")
 	}
 
+	sm.decryptedBytes.Observe(int64(encrypted.Length()), t0.Elapsed())
 	sm.Stats.foundValidContent()
 	sm.Stats.decrypted(output.Length())
 
@@ -384,7 +395,7 @@ func (sm *SharedManager) namedLogger(n string) logging.Logger {
 	return sm.contextLogger
 }
 
-func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *CachingOptions) error {
+func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *CachingOptions, mr *metrics.Registry) error {
 	dataCache, err := cache.NewContentCache(ctx, sm.st, cache.Options{
 		BaseCacheDirectory: caching.CacheDirectory,
 		CacheSubDir:        "contents",
@@ -393,7 +404,7 @@ func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *Ca
 			MaxSizeBytes: caching.MaxCacheSizeBytes,
 			MinSweepAge:  caching.MinContentSweepAge.DurationOrDefault(DefaultDataCacheSweepAge),
 		},
-	})
+	}, mr)
 	if err != nil {
 		return errors.Wrap(err, "unable to initialize content cache")
 	}
@@ -412,7 +423,7 @@ func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *Ca
 			MaxSizeBytes: metadataCacheSize,
 			MinSweepAge:  caching.MinMetadataSweepAge.DurationOrDefault(DefaultMetadataCacheSweepAge),
 		},
-	})
+	}, mr)
 	if err != nil {
 		return errors.Wrap(err, "unable to initialize metadata cache")
 	}
@@ -422,10 +433,10 @@ func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *Ca
 		return errors.Wrap(err, "unable to initialize index blob cache storage")
 	}
 
-	indexBlobCache, err := cache.NewPersistentCache(ctx, "index blob cache", indexBlobStorage, cache.ChecksumProtection(caching.HMACSecret), cache.SweepSettings{
+	indexBlobCache, err := cache.NewPersistentCache(ctx, "index-blobs", indexBlobStorage, cache.ChecksumProtection(caching.HMACSecret), cache.SweepSettings{
 		MaxSizeBytes: metadataCacheSize,
 		MinSweepAge:  caching.MinMetadataSweepAge.DurationOrDefault(DefaultMetadataCacheSweepAge),
-	})
+	}, mr)
 	if err != nil {
 		return errors.Wrap(err, "unable to create index blob cache")
 	}
@@ -552,7 +563,15 @@ func (sm *SharedManager) release(ctx context.Context) error {
 
 	sm.indexBlobManagerV1.epochMgr.Flush()
 
-	return errors.Wrap(sm.st.Close(ctx), "error closing storage")
+	if err := sm.st.Close(ctx); err != nil {
+		return errors.Wrap(err, "error closing storage")
+	}
+
+	if err := sm.metricsEmitter.Close(ctx); err != nil {
+		return errors.Wrap(err, "error closing metrics")
+	}
+
+	return nil
 }
 
 // AlsoLogToContentLog wraps the provided content so that all logs are also sent to
@@ -571,7 +590,7 @@ func (sm *SharedManager) shouldRefreshIndexes() bool {
 }
 
 // NewSharedManager returns SharedManager that is used by SessionWriteManagers on top of a repository.
-func NewSharedManager(ctx context.Context, st blob.Storage, prov format.Provider, caching *CachingOptions, opts *ManagerOptions) (*SharedManager, error) {
+func NewSharedManager(ctx context.Context, st blob.Storage, prov format.Provider, caching *CachingOptions, opts *ManagerOptions, mr *metrics.Registry) (*SharedManager, error) {
 	opts = opts.CloneOrDefault()
 	if opts.TimeNow == nil {
 		opts.TimeNow = clock.Now
@@ -601,6 +620,8 @@ func NewSharedManager(ctx context.Context, st blob.Storage, prov format.Provider
 		internalLogManager:      ilm,
 		internalLogger:          internalLog,
 		contextLogger:           logging.Module(FormatLogModule)(ctx),
+
+		metricsStruct: initMetricsStruct(mr),
 	}
 
 	// remember logger defined for the context.
@@ -608,7 +629,7 @@ func NewSharedManager(ctx context.Context, st blob.Storage, prov format.Provider
 
 	caching = caching.CloneOrDefault()
 
-	if err := sm.setupReadManagerCaches(ctx, caching); err != nil {
+	if err := sm.setupReadManagerCaches(ctx, caching, mr); err != nil {
 		return nil, errors.Wrap(err, "error setting up read manager caches")
 	}
 

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/metrics"
 	"github.com/kopia/kopia/repo/compression"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/logging"
@@ -266,7 +267,7 @@ type ManagerOptions struct {
 }
 
 // NewManager returns new manifest manager for the provided content manager.
-func NewManager(ctx context.Context, b contentManager, options ManagerOptions) (*Manager, error) {
+func NewManager(ctx context.Context, b contentManager, options ManagerOptions, mr *metrics.Registry) (*Manager, error) {
 	timeNow := options.TimeNow
 	if timeNow == nil {
 		timeNow = clock.Now

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -169,7 +169,7 @@ func TestManifestInitCorruptedBlock(t *testing.T) {
 
 	t.Cleanup(func() { bm0.Close(ctx) })
 
-	mgr, err := NewManager(ctx, bm, ManagerOptions{})
+	mgr, err := NewManager(ctx, bm, ManagerOptions{}, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestManifestInitCorruptedBlock(t *testing.T) {
 
 	t.Cleanup(func() { bm.Close(ctx) })
 
-	mgr, err = NewManager(ctx, bm, ManagerOptions{})
+	mgr, err = NewManager(ctx, bm, ManagerOptions{}, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -327,7 +327,7 @@ func newManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.Da
 
 	t.Cleanup(func() { bm.Close(ctx) })
 
-	mm, err := NewManager(ctx, bm, ManagerOptions{})
+	mm, err := NewManager(ctx, bm, ManagerOptions{}, nil)
 	require.NoError(t, err)
 
 	return mm

--- a/repo/object/object_manager.go
+++ b/repo/object/object_manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/metrics"
 	"github.com/kopia/kopia/repo/compression"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/format"
@@ -197,7 +198,7 @@ func PrefetchBackingContents(ctx context.Context, contentMgr contentManager, obj
 }
 
 // NewObjectManager creates an ObjectManager with the specified content manager and format.
-func NewObjectManager(ctx context.Context, bm contentManager, f format.ObjectFormat) (*Manager, error) {
+func NewObjectManager(ctx context.Context, bm contentManager, f format.ObjectFormat, mr *metrics.Registry) (*Manager, error) {
 	om := &Manager{
 		contentMgr: bm,
 		Format:     f,

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -112,7 +112,7 @@ func setupTest(t *testing.T, compressionHeaderID map[content.ID]compression.Head
 
 	r, err := NewObjectManager(testlogging.Context(t), fcm, format.ObjectFormat{
 		Splitter: "FIXED-1M",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("can't create object manager: %v", err)
 	}
@@ -283,7 +283,7 @@ func TestObjectWriterRaceBetweenCheckpointAndResult(t *testing.T) {
 
 	om, err := NewObjectManager(testlogging.Context(t), fcm, format.ObjectFormat{
 		Splitter: "FIXED-1M",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("can't create object manager: %v", err)
 	}


### PR DESCRIPTION
This may be a breaking change for users who rely on particular kopia metrics (unlikely):

- introduced blob-level metrics:

* `kopia_blob_download_full_blob_bytes_total`
* `kopia_blob_download_partial_blob_bytes_total`
* `kopia_blob_upload_bytes_total`
* `kopia_blob_storage_latency_ms` - per-method latency distribution
* `kopia_blob_errors_total` - per-method error counter

- updated cache metrics to indicate particular cache

* `kopia_cache_hit_bytes_total{cache="CACHE_TYPE"}`
* `kopia_cache_hit_total{cache="CACHE_TYPE"}`
* `kopia_cache_malformed_total{cache="CACHE_TYPE"}`
* `kopia_cache_miss_total{cache="CACHE_TYPE"}`
* `kopia_cache_miss_errors_total{cache="CACHE_TYPE"}`
* `kopia_cache_miss_bytes_total{cache="CACHE_TYPE"}`
* `kopia_cache_store_errors_total{cache="CACHE_TYPE"}`

where `CACHE_TYPE` is one of `contents`, `metadata` or `index-blobs`

- reorganized and unified content-level metrics:

* `kopia_content_write_bytes_total`
* `kopia_content_write_duration_nanos_total`
* `kopia_content_compression_attempted_bytes_total`
* `kopia_content_compression_attempted_duration_nanos_total`
* `kopia_content_compression_savings_bytes_total`
* `kopia_content_compressible_bytes_total`
* `kopia_content_non_compressible_bytes_total`
* `kopia_content_after_compression_bytes_total`
* `kopia_content_decompressed_bytes_total`
* `kopia_content_decompressed_duration_nanos_total`
* `kopia_content_encrypted_bytes_total`
* `kopia_content_encrypted_duration_nanos_total`
* `kopia_content_hashed_bytes_total`
* `kopia_content_hashed_duration_nanos_total`
* `kopia_content_deduplicated_bytes_total`
* `kopia_content_read_bytes_total`
* `kopia_content_read_duration_nanos_total`
* `kopia_content_decrypted_bytes_total`
* `kopia_content_decrypted_duration_nanos_total`
* `kopia_content_uploaded_bytes_total`

Also introduced `internal/metrics` framework which constructs Prometheus metrics in a uniform way and will allow us to include some of these metrics in telemetry report in future PRs.
