### PR TITLE
feat(snapshot): Add labels to snapshot checkpoint manifests

### DIFF
--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -293,7 +293,7 @@ func (c *commandSnapshotCreate) snapshotSingleSource(ctx context.Context, rep re
 		return errors.Wrap(err, "unable to get policy tree")
 	}
 
-	manifest, err := u.Upload(ctx, fsEntry, policyTree, sourceInfo, previous...)
+	manifest, err := u.Upload(ctx, fsEntry, policyTree, sourceInfo, nil, previous...)
 	if err != nil {
 		// fail-fast uploads will fail here without recording a manifest, other uploads will
 		// possibly fail later.

--- a/cli/command_snapshot_migrate.go
+++ b/cli/command_snapshot_migrate.go
@@ -280,7 +280,7 @@ func (c *commandSnapshotMigrate) migrateSingleSourceSnapshot(ctx context.Context
 
 	uploader.DisableIgnoreRules = !c.applyIgnoreRules
 
-	newm, err := uploader.Upload(ctx, sourceEntry, policyTree, m.Source, previous...)
+	newm, err := uploader.Upload(ctx, sourceEntry, policyTree, m.Source, nil, previous...)
 	if err != nil {
 		return errors.Wrapf(err, "error migrating shapshot %v @ %v", m.Source, m.StartTime)
 	}

--- a/internal/repotesting/repotesting_test.go
+++ b/internal/repotesting/repotesting_test.go
@@ -87,7 +87,7 @@ func TestTimeFuncWiring(t *testing.T) {
 	u := snapshotfs.NewUploader(env.RepositoryWriter)
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 
-	s1, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{})
+	s1, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{}, nil)
 	if err != nil {
 		t.Fatal("failed to create snapshot:", err)
 	}

--- a/internal/server/api_restore_test.go
+++ b/internal/server/api_restore_test.go
@@ -38,7 +38,7 @@ func TestRestoreSnapshots(t *testing.T) {
 		dir1.AddFile("file1", []byte{1, 2, 3}, 0o644)
 		dir1.AddDir("dir1", 0o644).AddFile("file2", []byte{1, 2, 4}, 0o644)
 
-		man11, err := u.Upload(ctx, dir1, nil, si1)
+		man11, err := u.Upload(ctx, dir1, nil, si1, nil)
 		require.NoError(t, err)
 		id11, err = snapshot.SaveSnapshot(ctx, w, man11)
 		require.NoError(t, err)

--- a/internal/server/api_snapshots_test.go
+++ b/internal/server/api_snapshots_test.go
@@ -32,33 +32,33 @@ func TestListAndDeleteSnapshots(t *testing.T) {
 		dir1.AddFile("file1", []byte{1, 2, 3}, 0o644)
 		dir1.AddFile("file2", []byte{1, 2, 4}, 0o644)
 
-		man11, err := u.Upload(ctx, dir1, nil, si1)
+		man11, err := u.Upload(ctx, dir1, nil, si1, nil)
 		require.NoError(t, err)
 		id11, err = snapshot.SaveSnapshot(ctx, w, man11)
 		require.NoError(t, err)
 
-		man12, err := u.Upload(ctx, dir1, nil, si1)
+		man12, err := u.Upload(ctx, dir1, nil, si1, nil)
 		require.NoError(t, err)
 		id12, err = snapshot.SaveSnapshot(ctx, w, man12)
 		require.NoError(t, err)
 
 		dir1.AddFile("file3", []byte{1, 2, 5}, 0o644)
 
-		man13, err := u.Upload(ctx, dir1, nil, si1)
+		man13, err := u.Upload(ctx, dir1, nil, si1, nil)
 		require.NoError(t, err)
 		id13, err = snapshot.SaveSnapshot(ctx, w, man13)
 		require.NoError(t, err)
 
 		dir1.AddFile("file4", []byte{1, 2, 6}, 0o644)
 
-		man14, err := u.Upload(ctx, dir1, nil, si1)
+		man14, err := u.Upload(ctx, dir1, nil, si1, nil)
 		require.NoError(t, err)
 		id14, err = snapshot.SaveSnapshot(ctx, w, man14)
 		require.NoError(t, err)
 
 		dir2 := mockfs.NewDirectory()
 
-		man21, err := u.Upload(ctx, dir2, nil, si2)
+		man21, err := u.Upload(ctx, dir2, nil, si2, nil)
 		require.NoError(t, err)
 		id21, err = snapshot.SaveSnapshot(ctx, w, man21)
 		require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestEditSnapshots(t *testing.T) {
 		dir1.AddFile("file1", []byte{1, 2, 3}, 0o644)
 		dir1.AddFile("file2", []byte{1, 2, 4}, 0o644)
 
-		man11, err := u.Upload(ctx, dir1, nil, si1)
+		man11, err := u.Upload(ctx, dir1, nil, si1, nil)
 		require.NoError(t, err)
 		id11, err = snapshot.SaveSnapshot(ctx, w, man11)
 		require.NoError(t, err)

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -395,7 +395,7 @@ func (s *sourceManager) snapshotInternal(ctx context.Context, ctrl uitask.Contro
 		log(ctx).Debugf("starting upload of %v", s.src)
 		s.setUploader(u)
 
-		manifest, err := u.Upload(ctx, localEntry, policyTree, s.src, manifestsSinceLastCompleteSnapshot...)
+		manifest, err := u.Upload(ctx, localEntry, policyTree, s.src, nil, manifestsSinceLastCompleteSnapshot...)
 		prog.report(true)
 
 		s.setUploader(nil)

--- a/snapshot/snapshotfs/snapshot_storage_stats_test.go
+++ b/snapshot/snapshotfs/snapshot_storage_stats_test.go
@@ -30,18 +30,18 @@ func TestCalculateStorageStats(t *testing.T) {
 	}
 
 	u := snapshotfs.NewUploader(env.RepositoryWriter)
-	man1, err := u.Upload(ctx, sourceRoot, nil, src)
+	man1, err := u.Upload(ctx, sourceRoot, nil, src, nil)
 	require.NoError(t, err)
 	require.NoError(t, env.RepositoryWriter.Flush(ctx))
 
-	man2, err := u.Upload(ctx, sourceRoot, nil, src)
+	man2, err := u.Upload(ctx, sourceRoot, nil, src, nil)
 	require.NoError(t, err)
 	require.NoError(t, env.RepositoryWriter.Flush(ctx))
 
 	// add one more file, upload again
 	dir2.AddFile("file23", []byte{1, 2, 3, 4, 5}, 0o644)
 
-	man3, err := u.Upload(ctx, sourceRoot, nil, src)
+	man3, err := u.Upload(ctx, sourceRoot, nil, src, nil)
 	require.NoError(t, err)
 	require.NoError(t, env.RepositoryWriter.Flush(ctx))
 

--- a/snapshot/snapshotfs/snapshot_tree_walker_test.go
+++ b/snapshot/snapshotfs/snapshot_tree_walker_test.go
@@ -47,7 +47,7 @@ func TestSnapshotTreeWalker(t *testing.T) {
 	const numUniqueObjects = 5
 
 	u := snapshotfs.NewUploader(env.RepositoryWriter)
-	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	uploadedRoot, err := snapshotfs.SnapshotRoot(env.Repository, man)
@@ -66,7 +66,7 @@ func TestSnapshotTreeWalker(t *testing.T) {
 	// add one more file, upload again
 	dir2.AddFile("file23", []byte{1, 2, 3, 4, 5}, 0o644)
 
-	man, err = u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{})
+	man, err = u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	uploadedRoot, err = snapshotfs.SnapshotRoot(env.Repository, man)
@@ -111,7 +111,7 @@ func TestSnapshotTreeWalker_Errors(t *testing.T) {
 	dir2.AddFile("file22", []byte{1, 2, 3}, 0o644) // same content as dir11/file11
 
 	u := snapshotfs.NewUploader(env.RepositoryWriter)
-	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	uploadedRoot, err := snapshotfs.SnapshotRoot(env.Repository, man)
@@ -158,7 +158,7 @@ func TestSnapshotTreeWalker_MultipleErrors(t *testing.T) {
 	dir2.AddFile("file22", []byte{1, 2, 3, 4, 5}, 0o644)
 
 	u := snapshotfs.NewUploader(env.RepositoryWriter)
-	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	uploadedRoot, err := snapshotfs.SnapshotRoot(env.Repository, man)
@@ -208,7 +208,7 @@ func TestSnapshotTreeWalker_MultipleErrorsSameOID(t *testing.T) {
 	dir2.AddFile("file22", []byte{1, 2, 3}, 0o644) // same content as dir11/file11
 
 	u := snapshotfs.NewUploader(env.RepositoryWriter)
-	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	uploadedRoot, err := snapshotfs.SnapshotRoot(env.Repository, man)

--- a/snapshot/snapshotfs/snapshot_verifier_test.go
+++ b/snapshot/snapshotfs/snapshot_verifier_test.go
@@ -31,7 +31,7 @@ func TestSnapshotVerifier(t *testing.T) {
 	var obj1 object.ID
 
 	require.NoError(t, repo.WriteSession(ctx, te.Repository, repo.WriteSessionOptions{}, func(ctx context.Context, w repo.RepositoryWriter) error {
-		snap1, err := u.Upload(ctx, dir1, nil, si1)
+		snap1, err := u.Upload(ctx, dir1, nil, si1, nil)
 		require.NoError(t, err)
 		obj1 = snap1.RootObjectID()
 		return nil

--- a/snapshot/snapshotfs/source_directories_test.go
+++ b/snapshot/snapshotfs/source_directories_test.go
@@ -19,7 +19,7 @@ func TestAllSources(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	u := NewUploader(env.RepositoryWriter)
-	man, err := u.Upload(ctx, mockfs.NewDirectory(), nil, snapshot.SourceInfo{Host: "dummy", UserName: "dummy", Path: "dummy"})
+	man, err := u.Upload(ctx, mockfs.NewDirectory(), nil, snapshot.SourceInfo{Host: "dummy", UserName: "dummy", Path: "dummy"}, nil)
 	require.NoError(t, err)
 
 	manifests := []struct {

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -636,6 +636,11 @@ func TestUploadWithCheckpointing(t *testing.T) {
 		Path:     "path",
 	}
 
+	labels := map[string]string{
+		"shape": "square",
+		"color": "red",
+	}
+
 	// inject a action into mock filesystem to trigger and wait for checkpoints at few places.
 	// the places are not important, what's important that those are 3 separate points in time.
 	dirsToCheckpointAt := []*mockfs.Directory{
@@ -656,7 +661,7 @@ func TestUploadWithCheckpointing(t *testing.T) {
 		})
 	}
 
-	if _, err := u.Upload(ctx, th.sourceDir, policyTree, si); err != nil {
+	if _, err := u.Upload(ctx, th.sourceDir, policyTree, si, labels); err != nil {
 		t.Errorf("Upload error: %v", err)
 	}
 
@@ -671,6 +676,8 @@ func TestUploadWithCheckpointing(t *testing.T) {
 		if got, want := sn.IncompleteReason, IncompleteReasonCheckpoint; got != want {
 			t.Errorf("unexpected incompleteReason %q, want %q", got, want)
 		}
+
+		assert.Equal(t, labels, sn.Tags)
 	}
 }
 

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -148,7 +148,7 @@ func TestUpload(t *testing.T) {
 
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 
-	s1, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{})
+	s1, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil)
 	if err != nil {
 		t.Errorf("Upload error: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestUpload(t *testing.T) {
 
 	t.Logf("Uploading s2")
 
-	s2, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, s1)
+	s2, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil, s1)
 	if err != nil {
 		t.Errorf("Upload error: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestUpload(t *testing.T) {
 	// Add one more file, the s1.RootObjectID should change.
 	th.sourceDir.AddFile("d2/d1/f3", []byte{1, 2, 3, 4, 5}, defaultPermissions)
 
-	s3, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, s1)
+	s3, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil, s1)
 	if err != nil {
 		t.Errorf("upload failed: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestUpload(t *testing.T) {
 	// Now remove the added file, OID should be identical to the original before the file got added.
 	th.sourceDir.Subdir("d2", "d1").Remove("f3")
 
-	s4, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, s1)
+	s4, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil, s1)
 	if err != nil {
 		t.Errorf("upload failed: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestUpload(t *testing.T) {
 		t.Errorf("unexpected s4 stats: %+v", s4.Stats)
 	}
 
-	s5, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, s3)
+	s5, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil, s3)
 	if err != nil {
 		t.Errorf("upload failed: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestUpload_TopLevelDirectoryReadFailure(t *testing.T) {
 
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 
-	s, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{})
+	s, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil)
 	require.ErrorIs(t, err, errTest)
 	require.Nil(t, s)
 }
@@ -277,7 +277,7 @@ func TestUploadDoesNotReportProgressForIgnoredFilesTwice(t *testing.T) {
 		},
 	}, policy.DefaultPolicy)
 
-	_, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{})
+	_, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	// make sure ignored counter is only incremented by 1, even though we process each directory twice
@@ -301,7 +301,7 @@ func TestUpload_SubDirectoryReadFailureFailFast(t *testing.T) {
 
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 
-	man, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	require.NotEqual(t, "", man.IncompleteReason, "snapshot not marked as incomplete")
@@ -338,7 +338,7 @@ func TestUpload_SubDirectoryReadFailureIgnoredNoFailFast(t *testing.T) {
 		},
 	})
 
-	man, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	// 0 failed, 2 ignored
@@ -432,7 +432,7 @@ func TestUpload_ErrorEntries(t *testing.T) {
 				ErrorHandlingPolicy: tc.ehp,
 			})
 
-			man, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{})
+			man, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -459,7 +459,7 @@ func TestUpload_SubDirectoryReadFailureNoFailFast(t *testing.T) {
 
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 
-	man, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	// make sure we have 2 errors
@@ -511,7 +511,7 @@ func TestUpload_SubDirectoryReadFailureSomeIgnoredNoFailFast(t *testing.T) {
 		t.Fatalf("policy not effective")
 	}
 
-	man, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, th.sourceDir, policyTree, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	verifyErrors(t, man,
@@ -584,7 +584,7 @@ func TestUpload_FinishedFileProgress(t *testing.T) {
 		},
 	}, policy.DefaultPolicy)
 
-	man, err := u.Upload(ctx, root, policyTree, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, root, policyTree, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(0), atomic.LoadInt32(&man.Stats.ErrorCount), "ErrorCount")
@@ -597,7 +597,7 @@ func TestUpload_FinishedFileProgress(t *testing.T) {
 
 	// Upload a second time to check for cached files.
 	filesFinished = 0
-	man, err = u.Upload(ctx, root, policyTree, snapshot.SourceInfo{}, man)
+	man, err = u.Upload(ctx, root, policyTree, snapshot.SourceInfo{}, nil, man)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(0), atomic.LoadInt32(&man.Stats.ErrorCount), "ErrorCount")
@@ -732,7 +732,7 @@ func TestParallelUploadUploadsBlobsInParallel(t *testing.T) {
 	th.sourceDir.AddFile("d2/large3", randomBytes(1e7), defaultPermissions)
 	th.sourceDir.AddFile("d2/large4", randomBytes(1e7), defaultPermissions)
 
-	_, err := u.Upload(ctx, th.sourceDir, policyTree, si)
+	_, err := u.Upload(ctx, th.sourceDir, policyTree, si, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, th.repo.Flush(ctx))
@@ -842,7 +842,7 @@ func TestUpload_VirtualDirectoryWithStreamingFile(t *testing.T) {
 		virtualfs.StreamingFileFromReader("stream-file", r),
 	})
 
-	man, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{}, nil)
 	if err != nil {
 		t.Fatalf("Upload error: %v", err)
 	}
@@ -911,7 +911,7 @@ func TestUpload_VirtualDirectoryWithStreamingFileWithModTime(t *testing.T) {
 			})
 
 			// First snapshot should upload all files/directories.
-			man1, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{})
+			man1, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{}, nil)
 			require.NoError(t, err)
 			require.Equal(t, int32(0), atomic.LoadInt32(&man1.Stats.CachedFiles))
 			require.Equal(t, int32(1), atomic.LoadInt32(&man1.Stats.NonCachedFiles))
@@ -927,7 +927,7 @@ func TestUpload_VirtualDirectoryWithStreamingFileWithModTime(t *testing.T) {
 			})
 
 			// Second upload may find some cached files depending on timestamps.
-			man2, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{}, man1)
+			man2, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{}, nil, man1)
 			require.NoError(t, err)
 
 			assert.Equal(t, int32(1), atomic.LoadInt32(&man2.Stats.TotalDirectoryCount))
@@ -970,7 +970,7 @@ func TestUpload_StreamingDirectory(t *testing.T) {
 		),
 	})
 
-	man, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, atomic.LoadInt32(&man.Stats.CachedFiles), int32(0))
@@ -1017,7 +1017,7 @@ func TestUpload_StreamingDirectoryWithIgnoredFile(t *testing.T) {
 		),
 	})
 
-	man, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, atomic.LoadInt32(&man.Stats.CachedFiles), int32(0))
@@ -1110,7 +1110,7 @@ func TestParallelUploadDedup(t *testing.T) {
 	srcdir, err := localfs.Directory(td)
 	require.NoError(t, err)
 
-	_, err = u.Upload(ctx, srcdir, policyTree, snapshot.SourceInfo{})
+	_, err = u.Upload(ctx, srcdir, policyTree, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	// we wrote 500 MB, which can be deduped to 50MB, repo size must be less than 51MB
@@ -1172,7 +1172,7 @@ func TestParallelUploadOfLargeFiles(t *testing.T) {
 	srcdir, err := localfs.Directory(td)
 	require.NoError(t, err)
 
-	man, err := u.Upload(ctx, srcdir, policyTree, snapshot.SourceInfo{})
+	man, err := u.Upload(ctx, srcdir, policyTree, snapshot.SourceInfo{}, nil)
 	require.NoError(t, err)
 
 	t.Logf("man: %v", man.RootObjectID())
@@ -1573,7 +1573,7 @@ func TestUploadLogging(t *testing.T) {
 			polTree, err := policy.TreeForSource(ctx, th.repo, sourceInfo)
 			require.NoError(t, err)
 
-			man1, err := u.Upload(ctx, sourceDir, polTree, sourceInfo)
+			man1, err := u.Upload(ctx, sourceDir, polTree, sourceInfo, nil)
 			require.NoError(t, err)
 
 			var gotEntries []string
@@ -1590,7 +1590,7 @@ func TestUploadLogging(t *testing.T) {
 			ml.logged = nil
 
 			// run second upload with previous manifest to trigger cache.
-			_, err = u.Upload(ctx, sourceDir, polTree, sourceInfo, man1)
+			_, err = u.Upload(ctx, sourceDir, polTree, sourceInfo, nil, man1)
 			require.NoError(t, err)
 
 			var gotEntriesSecond []string

--- a/snapshot/snapshotmaintenance/helper_test.go
+++ b/snapshot/snapshotmaintenance/helper_test.go
@@ -30,7 +30,7 @@ func createSnapshot(ctx context.Context, rep repo.RepositoryWriter, e fs.Entry, 
 
 	u := snapshotfs.NewUploader(rep)
 
-	manifest, err := u.Upload(ctx, e, policyTree, si, previous...)
+	manifest, err := u.Upload(ctx, e, policyTree, si, nil, previous...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow adding labels to snapshot manifests created by checkpoint. This aids in finding these checkpoints later on and in a more granular fashion because `Repository.FindManifests` can now be used instead of just `snapshot.ListSnapshots`

For backwards compatibility, none of the internal calls of `Upload` populate checkpoint labels, leaving the CLI output undisturbed