### PR TITLE
test(repository): server testability refactoring

### DIFF
--- a/internal/acl/access_level_test.go
+++ b/internal/acl/access_level_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/acl"
 )
@@ -23,9 +24,7 @@ func TestAccessLevelJSONSerialization(t *testing.T) {
 	s1.E = acl.AccessLevelFull
 
 	v, err := json.MarshalIndent(s1, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	got := string(v)
 	want := `{

--- a/internal/cache/storage_protection_test.go
+++ b/internal/cache/storage_protection_test.go
@@ -20,9 +20,7 @@ func TestHMACStorageProtection(t *testing.T) {
 
 func TestEncryptionStorageProtection(t *testing.T) {
 	e, err := cache.AuthenticatedEncryptionProtection([]byte{1})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	testStorageProtection(t, e, true)
 }

--- a/internal/repotesting/repotesting_test.go
+++ b/internal/repotesting/repotesting_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/kopia/kopia/internal/faketime"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/mockfs"
@@ -28,9 +30,7 @@ func TestTimeFuncWiring(t *testing.T) {
 	r0 := rep.(repo.DirectRepository)
 
 	_, env.RepositoryWriter, err = r0.NewDirectWriter(ctx, repo.WriteSessionOptions{Purpose: "test"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// verify wiring for the repo layer
 	if got, want := env.RepositoryWriter.Time(), ft.NowFunc()(); !got.Equal(want) {

--- a/internal/server/api_cli_test.go
+++ b/internal/server/api_cli_test.go
@@ -9,17 +9,18 @@ import (
 	"github.com/kopia/kopia/internal/apiclient"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/servertesting"
 )
 
 func TestCLIAPI(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
-	srvInfo := startServer(t, env, false)
+	srvInfo := servertesting.StartServer(t, env, false)
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
 		BaseURL:                             srvInfo.BaseURL,
 		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
-		Username:                            testUIUsername,
-		Password:                            testUIPassword,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
 	})
 
 	require.NoError(t, err)

--- a/internal/server/api_paths_test.go
+++ b/internal/server/api_paths_test.go
@@ -8,18 +8,19 @@ import (
 	"github.com/kopia/kopia/internal/apiclient"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/servertesting"
 	"github.com/kopia/kopia/internal/testutil"
 )
 
 func TestPathsAPI(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
-	srvInfo := startServer(t, env, false)
+	srvInfo := servertesting.StartServer(t, env, false)
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
 		BaseURL:                             srvInfo.BaseURL,
 		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
-		Username:                            testUIUsername,
-		Password:                            testUIPassword,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
 	})
 
 	require.NoError(t, err)

--- a/internal/server/api_policies_test.go
+++ b/internal/server/api_policies_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kopia/kopia/internal/apiclient"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/servertesting"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/compression"
 	"github.com/kopia/kopia/snapshot"
@@ -19,13 +20,13 @@ import (
 
 func TestPolicies(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
-	srvInfo := startServer(t, env, false)
+	srvInfo := servertesting.StartServer(t, env, false)
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
 		BaseURL:                             srvInfo.BaseURL,
 		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
-		Username:                            testUIUsername,
-		Password:                            testUIPassword,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
 	})
 
 	require.NoError(t, err)

--- a/internal/server/api_restore_test.go
+++ b/internal/server/api_restore_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kopia/kopia/internal/mockfs"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/servertesting"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/internal/uitask"
 	"github.com/kopia/kopia/repo"
@@ -46,13 +47,13 @@ func TestRestoreSnapshots(t *testing.T) {
 		return nil
 	}))
 
-	srvInfo := startServer(t, env, false)
+	srvInfo := servertesting.StartServer(t, env, false)
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
 		BaseURL:                             srvInfo.BaseURL,
 		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
-		Username:                            testUIUsername,
-		Password:                            testUIPassword,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
 	})
 
 	require.NoError(t, err)

--- a/internal/server/api_snapshots_test.go
+++ b/internal/server/api_snapshots_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kopia/kopia/internal/mockfs"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/servertesting"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/snapshot"
@@ -72,13 +73,13 @@ func TestListAndDeleteSnapshots(t *testing.T) {
 		return nil
 	}))
 
-	srvInfo := startServer(t, env, false)
+	srvInfo := servertesting.StartServer(t, env, false)
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
 		BaseURL:                             srvInfo.BaseURL,
 		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
-		Username:                            testUIUsername,
-		Password:                            testUIPassword,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
 	})
 
 	require.NoError(t, err)
@@ -201,13 +202,13 @@ func TestEditSnapshots(t *testing.T) {
 		return nil
 	}))
 
-	srvInfo := startServer(t, env, false)
+	srvInfo := servertesting.StartServer(t, env, false)
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
 		BaseURL:                             srvInfo.BaseURL,
 		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
-		Username:                            testUIUsername,
-		Password:                            testUIPassword,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
 	})
 
 	require.NoError(t, err)

--- a/internal/server/api_sources_test.go
+++ b/internal/server/api_sources_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/servertesting"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/internal/uitask"
 	"github.com/kopia/kopia/snapshot"
@@ -20,13 +21,13 @@ import (
 
 func TestSnapshotCounters(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
-	srvInfo := startServer(t, env, false)
+	srvInfo := servertesting.StartServer(t, env, false)
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
 		BaseURL:                             srvInfo.BaseURL,
 		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
-		Username:                            testUIUsername,
-		Password:                            testUIPassword,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
 	})
 
 	require.NoError(t, err)
@@ -98,15 +99,15 @@ func TestSnapshotCounters(t *testing.T) {
 
 func TestSourceRefreshesAfterPolicy(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
-	srvInfo := startServer(t, env, false)
+	srvInfo := servertesting.StartServer(t, env, false)
 
 	_ = ctx
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
 		BaseURL:                             srvInfo.BaseURL,
 		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
-		Username:                            testUIUsername,
-		Password:                            testUIPassword,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
 	})
 
 	require.NoError(t, err)

--- a/internal/server/api_ui_pref_test.go
+++ b/internal/server/api_ui_pref_test.go
@@ -8,17 +8,18 @@ import (
 	"github.com/kopia/kopia/internal/apiclient"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/servertesting"
 )
 
 func TestUIPreferences(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
-	srvInfo := startServer(t, env, false)
+	srvInfo := servertesting.StartServer(t, env, false)
 
 	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
 		BaseURL:                             srvInfo.BaseURL,
 		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
-		Username:                            testUIUsername,
-		Password:                            testUIPassword,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
 	})
 
 	require.NoError(t, err)

--- a/internal/servertesting/servertesting.go
+++ b/internal/servertesting/servertesting.go
@@ -1,0 +1,107 @@
+// Package servertesting provides helpers for launching and testing Kopia server.
+package servertesting
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/auth"
+	"github.com/kopia/kopia/internal/passwordpersist"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/server"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/content"
+)
+
+const (
+	TestUsername = "foo"
+	TestHostname = "bar"
+	TestPassword = "123"
+
+	TestUIUsername = "ui-user"
+	TestUIPassword = "123456"
+)
+
+// StartServer starts a test server and returns APIServerInfo.
+func StartServer(t *testing.T, env *repotesting.Environment, tls bool) *repo.APIServerInfo {
+	t.Helper()
+
+	ctx := testlogging.Context(t)
+
+	s, err := server.New(ctx, &server.Options{
+		ConfigFile:      env.ConfigFile(),
+		PasswordPersist: passwordpersist.File(),
+		Authorizer:      auth.LegacyAuthorizer(),
+		Authenticator: auth.CombineAuthenticators(
+			auth.AuthenticateSingleUser(TestUsername+"@"+TestHostname, TestPassword),
+			auth.AuthenticateSingleUser(TestUIUsername, TestUIPassword),
+		),
+		RefreshInterval:   1 * time.Minute,
+		UIUser:            TestUIUsername,
+		UIPreferencesFile: filepath.Join(testutil.TempDirectory(t), "ui-pref.json"),
+	})
+
+	require.NoError(t, err)
+
+	s.SetRepository(ctx, env.Repository)
+
+	// ensure we disconnect the repository before shutting down the server.
+	t.Cleanup(func() { s.SetRepository(ctx, nil) })
+
+	require.NoError(t, err)
+
+	asi := &repo.APIServerInfo{}
+
+	m := mux.NewRouter()
+	s.SetupHTMLUIAPIHandlers(m)
+	s.SetupRepositoryAPIHandlers(m)
+	s.SetupControlAPIHandlers(m)
+	s.ServeStaticFiles(m, server.AssetFile())
+
+	hs := httptest.NewUnstartedServer(s.GRPCRouterHandler(m))
+	if tls {
+		hs.EnableHTTP2 = true
+		hs.StartTLS()
+		serverHash := sha256.Sum256(hs.Certificate().Raw)
+		asi.BaseURL = hs.URL
+		asi.TrustedServerCertificateFingerprint = hex.EncodeToString(serverHash[:])
+	} else {
+		hs.Start()
+		asi.BaseURL = hs.URL
+	}
+
+	t.Cleanup(hs.Close)
+
+	return asi
+}
+
+// ConnectAndOpenAPIServer creates temporary config file and to and opens API server for testing.
+func ConnectAndOpenAPIServer(t *testing.T, ctx context.Context, asi *repo.APIServerInfo, rco repo.ClientOptions, caching content.CachingOptions, password string, opt *repo.Options) (repo.Repository, error) {
+	t.Helper()
+
+	configFile := filepath.Join(t.TempDir(), "tmp.config")
+
+	if err := repo.ConnectAPIServer(ctx, configFile, asi, password, &repo.ConnectOptions{
+		ClientOptions:  rco,
+		CachingOptions: caching,
+	}); err != nil {
+		return nil, err
+	}
+
+	t.Cleanup(func() {
+		repo.Disconnect(ctx, configFile)
+	})
+
+	//
+	return repo.Open(ctx, configFile, password, opt)
+}

--- a/internal/sparsefile/sparsefile_test.go
+++ b/internal/sparsefile/sparsefile_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/kopia/kopia/internal/stat"
 )
 
@@ -20,9 +22,7 @@ func TestSparseCopy(t *testing.T) {
 	dir := t.TempDir()
 
 	blk, err := stat.GetBlockSize(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	type chunk struct {
 		slice []byte

--- a/internal/stat/stat_test.go
+++ b/internal/stat/stat_test.go
@@ -8,13 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetBlockSize(t *testing.T) {
 	s, err := GetBlockSize(os.DevNull)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if s <= 0 {
 		t.Fatalf("invalid disk block size: %d, must be greater than 0", s)
@@ -29,9 +29,7 @@ func TestGetFileAllocSize(t *testing.T) {
 	data := bytes.Repeat([]byte{1}, size)
 
 	err := os.WriteFile(f, data, os.ModePerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	s, err := GetFileAllocSize(f)
 	if err != nil {

--- a/repo/blob/filesystem/filesystem_storage_test.go
+++ b/repo/blob/filesystem/filesystem_storage_test.go
@@ -139,9 +139,7 @@ func TestFileStorageConcurrency(t *testing.T) {
 	st, err := New(ctx, &Options{
 		Path: path,
 	}, true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	blobtesting.VerifyConcurrentAccess(t, st, blobtesting.ConcurrentAccessOptions{
 		NumBlobs:                        16,

--- a/repo/blob/sftp/sftp_storage_test.go
+++ b/repo/blob/sftp/sftp_storage_test.go
@@ -38,14 +38,10 @@ func mustGetLocalTmpDir(t *testing.T) string {
 	t.Helper()
 
 	tmpDir, err := os.MkdirTemp(".", ".creds")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	tmpDir, err = filepath.Abs(tmpDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
@@ -80,9 +76,7 @@ func mustRunCommand(t *testing.T, cmd string, args ...string) []byte {
 	t.Helper()
 
 	v, err := runAndGetOutput(t, cmd, args...)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return v
 }
@@ -344,9 +338,7 @@ func mustReadFileToString(t *testing.T, fname string) string {
 	t.Helper()
 
 	data, err := os.ReadFile(fname)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return string(data)
 }

--- a/repo/content/sessions_test.go
+++ b/repo/content/sessions_test.go
@@ -3,6 +3,8 @@ package content
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -11,19 +13,13 @@ func TestGenerateSessionID(t *testing.T) {
 	n := clock.Now()
 
 	s1, err := generateSessionID(n)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	s2, err := generateSessionID(n)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	s3, err := generateSessionID(n)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	m := map[SessionID]bool{
 		s1: true,

--- a/repo/maintenance/blob_gc_test.go
+++ b/repo/maintenance/blob_gc_test.go
@@ -55,9 +55,7 @@ func (s *formatSpecificTestSuite) TestDeleteUnreferencedBlobs(t *testing.T) {
 	env.RepositoryWriter.Flush(ctx)
 
 	blobsBefore, err := blob.ListAllBlobs(ctx, env.RepositoryWriter.BlobStorage(), "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if got, want := len(blobsBefore), 4; got != want {
 		t.Fatalf("unexpected number of blobs after writing: %v", blobsBefore)
@@ -153,9 +151,7 @@ func (s *formatSpecificTestSuite) TestDeleteUnreferencedBlobs(t *testing.T) {
 	// make sure we're back to the starting point.
 
 	blobsAfter, err := blob.ListAllBlobs(ctx, env.RepositoryWriter.BlobStorage(), "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if diff := cmp.Diff(blobsBefore, blobsAfter); diff != "" {
 		t.Fatalf("unexpected diff: %v", diff)
@@ -190,9 +186,7 @@ func mustPutDummySessionBlob(t *testing.T, st blob.Storage, sessionIDSuffix blob
 	t.Helper()
 
 	j, err := json.Marshal(si)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	h := hmac.New(sha256.New, testHMACSecret)
 	h.Write(j)

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -359,9 +359,7 @@ func verifyFull(ctx context.Context, t *testing.T, om *Manager, oid ID, want []b
 func verifyNoError(t *testing.T, err error) {
 	t.Helper()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func verifyIndirectBlock(ctx context.Context, t *testing.T, om *Manager, oid ID) {
@@ -598,14 +596,10 @@ func mustWriteObject(t *testing.T, om *Manager, data []byte, compressor compress
 	defer w.Close()
 
 	_, err := w.Write(data)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	oid, err := w.Result()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return oid
 }

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -200,9 +200,7 @@ func mustAbs(t *testing.T, p string) string {
 	t.Helper()
 
 	p2, err := filepath.Abs(p)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return p2
 }

--- a/snapshot/snapshotmaintenance/snapshotmaintenance_test.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance_test.go
@@ -337,9 +337,7 @@ func (th *testHarness) openAnother(t *testing.T) repo.RepositoryWriter {
 	})
 
 	_, w, err := r.NewWriter(ctx, repo.WriteSessionOptions{Purpose: "test"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return w
 }

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -182,9 +182,7 @@ func TestSnapshotRestore(t *testing.T) {
 
 	// create a file with well-known name.
 	f, err := os.Create(filepath.Join(source, "single-file"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	fmt.Fprintf(f, "some-data")
 	f.Close()
@@ -427,9 +425,7 @@ func TestRestoreSnapshotOfSingleFile(t *testing.T) {
 	sourceFile := filepath.Join(sourceDir, "single-file")
 
 	f, err := os.Create(sourceFile)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	fmt.Fprintf(f, "some-data")
 	f.Close()
@@ -765,9 +761,7 @@ func verifyFileMode(t *testing.T, filename string, want os.FileMode) {
 	}
 
 	s, err := os.Lstat(filename)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// make sure we restored permissions correctly
 	if s.Mode() != want {
@@ -779,9 +773,7 @@ func verifyValidZipFile(t *testing.T, fname string) {
 	t.Helper()
 
 	zr, err := zip.OpenReader(fname)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	defer zr.Close()
 }
@@ -790,9 +782,8 @@ func verifyValidTarFile(t *testing.T, fname string) {
 	t.Helper()
 
 	f, err := os.Open(fname)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer f.Close()
 
 	verifyValidTarReader(t, tar.NewReader(f))
@@ -815,15 +806,12 @@ func verifyValidTarGzipFile(t *testing.T, fname string) {
 	t.Helper()
 
 	f, err := os.Open(fname)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer f.Close()
 
 	gz, err := gzip.NewReader(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	verifyValidTarReader(t, tar.NewReader(gz))
 }
@@ -842,9 +830,7 @@ func TestSnapshotRestoreByPath(t *testing.T) {
 
 	// create a file with well-known name.
 	f, err := os.Create(filepath.Join(source, "single-file"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	fmt.Fprintf(f, "some-data")
 	f.Close()

--- a/tests/end_to_end_test/snapshot_actions_test.go
+++ b/tests/end_to_end_test/snapshot_actions_test.go
@@ -368,17 +368,13 @@ func verifyFileExists(t *testing.T, fname string) {
 	t.Helper()
 
 	_, err := os.Stat(fname)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func verifyNoError(t *testing.T, err error) {
 	t.Helper()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func mustReadEnvFile(t *testing.T, fname string) map[string]string {


### PR DESCRIPTION
- removed repo.OpenAPIServer() which was only needed for testability
- introduced servertesting package to replace it