### PR TITLE
feat(repository): added internal/metricid package

### DIFF
--- a/internal/metricid/id_mapping.go
+++ b/internal/metricid/id_mapping.go
@@ -1,0 +1,70 @@
+// Package metricid provides mapping between metric names and persistent IDs.
+package metricid
+
+// Mapping contains translation of names to indexes and vice versa, which allows maps
+// of well-known keys to be converted to slices of just values with more compact JSON representations.
+type Mapping struct {
+	MaxIndex    int
+	NameToIndex map[string]int
+	IndexToName map[int]string
+}
+
+// MapToSlice converts the given map to a slice according to the provided mapping.
+// Keys not in the mapping are dropped.
+func MapToSlice[T any](mapping *Mapping, input map[string]T) []T {
+	result := make([]T, mapping.MaxIndex)
+
+	for k, v := range input {
+		id := mapping.NameToIndex[k]
+		if id > 0 {
+			result[id-1] = v
+		}
+	}
+
+	return result
+}
+
+// SliceToMap converts the given slice to a map according to the provided mapping.
+func SliceToMap[T any](mapping *Mapping, input []T) map[string]T {
+	result := map[string]T{}
+
+	for k, v := range input {
+		if n, ok := mapping.IndexToName[k+1]; ok {
+			result[n] = v
+		}
+	}
+
+	return result
+}
+
+// NewMapping creates a new Mapping given the provided name-to-index map.
+func NewMapping(fwd map[string]int) *Mapping {
+	m := &Mapping{
+		NameToIndex: fwd,
+		IndexToName: inverse(fwd),
+	}
+
+	max := 0
+
+	for _, index := range fwd {
+		if index > max {
+			max = index
+		}
+	}
+
+	m.MaxIndex = max
+
+	return m
+}
+
+func inverse(m map[string]int) map[int]string {
+	res := map[int]string{}
+
+	for k, v := range m {
+		if v > 0 {
+			res[v] = k
+		}
+	}
+
+	return res
+}

--- a/internal/metricid/id_mapping_test.go
+++ b/internal/metricid/id_mapping_test.go
@@ -1,0 +1,54 @@
+package metricid_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/metricid"
+)
+
+func TestMapToSlice(t *testing.T) {
+	m := metricid.NewMapping(map[string]int{
+		"a": 1,
+		"b": 2,
+		"d": 4,
+	})
+
+	cases := []struct {
+		input map[string]string
+		want  []string
+	}{
+		{nil, []string{"", "", "", ""}},
+		{map[string]string{"a": "foo", "b": "bar"}, []string{"foo", "bar", "", ""}},
+		{map[string]string{"a": "foo", "b": "bar", "d": "baz"}, []string{"foo", "bar", "", "baz"}},
+
+		// 'c' is dropped since it's not in the mapping
+		{map[string]string{"a": "foo", "b": "bar", "c": "qux", "d": "baz"}, []string{"foo", "bar", "", "baz"}},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, metricid.MapToSlice(m, tc.input))
+	}
+}
+
+func TestSliceToMap(t *testing.T) {
+	m := metricid.NewMapping(map[string]int{
+		"a": 1,
+		"b": 2,
+		"c": 3,
+	})
+
+	cases := []struct {
+		input []int
+		want  map[string]int
+	}{
+		{[]int{3}, map[string]int{"a": 3}},
+		{[]int{3, 4, 5}, map[string]int{"a": 3, "b": 4, "c": 5}},
+		{[]int{3, 4, 5, 6, 7}, map[string]int{"a": 3, "b": 4, "c": 5}},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, metricid.SliceToMap(m, tc.input))
+	}
+}

--- a/internal/metricid/metricid.go
+++ b/internal/metricid/metricid.go
@@ -1,0 +1,67 @@
+// Package metricid provides mapping between metric names and persistent IDs.
+package metricid
+
+// Counters contains a mapping of counter names to ID.
+//
+//nolint:gochecknoglobals,gomnd
+var Counters = NewMapping(map[string]int{
+	"blob_download_full_blob_bytes":                1,
+	"blob_download_partial_blob_bytes":             2,
+	"blob_errors[method:Close]":                    3,
+	"blob_errors[method:DeleteBlob]":               4,
+	"blob_errors[method:FlushCaches]":              5,
+	"blob_errors[method:GetBlob]":                  6,
+	"blob_errors[method:GetCapacity]":              7,
+	"blob_errors[method:GetMetadata]":              8,
+	"blob_errors[method:ListBlobs]":                9,
+	"blob_errors[method:PutBlob]":                  10,
+	"blob_list_items":                              11,
+	"blob_upload_bytes":                            12,
+	"content_after_compression_bytes":              13,
+	"content_compressible_bytes":                   14,
+	"content_compression_attempted_bytes":          15,
+	"content_compression_attempted_duration_nanos": 16,
+	"content_compression_savings_bytes":            17,
+	"content_decompressed_bytes":                   18,
+	"content_decompressed_duration_nanos":          19,
+	"content_decrypted_bytes":                      20,
+	"content_decrypted_duration_nanos":             21,
+	"content_deduplicated":                         22,
+	"content_deduplicated_bytes":                   23,
+	"content_encrypted_bytes":                      24,
+	"content_encrypted_duration_nanos":             25,
+	"content_get_error_count":                      26,
+	"content_get_not_found_count":                  27,
+	"content_hashed_bytes":                         28,
+	"content_hashed_duration_nanos":                29,
+	"content_non_compressible_bytes":               30,
+	"content_read_bytes":                           31,
+	"content_read_duration_nanos":                  32,
+	"content_uploaded_bytes":                       33,
+	"content_write_bytes":                          34,
+	"content_write_duration_nanos":                 35,
+	// add new items here, use consecutive values
+})
+
+// DurationDistributions contains a mapping of DurationDistribution names to ID.
+//
+//nolint:gochecknoglobals,gomnd
+var DurationDistributions = NewMapping(map[string]int{
+	"blob_storage_latency[method:Close]":           1,
+	"blob_storage_latency[method:DeleteBlob]":      2,
+	"blob_storage_latency[method:FlushCaches]":     3,
+	"blob_storage_latency[method:GetBlob-full]":    4,
+	"blob_storage_latency[method:GetBlob-partial]": 5,
+	"blob_storage_latency[method:GetCapacity]":     6,
+	"blob_storage_latency[method:GetMetadata]":     7,
+	"blob_storage_latency[method:ListBlobs]":       8,
+	"blob_storage_latency[method:PutBlob]":         9,
+	// add new items here, use consecutive values
+})
+
+// SizeDistributions provides mapping between SizeDistribution metric names to IDs.
+//
+//nolint:gochecknoglobals
+var SizeDistributions = NewMapping(map[string]int{
+	// add new items here, use consecutive values
+})

--- a/internal/metricid/metricid_test.go
+++ b/internal/metricid/metricid_test.go
@@ -1,0 +1,39 @@
+package metricid_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/metricid"
+)
+
+func TestMappings(t *testing.T) {
+	verifyMapping(t, metricid.Counters)
+	verifyMapping(t, metricid.DurationDistributions)
+	verifyMapping(t, metricid.SizeDistributions)
+}
+
+func verifyMapping(t *testing.T, mapping *metricid.Mapping) {
+	t.Helper()
+
+	id2name := map[int]string{}
+	maxv := 0
+
+	for k, v := range mapping.NameToIndex {
+		_, ok := id2name[v]
+		require.False(t, ok, "duplicate ID", v)
+
+		if v > maxv {
+			maxv = v
+		}
+
+		id2name[v] = k
+
+		require.Equal(t, k, mapping.IndexToName[v])
+	}
+
+	// make sure we use consecurive numbers
+	require.Equal(t, maxv, len(id2name))
+	require.Equal(t, mapping.MaxIndex, maxv)
+}

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kopia/kopia/internal/cache"
 	"github.com/kopia/kopia/internal/epoch"
 	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/metricid"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/servertesting"
 	"github.com/kopia/kopia/internal/testlogging"
@@ -827,6 +828,24 @@ func ensureMapEntry[T any](t *testing.T, m map[string]T, key string) T {
 	require.True(t, got, key)
 
 	return actual
+}
+
+func TestAllRegistryMetricsAreMapped(t *testing.T) {
+	_, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+
+	snap := env.Repository.Metrics().Snapshot(false)
+
+	for s := range snap.Counters {
+		require.Contains(t, metricid.Counters.NameToIndex, s)
+	}
+
+	for s := range snap.DurationDistributions {
+		require.Contains(t, metricid.DurationDistributions.NameToIndex, s)
+	}
+
+	for s := range snap.SizeDistributions {
+		require.Contains(t, metricid.SizeDistributions.NameToIndex, s)
+	}
 }
 
 func TestDeriveKey(t *testing.T) {


### PR DESCRIPTION
This manages mapping of metric names to IDs which allows efficient JSON representation of counter values for each set of metrics where only values are in the index order.

This will be used in the telemetry protocol and for storing counters in the repository.

Added test that ensures all metrics registered in a repository have the corresponding mapping.