### PR TITLE
fix(general): prevent storage retries on ESTALE errors

### DIFF
--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -51,6 +51,12 @@ func (fs *fsImpl) isRetriable(err error) bool {
 
 	err = errors.Cause(err)
 
+	if fs.osi.IsESTALE(err) {
+		// errors indicative of stale resource handle or invalid
+		// descriptors should not be retried
+		return false
+	}
+
 	if fs.osi.IsNotExist(err) {
 		return false
 	}

--- a/repo/blob/filesystem/filesystem_storage_unix_test.go
+++ b/repo/blob/filesystem/filesystem_storage_unix_test.go
@@ -1,0 +1,48 @@
+//go:build linux || freebsd || darwin
+// +build linux freebsd darwin
+
+package filesystem
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/sharded"
+)
+
+func TestFileStorage_ESTALE_ErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+
+	dataDir := testutil.TempDirectory(t)
+
+	osi := newMockOS()
+
+	st, err := New(ctx, &Options{
+		Path: dataDir,
+		Options: sharded.Options{
+			DirectoryShards: []int{5, 2},
+		},
+	}, true)
+	require.NoError(t, err)
+
+	st.(*fsStorage).Impl.(*fsImpl).osi = osi
+
+	require.False(t, st.(*fsStorage).Impl.(*fsImpl).isRetriable(syscall.ESTALE), "ESTALE should not be retryable")
+
+	defer st.Close(ctx)
+
+	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
+
+	osi.eStaleRemainingErrors.Store(1)
+
+	_, err = st.GetMetadata(ctx, "someblob1234567812345678")
+	require.ErrorIs(t, err, syscall.ESTALE)
+}

--- a/repo/blob/filesystem/osinterface.go
+++ b/repo/blob/filesystem/osinterface.go
@@ -27,6 +27,9 @@ type osInterface interface {
 	Chtimes(fname string, atime, mtime time.Time) error
 	Geteuid() int
 	Chown(fname string, uid, gid int) error
+
+	// Errno
+	IsESTALE(err error) bool
 }
 
 type osReadFile interface {

--- a/repo/blob/filesystem/osinterface_mock_other_test.go
+++ b/repo/blob/filesystem/osinterface_mock_other_test.go
@@ -1,0 +1,12 @@
+//go:build !linux && !freebsd && !darwin
+// +build !linux,!freebsd,!darwin
+
+package filesystem
+
+func (osi *mockOS) Stat(fname string) (fs.FileInfo, error) {
+	if osi.statRemainingErrors.Add(-1) >= 0 {
+		return nil, &os.PathError{Op: "stat", Err: errors.Errorf("underlying problem")}
+	}
+
+	return osi.osInterface.Stat(fname)
+}

--- a/repo/blob/filesystem/osinterface_mock_other_test.go
+++ b/repo/blob/filesystem/osinterface_mock_other_test.go
@@ -3,6 +3,13 @@
 
 package filesystem
 
+import (
+	"io/fs"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
 func (osi *mockOS) Stat(fname string) (fs.FileInfo, error) {
 	if osi.statRemainingErrors.Add(-1) >= 0 {
 		return nil, &os.PathError{Op: "stat", Err: errors.Errorf("underlying problem")}

--- a/repo/blob/filesystem/osinterface_mock_test.go
+++ b/repo/blob/filesystem/osinterface_mock_test.go
@@ -32,6 +32,7 @@ type mockOS struct {
 	effectiveUID int
 
 	// remaining syscall errnos
+	//nolint:unused // Used with platform specific code
 	eStaleRemainingErrors atomic.Int32
 
 	osInterface

--- a/repo/blob/filesystem/osinterface_mock_test.go
+++ b/repo/blob/filesystem/osinterface_mock_test.go
@@ -31,6 +31,9 @@ type mockOS struct {
 
 	effectiveUID int
 
+	// remaining syscall errnos
+	eStaleRemainingErrors atomic.Int32
+
 	osInterface
 }
 
@@ -92,14 +95,6 @@ func (osi *mockOS) Remove(fname string) error {
 	}
 
 	return osi.osInterface.Remove(fname)
-}
-
-func (osi *mockOS) Stat(fname string) (fs.FileInfo, error) {
-	if osi.statRemainingErrors.Add(-1) >= 0 {
-		return nil, &os.PathError{Op: "stat", Err: errors.Errorf("underlying problem")}
-	}
-
-	return osi.osInterface.Stat(fname)
 }
 
 func (osi *mockOS) Chtimes(fname string, atime, mtime time.Time) error {

--- a/repo/blob/filesystem/osinterface_mock_unix_test.go
+++ b/repo/blob/filesystem/osinterface_mock_unix_test.go
@@ -1,0 +1,24 @@
+//go:build linux || freebsd || darwin
+// +build linux freebsd darwin
+
+package filesystem
+
+import (
+	"io/fs"
+	"os"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+func (osi *mockOS) Stat(fname string) (fs.FileInfo, error) {
+	if osi.statRemainingErrors.Add(-1) >= 0 {
+		return nil, &os.PathError{Op: "stat", Err: errors.Errorf("underlying problem")}
+	}
+
+	if osi.eStaleRemainingErrors.Add(-1) >= 0 {
+		return nil, &os.PathError{Op: "stat", Err: syscall.ESTALE}
+	}
+
+	return osi.osInterface.Stat(fname)
+}

--- a/repo/blob/filesystem/osinterface_realos_other.go
+++ b/repo/blob/filesystem/osinterface_realos_other.go
@@ -1,0 +1,8 @@
+//go:build !linux && !freebsd && !darwin
+// +build !linux,!freebsd,!darwin
+
+package filesystem
+
+func (realOS) IsESTALE(err error) bool {
+	return false
+}

--- a/repo/blob/filesystem/osinterface_realos_unix.go
+++ b/repo/blob/filesystem/osinterface_realos_unix.go
@@ -1,0 +1,16 @@
+//go:build linux || freebsd || darwin
+// +build linux freebsd darwin
+
+package filesystem
+
+import (
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+func (realOS) IsESTALE(err error) bool {
+	var errno syscall.Errno
+
+	return errors.As(err, &errno) && errno == syscall.ESTALE
+}


### PR DESCRIPTION
Running Kopia over certain (like NFS) backends can lead to ESTALE errors when working with a stale mount or file-descriptors. Currently an ESTALE from FS calls like o.Stat() end up getting retried unnecessarily. This patch introduces a fix to prevent retries on UNIX platforms.