### PR TITLE
Support specifying a credential container during S3 init

### DIFF
--- a/repo/blob/s3/s3_options.go
+++ b/repo/blob/s3/s3_options.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/repo/blob/throttling"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 // Options defines options for S3-based storage.
@@ -29,4 +30,7 @@ type Options struct {
 
 	// PointInTime specifies a view of the (versioned) store at that time
 	PointInTime *time.Time `json:"pointInTime,omitempty"`
+
+	// Creds is an optional credential container to use
+	Creds *credentials.Credentials `json:"-"`
 }

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -335,6 +335,11 @@ func newStorage(ctx context.Context, opt *Options) (*s3Storage, error) {
 		},
 	)
 
+	// If a credential container was specified, use that instead.
+	if opt.Creds != nil {
+		creds = opt.Creds
+	}
+
 	return newStorageWithCredentials(ctx, creds, opt)
 }
 

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -347,6 +347,29 @@ func TestTokenExpiration(t *testing.T) {
 	verifyBlobNotFoundForGetBlob(ctx, t, rst)
 }
 
+func TestS3StorageCustomCredentials(t *testing.T) {
+	t.Parallel()
+
+	// skip the test if AWS creds are not provided
+	creds := miniocreds.New(&miniocreds.Static{
+		Value: miniocreds.Value{
+			AccessKeyID:     getEnvOrSkip(t, testAccessKeyIDEnv),
+			SecretAccessKey: getEnvOrSkip(t, testSecretAccessKeyEnv),
+			SignerType:      miniocreds.SignatureV4,
+		},
+	})
+
+	options := &Options{
+		Endpoint:   getEnv(testEndpointEnv, awsEndpoint),
+		BucketName: getEnvOrSkip(t, testBucketEnv),
+		Region:     getEnvOrSkip(t, testRegionEnv),
+		Creds:      creds,
+	}
+
+	getOrCreateBucket(t, options)
+	testStorage(t, options, false, blob.PutOptions{})
+}
+
 func TestS3StorageMinio(t *testing.T) {
 	t.Parallel()
 	testutil.ProviderTest(t)


### PR DESCRIPTION
This commit allows us to specify a custom credential container when initializing an S3 storage provider.

This functionality can be leveraged to plugin custom credential providers to override the default credential
chain currently used.