### PR TITLE
Enable configuration of kopia server arguments when using KopiaUI

### DIFF
--- a/app/public/config.js
+++ b/app/public/config.js
@@ -10,6 +10,19 @@ let configDir = "";
 let isPortable = false;
 let firstRun = false;
 
+// returns additional server args for starting Kopia server
+function additionalServerArgs(repoID) {
+    const argsFile=path.resolve(globalConfigDir(), `server_args-${repoID}.conf`)
+    log.info(`Checking for additional server args in ${argsFile}`)
+    if(fs.existsSync(argsFile)){
+        const additionalArgs=fs.readFileSync(argsFile).toString().split("\n").filter(v => v.trim().length >= 0)
+        log.info(`Found additional server args for ${repoID}: ${JSON.stringify(additionalArgs)}`)
+        return additionalArgs
+    } else {
+        return []
+    }
+}
+
 // returns the list of directories to be checked for portable configurations
 function portableConfigDirs() {
     let result = [];
@@ -107,6 +120,7 @@ function deleteConfigIfDisconnected(repoID) {
 }
 
 module.exports = {
+    additionalServerArgs,
     loadConfigs() {
         fs.mkdirSync(globalConfigDir(), { recursive: true, mode: 0700 });
         let entries = fs.readdirSync(globalConfigDir());

--- a/app/public/server.js
+++ b/app/public/server.js
@@ -5,7 +5,7 @@ const https = require('https');
 const { defaultServerBinary } = require('./utils');
 const { spawn } = require('child_process');
 const log = require("electron-log")
-const { configDir, isPortableConfig } = require('./config');
+const { configDir, isPortableConfig, additionalServerArgs } = require('./config');
 
 let servers = {};
 
@@ -44,6 +44,8 @@ function newServerForRepo(repoID) {
                 '--shutdown-on-stdin', // shutdown the server when parent dies
                 '--address=localhost:0');
     
+            args.push(...additionalServerArgs(repoID))
+
 
             args.push("--config-file", path.resolve(configDir(), repoID + ".config"));
             if (isPortableConfig()) {

--- a/site/content/docs/Reference/Command-Line/_index.md
+++ b/site/content/docs/Reference/Command-Line/_index.md
@@ -97,3 +97,27 @@ The configuration file stores the connection parameters, for example:
 ```
 
 The password to the repository is stored in operating-system specific credential storage (KeyChain on macOS, Credential Manager on Windows or KeyRing on Linux).
+
+#### Set command line arguments when using KopiaUI
+
+
+
+KopiaUI starts the kopia server processes for for each configured repository. Additional arguments for the server process can be configured by creating a special config file.
+
+>NOTE: additional command line options might prevent kopia server from starting up. Please ensure you know what you are doing.
+
+The special config file is located here:
+
+* `%APPDATA%\kopia\server_args-<RepositoryID>.conf` on Windows
+* `$HOME/Library/Application Support/kopia/server_args-<RepositoryID>.conf` on macOS
+* `$HOME/.config/kopia/server_args-<RepositoryID>.conf` on Linux
+
+whereas `<RepositoryID>` is to be replaced with the ID of the repository you want to configure the arguments for.
+
+The file has to contain exactly one argument per line. Example:
+
+```
+--refresh-interval=12h
+--log-level=info
+```
+


### PR DESCRIPTION
This PR enables to supply additional arguments to the kopia server processes that are started by KopiaUI.

Fixes #1432