### PR TITLE
feat(snapshots): Return ReadCloser from StreamingFiles

### DIFF
--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 	"time"
@@ -273,7 +274,7 @@ func (c *commandSnapshotCreate) snapshotSingleSource(ctx context.Context, rep re
 		// stdin source will be snapshotted using a virtual static root directory with a single streaming file entry
 		// Create a new static directory with the given name and add a streaming file entry with os.Stdin reader
 		fsEntry = virtualfs.NewStaticDirectory(sourceInfo.Path, []fs.Entry{
-			virtualfs.StreamingFileFromReader(c.snapshotCreateStdinFileName, c.svc.stdin()),
+			virtualfs.StreamingFileFromReader(c.snapshotCreateStdinFileName, io.NopCloser(c.svc.stdin())),
 		})
 		setManual = true
 	} else {

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -53,7 +53,7 @@ type File interface {
 // StreamingFile represents an entry that is a stream.
 type StreamingFile interface {
 	Entry
-	GetReader(ctx context.Context) (io.Reader, error)
+	GetReader(ctx context.Context) (io.ReadCloser, error)
 }
 
 // Directory represents contents of a directory.

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -167,7 +167,7 @@ func NewStreamingDirectory(
 // virtualFile is an implementation of fs.StreamingFile with an io.Reader.
 type virtualFile struct {
 	virtualEntry
-	reader io.Reader
+	reader io.ReadCloser
 }
 
 var errReaderAlreadyUsed = errors.New("cannot use streaming file reader more than once")
@@ -175,7 +175,7 @@ var errReaderAlreadyUsed = errors.New("cannot use streaming file reader more tha
 // GetReader returns the streaming file's reader.
 // Note: Caller of this function has to ensure concurrency safety.
 // The file's reader is set to nil after the first call.
-func (vf *virtualFile) GetReader(ctx context.Context) (io.Reader, error) {
+func (vf *virtualFile) GetReader(ctx context.Context) (io.ReadCloser, error) {
 	if vf.reader == nil {
 		return nil, errReaderAlreadyUsed
 	}
@@ -188,12 +188,12 @@ func (vf *virtualFile) GetReader(ctx context.Context) (io.Reader, error) {
 }
 
 // StreamingFileFromReader returns a streaming file with given name and reader.
-func StreamingFileFromReader(name string, reader io.Reader) fs.StreamingFile {
+func StreamingFileFromReader(name string, reader io.ReadCloser) fs.StreamingFile {
 	return StreamingFileWithModTimeFromReader(name, clock.Now(), reader)
 }
 
 // StreamingFileWithModTimeFromReader returns a streaming file with given name, modified time, and reader.
-func StreamingFileWithModTimeFromReader(name string, t time.Time, reader io.Reader) fs.StreamingFile {
+func StreamingFileWithModTimeFromReader(name string, t time.Time, reader io.ReadCloser) fs.StreamingFile {
 	return &virtualFile{
 		virtualEntry: virtualEntry{
 			name:    name,

--- a/fs/virtualfs/virtualfs_test.go
+++ b/fs/virtualfs/virtualfs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -76,9 +77,9 @@ func TestStreamingFile(t *testing.T) {
 
 func TestStreamingFileModTime(t *testing.T) {
 	data := []byte("data")
-	f1 := StreamingFileFromReader("f1", bytes.NewReader(data))
+	f1 := StreamingFileFromReader("f1", io.NopCloser(bytes.NewReader(data)))
 	mt := time.Date(2021, 1, 2, 3, 4, 5, 0, time.UTC)
-	f2 := StreamingFileWithModTimeFromReader("f2", mt, bytes.NewReader(data))
+	f2 := StreamingFileWithModTimeFromReader("f2", mt, io.NopCloser(bytes.NewReader(data)))
 
 	assert.True(t, f1.ModTime().After(f2.ModTime()))
 }
@@ -130,7 +131,7 @@ func TestStreamingFileGetReader(t *testing.T) {
 func TestStreamingDirectory(t *testing.T) {
 	// Create a temporary file with test data
 	content := []byte("Temporary file content")
-	r := bytes.NewReader(content)
+	r := io.NopCloser(bytes.NewReader(content))
 
 	f := StreamingFileFromReader(testFileName, r)
 
@@ -167,7 +168,7 @@ func TestStreamingDirectory(t *testing.T) {
 func TestStreamingDirectory_MultipleIterationsFails(t *testing.T) {
 	// Create a temporary file with test data
 	content := []byte("Temporary file content")
-	r := bytes.NewReader(content)
+	r := io.NopCloser(bytes.NewReader(content))
 
 	f := StreamingFileFromReader(testFileName, r)
 
@@ -195,7 +196,7 @@ var errCallback = errors.New("callback error")
 func TestStreamingDirectory_ReturnsCallbackError(t *testing.T) {
 	// Create a temporary file with test data
 	content := []byte("Temporary file content")
-	r := bytes.NewReader(content)
+	r := io.NopCloser(bytes.NewReader(content))
 
 	f := StreamingFileFromReader(testFileName, r)
 

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -342,6 +342,8 @@ func (u *Uploader) uploadStreamingFileInternal(ctx context.Context, relativePath
 		return nil, errors.Wrap(err, "unable to get streaming file reader")
 	}
 
+	defer reader.Close() //nolint:errcheck
+
 	var streamSize int64
 
 	u.Progress.HashingFile(relativePath)

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -886,7 +886,7 @@ func TestUpload_VirtualDirectoryWithStreamingFileWithModTime(t *testing.T) {
 		{
 			desc: "CurrentTime",
 			getFile: func() fs.StreamingFile {
-				return virtualfs.StreamingFileFromReader("a", bytes.NewReader(content))
+				return virtualfs.StreamingFileFromReader("a", io.NopCloser(bytes.NewReader(content)))
 			},
 			cachedFiles:   0,
 			uploadedFiles: 1,
@@ -894,7 +894,7 @@ func TestUpload_VirtualDirectoryWithStreamingFileWithModTime(t *testing.T) {
 		{
 			desc: "FixedTime",
 			getFile: func() fs.StreamingFile {
-				return virtualfs.StreamingFileWithModTimeFromReader("a", mt, bytes.NewReader(content))
+				return virtualfs.StreamingFileWithModTimeFromReader("a", mt, io.NopCloser(bytes.NewReader(content)))
 			},
 			cachedFiles:   1,
 			uploadedFiles: 0,

--- a/tests/tools/kopiaclient/kopiaclient.go
+++ b/tests/tools/kopiaclient/kopiaclient.go
@@ -210,7 +210,7 @@ func (kc *KopiaClient) getStorage(ctx context.Context, repoDir, bucketName strin
 // reads its contents from `val`.
 func (kc *KopiaClient) getSourceForKeyVal(key string, val []byte) fs.Entry {
 	return virtualfs.NewStaticDirectory(key, []fs.Entry{
-		virtualfs.StreamingFileFromReader(dataFileName, bytes.NewReader(val)),
+		virtualfs.StreamingFileFromReader(dataFileName, io.NopCloser(bytes.NewReader(val))),
 	})
 }
 


### PR DESCRIPTION
Allow better resource cleanup by returning ReadClosers from StreamingFiles and having the uploader close it when it's done

This breaks the previous interface for external users for virtualfs.streamingFile as it changes one of the parameters for the initializer