### PR TITLE
feat(repository): increase GRPC maximum message size to 36 MiB

### DIFF
--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -34,7 +34,7 @@ import (
 // MaxGRPCMessageSize is the maximum size of a message sent or received over GRPC API when talking to
 // Kopia repository server. This is bigger than the size of any possible content, which is
 // defined by supported splitters.
-const MaxGRPCMessageSize = 20 << 21
+const MaxGRPCMessageSize = 20 << 20
 
 const (
 	// when writing contents of this size or above, make a round-trip to the server to

--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -34,7 +34,7 @@ import (
 // MaxGRPCMessageSize is the maximum size of a message sent or received over GRPC API when talking to
 // Kopia repository server. This is bigger than the size of any possible content, which is
 // defined by supported splitters.
-const MaxGRPCMessageSize = 20 << 21
+const MaxGRPCMessageSize = 24 << 20
 
 const (
 	// when writing contents of this size or above, make a round-trip to the server to

--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -34,7 +34,7 @@ import (
 // MaxGRPCMessageSize is the maximum size of a message sent or received over GRPC API when talking to
 // Kopia repository server. This is bigger than the size of any possible content, which is
 // defined by supported splitters.
-const MaxGRPCMessageSize = 20 << 20
+const MaxGRPCMessageSize = 20 << 21
 
 const (
 	// when writing contents of this size or above, make a round-trip to the server to

--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -34,7 +34,7 @@ import (
 // MaxGRPCMessageSize is the maximum size of a message sent or received over GRPC API when talking to
 // Kopia repository server. This is bigger than the size of any possible content, which is
 // defined by supported splitters.
-const MaxGRPCMessageSize = 24 << 20
+const MaxGRPCMessageSize = 36 << 20
 
 const (
 	// when writing contents of this size or above, make a round-trip to the server to


### PR DESCRIPTION
[Issue 2660](https://github.com/kopia/kopia/issues/2660)

Kopia remote client needs GRPC message size > 2GB, due to nig repo with 160k+ of snapshots. Suggest to double the max. GRPC message size to 4GB for the time being. It would probablöy be best, to make this a tuneable via the config file.