### PR TITLE
feat(server): improved server shutdown and integration tests

### DIFF
--- a/.github/workflows/race-detector.yml
+++ b/.github/workflows/race-detector.yml
@@ -22,5 +22,3 @@ jobs:
         fetch-depth: 0
     - name: Unit Tests
       run: make -j2 test UNIT_TEST_RACE_FLAGS=-race UNIT_TESTS_TIMEOUT=1200s
-    - name: Integration Tests
-      run: make -j2 ci-integration-tests INTEGRATION_TEST_RACE_FLAGS=-race

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ GOTESTSUM_FLAGS=--format=$(GOTESTSUM_FORMAT) --no-summary=skipped
 GO_TEST?=$(gotestsum) $(GOTESTSUM_FLAGS) --
 
 LINTER_DEADLINE=600s
-UNIT_TESTS_TIMEOUT=600s
+UNIT_TESTS_TIMEOUT=1200s
 
 ifeq ($(GOARCH),amd64)
 PARALLEL=8
@@ -250,7 +250,7 @@ dev-deps:
 test-with-coverage: export KOPIA_COVERAGE_TEST=1
 test-with-coverage: export TESTING_ACTION_EXE ?= $(TESTING_ACTION_EXE)
 test-with-coverage: $(gotestsum) $(TESTING_ACTION_EXE)
-	$(GO_TEST) $(UNIT_TEST_RACE_FLAGS) -tags testing -count=$(REPEAT_TEST) -short -covermode=atomic -coverprofile=coverage.txt --coverpkg $(COVERAGE_PACKAGES) -timeout 300s ./...
+	$(GO_TEST) $(UNIT_TEST_RACE_FLAGS) -tags testing -count=$(REPEAT_TEST) -short -covermode=atomic -coverprofile=coverage.txt --coverpkg $(COVERAGE_PACKAGES) -timeout $(UNIT_TESTS_TIMEOUT) ./...
 
 test: GOTESTSUM_FLAGS=--format=$(GOTESTSUM_FORMAT) --no-summary=skipped --jsonfile=.tmp.unit-tests.json
 test: export TESTING_ACTION_EXE ?= $(TESTING_ACTION_EXE)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ all_go_sources=$(foreach d,$(go_source_dirs),$(call rwildcard,$d/,*.go)) $(wildc
 all:
 	$(MAKE) test
 	$(MAKE) lint
-	$(MAKE) integration-tests
 
 include tools/tools.mk
 
@@ -213,7 +212,6 @@ download-rclone:
 ci-tests: lint vet test 
 
 ci-integration-tests:
-	$(MAKE) integration-tests
 	$(MAKE) robustness-tool-tests
 
 ci-publish-coverage:
@@ -285,15 +283,6 @@ build-integration-test-binary:
 
 $(TESTING_ACTION_EXE): tests/testingaction/main.go
 	go build -o $(TESTING_ACTION_EXE) -tags testing github.com/kopia/kopia/tests/testingaction
-
-integration-tests: export KOPIA_EXE ?= $(KOPIA_INTEGRATION_EXE)
-integration-tests: export KOPIA_08_EXE=$(kopia08)
-integration-tests: export KOPIA_TRACK_CHUNK_ALLOC=1
-integration-tests: export TESTING_ACTION_EXE ?= $(TESTING_ACTION_EXE)
-integration-tests: GOTESTSUM_FLAGS=--format=testname --no-summary=skipped --jsonfile=.tmp.integration-tests.json
-integration-tests: build-integration-test-binary $(gotestsum) $(TESTING_ACTION_EXE) $(kopia08)
-	$(GO_TEST) $(TEST_FLAGS) -count=$(REPEAT_TEST) -parallel $(PARALLEL) -timeout 3600s github.com/kopia/kopia/tests/end_to_end_test
-	-$(gotestsum) tool slowest --jsonfile .tmp.integration-tests.json  --threshold 1000ms
 
 compat-tests: export KOPIA_CURRENT_EXE=$(CURDIR)/$(kopia_ui_embedded_exe)
 compat-tests: export KOPIA_08_EXE=$(kopia08)

--- a/cli/command_repository_upgrade_test.go
+++ b/cli/command_repository_upgrade_test.go
@@ -205,6 +205,8 @@ func lockRepositoryForUpgrade(t *testing.T, env *testenv.CLITest) {
 }
 
 func (s *formatSpecificTestSuite) TestRepositoryUpgradeStatusWhileLocked(t *testing.T) {
+	t.Parallel()
+
 	env := testenv.NewCLITest(t, s.formatFlags, testenv.NewInProcRunner(t))
 
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -63,6 +63,8 @@ type commandServerStart struct {
 	uiPreferencesFile                   string
 	asyncRepoConnect                    bool
 
+	shutdownGracePeriod time.Duration
+
 	logServerRequests bool
 
 	disableCSRFTokenChecks bool // disable CSRF token checks - used for development/debugging only
@@ -111,6 +113,8 @@ func (c *commandServerStart) setup(svc advancedAppServices, parent commandParent
 
 	cmd.Flag("log-server-requests", "Log server requests").Hidden().BoolVar(&c.logServerRequests)
 	cmd.Flag("disable-csrf-token-checks", "Disable CSRF token").Hidden().BoolVar(&c.disableCSRFTokenChecks)
+
+	cmd.Flag("shutdown-grace-period", "Grace period for shutting down the server").Default("5s").DurationVar(&c.shutdownGracePeriod)
 
 	c.sf.setup(svc, cmd)
 	c.co.setup(svc, cmd)
@@ -191,7 +195,23 @@ func (c *commandServerStart) run(ctx context.Context) error {
 		},
 	}
 
-	srv.OnShutdown = httpServer.Shutdown
+	srv.OnShutdown = func(ctx context.Context) error {
+		ctx2, cancel := context.WithTimeout(ctx, c.shutdownGracePeriod)
+		defer cancel()
+
+		// wait for all connections to finish for up to 5 seconds
+		log(ctx2).Debugf("attempting graceful shutdown for %v", c.shutdownGracePeriod)
+
+		if serr := httpServer.Shutdown(ctx2); serr != nil {
+			// graceful shutdown unsuccessful, force close
+			log(ctx2).Debugf("unable to shut down gracefully - closing: %v", serr)
+			return errors.Wrap(httpServer.Close(), "close")
+		}
+
+		log(ctx2).Debugf("graceful shutdown succeeded")
+
+		return nil
+	}
 
 	c.svc.onCtrlC(func() {
 		log(ctx).Infof("Shutting down...")

--- a/tests/end_to_end_test/api_server_repository_test.go
+++ b/tests/end_to_end_test/api_server_repository_test.go
@@ -62,16 +62,21 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 		connectArgs = []string{"--no-grpc"}
 	}
 
-	runner := testenv.NewExeRunner(t)
+	runner := testenv.NewInProcRunner(t)
 	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
 
 	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
 
-	// create one snapshot as foo@bar
+	// create 5 snapshots as foo@bar
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-username", "foo", "--override-hostname", "bar")
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
 	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
 
 	e1 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
 	defer e1.RunAndExpectSuccess(t, "repo", "disconnect")
 
 	// create one snapshot as not-foo@bar
@@ -99,7 +104,12 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 
 	var sp testutil.ServerParameters
 
-	e.RunAndProcessStderr(t, sp.ProcessOutput,
+	e.LogOutput = true
+	e.LogOutputPrefix = "<first> "
+
+	t.Logf("******** first server startup ********")
+
+	wait, _ := e.RunAndProcessStderr(t, sp.ProcessOutput,
 		append([]string{
 			"server", "start",
 			"--address=localhost:0",
@@ -110,7 +120,9 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 			"--server-password", uiPassword,
 			"--server-control-username", controlUsername,
 			"--server-control-password", controlPassword,
+			"--shutdown-grace-period", "100ms",
 		}, serverStartArgs...)...)
+
 	t.Logf("detected server parameters %#v", sp)
 
 	controlClient, err := apiclient.NewKopiaAPIClient(apiclient.Options{
@@ -120,11 +132,11 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 		TrustedServerCertificateFingerprint: sp.SHA256Fingerprint,
 		LogRequests:                         true,
 	})
-	if err != nil {
-		t.Fatalf("unable to create API apiclient")
-	}
+	require.NoError(t, err)
 
 	waitUntilServerStarted(ctx, t, controlClient)
+
+	t.Logf("******** first server completed startup ********")
 
 	// open repository client.
 	ctx2, cancel := context.WithCancel(ctx)
@@ -148,16 +160,22 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 	_, writeSess, err := rep.NewWriter(ctx, repo.WriteSessionOptions{Purpose: "some writer"})
 	require.NoError(t, err)
 
-	logErrorAndIgnore(t, serverapi.Shutdown(ctx, controlClient))
+	defer writeSess.Close(ctx)
 
-	// give the server a moment to wind down.
-	time.Sleep(1 * time.Second)
+	t.Logf("******** server shutdown ********")
+	require.NoError(t, serverapi.Shutdown(ctx, controlClient))
+	// wait for the server to wind down.
+	wait()
+	t.Logf("******** finished server shutdown ********")
 
 	defer rep.Close(ctx)
 
+	e.LogOutput = true
+	e.LogOutputPrefix = "<second> "
+
 	// start the server again, using the same address & TLS key+cert, so existing connection
 	// should be re-established.
-	e.RunAndProcessStderr(t, sp.ProcessOutput,
+	wait2, _ := e.RunAndProcessStderr(t, sp.ProcessOutput,
 		append([]string{
 			"server", "start",
 			"--address=" + sp.BaseURL,
@@ -168,11 +186,10 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 			"--server-control-username", controlUsername,
 			"--server-control-password", controlPassword,
 		}, serverStartArgs...)...)
+
 	t.Logf("detected server parameters %#v", sp)
 
 	waitUntilServerStarted(ctx, t, controlClient)
-
-	defer serverapi.Shutdown(ctx, controlClient)
 
 	someLabels := map[string]string{
 		"type":     "snapshot",
@@ -181,21 +198,22 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 	}
 
 	// invoke some read method, the repository will automatically reconnect to the server.
-	verifyFindManifestCount(ctx, t, rep, someLabels, 1)
+	verifyFindManifestCount(ctx, t, rep, someLabels, 5)
 
 	if useGRPC {
 		// the same method on a GRPC write session should fail because the stream was broken.
-		if _, err := writeSess.FindManifests(ctx, someLabels); err == nil {
-			t.Fatalf("expected failure on write session method, got success.")
-		}
+		_, err := writeSess.FindManifests(ctx, someLabels)
+		require.Error(t, err)
 	} else {
 		// invoke some method on write session, this will succeed because legacy API is stateless
 		// (also incorrect in this case).
-		verifyFindManifestCount(ctx, t, writeSess, someLabels, 1)
+		verifyFindManifestCount(ctx, t, writeSess, someLabels, 5)
 	}
 
-	runner2 := testenv.NewExeRunner(t)
+	runner2 := testenv.NewInProcRunner(t)
 	e2 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner2)
+	e2.LogOutput = true
+	e2.LogOutputPrefix = "client2 "
 
 	defer e2.RunAndExpectSuccess(t, "repo", "disconnect")
 
@@ -215,9 +233,7 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 
 	// should see one snapshot
 	snapshots := clitestutil.ListSnapshotsAndExpectSuccess(t, e2)
-	if got, want := len(snapshots), 1; got != want {
-		t.Errorf("invalid number of snapshots for foo@bar")
-	}
+	require.Len(t, snapshots, 1)
 
 	// create very small directory
 	smallDataDir := filepath.Join(sharedTestDataDirBase, "dir-small")
@@ -234,25 +250,20 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 
 	// make sure snapshot created by the client resulted in blobs being created by the server
 	// as opposed to buffering it in memory
-	if got, want := len(e.RunAndExpectSuccess(t, "blob", "list", "--prefix=p")), originalPBlobCount; got <= want {
-		t.Errorf("unexpected number of P blobs on the server: %v, wanted > %v", got, want)
-	}
-
-	if got, want := len(e.RunAndExpectSuccess(t, "blob", "list", "--prefix=q")), originalQBlobCount; got <= want {
-		t.Errorf("unexpected number of Q blobs on the server: %v, wanted > %v", got, want)
-	}
+	require.Greater(t, len(e.RunAndExpectSuccess(t, "blob", "list", "--prefix=p")), originalPBlobCount)
+	require.Greater(t, len(e.RunAndExpectSuccess(t, "blob", "list", "--prefix=q")), originalQBlobCount)
 
 	// create snapshot using remote repository client
 	e2.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir2)
 
 	// now should see two snapshots
 	snapshots = clitestutil.ListSnapshotsAndExpectSuccess(t, e2)
-	if got, want := len(snapshots), 3; got != want {
-		t.Errorf("invalid number of snapshots for foo@bar")
-	}
+	require.Len(t, snapshots, 3)
 
 	// shutdown the server
-	logErrorAndIgnore(t, serverapi.Shutdown(ctx, controlClient))
+	require.NoError(t, serverapi.Shutdown(ctx, controlClient))
+
+	wait2()
 
 	// open repository client to a dead server, this should fail quickly instead of retrying forever.
 	timer := timetrack.StartTimer()
@@ -267,28 +278,13 @@ func testAPIServerRepository(t *testing.T, serverStartArgs []string, useGRPC, al
 	}, content.CachingOptions{}, "baz", &repo.Options{})
 
 	//nolint:forbidigo
-	if dur := timer.Elapsed(); dur > 15*time.Second {
-		t.Fatalf("failed connection took %v", dur)
-	}
+	require.Less(t, timer.Elapsed(), 15*time.Second)
 }
 
 func verifyFindManifestCount(ctx context.Context, t *testing.T, rep repo.Repository, labels map[string]string, wantCount int) {
 	t.Helper()
 
 	man, err := rep.FindManifests(ctx, labels)
-	if err != nil {
-		t.Fatalf("unable to list manifests using repository %v", err)
-	}
-
-	if got, want := len(man), wantCount; got != want {
-		t.Fatalf("invalid number of manifests: %v, want %v", got, want)
-	}
-}
-
-func logErrorAndIgnore(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Log(err)
-	}
+	require.NoError(t, err)
+	require.Len(t, man, wantCount)
 }

--- a/tests/htmlui_e2e_test/htmlui_e2e_test.go
+++ b/tests/htmlui_e2e_test/htmlui_e2e_test.go
@@ -60,8 +60,9 @@ func runInBrowser(t *testing.T, run func(ctx context.Context, sp *testutil.Serve
 		args = append(args, "--html="+os.Getenv("HTMLUI_BUILD_DIR"))
 	}
 
-	_, kill := e.RunAndProcessStderr(t, sp.ProcessOutput, args...)
+	wait, kill := e.RunAndProcessStderr(t, sp.ProcessOutput, args...)
 
+	defer wait()
 	defer kill()
 
 	t.Logf("detected server parameters %#v", sp)


### PR DESCRIPTION
Added `--shutdown-grace-period` flag to `kopia server start` command which can be used to specify how long the server will wait for active connections to finish before forcibly shutting down.

This allowed removal of final out-of-process execution of during integration tests and the need for `integration-tests` target which was running the same tests as `tests` but in out-of-process mode.

We thus now have all the test coverage in-process without having to build and launch `kopia` binary.