### PR TITLE
feat(repository): added RepositoryWriter.ReplaceManifests

### DIFF
--- a/internal/user/user_manager.go
+++ b/internal/user/user_manager.go
@@ -121,26 +121,12 @@ func SetUserProfile(ctx context.Context, w repo.RepositoryWriter, p *Profile) er
 		return err
 	}
 
-	manifests, err := w.FindManifests(ctx, map[string]string{
-		manifest.TypeLabelKey:   ManifestType,
-		UsernameAtHostnameLabel: p.Username,
-	})
-	if err != nil {
-		return errors.Wrap(err, "error looking for user profile")
-	}
-
-	id, err := w.PutManifest(ctx, map[string]string{
+	id, err := w.ReplaceManifests(ctx, map[string]string{
 		manifest.TypeLabelKey:   ManifestType,
 		UsernameAtHostnameLabel: p.Username,
 	}, p)
 	if err != nil {
-		return errors.Wrap(err, "error writing user profile")
-	}
-
-	for _, m := range manifests {
-		if err := w.DeleteManifest(ctx, m.ID); err != nil {
-			return errors.Wrapf(err, "error deleting user profile %v", p.Username)
-		}
+		return errors.Wrap(err, "error looking for user profile")
 	}
 
 	p.ManifestID = id

--- a/repo/api_server_repository.go
+++ b/repo/api_server_repository.go
@@ -104,6 +104,11 @@ func (r *apiServerRepository) PutManifest(ctx context.Context, labels map[string
 	return resp.ID, nil
 }
 
+// ReplaceManifests saves the given manifest payload with a set of labels and replaces any previous manifests with the same labels.
+func (r *apiServerRepository) ReplaceManifests(ctx context.Context, labels map[string]string, payload interface{}) (manifest.ID, error) {
+	return replaceManifestsHelper(ctx, r, labels, payload)
+}
+
 func (r *apiServerRepository) SetFindManifestPageSizeForTesting(v int32) {
 }
 

--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -303,6 +303,11 @@ func (r *grpcRepositoryClient) PutManifest(ctx context.Context, labels map[strin
 	})
 }
 
+// ReplaceManifests saves the given manifest payload with a set of labels and replaces any previous manifests with the same labels.
+func (r *grpcRepositoryClient) ReplaceManifests(ctx context.Context, labels map[string]string, payload interface{}) (manifest.ID, error) {
+	return replaceManifestsHelper(ctx, r, labels, payload)
+}
+
 func (r *grpcInnerSession) PutManifest(ctx context.Context, labels map[string]string, payload interface{}) (manifest.ID, error) {
 	v, err := json.Marshal(payload)
 	if err != nil {

--- a/repo/maintenance/maintenance_params.go
+++ b/repo/maintenance/maintenance_params.go
@@ -99,19 +99,8 @@ func GetParams(ctx context.Context, rep repo.Repository) (*Params, error) {
 
 // SetParams sets the maintenance parameters.
 func SetParams(ctx context.Context, rep repo.RepositoryWriter, par *Params) error {
-	md, err := manifestIDs(ctx, rep)
-	if err != nil {
-		return err
-	}
-
-	if _, err := rep.PutManifest(ctx, manifestLabels, par); err != nil {
+	if _, err := rep.ReplaceManifests(ctx, manifestLabels, par); err != nil {
 		return errors.Wrap(err, "put manifest")
-	}
-
-	for _, m := range md {
-		if err := rep.DeleteManifest(ctx, m.ID); err != nil {
-			return errors.Wrap(err, "delete manifest")
-		}
 	}
 
 	return nil

--- a/snapshot/policy/policy_manager.go
+++ b/snapshot/policy/policy_manager.go
@@ -170,19 +170,8 @@ func SetPolicy(ctx context.Context, rep repo.RepositoryWriter, si snapshot.Sourc
 		}
 	}
 
-	md, err := rep.FindManifests(ctx, LabelsForSource(si))
-	if err != nil {
-		return errors.Wrapf(err, "unable to load manifests for %v", si)
-	}
-
-	if _, err := rep.PutManifest(ctx, LabelsForSource(si), pol); err != nil {
+	if _, err := rep.ReplaceManifests(ctx, LabelsForSource(si), pol); err != nil {
 		return errors.Wrap(err, "error writing policy manifest")
-	}
-
-	for _, em := range md {
-		if err := rep.DeleteManifest(ctx, em.ID); err != nil {
-			return errors.Wrap(err, "unable to delete previous policy manifest")
-		}
 	}
 
 	return nil


### PR DESCRIPTION
This simplifies use cases where we intend to replace a manifest uniquely identified by a set of labels with another one as is the case for policies.

This helped fix annoying test flake on Windows where the clock is not guaranteed to move forward when read in quick succession.

This is now passing on Windows:

```
$ go test -timeout 1000s ./internal/server -run TestSourceRefreshesAfterPolicy -count=1000
```