### PR TITLE
feat(cli): new storage config input from file when creating a repo

### DIFF
--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -57,10 +57,6 @@ func (c *commandRepositoryCreate) setup(svc advancedAppServices, parent commandP
 	c.out.setup(svc)
 
 	for _, prov := range svc.storageProviders() {
-		if prov.Name == "from-config" {
-			continue
-		}
-
 		// Set up 'create' subcommand
 		f := prov.NewFlags()
 		cc := cmd.Command(prov.Name, "Create repository in "+prov.Description)

--- a/cli/command_repository_create_test.go
+++ b/cli/command_repository_create_test.go
@@ -20,6 +20,9 @@ func TestRepositoryCreateWithConfigFile(t *testing.T) {
 	_, stderr := env.RunAndExpectFailure(t, "repo", "create", "from-config", "--file", path.Join(env.ConfigDir, "does_not_exist.config"))
 	require.Contains(t, stderr, "can't connect to storage: one of --token-file, --token-stdin or --token must be provided")
 
+	_, stderr = env.RunAndExpectFailure(t, "repo", "connect", "from-config")
+	require.Contains(t, stderr, "can't connect to storage: one of --file, --token-file, --token-stdin or --token must be provided")
+
 	_, stderr = env.RunAndExpectFailure(t, "repo", "create", "from-config", "--token", "bad-token")
 	require.Contains(t, stderr, "can't connect to storage: invalid token: unable to decode token")
 
@@ -30,6 +33,10 @@ func TestRepositoryCreateWithConfigFile(t *testing.T) {
 	}
 	token, err := repo.EncodeToken("12345678", ci)
 	require.Nil(t, err)
+
+	// expect failure before writing to file
+	_, stderr = env.RunAndExpectFailure(t, "repo", "create", "from-config", "--token-file", storageCfgFName)
+	require.Contains(t, strings.Join(stderr, "\n"), "can't connect to storage: unable to open token file")
 
 	require.Nil(t, os.WriteFile(storageCfgFName, []byte(token), 0o600))
 

--- a/cli/storage_providers.go
+++ b/cli/storage_providers.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"io"
 
 	"github.com/alecthomas/kingpin/v2"
 
@@ -15,6 +16,7 @@ type StorageProviderServices interface {
 	EnvName(s string) string
 	setPasswordFromToken(pwd string)
 	storageProviders() []StorageProvider
+	stdin() io.Reader
 }
 
 // StorageFlags is implemented by cli storage providers which need to support a

--- a/repo/token.go
+++ b/repo/token.go
@@ -18,9 +18,15 @@ type tokenInfo struct {
 // Token returns an opaque token that contains repository connection information
 // and optionally the provided password.
 func (r *directRepository) Token(password string) (string, error) {
+	return EncodeToken(password, r.blobs.ConnectionInfo())
+}
+
+// EncodeToken returns an opaque token that contains the given connection information
+// and optionally the provided password.
+func EncodeToken(password string, ci blob.ConnectionInfo) (string, error) {
 	ti := &tokenInfo{
 		Version:  "1",
-		Storage:  r.blobs.ConnectionInfo(),
+		Storage:  ci,
 		Password: password,
 	}
 


### PR DESCRIPTION
When creating a repo we are currently required to supply storage config secrets as CLI arguments. CLI commands often get logged which can accidentally expose these creds. This PR extends the `from-config` storage flags to be supplied at the time of creation with a dedicated `--token-file` option or `--token-stdin` option that reads from stdin.

```
echo "${kopia_string}" | kopia repository create from-config --token-stdin
```

```
kopia repository create from-config --token-file /path/to/token-file
```