### PR TITLE
test(general): parse stdout instead of stderr in robustness framework helper

### DIFF
--- a/tests/tools/kopiarunner/kopia_snapshotter.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter.go
@@ -132,9 +132,13 @@ func (ks *KopiaSnapshotter) ConnectOrCreateFilesystem(repoPath string) error {
 // CreateSnapshot implements the Snapshotter interface, issues a kopia snapshot
 // create command on the provided source path.
 func (ks *KopiaSnapshotter) CreateSnapshot(source string) (snapID string, err error) {
-	_, errOut, err := ks.Runner.Run("snapshot", "create", parallelFlag, strconv.Itoa(parallelSetting), noProgressFlag, source)
+	stdOut, errOut, err := ks.Runner.Run("snapshot", "create", parallelFlag, strconv.Itoa(parallelSetting), noProgressFlag, source)
 	if err != nil {
 		return "", err
+	}
+
+	if stdOut != "" {
+		return parseSnapID(strings.Split(stdOut, "\n"))
 	}
 
 	return parseSnapID(strings.Split(errOut, "\n"))


### PR DESCRIPTION
Parse `stdout` instead of `stderr` in `KopiaSnapshotter.CreateSnapshot`.
This is contained to the Robustness Framework.