### PR TITLE
fix(kopiaui): added missing entitlement for M1 build

### DIFF
--- a/app/entitlements.mac.plist
+++ b/app/entitlements.mac.plist
@@ -4,5 +4,7 @@
   <dict>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
This fixes crash on startup after recent upgrade of Electron dependency.