### PR TITLE
feat(cli): Make format upgrade command idempotent

### DIFF
--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -154,7 +154,8 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 		if s.formatVersion < format.MaxFormatVersion {
 			env.RunAndExpectSuccess(t, cmd...)
 		} else {
-			env.RunAndExpectFailure(t, cmd...)
+			_, stderr := env.RunAndExpectSuccessWithErrOut(t, cmd...)
+			require.Contains(t, stderr, "Repository format is already upto date.")
 		}
 	}
 

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -314,6 +314,14 @@ func (c *commandRepositoryUpgrade) setLockIntent(ctx context.Context, rep repo.D
 	// This will fail if we have already upgraded.
 	l, err := rep.FormatManager().SetUpgradeLockIntent(ctx, *l)
 	if err != nil {
+		if errors.Is(err, format.ErrFormatUptoDate) {
+			log(ctx).Info("Repository format is already upto date.")
+
+			c.skip = true
+
+			return nil
+		}
+
 		return errors.Wrap(err, "error setting the upgrade lock intent")
 	}
 	// we need to reopen the repository after this point

--- a/cli/command_repository_upgrade_test.go
+++ b/cli/command_repository_upgrade_test.go
@@ -42,11 +42,12 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
 	default:
 		require.Contains(t, out, "Format version:      3")
-		env.RunAndExpectFailure(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--max-permitted-clock-drift", "1s")
+		require.Contains(t, stderr, "Repository format is already upto date.")
 	}
 
 	out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
@@ -92,11 +93,12 @@ func (s *formatSpecificTestSuite) TestRepositoryCorruptedUpgrade(t *testing.T) {
 		require.Contains(t, stderr, "Repository indices have already been migrated to the epoch format, no need to drain other clients")
 	default:
 		require.Contains(t, out, "Format version:      3")
-		env.RunAndExpectFailure(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--max-permitted-clock-drift", "1s")
+		require.Contains(t, stderr, "Repository format is already upto date.")
 	}
 }
 
@@ -137,12 +139,13 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeCommitNever(t *testing.T)
 		require.Contains(t, stderr, "failed to open repository: repository upgrade in progress")
 	default:
 		require.Contains(t, stdout, "Format version:      3")
-		env.RunAndExpectFailure(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--commit-mode", "never",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--max-permitted-clock-drift", "1s")
+		require.Contains(t, stderr, "Repository format is already upto date.")
 
 		env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
 	}
@@ -179,12 +182,13 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeCommitAlways(t *testing.T
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
 	default:
 		require.Contains(t, out, "Format version:      3")
-		env.RunAndExpectFailure(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--commit-mode", "always",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--max-permitted-clock-drift", "1s")
+		require.Contains(t, stderr, "Repository format is already upto date.")
 	}
 
 	out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
@@ -278,11 +282,12 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeStatusWhileLocked(t *test
 		env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
 	default:
 		require.Contains(t, out, "Format version:      3")
-		env.RunAndExpectFailure(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
 			"--max-permitted-clock-drift", "1s")
+		require.Contains(t, stderr, "Repository format is already upto date.")
 	}
 
 	out = env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")

--- a/repo/format/upgrade_lock.go
+++ b/repo/format/upgrade_lock.go
@@ -19,6 +19,8 @@ const (
 	LegacyIndexPoisonBlobID = "n00000000000000000000000000000000-repository_unreadable_by_this_kopia_version_upgrade_required"
 )
 
+// ErrFormatUptoDate is returned whenever a lock intent is attempted to be set
+// on a repository that is already using the latest format version.
 var ErrFormatUptoDate = errors.New("repository format is up to date")
 
 // BackupBlobID gets the upgrade backu pblob-id fro mthe lock.

--- a/repo/format/upgrade_lock.go
+++ b/repo/format/upgrade_lock.go
@@ -19,6 +19,8 @@ const (
 	LegacyIndexPoisonBlobID = "n00000000000000000000000000000000-repository_unreadable_by_this_kopia_version_upgrade_required"
 )
 
+var ErrFormatUptoDate = errors.New("repository format is up to date")
+
 // BackupBlobID gets the upgrade backu pblob-id fro mthe lock.
 func BackupBlobID(l UpgradeLockIntent) blob.ID {
 	return blob.ID(BackupBlobIDPrefix + l.OwnerID)
@@ -48,7 +50,7 @@ func (m *Manager) SetUpgradeLockIntent(ctx context.Context, l UpgradeLockIntent)
 		// when we are putting a new lock then ensure that we can upgrade
 		// to that version
 		if m.repoConfig.ContentFormat.Version >= MaxFormatVersion {
-			return nil, errors.Errorf("repository is using version %d, and version %d is the maximum",
+			return nil, errors.WithMessagef(ErrFormatUptoDate, "repository is using version %d, and version %d is the maximum",
 				m.repoConfig.ContentFormat.Version, MaxFormatVersion)
 		}
 

--- a/repo/format/upgrade_lock_test.go
+++ b/repo/format/upgrade_lock_test.go
@@ -85,7 +85,7 @@ func TestFormatUpgradeAlreadyUpgraded(t *testing.T) {
 	}
 
 	_, err := env.RepositoryWriter.FormatManager().SetUpgradeLockIntent(ctx, *l)
-	require.EqualError(t, err, fmt.Sprintf("repository is using version %d, and version %d is the maximum",
+	require.ErrorContains(t, err, fmt.Sprintf("repository is using version %d, and version %d is the maximum",
 		format.MaxFormatVersion, format.MaxFormatVersion))
 }
 


### PR DESCRIPTION
This commit changes the behavior of the command
`kopia repo upgrade begin...` to not fail (exit code 1) when the repository is already using the latest format version. Instead, a helpful message is output and the program exits with zero code. In effect the command becomes idempotent-successive upgrades would return the same exit code. Such an idempotent api is desirable, especially in cases where we build automation around format upgrades.

Before this change, an error code `1` is returned when upgrading a repository that is already up to date:
```console
$ kopia repo status | grep "Format Version"
Format version:      3
$ kopia repo upgrade begin --upgrade-owner-id admin
[1] ERROR error setting the upgrade lock intent: repository is using version 3, and version 3 is the maximum
```

and after this change, a `0` code is returned:
```console
$ kopia repo upgrade begin --upgrade-owner-id admin
[0] Repository format is already upto date.
```