### PR TITLE
docs(site): added a documentation on kopiaignore

### DIFF
--- a/site/content/docs/Advanced/Actions/_index.md
+++ b/site/content/docs/Advanced/Actions/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Actions"
 linkTitle: "Actions"
-weight: 40
+weight: 45
 ---
 
 ## Actions

--- a/site/content/docs/Advanced/Caching/_index.md
+++ b/site/content/docs/Advanced/Caching/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Caching"
 linkTitle: "Caching"
-weight: 45
+weight: 50
 ---
 
 ## Caching

--- a/site/content/docs/Advanced/Compatibility/_index.md
+++ b/site/content/docs/Advanced/Compatibility/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Compatibility
 linkTitle: Compatibility
-weight: 65
+weight: 70
 ---
 
 ## Compatibility

--- a/site/content/docs/Advanced/Kopiaignore/_index.md
+++ b/site/content/docs/Advanced/Kopiaignore/_index.md
@@ -1,0 +1,104 @@
+---
+title: "Ignoring Files and Folders in Snapshots"
+linkTitle: "Ignoring Files and Folders in Snapshots"
+weight: 40
+---
+
+## Ignoring Files and Folders in Snapshots
+
+Users may want to exclude folders and files not to be saved within the repository when creating snapshots. The benefits of omitting unnecessary files and folders are smaller and faster snapshots while saving only essential data. 
+
+Kopia features `pattern-based` ignore rules to omit folders and files from snapshots. While scanning directories and their content, Kopia looks explicitly for files that contain such patterns. 
+If such a file is placed within a directory, `Kopia` omits files and folders `matching` the pattern.
+
+>NOTE The default file is called `.kopiaignore`. However, files containing ignore patterns can be specified within the global or snapshot-specific `policy`.   
+
+In the following, we explain different patterns and provide examples to create `.kopiaignore` files.
+
+### Kopiaignore Files
+
+Let us start with an example directory that contains the following files and folders:
+
+```shell
+thesis/
+  --title.png
+  --manuscript.tex
+  --figures/
+	--architecture.png
+	--server.png
+  --chapters/
+	--introduction.tex
+	--abstract.tex
+	--conclusion.tex
+	--logs/
+	    --chapter.log
+  --logs/
+	--gen.log
+	--fail.log
+	--log.db
+	--tmp.db
+	--tmp.dba
+  --tmp.db
+  --atmp.db
+  --abtmp.db
+  --logs.dat
+```
+
+The above directory consists of a bunch of `tex` files, figures, and temporary files. Generally, a `.kopiaignore` file is a simple text file where each line represents a single pattern. To only save the essential files, we create the following `.kopiaignore` file:
+
+```shell
+# Ignoring all files that end with ".dat"
+*.dat
+
+# Ignoring all files and folders within the "thesis/logs" directory
+/logs/*
+
+# Ignoring "tmp.db" files within the whole directory
+tmp.db
+```
+
+The example above contains three simple patterns to exclude files and folders from a `snapshot` and some comments. 
+Each line that begins with a `#` is a `comment` and can be used to describe the pattern. 
+
+* The first pattern, `*.dat` contains a `wildcard` and ignores all files with a filename that ends with `.dat`. 
+* The second pattern, `/logs/*` ignores all files within the `logs` directory. Only the `logs` directory at the `root` will be ignored as the pattern begins with a `/`.
+* The third pattern, `tmp.db` ignores the corresponding files within the whole directory. In our example both `tmp.db` files will be ignored. 
+
+The example shows that excluding files using `.kopiaignore` from a snapshot is easy. However, there is also the risk of accidentally excluding files when creating patterns - leading to incomplete snapshots or data loss. 
+ 
+### Supported Patters
+
+`Kopia` supports a lot of different patterns allowing users to precisely exclude unnecessary files or folders. The following table shows special operators used to generate patterns.
+
+| **Special Operator**	| **Explanation**												|
+|-----------------------|---------------------------------------------------------------|
+| `#`					| `Comment` that is ignored by `Kopia`							|
+| `!`					| `Negates` a following pattern									|
+| `*`					| `Wildcard` that matches any character zero or multiple times	|
+| `**`					| Double `Wildcard` that matches zero or multiple directories	|
+| `?`					| Matches any character exactly `one` time						|
+| `[0-9]`				| Matches any single number between `0` and `9`					|
+| `[a-z]`				| Matches any single character between `a` and `z`				|
+| `[A-Z]`				| Matches any single character between `A` and `Z`				|
+| `[abc]`				| Matches one of `a`, `b`, or `c`								|
+| `/`					| Matches a following pattern only at the `root` directory		|
+
+### Examples of Kopiaignore Patters 
+
+The following table provides some example patterns related to our [example](#kopiaignore-files). Files and folders that `match` the given pattern are excluded from the snapshot.
+
+| **Pattern**			| **Explanation**																												| **Matches**													|**Ignores**							|
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|---------------------------------------|
+| `logs`				| Matches files and folders that are named `logs`																				| thesis/logs/ </br> thesis/chapters/logs/						| 2 directories, 6 files				|
+| `/logs`				| Matches files and folders that are named `logs` only within the parent directory												| thesis/logs/													| 1 directory, 5 files					|   
+| `*.db`				| Matches files with extension `.db`																							| thesis/tmp.db </br> thesis/logs/log.db						| 0 directories, 2 files				|
+| `*.db*`				| Matches files with extension `.db` followed by any other number or character													| thesis/tmp.db </br> thesis/logs/tmp.dba						| 0 directories, 6 files				|
+| `**/logs/**`			| Matches all occurences of `logs` within the parent  																			| thesis/logs/ </br> thesis/chapters/logs/						| 2 directories, 6 files				|										|      
+| `chapters/**/*.log`	| Matches all files with extension `.log` in all sub-directories within `chapters` 												| thesis/chapters/logs/chapter.log								| 0 directores, 1 file					|      
+| `*.*`					| Matches all files in `thesis`																									| thesis/ </br> thesis/tmp.db etc.								| 5 directories, 17 files (all)			|
+| `!*.*`				| Matches no files in `thesis`																									| -																| 0 directories, 0 files				|
+| `[a-z]?tmp.db`		| Matches files beginning with characters between `a` and `z`, followed by a single character, ending with `tmp.db`				| thesis/abtmp.db												| 0 directories, 1 file					|
+| `?tmp.db`				| Matches files with exactly one character ending with `tmp.db`																	| thesis/atmp.db												| 0 directories, 1 file					|
+| `[a-z]*tmp.db`		| Matches files beginning with characters between `a` and `z`, followed by zero or multiple characters, ending with `tmp.db`	| thesis/abtmp.db </br> thesis/atmp.db </br> thesis/logs/tmp.db	| 0 directories, 3 files				|
+
+>NOTE Make sure that you have tested your `.kopiaignore` file and the resulting snapshot for correctnes. If a file or folder is missing, you will need to adjust the patterns to your needs.

--- a/site/content/docs/Advanced/Kopiaignore/_index.md
+++ b/site/content/docs/Advanced/Kopiaignore/_index.md
@@ -11,7 +11,7 @@ Users may want to exclude folders and files not to be saved within the repositor
 Kopia features `pattern-based` ignore rules to omit folders and files from snapshots. While scanning directories and their content, Kopia looks explicitly for files that contain such patterns. 
 If such a file is placed within a directory, `Kopia` omits files and folders `matching` the pattern.
 
->NOTE The default file is called `.kopiaignore`. However, files containing ignore patterns can be specified within the global or snapshot-specific `policy`.   
+>NOTE The default file is called `.kopiaignore`. However, ignore patterns can be specified within the global or snapshot-specific `policy` - either directly or by providing a path to file containing such patterns.   
 
 In the following, we explain different patterns and provide examples to create `.kopiaignore` files.
 
@@ -91,11 +91,11 @@ The following table provides some example patterns related to our [example](#kop
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|---------------------------------------|
 | `logs`				| Matches files and folders that are named `logs`																				| thesis/logs/ </br> thesis/chapters/logs/						| 2 directories, 6 files				|
 | `/logs`				| Matches files and folders that are named `logs` only within the parent directory												| thesis/logs/													| 1 directory, 5 files					|   
-| `*.db`				| Matches files with extension `.db`																							| thesis/tmp.db </br> thesis/logs/log.db						| 0 directories, 2 files				|
-| `*.db*`				| Matches files with extension `.db` followed by any other number or character													| thesis/tmp.db </br> thesis/logs/tmp.dba						| 0 directories, 6 files				|
-| `**/logs/**`			| Matches all occurences of `logs` within the parent  																			| thesis/logs/ </br> thesis/chapters/logs/						| 2 directories, 6 files				|										|      
+| `*.db`				| Matches files with extension `.db`																							| (...) </br> thesis/tmp.db </br> thesis/logs/log.db			| 0 directories, 5 files				|
+| `*.db*`				| Matches files with extension `.db` followed by any other number or character													| (...) </br> thesis/tmp.db </br> thesis/logs/tmp.dba			| 0 directories, 6 files				|
+| `**/logs/**`			| Matches all occurences of `logs` within the `thesis` and sub-directories  													| (...) </br> thesis/logs/ </br> thesis/chapters/logs/			| 2 directories, 6 files				|
 | `chapters/**/*.log`	| Matches all files with extension `.log` in all sub-directories within `chapters` 												| thesis/chapters/logs/chapter.log								| 0 directores, 1 file					|      
-| `*.*`					| Matches all files in `thesis`																									| thesis/ </br> thesis/tmp.db etc.								| 5 directories, 17 files (all)			|
+| `*.*`					| Matches all files in `thesis`																									| (...) </br> thesis/ </br> thesis/tmp.db						| 5 directories, 17 files (all)			|
 | `!*.*`				| Matches no files in `thesis`																									| -																| 0 directories, 0 files				|
 | `[a-z]?tmp.db`		| Matches files beginning with characters between `a` and `z`, followed by a single character, ending with `tmp.db`				| thesis/abtmp.db												| 0 directories, 1 file					|
 | `?tmp.db`				| Matches files with exactly one character ending with `tmp.db`																	| thesis/atmp.db												| 0 directories, 1 file					|

--- a/site/content/docs/Advanced/Logging/_index.md
+++ b/site/content/docs/Advanced/Logging/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging"
 linkTitle: "Logging"
-weight: 60
+weight: 65
 ---
 
 ## Logging

--- a/site/content/docs/Advanced/Sharding/_index.md
+++ b/site/content/docs/Advanced/Sharding/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Sharding"
 linkTitle: "Sharding"
-weight: 55
+weight: 60
 ---
 
 ## Sharding

--- a/site/content/docs/Advanced/Synchronization/_index.md
+++ b/site/content/docs/Advanced/Synchronization/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Synchronization"
 linkTitle: "Synchronization"
-weight: 50
+weight: 55
 ---
 
 ## Synchronization

--- a/site/content/docs/Advanced/_index.md
+++ b/site/content/docs/Advanced/_index.md
@@ -18,6 +18,7 @@ In the following, we will highlight and explain some advanced topics related to 
 * [Consistency](consistency/#consistency)
 	* [Verifying Validity of Snapshots](consistency/#verifying-validity-of-snapshots )
 	* [Repairing Corruption of Snapshots](consistency/#repairing-corruption-of-snapshots)
+* [Ignoring Files and Folders in Snapshots](kopiaignore/#ignoring-files-and-folders-in-snapshots)
 * [Actions](actions/#actions)
 * [Caching](caching/#caching)
 * [Synchronization](synchronization/#synchronization)

--- a/site/content/docs/Installation/_index.md
+++ b/site/content/docs/Installation/_index.md
@@ -295,8 +295,8 @@ services:
             - --disable-csrf-token-checks
             - --insecure
             - --address=0.0.0.0:51515
-            - --server-username="USERNAME"
-            - --server-password="SECRET_PASSWORD"
+            - --server-username=USERNAME
+            - --server-password=SECRET_PASSWORD
         environment:
             # Set repository password
             KOPIA_PASSWORD: "SECRET"


### PR DESCRIPTION
Hi, 

this PR comes with the following changes:

- Added a new under "Advanced Topics" to document kopiaignore files and patterns
- Added an example for kopiaignore for better understanding

I have tested the patterns with kopia 0.12.1 and they should work as described. However, I think there is still a strange behavior when using "/" together with "*" in a pattern. 

This PR closes #1945 and #2847

Open for feedback. 