### PR TITLE
fix(general): Fixed ordering in function "isAbs" in ospath

### DIFF
--- a/internal/ospath/ospath.go
+++ b/internal/ospath/ospath.go
@@ -26,11 +26,6 @@ func LogsDir() string {
 
 // IsAbs determines if a given path is absolute, in particular treating \\hostname\share as absolute on Windows.
 func IsAbs(s string) bool {
-	//nolint:forbidigo
-	if filepath.IsAbs(s) {
-		return true
-	}
-
 	// On Windows, treat \\hostname\share as absolute paths, which is not what filepath.IsAbs() does.
 	if runtime.GOOS == "windows" {
 		if strings.HasPrefix(s, "\\\\") {
@@ -38,6 +33,11 @@ func IsAbs(s string) bool {
 
 			return len(parts) > 1 && len(parts[1]) > 0
 		}
+	}
+
+	//nolint:forbidigo
+	if filepath.IsAbs(s) {
+		return true
 	}
 
 	return false


### PR DESCRIPTION
There is a special case when checking if a given path is absolute. 

On Windows paths like "\\hostname\share" are treated as absolute. Therefore, the function "isAbs" has to first check for this before calling "filepath.IsAbs" as this returns true for non-absolute paths (e.g. \\host).  

The test for internal\ospath now return success and was failing before on windows due to the wrong order.  

Cheers, 