### PR TITLE
breaking(cli): remove default behavior for CLI command

### DIFF
--- a/app/public/server.js
+++ b/app/public/server.js
@@ -34,7 +34,7 @@ function newServerForRepo(repoID) {
             let kopiaPath = defaultServerBinary();
             let args = [];
 
-            args.push('server', '--ui',
+            args.push('server', 'start', '--ui',
                 '--tls-print-server-cert',
                 '--tls-generate-cert-name=127.0.0.1',
                 '--random-password',

--- a/cli/command_cache_info.go
+++ b/cli/command_cache_info.go
@@ -22,7 +22,7 @@ type commandCacheInfo struct {
 }
 
 func (c *commandCacheInfo) setup(svc appServices, parent commandParent) {
-	cmd := parent.Command("info", "Displays cache information and statistics").Default()
+	cmd := parent.Command("info", "Displays cache information and statistics")
 	cmd.Flag("path", "Only display cache path").BoolVar(&c.onlyShowPath)
 	cmd.Action(svc.repositoryReaderAction(c.run))
 

--- a/cli/command_index_list.go
+++ b/cli/command_index_list.go
@@ -19,7 +19,7 @@ type commandIndexList struct {
 }
 
 func (c *commandIndexList) setup(svc appServices, parent commandParent) {
-	cmd := parent.Command("list", "List content indexes").Alias("ls").Default()
+	cmd := parent.Command("list", "List content indexes").Alias("ls")
 	cmd.Flag("summary", "Display index blob summary").BoolVar(&c.blockIndexListSummary)
 	cmd.Flag("superseded", "Include inactive index files superseded by compaction").BoolVar(&c.blockIndexListIncludeSuperseded)
 	cmd.Flag("sort", "Index blob sort order").Default("time").EnumVar(&c.blockIndexListSort, "time", "size", "name")

--- a/cli/command_maintenance_run.go
+++ b/cli/command_maintenance_run.go
@@ -17,7 +17,7 @@ type commandMaintenanceRun struct {
 }
 
 func (c *commandMaintenanceRun) setup(svc appServices, parent commandParent) {
-	cmd := parent.Command("run", "Run repository maintenance").Default()
+	cmd := parent.Command("run", "Run repository maintenance")
 	cmd.Flag("full", "Full maintenance").BoolVar(&c.maintenanceRunFull)
 	cmd.Flag("force", "Run maintenance even if not owned (unsafe)").Hidden().BoolVar(&c.maintenanceRunForce)
 	safetyFlagVar(cmd, &c.safety)

--- a/cli/command_manifest_ls.go
+++ b/cli/command_manifest_ls.go
@@ -20,7 +20,7 @@ type commandManifestList struct {
 }
 
 func (c *commandManifestList) setup(svc appServices, parent commandParent) {
-	cmd := parent.Command("list", "List manifest items").Alias("ls").Default()
+	cmd := parent.Command("list", "List manifest items").Alias("ls")
 	cmd.Flag("filter", "List of key:value pairs").StringsVar(&c.manifestListFilter)
 	cmd.Flag("sort", "List of keys to sort by").StringsVar(&c.manifestListSort)
 	c.jo.setup(svc, cmd)

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -143,7 +143,7 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersUpgrade(t *testing.
 
 	{
 		cmd := []string{
-			"repository", "upgrade",
+			"repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",

--- a/cli/command_repository_upgrade.go
+++ b/cli/command_repository_upgrade.go
@@ -57,7 +57,7 @@ func (c *commandRepositoryUpgrade) setup(svc advancedAppServices, parent command
 			return nil
 		})
 
-	beginCmd := parent.Command("begin", "Begin upgrade.").Default()
+	beginCmd := parent.Command("begin", "Begin upgrade.")
 	beginCmd.Flag("io-drain-timeout", "Max time it should take all other Kopia clients to drop repository connections").Default(format.DefaultRepositoryBlobCacheDuration.String()).DurationVar(&c.ioDrainTimeout)
 	beginCmd.Flag("allow-unsafe-upgrade", "Force using an unsafe io-drain-timeout for the upgrade lock").Default("false").Hidden().BoolVar(&c.allowUnsafeUpgradeTimings)
 	beginCmd.Flag("status-poll-interval", "An advisory polling interval to check for the status of upgrade").Default("60s").DurationVar(&c.statusPollInterval)

--- a/cli/command_repository_upgrade_test.go
+++ b/cli/command_repository_upgrade_test.go
@@ -24,7 +24,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 	switch s.formatVersion {
 	case format.FormatVersion1:
 		require.Contains(t, out, "Format version:      1")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
@@ -33,7 +33,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
 	case format.FormatVersion2:
 		require.Contains(t, out, "Format version:      2")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
@@ -42,7 +42,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgrade(t *testing.T) {
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
 	default:
 		require.Contains(t, out, "Format version:      3")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
@@ -69,7 +69,7 @@ func (s *formatSpecificTestSuite) TestRepositoryCorruptedUpgrade(t *testing.T) {
 		require.Contains(t, out, "Format version:      1")
 		// run upgrade first with commit-mode set to never.  this leaves the lock and new index intact so that
 		// the file can be corrupted with "TweakFile".
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner",
 			"--commit-mode", "never",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
@@ -80,12 +80,12 @@ func (s *formatSpecificTestSuite) TestRepositoryCorruptedUpgrade(t *testing.T) {
 		require.Contains(t, stderr, "index validation succeeded")
 		env.TweakFile(t, env.RepoDir, "x*/*/*.f")
 		// then re-run the upgrade with the corrupted index.  This should fail on index validation.
-		_, stderr = env.RunAndExpectFailure(t, "repository", "upgrade",
+		_, stderr = env.RunAndExpectFailure(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner")
 		require.Regexp(t, "failed to load index entries for new index: failed to load index blob with BlobID", stderr)
 	case format.FormatVersion2:
 		require.Contains(t, out, "Format version:      2")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
@@ -93,7 +93,7 @@ func (s *formatSpecificTestSuite) TestRepositoryCorruptedUpgrade(t *testing.T) {
 		require.Contains(t, stderr, "Repository indices have already been migrated to the epoch format, no need to drain other clients")
 	default:
 		require.Contains(t, out, "Format version:      3")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
@@ -113,7 +113,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeCommitNever(t *testing.T)
 	switch s.formatVersion {
 	case format.FormatVersion1:
 		require.Contains(t, stdout, "Format version:      1")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--commit-mode", "never",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
@@ -126,7 +126,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeCommitNever(t *testing.T)
 		require.Contains(t, stderr, "failed to open repository: repository upgrade in progress")
 	case format.FormatVersion2:
 		require.Contains(t, stdout, "Format version:      2")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--commit-mode", "never",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
@@ -139,7 +139,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeCommitNever(t *testing.T)
 		require.Contains(t, stderr, "failed to open repository: repository upgrade in progress")
 	default:
 		require.Contains(t, stdout, "Format version:      3")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--commit-mode", "never",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
@@ -162,7 +162,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeCommitAlways(t *testing.T
 	switch s.formatVersion {
 	case format.FormatVersion1:
 		require.Contains(t, out, "Format version:      1")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--commit-mode", "always",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
@@ -172,7 +172,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeCommitAlways(t *testing.T
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
 	case format.FormatVersion2:
 		require.Contains(t, out, "Format version:      2")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--commit-mode", "always",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
@@ -182,7 +182,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeCommitAlways(t *testing.T
 		require.Contains(t, stderr, "Repository has been successfully upgraded.")
 	default:
 		require.Contains(t, out, "Format version:      3")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--commit-mode", "always",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
@@ -201,7 +201,7 @@ func lockRepositoryForUpgrade(t *testing.T, env *testenv.CLITest) {
 	t.Helper()
 
 	t.Log("Placing upgrade lock ...")
-	env.RunAndExpectSuccess(t, "repository", "upgrade",
+	env.RunAndExpectSuccess(t, "repository", "upgrade", "begin",
 		"--upgrade-owner-id", "owner",
 		"--io-drain-timeout", "30s", "--allow-unsafe-upgrade",
 		"--status-poll-interval", "1s", "--lock-only",
@@ -224,7 +224,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeStatusWhileLocked(t *test
 		lockRepositoryForUpgrade(t, env)
 
 		// verify that non-owner clients will fail to connect/upgrade
-		env.RunAndExpectFailure(t, "repository", "upgrade",
+		env.RunAndExpectFailure(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "non-owner",
 			"--io-drain-timeout", "15s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s", "--upgrade-no-block",
@@ -258,7 +258,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeStatusWhileLocked(t *test
 		require.Contains(t, out, "Lock status:         Fully Established")
 
 		// finalize the upgrade
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "15s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
@@ -271,7 +271,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeStatusWhileLocked(t *test
 		require.Contains(t, out, "Format version:      2")
 
 		// perform the upgrade
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",
@@ -282,7 +282,7 @@ func (s *formatSpecificTestSuite) TestRepositoryUpgradeStatusWhileLocked(t *test
 		env.RunAndExpectSuccess(t, "repository", "status", "--upgrade-no-block")
 	default:
 		require.Contains(t, out, "Format version:      3")
-		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade",
+		_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repository", "upgrade", "begin",
 			"--upgrade-owner-id", "owner",
 			"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 			"--status-poll-interval", "1s",

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -75,7 +75,7 @@ type commandServerStart struct {
 }
 
 func (c *commandServerStart) setup(svc advancedAppServices, parent commandParent) {
-	cmd := parent.Command("start", "Start Kopia server").Default()
+	cmd := parent.Command("start", "Start Kopia server")
 	cmd.Flag("html", "Server the provided HTML at the root URL").ExistingDirVar(&c.serverStartHTMLPath)
 	cmd.Flag("ui", "Start the server with HTML UI").Default("true").BoolVar(&c.serverStartUI)
 

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -51,7 +51,7 @@ type commandSnapshotCreate struct {
 }
 
 func (c *commandSnapshotCreate) setup(svc appServices, parent commandParent) {
-	cmd := parent.Command("create", "Creates a snapshot of local directory or file.").Default()
+	cmd := parent.Command("create", "Creates a snapshot of local directory or file.")
 
 	cmd.Arg("source", "Files or directories to create snapshot(s) of.").StringsVar(&c.snapshotCreateSources)
 	cmd.Flag("all", "Create snapshots for files or directories previously backed up by this user on this computer").BoolVar(&c.snapshotCreateAll)

--- a/tests/compat_test/compat_test.go
+++ b/tests/compat_test/compat_test.go
@@ -39,7 +39,7 @@ func TestRepoCreatedWith08CanBeOpenedWithCurrent(t *testing.T) {
 	e2.Environment["KOPIA_UPGRADE_LOCK_ENABLED"] = "1"
 
 	// upgrade
-	e2.RunAndExpectSuccess(t, "repository", "upgrade",
+	e2.RunAndExpectSuccess(t, "repository", "upgrade", "begin",
 		"--upgrade-owner-id", "owner",
 		"--io-drain-timeout", "1s", "--allow-unsafe-upgrade",
 		"--status-poll-interval", "1s",

--- a/tests/robustness/snapmeta/kopia_snapshotter.go
+++ b/tests/robustness/snapmeta/kopia_snapshotter.go
@@ -205,7 +205,7 @@ func (ks *KopiaSnapshotter) UpgradeRepository() error {
 	// in case the test fails
 	os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "1")
 
-	_, _, err := ks.snap.Run("repository", "upgrade",
+	_, _, err := ks.snap.Run("repository", "upgrade", "begin",
 		"--upgrade-owner-id", "robustness-tests",
 		"--io-drain-timeout", "30s", "--allow-unsafe-upgrade",
 		"--status-poll-interval", "1s")


### PR DESCRIPTION
| Command        | Previous default subcommand |
| ---------------| --------------------------- |
| `cache`        | `info`   |
| `index`        | `list`   |
| `manifest`     | `list`   |
| `maintenance`  | `run`    |
| `repo upgrade` | `begin`  |
| `snapshot`     | `create` |


Ref #2823