### PR TITLE
docs(site): improved faq and kopiaignore section 

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -44,6 +44,10 @@ pygmentsStyle = "tango"
     name = "Download Now"
     weight = 3
     url = "docs/installation/"
+[[menu.main]]
+    name = "FAQs"
+    weight = 4
+    url = "docs/faqs/"
 
 # Configure how URLs look like per section.
 [permalinks]

--- a/site/content/docs/Advanced/Kopiaignore/_index.md
+++ b/site/content/docs/Advanced/Kopiaignore/_index.md
@@ -8,7 +8,7 @@ weight: 40
 
 Users may want to exclude folders and files not to be saved within the repository when creating snapshots. The benefits of omitting unnecessary files and folders are smaller and faster snapshots while saving only essential data. 
 
-Kopia features `pattern-based` ignore rules to omit folders and files from snapshots. While scanning directories and their content, Kopia looks explicitly for files that contain such rules. 
+Kopia uses `pattern-based` ignore rules to omit folders and files from snapshots. While scanning directories and their content, Kopia looks explicitly for files that contain such rules. 
 If such a file is placed within a directory, `Kopia` omits files and folders `matching` the rule.
 
 >NOTE The default file is called `.kopiaignore`. However, ignore rules can be specified within the global or snapshot-specific `policy` - either directly or by providing a path to file containing such rules.   

--- a/site/content/docs/Advanced/Kopiaignore/_index.md
+++ b/site/content/docs/Advanced/Kopiaignore/_index.md
@@ -8,12 +8,12 @@ weight: 40
 
 Users may want to exclude folders and files not to be saved within the repository when creating snapshots. The benefits of omitting unnecessary files and folders are smaller and faster snapshots while saving only essential data. 
 
-Kopia features `pattern-based` ignore rules to omit folders and files from snapshots. While scanning directories and their content, Kopia looks explicitly for files that contain such patterns. 
-If such a file is placed within a directory, `Kopia` omits files and folders `matching` the pattern.
+Kopia features `pattern-based` ignore rules to omit folders and files from snapshots. While scanning directories and their content, Kopia looks explicitly for files that contain such rules. 
+If such a file is placed within a directory, `Kopia` omits files and folders `matching` the rule.
 
->NOTE The default file is called `.kopiaignore`. However, ignore patterns can be specified within the global or snapshot-specific `policy` - either directly or by providing a path to file containing such patterns.   
+>NOTE The default file is called `.kopiaignore`. However, ignore rules can be specified within the global or snapshot-specific `policy` - either directly or by providing a path to file containing such rules.   
 
-In the following, we explain different patterns and provide examples to create `.kopiaignore` files.
+In the following, we explain different rules and provide examples to create `.kopiaignore` files.
 
 ### Kopiaignore Files
 
@@ -44,7 +44,7 @@ thesis/
   --logs.dat
 ```
 
-The above directory consists of a bunch of `tex` files, figures, and temporary files. Generally, a `.kopiaignore` file is a simple text file where each line represents a single pattern. To only save the essential files, we create the following `.kopiaignore` file:
+The above directory consists of a bunch of `tex` files, figures, and temporary files. Generally, a `.kopiaignore` file is a simple text file where each line represents a single rule. To only save the essential files, we create the following `.kopiaignore` file:
 
 ```shell
 # Ignoring all files that end with ".dat"
@@ -57,23 +57,23 @@ The above directory consists of a bunch of `tex` files, figures, and temporary f
 tmp.db
 ```
 
-The example above contains three simple patterns to exclude files and folders from a `snapshot` and some comments. 
-Each line that begins with a `#` is a `comment` and can be used to describe the pattern. 
+The example above contains three simple rules to exclude files and folders from a `snapshot` and some comments. 
+Each line that begins with a `#` is a `comment` and can be used to describe the rule. 
 
-* The first pattern, `*.dat` contains a `wildcard` and ignores all files with a filename that ends with `.dat`. 
-* The second pattern, `/logs/*` ignores all files within the `logs` directory. Only the `logs` directory at the `root` will be ignored as the pattern begins with a `/`.
-* The third pattern, `tmp.db` ignores the corresponding files within the whole directory. In our example both `tmp.db` files will be ignored. 
+* The first rule, `*.dat` contains a `wildcard` and ignores all files with a filename that ends with `.dat`. 
+* The second rule, `/logs/*` ignores all files within the `logs` directory. Only the `logs` directory at the `root` will be ignored as the rule begins with a `/`.
+* The third rule, `tmp.db` ignores the corresponding files within the whole directory. In our example both `tmp.db` files will be ignored. 
 
-The example shows that excluding files using `.kopiaignore` from a snapshot is easy. However, there is also the risk of accidentally excluding files when creating patterns - leading to incomplete snapshots or data loss. 
+The example shows that excluding files using `.kopiaignore` from a snapshot is easy. However, there is also the risk of accidentally excluding files when creating rule - leading to incomplete snapshots or data loss. 
  
 ### Supported Patters
 
-`Kopia` supports a lot of different patterns allowing users to precisely exclude unnecessary files or folders. The following table shows special operators used to generate patterns.
+`Kopia` supports a lot of different operators allowing users to precisely exclude unnecessary files or folders. The following table shows special operators used to generate rules.
 
 | **Special Operator**	| **Explanation**												|
 |-----------------------|---------------------------------------------------------------|
 | `#`					| `Comment` that is ignored by `Kopia`							|
-| `!`					| `Negates` a following pattern									|
+| `!`					| `Negates` a following rule									|
 | `*`					| `Wildcard` that matches any character zero or multiple times	|
 | `**`					| Double `Wildcard` that matches zero or multiple directories	|
 | `?`					| Matches any character exactly `one` time						|
@@ -81,13 +81,13 @@ The example shows that excluding files using `.kopiaignore` from a snapshot is e
 | `[a-z]`				| Matches any single character between `a` and `z`				|
 | `[A-Z]`				| Matches any single character between `A` and `Z`				|
 | `[abc]`				| Matches one of `a`, `b`, or `c`								|
-| `/`					| Matches a following pattern only at the `root` directory		|
+| `/`					| Matches a following rule only at the `root` directory		|
 
-### Examples of Kopiaignore Patters 
+### Examples of Kopiaignore Rules 
 
-The following table provides some example patterns related to our [example](#kopiaignore-files). Files and folders that `match` the given pattern are excluded from the snapshot.
+The following table provides some example rules related to our [example](#kopiaignore-files). Files and folders that `match` the given rules are excluded from the snapshot.
 
-| **Pattern**			| **Explanation**																												| **Matches**													|**Ignores**							|
+| **Rule**			| **Explanation**																												| **Matches**													|**Ignores**							|
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|---------------------------------------|
 | `logs`				| Matches files and folders that are named `logs`																				| thesis/logs/ </br> thesis/chapters/logs/						| 2 directories, 6 files				|
 | `/logs`				| Matches files and folders that are named `logs` only within the parent directory												| thesis/logs/													| 1 directory, 5 files					|   
@@ -101,4 +101,4 @@ The following table provides some example patterns related to our [example](#kop
 | `?tmp.db`				| Matches files with exactly one character ending with `tmp.db`																	| thesis/atmp.db												| 0 directories, 1 file					|
 | `[a-z]*tmp.db`		| Matches files beginning with characters between `a` and `z`, followed by zero or multiple characters, ending with `tmp.db`	| thesis/abtmp.db </br> thesis/atmp.db </br> thesis/logs/tmp.db	| 0 directories, 3 files				|
 
->NOTE Make sure that you have tested your `.kopiaignore` file and the resulting snapshot for correctnes. If a file or folder is missing, you will need to adjust the patterns to your needs.
+>NOTE Make sure that you have tested your `.kopiaignore` file and the resulting snapshot for correctnes. If a file or folder is missing, you will need to adjust the rules to your needs.

--- a/site/content/docs/Advanced/Kopiaignore/_index.md
+++ b/site/content/docs/Advanced/Kopiaignore/_index.md
@@ -9,7 +9,7 @@ weight: 40
 Users may want to exclude folders and files not to be saved within the repository when creating snapshots. The benefits of omitting unnecessary files and folders are smaller and faster snapshots while saving only essential data. 
 
 Kopia uses `pattern-based` ignore rules to omit folders and files from snapshots. While scanning directories and their content, Kopia looks explicitly for files that contain such rules. 
-If such a file is placed within a directory, `Kopia` omits files and folders `matching` the rule.
+If such a file is placed within a directory, `Kopia` omits files and folders `matching` the rules.
 
 >NOTE The default file is called `.kopiaignore`. However, ignore rules can be specified within the global or snapshot-specific `policy` - either directly or by providing a path to file containing such rules.   
 

--- a/site/content/docs/FAQs/_index.md
+++ b/site/content/docs/FAQs/_index.md
@@ -10,6 +10,7 @@ weight: 40
 * [What is a Repository?](#what-is-a-repository)
 * [What is a Policy?](#what-is-a-policy)
 * [How to Restore My Backed Up Files/Directories?](#how-to-restore-my-backed-up-filesdirectories)
+* [How Do I Define Files And Folders To Be Ignored By Kopia](#how-do-i-define-files-and-folders-to-be-ignored-by-kopia)
 * [How Do I Enable Encryption?](#how-do-i-enable-encryption)
 * [How Do I Enable Compression?](#how-do-i-enable-compression)
 * [How Do I Enable Data Deduplication?](#how-do-i-enable-data-deduplication)
@@ -17,6 +18,7 @@ weight: 40
 * [Does Kopia Support Storage Classes, Like Amazon Glacier?](#does-kopia-support-storage-classes-like-amazon-glacier)
 * [How Do I Decrease Kopia's CPU Usage?](#how-do-i-decrease-kopias-cpu-usage)
 * [How Do I Decrease Kopia's Memory (RAM) Usage?](#how-do-i-decrease-kopias-memory-ram-usage)
+* [What are Incomplete Snapshots?](#what-are-incomplete-snapshots)
 * [What is a Kopia Repository Server?](#what-is-a-kopia-repository-server)
 
 **Is your question not answered here? Please ask in the [Kopia discussion forums](https://kopia.discourse.group/) for help!**
@@ -35,7 +37,7 @@ See the [repository help docs](../repositories) for more information.
 
 #### What is a Policy?
 
-A `policy` is a set of rules that tells Kopia how to create/manage snapshots; this includes features such as [compression, snapshot retention, and scheduling when to take automatically snapshots](../features#policies-control-what-and-how-filesdirectories-are-saved-in-snapshots).
+A `policy` is a set of rules that tells Kopia how to create/manage snapshots; this includes features such as [compression, snapshot retention, and scheduling when to take snapshots automatically](../features#policies-control-what-and-how-filesdirectories-are-saved-in-snapshots).
 
 #### How to Restore My Backed Up Files/Directories?
 
@@ -49,13 +51,19 @@ Files/directories are restored from the snapshots you create. To restore the dat
 
 The [Getting Started Guide](../getting-started/) provides directions on how to restore files/directions [when using Kopia GUI](../getting-started/#restoring-filesdirectories-from-snapshots) and [when using Kopia CLI](../getting-started/#mounting-snapshots-and-restoring-filesdirectories-from-snapshots).
 
+#### How Do I Define Files And Folders To Be Ignored By Kopia?
+
+Files and directories can be ignored from snapshots by adding `ignore rules` to the `policy` or creating `.kopiagignore` files. For more information, please refer to our [guide on creating ignore rules](../advanced/kopiaignore/).
+
 #### How Do I Enable Encryption?
 
-Encryption is at the `repository` level, and Kopia encrypts all snapshots in all repositories by default. You should have been asked for a password when you created your `repository`. That password is used to encrypt your backups. (Do not forget it, there is no way to recover the password!)
+Encryption is at the `repository` level, and Kopia encrypts all snapshots in all repositories by default. Kopia asks for a password when creating your `repository`. This password is used to encrypt your backups. 
 
 By default, Kopia uses the `AES256-GCM-HMAC-SHA256` encryption algorithm for all repositories, but you can choose `CHACHA20-POLY1305-HMAC-SHA256` if you want to. Picking an encryption algorithm is done when you initially create a `repository`. In `KopiaUI`, to pick the `CHACHA20-POLY1305-HMAC-SHA256` encryption algorithm, you need to click the `Show Advanced Options` button at the screen where you enter your password when creating a new `repository`. For Kopia CLI users, you need to use the `--encryption=CHACHA20-POLY1305-HMAC-SHA256` option when [creating a `repository`](../getting-started/#creating-a-repository) with the [`kopia repository create` command](../reference/command-line/common/#commands-to-manipulate-repository).
 
 Currently, encryption algorithms cannot be changed after a `repository` has been created.
+
+> NOTE Do not forget your repository password. If it is lost, there is no way to recover it or the files and folders within that repository.
 
 #### How Do I Enable Compression?
 
@@ -111,6 +119,12 @@ It is difficult to know what is causing high memory use on your machine without 
 
 * Disabling compression will result in less memory usage than enabling compression. If you want to keep compression, [compression benchmarks](../advanced/compression/) suggest `s2`, `deflate`, and `gzip` are the most memory-friendly compression algorithms when backing up small files. When backing up large files, all the compression algorithms have similar memory usage. Thus, if your machine has low memory, try `s2`, `deflate`, or `gzip`. Read the FAQ on [enabling compression](#how-do-i-decrease-kopias-cpu-usage) to learn how to change or remove compression in Kopia.
 * Decreasing the number of parallel snapshots and parallel file reads will decrease Kopia's memory usage because Kopia will run fewer simultaneous processes. Read the FAQ on [decreasing Kopia's CPU usage](#how-do-i-decrease-kopias-cpu-usage) to learn how to decrease parallelism in Kopia.
+
+#### What are Incomplete Snapshots?
+
+When creating snapshots from large files or folders, `Kopia` sometimes marks snapshots as incomplete. This is because `Kopia` creates `checkpoints` at predefined time intervals. If a snapshot takes longer than the predefined checkpoint interval, `Kopia` creates a temporary **incomplete** snapshot, preventing the snapshot from being garbage-collected by the maintenance tasks. *Kopia* will remove incomplete snapshots once a **complete** snapshot of the files and directories has been created. 
+
+For more information on the `checkpoint interval`, please refer to the [command-line reference](../reference/command-line/common/).
 
 #### What is a Kopia Repository Server?
 

--- a/site/content/docs/FAQs/_index.md
+++ b/site/content/docs/FAQs/_index.md
@@ -63,7 +63,7 @@ By default, Kopia uses the `AES256-GCM-HMAC-SHA256` encryption algorithm for all
 
 Currently, encryption algorithms cannot be changed after a `repository` has been created.
 
-> NOTE Do not forget your repository password. If it is lost, there is no way to recover it or the files and folders within that repository.
+> NOTE There is no way to recover it or the files and folders within that repository. Store your repository password in a safe place, such as a password manager, so you can retrieve it later.
 
 #### How Do I Enable Compression?
 

--- a/site/content/docs/Features/_index.md
+++ b/site/content/docs/Features/_index.md
@@ -40,7 +40,7 @@ Kopia uses [content-addressable storage](https://en.wikipedia.org/wiki/Content-a
 Kopia allows you to create an unlimited number of policies for each repository. Policies allow you to define what files/directories to backup in a snapshot and other features of a snapshot, including but not limited to:
 
 * how frequently/when Kopia should automatically create snapshots of your data
-* whether to exclude certain files/directories from snapshots, similar to `.gitignore`
+* whether to exclude [certain files/directories](../advanced/kopiaignore/) from snapshots
 * how long to retain a snapshot before expiring it and removing it from the repository
 * whether and how to compress the files/directories being backed up
 


### PR DESCRIPTION
The PR comes with the following changes:

- Added the documentation on kopiaignore to the FAQs
- Added the FAQs to the main menu
- Added a link the kopiaignore documentation in the "features" section
- Added a paragraph on incomplete snapshots in the FAQs. 

This PR closes #2681

Feedback is welcomed. 

Cheers, 