### PR TITLE
build(infra): checkout repo before setting up Go

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -11,15 +11,15 @@ jobs:
     name: Code Coverage Tests
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go.
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
       id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Run Tests
       run: make test-with-coverage
     - name: Upload Coverage

--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -13,15 +13,15 @@ jobs:
     name: Compat Test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go.
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
       id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Compat Test
       run: make compat-tests
     - name: Upload Logs

--- a/.github/workflows/endurance-test.yml
+++ b/.github/workflows/endurance-test.yml
@@ -18,15 +18,15 @@ jobs:
     if: ${{ github.repository == 'kopia/kopia' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go.
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
       id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Endurance Tests
       run: make endurance-tests
     - name: Upload Logs

--- a/.github/workflows/htmlui-tests.yml
+++ b/.github/workflows/htmlui-tests.yml
@@ -26,15 +26,15 @@ jobs:
     name: E2E Test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go.
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
       id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Run Tests
       run: make htmlui-e2e-test
     - name: Upload Screenshots

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -11,15 +11,15 @@ jobs:
     name: License Check
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go.
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
       id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Download dependencies
       run: go mod vendor
     - name: Run License Check

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -39,7 +39,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ contains(matrix.os, 'self-hosted') }}
     steps:
-    - name: Set up Go.
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
@@ -54,10 +58,6 @@ jobs:
     - name: Install macOS-specific packages
       run: "sudo xcode-select -r"
       if: ${{ contains(matrix.os, 'macos') }}
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Setup
       run: make -j4 ci-setup
     - name: Install macOS certificates

--- a/.github/workflows/provider-tests.yml
+++ b/.github/workflows/provider-tests.yml
@@ -16,15 +16,15 @@ jobs:
     if: ${{ github.repository == 'kopia/kopia' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go.
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
       id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Install Dependencies
       run: make provider-tests-deps
     - name: Azure

--- a/.github/workflows/race-detector.yml
+++ b/.github/workflows/race-detector.yml
@@ -11,14 +11,14 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go.
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
       id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Unit Tests
       run: make -j2 test UNIT_TEST_RACE_FLAGS=-race UNIT_TESTS_TIMEOUT=1200s

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -17,15 +17,15 @@ jobs:
     if: ${{ github.repository == 'kopia/kopia' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go.
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
       id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Stress Test
       run: make stress-test
     - name: Upload Logs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ contains(matrix.os, 'self-hosted') }}
     steps:
-    - name: Set up Go.
+    - name: Check out repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
@@ -52,10 +56,6 @@ jobs:
     - name: Install macOS-specific packages
       run: "sudo xcode-select -r"
       if: ${{ contains(matrix.os, 'macos') }}
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Setup
       run: make -j4 ci-setup
     - name: Tests


### PR DESCRIPTION
This way GH caching for Go packages has a chance to work.

See https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs

A cursory test shows that restoring the Go mod cache takes about ~20s.
Downloading the dependencies without a cache takes 60+s. With a cache, that step is ~5s.
Overall the gains are between 2x - 3x for this stage.

Now, when the go mod cache is modified (e.g., during a dependency upgrade) there is an additional 60s cost at the end of the job to update the cache. Once the cache is updated, other jobs get the benefit. Notice that the cache is only updated when the job is successful. When the job fails, the cache artifact is not uploaded.