### PR TITLE
chore(infra): do not remove branches on stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           # process older PRs first
           ascending: true
-          delete-branch: true
           operations-per-run: 100
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'


### PR DESCRIPTION
That requires repo content write access.