### PR TITLE
chore(general): fixed remaining checklocks violations

### DIFF
--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -203,6 +203,7 @@ func (c *PersistentCache) GetPartial(ctx context.Context, key string, offset, le
 	return false
 }
 
+// +checklocks:c.listCacheMutex
 func (c *PersistentCache) isCacheFullLocked() bool {
 	return c.listCache.DataSize() > c.sweep.MaxSizeBytes
 }
@@ -330,6 +331,7 @@ func (h *contentMetadataHeap) LookupByID(id blob.ID) (int, *blobCacheEntry) {
 
 func (h contentMetadataHeap) DataSize() int64 { return h.dataSize }
 
+// +checklocks:c.listCacheMutex
 func (c *PersistentCache) listCacheCleanupLocked(ctx context.Context) {
 	var (
 		unsuccessfulDeletes     []blob.Metadata
@@ -391,7 +393,7 @@ func (c *PersistentCache) initialScan(ctx context.Context) error {
 			tooRecentBytes += it.Length
 		}
 
-		heap.Push(&c.listCache, it)
+		heap.Push(&c.listCache, it) // +checklocksignore
 
 		return nil
 	})

--- a/internal/metrics/metrics_distribution.go
+++ b/internal/metrics/metrics_distribution.go
@@ -63,8 +63,8 @@ func (s *DistributionState[T]) Mean() T {
 // Distribution measures distribution/summary of values.
 type Distribution[T constraints.Integer | constraints.Float] struct {
 	mu               sync.Mutex
-	state            atomic.Pointer[DistributionState[T]]
-	bucketThresholds []T
+	state            atomic.Pointer[DistributionState[T]] // +checklocksignore
+	bucketThresholds []T                                  // +checklocksignore
 
 	prom            prometheus.Observer
 	prometheusScale float64

--- a/internal/metrics/prom_cache.go
+++ b/internal/metrics/prom_cache.go
@@ -16,7 +16,9 @@ const (
 //nolint:gochecknoglobals
 var (
 	promCacheMutex sync.Mutex
-	promCounters   = map[string]*prometheus.CounterVec{}
+	// +checklocks:promCacheMutex
+	promCounters = map[string]*prometheus.CounterVec{}
+	// +checklocks:promCacheMutex
 	promHistograms = map[string]*prometheus.HistogramVec{}
 )
 

--- a/repo/blob/s3/s3_versioned_test.go
+++ b/repo/blob/s3/s3_versioned_test.go
@@ -649,7 +649,8 @@ func randHex(tb testing.TB, length int) string {
 // Notice that this is not a crypto RNG.
 var (
 	rMu sync.Mutex
-	r   = rand.New(rand.NewSource(clock.Now().UnixNano()))
+	// +checklocks:rMu
+	r = rand.New(rand.NewSource(clock.Now().UnixNano()))
 )
 
 func randLongHex(tb testing.TB, length int) string {

--- a/repo/content/committed_content_index.go
+++ b/repo/content/committed_content_index.go
@@ -26,11 +26,12 @@ import (
 const smallIndexEntryCountThreshold = 100
 
 type committedContentIndex struct {
-	rev                    atomic.Int64
-	cache                  committedContentIndexCache
-	permissiveCacheLoading bool
+	rev   atomic.Int64
+	cache committedContentIndexCache
 
 	mu sync.RWMutex
+	// +checklocks:mu
+	permissiveCacheLoading bool
 	// +checklocks:mu
 	deletionWatermark time.Time
 	// +checklocks:mu

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -2683,6 +2683,7 @@ func (o withDeleted) GetDeleted() bool {
 }
 
 var (
+	// +checklocks:rMu
 	r   = rand.New(rand.NewSource(rand.Int63()))
 	rMu sync.Mutex
 )

--- a/repo/format/upgrade_lock.go
+++ b/repo/format/upgrade_lock.go
@@ -21,7 +21,7 @@ const (
 
 // ErrFormatUptoDate is returned whenever a lock intent is attempted to be set
 // on a repository that is already using the latest format version.
-var ErrFormatUptoDate = errors.New("repository format is up to date")
+var ErrFormatUptoDate = errors.New("repository format is up to date") // +checklocksignore
 
 // BackupBlobID gets the upgrade backu pblob-id fro mthe lock.
 func BackupBlobID(l UpgradeLockIntent) blob.ID {

--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -47,9 +47,11 @@ type CLITest struct {
 
 	DefaultRepositoryCreateFlags []string
 
-	logMu            sync.RWMutex
+	logMu sync.RWMutex
+	// +checklocks:logMu
 	logOutputEnabled bool
-	logOutputPrefix  string
+	// +checklocks:logMu
+	logOutputPrefix string
 }
 
 // RepoFormatNotImportant chooses arbitrary format version where it's not important to the test.


### PR DESCRIPTION
We can't enable checklocks on CI yet until https://github.com/google/gvisor/pull/8807 is merged upstream.

This was tested with private build of checklocks with this patch applied and the results were clean.