### PR TITLE
chore(ci): trigger CI rebuild after signing key update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 COVERAGE_PACKAGES=./repo/...,./fs/...,./snapshot/...,./cli/...,./internal/...
 TEST_FLAGS?=
-
 KOPIA_INTEGRATION_EXE=$(CURDIR)/dist/testing_$(GOOS)_$(GOARCH)/kopia.exe
 TESTING_ACTION_EXE=$(CURDIR)/dist/testing_$(GOOS)_$(GOARCH)/testingaction.exe
 FIO_DOCKER_TAG=ljishen/fio


### PR DESCRIPTION
this is a dummy change to trigger CI/CD pipeline. This should produce updated DEB binaries in `unstable` to address #2949 #2947 #2946.

Once it's confirmed the key has been fixed, we'll re-sign stable and testing.