### PR TITLE
docs(site): update installation instructions for apt key location

### DIFF
--- a/site/content/docs/Installation/_index.md
+++ b/site/content/docs/Installation/_index.md
@@ -124,13 +124,13 @@ Kopia offers APT repository compatible with Debian, Ubuntu and other similar dis
 To begin, install the GPG signing key to verify authenticity of the releases.
 
 ```shell
-curl -s https://kopia.io/signing-key | sudo gpg --dearmor -o /usr/share/keyrings/kopia-keyring.gpg
+curl -s https://kopia.io/signing-key | sudo gpg --dearmor -o /etc/apt/keyrings/kopia-keyring.gpg
 ```
 
 Register APT source:
 
 ```shell
-echo "deb [signed-by=/usr/share/keyrings/kopia-keyring.gpg] http://packages.kopia.io/apt/ stable main" | sudo tee /etc/apt/sources.list.d/kopia.list
+echo "deb [signed-by=/etc/apt/keyrings/kopia-keyring.gpg] http://packages.kopia.io/apt/ stable main" | sudo tee /etc/apt/sources.list.d/kopia.list
 sudo apt update
 ```
 


### PR DESCRIPTION
The current installation instructions mention `/usr/share/keyrings` as the location to copy the apt key files to, but according to the sources.list and apt-key manpages, the correct location for manually installed keys would be `/etc/apt/keyrings`.

This PR changes the instructions to point to that location instead.

From the sources.list manpage:
> The recommended locations for keyrings are /usr/share/keyrings for keyrings managed by packages, and /etc/apt/keyrings for keyrings managed by the system operator.

From the apt-key manpage:
> FILES
>    /etc/apt/trusted.gpg
>            Keyring of local trusted keys, new keys will be added here. Configuration Item: Dir::Etc::Trusted.
> 
>    /etc/apt/trusted.gpg.d/
>            File fragments for the trusted keys, additional keyrings can be stored here (by other packages or the administrator). Configuration Item Dir::Etc::TrustedParts.
> 
>    /etc/apt/keyrings/
>            Place to store additional keyrings to be used with Signed-By.
