### PR TITLE
feat(repository): Reduce memory usage when parsing manifests

### DIFF
--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -346,7 +346,8 @@ func loadManifestContent(ctx context.Context, b contentManager, contentID conten
 		return man, errors.Wrapf(err, "unable to unpack manifest data %q", contentID)
 	}
 
-	// Not needed?
+	// Will be GC-ed even if we don't close it?
+	//nolint:errcheck
 	defer gz.Close()
 
 	man, err = decodeManifestArray(gz)

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -346,11 +346,12 @@ func loadManifestContent(ctx context.Context, b contentManager, contentID conten
 		return man, errors.Wrapf(err, "unable to unpack manifest data %q", contentID)
 	}
 
-	if err := json.NewDecoder(gz).Decode(&man); err != nil {
-		return man, errors.Wrapf(err, "unable to parse manifest %q", contentID)
-	}
+	// Not needed?
+	defer gz.Close()
 
-	return man, nil
+	man, err = decodeManifestArray(gz)
+
+	return man, errors.Wrapf(err, "unable to parse manifest %q", contentID)
 }
 
 func newCommittedManager(b contentManager) *committedManifestManager {

--- a/repo/manifest/serialized.go
+++ b/repo/manifest/serialized.go
@@ -2,7 +2,10 @@ package manifest
 
 import (
 	"encoding/json"
+	"io"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 type manifest struct {
@@ -15,4 +18,100 @@ type manifestEntry struct {
 	ModTime time.Time         `json:"modified"`
 	Deleted bool              `json:"deleted,omitempty"`
 	Content json.RawMessage   `json:"data"`
+}
+
+const (
+	objectOpen  = "{"
+	objectClose = "}"
+	arrayOpen   = "["
+	arrayClose  = "]"
+)
+
+var errEOF = errors.New("unexpected end of input")
+
+func expectDelimToken(dec *json.Decoder, expectedToken string) error {
+	t, err := dec.Token()
+	if err == io.EOF {
+		return errors.WithStack(errEOF)
+	} else if err != nil {
+		return errors.Wrap(err, "reading JSON token")
+	}
+
+	d, ok := t.(json.Delim)
+	if !ok {
+		return errors.Errorf("unexpected token: (%T) %v", t, t)
+	} else if d.String() != expectedToken {
+		return errors.Errorf("unexpected token; wanted %s, got %s", expectedToken, d)
+	}
+
+	return nil
+}
+
+func decodeManifestArray(r io.Reader) (manifest, error) {
+	var (
+		dec = json.NewDecoder(r)
+		res = manifest{}
+	)
+
+	if err := expectDelimToken(dec, objectOpen); err != nil {
+		return res, err
+	}
+
+	// Need to manually decode fields here since we can't reuse the stdlib
+	// decoder due to memory issues.
+	if err := parseFields(dec, &res); err != nil {
+		return res, err
+	}
+
+	// Consumes closing object curly brace after we're done. Don't need to check
+	// for EOF because json.Decode only guarantees decoding the next JSON item in
+	// the stream so this follows that.
+	return res, expectDelimToken(dec, objectClose)
+}
+
+func parseFields(dec *json.Decoder, res *manifest) error {
+	for dec.More() {
+		t, err := dec.Token()
+		if err == io.EOF {
+			return errors.WithStack(errEOF)
+		} else if err != nil {
+			return errors.Wrap(err, "reading JSON token")
+		}
+
+		l, ok := t.(string)
+		if !ok {
+			return errors.Errorf("unexpected token (%T) %v; wanted field name", t, t)
+		}
+
+		// Only have `entries` field right now.
+		if l != "entries" {
+			return errors.Errorf("unexpected field name %s", l)
+		}
+
+		if err = decodeArray(dec, &res.Entries); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func decodeArray[T any](dec *json.Decoder, output *[]T) error {
+	// Consume starting bracket.
+	if err := expectDelimToken(dec, arrayOpen); err != nil {
+		return err
+	}
+
+	// Read elements.
+	for dec.More() {
+		tmp := *new(T)
+		if err := dec.Decode(&tmp); err != nil {
+			return errors.Wrap(err, "decoding array element")
+		}
+
+		*output = append(*output, tmp)
+	}
+
+	// Consume ending bracket.
+	return expectDelimToken(dec, arrayClose)
 }

--- a/repo/manifest/serialized_test.go
+++ b/repo/manifest/serialized_test.go
@@ -39,6 +39,10 @@ func TestManifestDecode_GoodInput(t *testing.T) {
 			name:  "StopsAtStructEnd",
 			input: []byte(testdata.ExtraInputAtEnd),
 		},
+		{
+			name:  "CaseInsensitive",
+			input: []byte(testdata.CaseInsensitive),
+		},
 	}
 
 	for _, test := range table {

--- a/repo/manifest/serialized_test.go
+++ b/repo/manifest/serialized_test.go
@@ -12,16 +12,6 @@ import (
 	"github.com/kopia/kopia/repo/manifest/testdata"
 )
 
-func newDecodeInput(t *testing.T, input []byte) manifest {
-	t.Helper()
-
-	arrReader := bytes.NewReader([]byte(input))
-	arrDec, err := decodeManifestArray(arrReader)
-	require.NoError(t, err)
-
-	return arrDec
-}
-
 func TestManifestDecode_GoodInput(t *testing.T) {
 	table := []struct {
 		name  string

--- a/repo/manifest/serialized_test.go
+++ b/repo/manifest/serialized_test.go
@@ -1,0 +1,73 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/repo/manifest/testdata"
+)
+
+func newDecodeInput(t *testing.T, input []byte) manifest {
+	t.Helper()
+
+	arrReader := bytes.NewReader([]byte(input))
+	arrDec, err := decodeManifestArray(arrReader)
+	require.NoError(t, err)
+
+	return arrDec
+}
+
+func TestManifestDecode_GoodInput(t *testing.T) {
+	table := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "MultipleManifests",
+			input: []byte(testdata.GoodManifests),
+		},
+		{
+			name:  "IgnoredField",
+			input: []byte(testdata.IgnoredField),
+		},
+		{
+			name:  "StopsAtStructEnd",
+			input: []byte(testdata.ExtraInputAtEnd),
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			stdlibDec := manifest{}
+
+			stdReader := bytes.NewReader(test.input)
+			require.NoError(t, json.NewDecoder(stdReader).Decode(&stdlibDec))
+
+			arrReader := bytes.NewReader(test.input)
+			arrDec, err := decodeManifestArray(arrReader)
+			require.NoError(t, err)
+
+			assert.Equal(t, stdlibDec, arrDec)
+
+			assert.True(t, reflect.DeepEqual(stdlibDec, arrDec))
+		})
+	}
+}
+
+func TestManifestDecode_BadInput(t *testing.T) {
+	for _, test := range testdata.BadInputs {
+		t.Run(test.Name, func(t *testing.T) {
+			r := bytes.NewReader([]byte(test.Input))
+			_, err := decodeManifestArray(r)
+
+			t.Logf("%v", err)
+
+			assert.Error(t, err)
+		})
+	}
+}

--- a/repo/manifest/testdata/manifests.go
+++ b/repo/manifest/testdata/manifests.go
@@ -771,4 +771,109 @@ const (
 	}
 	]
 }abcdefg`
+	CaseInsensitive = `
+{
+	"Entries": [
+	{
+		"id": "2e14cba9427c57223dd768bd1ddf694c",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"tag": "value",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-17T01:08:32.962808Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-17T01:08:29.674573Z",
+			"endTime": "2023-03-17T01:08:32.962614Z",
+			"stats": {
+				"totalSize": 427221,
+				"excludedTotalSize": 0,
+				"fileCount": 143,
+				"cachedFiles": 0,
+				"nonCachedFiles": 143,
+				"dirCount": 10,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "kfe00a91781912fc352edca26571a5f83",
+				"summ": {
+					"size": 427221,
+					"files": 143,
+					"symlinks": 0,
+					"dirs": 10,
+					"maxTime": "2023-03-17T01:08:29.677079Z",
+					"numFailed": 0
+				}
+			},
+			"tags": {
+				"tag": "value"
+			}
+		}
+	},
+	{
+		"id": "2c54893efd80bcda7102f622da5c63ee",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-17T01:11:34.506121Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-17T01:11:22.34148Z",
+			"endTime": "2023-03-17T01:11:34.505952Z",
+			"stats": {
+				"totalSize": 427221,
+				"excludedTotalSize": 0,
+				"fileCount": 2,
+				"cachedFiles": 141,
+				"nonCachedFiles": 2,
+				"dirCount": 10,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k4f1a9e8049091615cbe4ad93507680f3",
+				"summ": {
+					"size": 427221,
+					"files": 143,
+					"symlinks": 0,
+					"dirs": 10,
+					"maxTime": "2023-03-17T01:11:22.725375Z",
+					"numFailed": 0
+				}
+			}
+		}
+	}
+	]
+}`
 )

--- a/repo/manifest/testdata/manifests.go
+++ b/repo/manifest/testdata/manifests.go
@@ -1,0 +1,774 @@
+package testdata
+
+type testInput struct {
+	Name  string
+	Input string
+}
+
+var (
+	BadInputs = []testInput{
+		{
+			Name: "RepeatedEntriesField",
+			Input: `
+{
+	"entries": [
+	{
+		"id": "25905b6f222a153561543baea0a67043",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-16T20:46:59.70714Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-16T20:46:55.76843Z",
+			"endTime": "2023-03-16T20:46:59.707064Z",
+			"stats": {
+				"totalSize": 536927459,
+				"excludedTotalSize": 0,
+				"fileCount": 18,
+				"cachedFiles": 0,
+				"nonCachedFiles": 18,
+				"dirCount": 14,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k74647859396c88127696f426b4c79088",
+				"summ": {
+					"size": 536927459,
+					"files": 18,
+					"symlinks": 0,
+					"dirs": 14,
+					"maxTime": "2023-03-16T20:46:56.187394Z",
+					"numFailed": 0
+				}
+			},
+		}
+	},
+	],
+	entries: []
+}`,
+		},
+		{
+			Name: "MissingObjectStart",
+			Input: `
+	"entries": [
+	{
+		"id": "25905b6f222a153561543baea0a67043",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-16T20:46:59.70714Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-16T20:46:55.76843Z",
+			"endTime": "2023-03-16T20:46:59.707064Z",
+			"stats": {
+				"totalSize": 536927459,
+				"excludedTotalSize": 0,
+				"fileCount": 18,
+				"cachedFiles": 0,
+				"nonCachedFiles": 18,
+				"dirCount": 14,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k74647859396c88127696f426b4c79088",
+				"summ": {
+					"size": 536927459,
+					"files": 18,
+					"symlinks": 0,
+					"dirs": 14,
+					"maxTime": "2023-03-16T20:46:56.187394Z",
+					"numFailed": 0
+				}
+			}
+		}
+	}
+	]
+}`,
+		},
+		{
+			Name: "MissingObjectEnd",
+			Input: `
+{
+	"entries": [
+	{
+		"id": "25905b6f222a153561543baea0a67043",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-16T20:46:59.70714Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-16T20:46:55.76843Z",
+			"endTime": "2023-03-16T20:46:59.707064Z",
+			"stats": {
+				"totalSize": 536927459,
+				"excludedTotalSize": 0,
+				"fileCount": 18,
+				"cachedFiles": 0,
+				"nonCachedFiles": 18,
+				"dirCount": 14,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k74647859396c88127696f426b4c79088",
+				"summ": {
+					"size": 536927459,
+					"files": 18,
+					"symlinks": 0,
+					"dirs": 14,
+					"maxTime": "2023-03-16T20:46:56.187394Z",
+					"numFailed": 0
+				}
+			}
+		}
+	}
+	]`,
+		},
+		{
+			Name: "MissingArrayStart",
+			Input: `
+{
+	"entries":
+	{
+		"id": "25905b6f222a153561543baea0a67043",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-16T20:46:59.70714Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-16T20:46:55.76843Z",
+			"endTime": "2023-03-16T20:46:59.707064Z",
+			"stats": {
+				"totalSize": 536927459,
+				"excludedTotalSize": 0,
+				"fileCount": 18,
+				"cachedFiles": 0,
+				"nonCachedFiles": 18,
+				"dirCount": 14,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k74647859396c88127696f426b4c79088",
+				"summ": {
+					"size": 536927459,
+					"files": 18,
+					"symlinks": 0,
+					"dirs": 14,
+					"maxTime": "2023-03-16T20:46:56.187394Z",
+					"numFailed": 0
+				}
+			}
+		}
+	}
+	]
+}`,
+		},
+		{
+			Name: "MissingArrayEnd",
+			Input: `
+{
+	"entries": [
+	{
+		"id": "25905b6f222a153561543baea0a67043",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-16T20:46:59.70714Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-16T20:46:55.76843Z",
+			"endTime": "2023-03-16T20:46:59.707064Z",
+			"stats": {
+				"totalSize": 536927459,
+				"excludedTotalSize": 0,
+				"fileCount": 18,
+				"cachedFiles": 0,
+				"nonCachedFiles": 18,
+				"dirCount": 14,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k74647859396c88127696f426b4c79088",
+				"summ": {
+					"size": 536927459,
+					"files": 18,
+					"symlinks": 0,
+					"dirs": 14,
+					"maxTime": "2023-03-16T20:46:56.187394Z",
+					"numFailed": 0
+				}
+			}
+		}
+	}
+}`,
+		},
+		{
+			Name: "MissingInnerObjectStart",
+			Input: `
+{
+	"entries": [
+		"id": "25905b6f222a153561543baea0a67043",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-16T20:46:59.70714Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-16T20:46:55.76843Z",
+			"endTime": "2023-03-16T20:46:59.707064Z",
+			"stats": {
+				"totalSize": 536927459,
+				"excludedTotalSize": 0,
+				"fileCount": 18,
+				"cachedFiles": 0,
+				"nonCachedFiles": 18,
+				"dirCount": 14,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k74647859396c88127696f426b4c79088",
+				"summ": {
+					"size": 536927459,
+					"files": 18,
+					"symlinks": 0,
+					"dirs": 14,
+					"maxTime": "2023-03-16T20:46:56.187394Z",
+					"numFailed": 0
+				}
+			}
+		}
+	},
+	]
+}`,
+		},
+		{
+			Name: "BadInnerObject",
+			Input: `
+{
+	"entries": [
+	{
+		"id": "25905b6f222a153561543baea0a67043",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-16T20:46:59.70714Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-16T20:46:55.76843Z",
+			"endTime": "2023-03-16T20:46:59.707064Z",
+			"stats": {
+				"totalSize": 536927459,
+				"excludedTotalSize": 0,
+				"fileCount": 18,
+				"cachedFiles": 0,
+				"nonCachedFiles": 18,
+				"dirCount": 14,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k74647859396c88127696f426b4c79088",
+				"summ": {
+					"size": 536927459,
+					"files": 18,
+					"symlinks": 0,
+					"dirs": 14,
+					"maxTime": "2023-03-16T20:46:56.187394Z",
+					"numFailed": 0
+				}
+		}
+	}
+	]
+}`,
+		},
+		{
+			Name: "MissingInnerObjectEnd",
+			Input: `
+{
+	"entries": [
+	{
+		"id": "25905b6f222a153561543baea0a67043",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-16T20:46:59.70714Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-16T20:46:55.76843Z",
+			"endTime": "2023-03-16T20:46:59.707064Z",
+			"stats": {
+				"totalSize": 536927459,
+				"excludedTotalSize": 0,
+				"fileCount": 18,
+				"cachedFiles": 0,
+				"nonCachedFiles": 18,
+				"dirCount": 14,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k74647859396c88127696f426b4c79088",
+				"summ": {
+					"size": 536927459,
+					"files": 18,
+					"symlinks": 0,
+					"dirs": 14,
+					"maxTime": "2023-03-16T20:46:56.187394Z",
+					"numFailed": 0
+				}
+			}
+		}
+	]
+}`,
+		},
+	}
+)
+
+const (
+	GoodManifests = `
+{
+	"entries": [
+	{
+		"id": "2e14cba9427c57223dd768bd1ddf694c",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"tag": "value",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-17T01:08:32.962808Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-17T01:08:29.674573Z",
+			"endTime": "2023-03-17T01:08:32.962614Z",
+			"stats": {
+				"totalSize": 427221,
+				"excludedTotalSize": 0,
+				"fileCount": 143,
+				"cachedFiles": 0,
+				"nonCachedFiles": 143,
+				"dirCount": 10,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "kfe00a91781912fc352edca26571a5f83",
+				"summ": {
+					"size": 427221,
+					"files": 143,
+					"symlinks": 0,
+					"dirs": 10,
+					"maxTime": "2023-03-17T01:08:29.677079Z",
+					"numFailed": 0
+				}
+			},
+			"tags": {
+				"tag": "value"
+			}
+		}
+	},
+	{
+		"id": "2c54893efd80bcda7102f622da5c63ee",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-17T01:11:34.506121Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-17T01:11:22.34148Z",
+			"endTime": "2023-03-17T01:11:34.505952Z",
+			"stats": {
+				"totalSize": 427221,
+				"excludedTotalSize": 0,
+				"fileCount": 2,
+				"cachedFiles": 141,
+				"nonCachedFiles": 2,
+				"dirCount": 10,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k4f1a9e8049091615cbe4ad93507680f3",
+				"summ": {
+					"size": 427221,
+					"files": 143,
+					"symlinks": 0,
+					"dirs": 10,
+					"maxTime": "2023-03-17T01:11:22.725375Z",
+					"numFailed": 0
+				}
+			}
+		}
+	}
+	]
+}
+`
+	IgnoredField = `
+{
+	"entries": [
+	{
+		"id": "2e14cba9427c57223dd768bd1ddf694c",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"tag": "value",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-17T01:08:32.962808Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-17T01:08:29.674573Z",
+			"endTime": "2023-03-17T01:08:32.962614Z",
+			"stats": {
+				"totalSize": 427221,
+				"excludedTotalSize": 0,
+				"fileCount": 143,
+				"cachedFiles": 0,
+				"nonCachedFiles": 143,
+				"dirCount": 10,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "kfe00a91781912fc352edca26571a5f83",
+				"summ": {
+					"size": 427221,
+					"files": 143,
+					"symlinks": 0,
+					"dirs": 10,
+					"maxTime": "2023-03-17T01:08:29.677079Z",
+					"numFailed": 0
+				}
+			},
+			"tags": {
+				"tag": "value"
+			}
+		}
+	},
+	{
+		"id": "2c54893efd80bcda7102f622da5c63ee",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-17T01:11:34.506121Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-17T01:11:22.34148Z",
+			"endTime": "2023-03-17T01:11:34.505952Z",
+			"stats": {
+				"totalSize": 427221,
+				"excludedTotalSize": 0,
+				"fileCount": 2,
+				"cachedFiles": 141,
+				"nonCachedFiles": 2,
+				"dirCount": 10,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k4f1a9e8049091615cbe4ad93507680f3",
+				"summ": {
+					"size": 427221,
+					"files": 143,
+					"symlinks": 0,
+					"dirs": 10,
+					"maxTime": "2023-03-17T01:11:22.725375Z",
+					"numFailed": 0
+				}
+			}
+		}
+	}
+	],
+	"ignored": "hello world"
+}`
+	ExtraInputAtEnd = `
+{
+	"entries": [
+	{
+		"id": "2e14cba9427c57223dd768bd1ddf694c",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"tag": "value",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-17T01:08:32.962808Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-17T01:08:29.674573Z",
+			"endTime": "2023-03-17T01:08:32.962614Z",
+			"stats": {
+				"totalSize": 427221,
+				"excludedTotalSize": 0,
+				"fileCount": 143,
+				"cachedFiles": 0,
+				"nonCachedFiles": 143,
+				"dirCount": 10,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "kfe00a91781912fc352edca26571a5f83",
+				"summ": {
+					"size": 427221,
+					"files": 143,
+					"symlinks": 0,
+					"dirs": 10,
+					"maxTime": "2023-03-17T01:08:29.677079Z",
+					"numFailed": 0
+				}
+			},
+			"tags": {
+				"tag": "value"
+			}
+		}
+	},
+	{
+		"id": "2c54893efd80bcda7102f622da5c63ee",
+		"labels": {
+			"hostname": "host-name",
+			"path": "/root/tmp/test",
+			"type": "snapshot",
+			"username": "user-name"
+		},
+		"modified": "2023-03-17T01:11:34.506121Z",
+		"data": {
+			"id": "",
+			"source": {
+				"host": "host-name",
+				"userName": "user-name",
+				"path": "/root/tmp/test"
+			},
+			"description": "",
+			"startTime": "2023-03-17T01:11:22.34148Z",
+			"endTime": "2023-03-17T01:11:34.505952Z",
+			"stats": {
+				"totalSize": 427221,
+				"excludedTotalSize": 0,
+				"fileCount": 2,
+				"cachedFiles": 141,
+				"nonCachedFiles": 2,
+				"dirCount": 10,
+				"excludedFileCount": 0,
+				"excludedDirCount": 0,
+				"ignoredErrorCount": 0,
+				"errorCount": 0
+			},
+			"rootEntry": {
+				"name": "test",
+				"type": "d",
+				"mode": "0777",
+				"mtime": "1754-08-30T22:43:41.128654848Z",
+				"obj": "k4f1a9e8049091615cbe4ad93507680f3",
+				"summ": {
+					"size": 427221,
+					"files": 143,
+					"symlinks": 0,
+					"dirs": 10,
+					"maxTime": "2023-03-17T01:11:22.725375Z",
+					"numFailed": 0
+				}
+			}
+		}
+	}
+	]
+}abcdefg`
+)


### PR DESCRIPTION
Golang's stdlib JSON decoder allocates lots of memory when decoding large objects/arrays because it needs to have the entire object/array in-memory (see a [medium post](https://medium.com/safetycultureengineering/analyzing-and-improving-memory-usage-in-go-46be8c3be0a8) by another person for some debugging of this phenomenon in an unrelated project). This can cause OOMs or increased costs when accessing manifests in a kopia repo that has lots of snapshots in it

This PR adds some manual parsing to the decoding of manifests in kopia. It manually parses the `manifest` struct and pulls off the `[` and `]` denoting the array of manifest entries. Parsing of individual entries in the array is deferred to the stdlib decoder as it behaves reasonably well for those

This does not completely solve the memory problem when there are large numbers of manifests in a repo, but it does help

Some [benchmarking](https://github.com/alcionai/corso/blob/json-debug-benchmarks/src/cmd/jsondebug/benchmark/benchmark_test.go) results for various configurations (sorry the benchmark is in an unrelated repo, we were making things on the fly). The benchmark ran against a single serialized manifest entry that contained 1000 randomly generated kopia snapshot manifests in the array. 500 runs of the benchmark were done with the input gzipped like kopia has it. `Stdlib` is the golang JSON decoder. `JsonParser` uses the JsonParser [library](https://github.com/buger/jsonparser) to extract data, though it still requires having the full JSON array in-memory. `Array` is the implementation in this PR. `ArrayFull` is an extension of this implementation that only uses golang's stdlib decoder to get the values of individual fields in each array entry
```text
Benchmark_FromFile/Stdlib/Zipped-6                   500             42829 ns/op           13125 B/op         72 allocs/op
Benchmark_FromFile/JsonParser/Zipped-6               500             38351 ns/op           22079 B/op         83 allocs/op
Benchmark_FromFile/Array/Zipped-6                    500             42462 ns/op            4764 B/op         74 allocs/op
Benchmark_FromFile/ArrayFull/Zipped-6                500             49263 ns/op            6356 B/op        168 allocs/op
```