### PR TITLE
Fix: SFTP blob creation fails with "Operation unsupported" on initial setup #3035

### DIFF
--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -209,7 +209,19 @@ func (s *sftpImpl) PutBlobInPath(ctx context.Context, dirPath, fullPath string, 
 			return errors.Wrap(err, "can't close temporary file")
 		}
 
-		err = sftpClientFromConnection(conn).PosixRename(tempFile, fullPath)
+		_, err = sftpClientFromConnection(conn).Stat(fullPath)
+		if err != nil {
+			if !isNotExist(err) {
+				return errors.Wrap(err, "can't check if old backup folder exists")
+			}
+			log(ctx).Infof("no old backup folder exists: %v", err)
+		} else {
+			if err = sftpClientFromConnection(conn).Remove(fullPath); err != nil {
+				return errors.Wrap(err, "can't remove leftover backup path file")
+			}
+		}
+
+		err = sftpClientFromConnection(conn).Rename(tempFile, fullPath)
 		if err != nil {
 			if removeErr := sftpClientFromConnection(conn).Remove(tempFile); removeErr != nil {
 				log(ctx).Warnf("can't remove temp file: %v", removeErr)


### PR DESCRIPTION
This pull request is a fix to the following issue:

https://github.com/kopia/kopia/issues/3035

basically kopia fails if the ftp backend doesnt support the posix rename extention, a simple remove&&rename will fullfill the same purpose but won't cause this issue