### PR TITLE
fix(cli): restore objects with I prefix fails

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -21,7 +21,6 @@ import (
 	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo"
-	"github.com/kopia/kopia/repo/content/index"
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/restore"
@@ -147,7 +146,7 @@ func (c *commandRestore) setup(svc appServices, parent commandParent) {
 	cmd.Flag("skip-existing", "Skip files and symlinks that exist in the output").BoolVar(&c.restoreIncremental)
 	cmd.Flag("shallow", "Shallow restore the directory hierarchy starting at this level (default is to deep restore the entire hierarchy.)").Int32Var(&c.restoreShallowAtDepth)
 	cmd.Flag("shallow-minsize", "When doing a shallow restore, write actual files instead of placeholders smaller than this size.").Int32Var(&c.minSizeForPlaceholder)
-	cmd.Flag("snapshot-time", "When using a path as the source, use the latest snapshot available before this date. Default is latest").StringVar(&c.snapshotTime)
+	cmd.Flag("snapshot-time", "When using a path as the source, use the latest snapshot available before this date. Default is latest").Default("latest").StringVar(&c.snapshotTime)
 	cmd.Action(svc.repositoryReaderAction(c.run))
 }
 
@@ -452,7 +451,7 @@ func (c *commandRestore) tryToConvertPathToID(ctx context.Context, rep repo.Repo
 	pathElements := strings.Split(filepath.ToSlash(source), "/")
 
 	if pathElements[0] != "" {
-		_, err := index.ParseID(pathElements[0])
+		_, err := object.ParseID(pathElements[0])
 		if err == nil {
 			// source is an ID
 			return source, nil

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -864,6 +864,6 @@ func TestRestoreByPathWithoutTarget(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, originalData, data)
 
-	// Must pass snapshot time
-	e.RunAndExpectFailure(t, "restore", srcdir)
+	// Defaults to latest snapshot time
+	e.RunAndExpectSuccess(t, "restore", srcdir)
 }


### PR DESCRIPTION
Fixes  #2945
The tryToConvertToPath would return an error when given an ID with an I prefix. Call object.parseID instead of index.parseID Also set the default for snapshot-time as that was missing. In my testing this seems to fix the issue