### PR TITLE
chore(ci): restore dependabot removed in PR3017

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,92 @@
+# This file contains rules for auto-approving Dependabot PRs.
+#
+# We should only have entries for regularly-delivered updates from reputable vendors
+# that have been proven to be stable.
+
+# AWS-provided libraries
+- match:
+    dependency_name: "github.com/aws/aws-sdk-go"
+    update_type: "semver:minor"
+
+# golang.org/x 
+- match:
+    dependency_name: "golang.org/x/.*"
+    update_type: "semver:minor"
+
+# Google-provided libraries
+- match:
+    dependency_name: "google.golang.org/grpc"
+    update_type: "semver:minor"
+- match:
+    dependency_name: "google.golang.org/api"
+    update_type: "semver:minor"
+- match:
+    dependency_name: "google.golang.org/protobuf"
+    update_type: "semver:minor"
+- match:
+    dependency_name: "cloud.google.com/go/storage"
+    update_type: "semver:minor"
+
+# minio
+- match:
+    dependency_name: "github.com/minio/minio-go/v7"
+    update_type: "semver:minor"
+
+# Playwright test framework
+- match:
+    dependency_name: "@playwright/test"
+    update_type: "semver:minor"
+- match:
+    dependency_name: "playwright"
+    update_type: "semver:minor"
+- match:
+    dependency_name: "playwright-core"
+    update_type: "semver:minor"
+
+# otel
+- match:
+    dependency_name: "go.opentelemetry.io/.*"
+    update_type: "semver:minor"
+
+# chromedp
+- match:
+    dependency_name: "github.com/chromedp/.*"
+    update_type: "semver:minor"
+
+# Prometheus
+- match:
+    dependency_name: "github.com/prometheus/common"
+    update_type: "semver:minor"
+- match:
+    dependency_name: "github.com/prometheus/client_golang"
+    update_type: "semver:minor"
+
+# ReactJS
+- match:
+    dependency_name: "react-scripts"
+    update_type: "semver:patch"
+
+# test-only dependencies where we have good coverage to auto approve minor updates
+- match:
+    dependency_name: "github.com/chromedp/chromedp"
+    update_type: "semver:minor"
+- match:
+    dependency_name: "github.com/stretchr/testify"
+    update_type: "semver:minor"
+
+- match:
+    dependency_name: "electron-log"
+    update_type: "semver:minor"
+
+- match:
+    dependency_name: "concurrently"
+    update_type: "semver:minor"
+
+# DO NOT ADD large electron dependencies here:
+#
+# electron
+# electron-builder
+# electron-updater
+#
+# Those have been known to break in the past and we don't have adequate 
+# coverage to detect regressions in all cases (desktop app installation and upgrade).

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,2 @@
+PR_TITLE_REGEX: /(feat|fix|breaking|build|chore|docs|style|refactor|test)\((app|cli|server|providers|deps|site|ci|infra|general)\): .*/
+COMMIT_MESSAGE_REGEX: /(feat|fix|breaking|build|chore|docs|style|refactor|test)\((app|cli|server|providers|deps|site|ci|infra|general)\): .*/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,16 @@
 version: 2
 updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: daily
   - package-ecosystem: github-actions
     directory: "/"
     open-pull-requests-limit: 3
     schedule:
       interval: weekly
+  - package-ecosystem: npm
+    directory: "/app"
+    schedule:
+      interval: monthly

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          # auto-merge rules are in /.github/auto-merge.yml
+          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: deepakputhraya/action-pr-title@master
       with:
-        regex: '^(\[Snyk\]|(feat|fix|breaking|build|chore|docs|style|refactor|test)\((kopiaui|cli|ui|repository|snapshots|server|providers|deps|deps-dev|site|ci|infra|general)\)!{0,1}:) .*$'
+        regex: '^(feat|fix|breaking|build|chore|docs|style|refactor|test)\((kopiaui|cli|ui|repository|snapshots|server|providers|deps|deps-dev|site|ci|infra|general)\)!{0,1}: .*$'


### PR DESCRIPTION
This reverts commit f9de453efc198b6e993af8922f953a7e5322dc5f.

Turns out Snyk has many more quirks than Dependabot and our dependencies have not been regularly updated.