### PR TITLE
chore(ci): group dependabot updates and make them weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,20 @@ updates:
     directory: "/"
     open-pull-requests-limit: 5
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      # create large PR upgrading multiple infrastructure dependencies in one shot,
+      # only include upstream dependencies that are stable and have somewhat
+      # regular releases which would be otherwise hard to manually manage.
+      common-golang-dependencies:
+        patterns:
+        - "cloud.google.com/*"
+        - "github.com/aws/aws-sdk-go/*"
+        - "github.com/minio/minio-go/*"
+        - "golang.org/x/*"
+        - "google.golang.org/*"
+        - "github.com/prometheus/*"
+        - "go.opentelemetry.io/*"
   - package-ecosystem: github-actions
     directory: "/"
     open-pull-requests-limit: 3
@@ -14,3 +27,9 @@ updates:
     directory: "/app"
     schedule:
       interval: monthly
+    groups:
+      # create once-per-week PR for all KopiaUI dependency bumps, that usually includes
+      # electron, electron-builder, etc.
+      common-golang-dependencies:
+        patterns:
+        - "*"


### PR DESCRIPTION
This generates larger PRs for multiple dependencies at a time, such as https://github.com/jkowalski/kopia/pull/476

It uses relatively new feature of Dependabot described here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups