### PR TITLE
chore(infra): update stale workflow settings

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,8 +6,8 @@ permissions:
 
 on:
   schedule:
-    # Sundays at 8:17 p.m. UTC
-    - cron: '17 20 * * 0'
+    # Sundays and Wednesdays at 8:17 p.m. UTC
+    - cron: '17 20 * * 0,3'
   workflow_dispatch:
 
 jobs:
@@ -21,3 +21,7 @@ jobs:
           operations-per-run: 100
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
+          exempt-issue-labels: 'bug,keep-open'
+          exempt-pr-labels: 'keep-open'
+          stale-issue-message: 'Closed due to inactivity. Re-open and remove "stale" label if it should remain open for an additional period of time'
+          stale-pr-message: 'Closed due to inactivity. Re-open and remove "stale" label if it should remain open for an additional period of time'


### PR DESCRIPTION
- add message to provide additional information when issues or PRs are closed.
- exclude PRs and issues with the 'keep-open' label
- run twice a week