### PR TITLE
chore(general): cleanup "stale" error naming

### DIFF
--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -52,7 +52,7 @@ func (fs *fsImpl) isRetriable(err error) bool {
 
 	err = errors.Cause(err)
 
-	if fs.osi.IsESTALE(err) {
+	if fs.osi.IsStale(err) {
 		// errors indicative of stale resource handle or invalid
 		// descriptors should not be retried
 		return false

--- a/repo/blob/filesystem/osinterface.go
+++ b/repo/blob/filesystem/osinterface.go
@@ -17,6 +17,7 @@ type osInterface interface {
 	IsPathError(err error) bool
 	IsLinkError(err error) bool
 	IsPathSeparator(c byte) bool
+	IsStale(err error) bool
 	Remove(fname string) error
 	Rename(oldname, newname string) error
 	ReadDir(dirname string) ([]fs.DirEntry, error)
@@ -27,9 +28,6 @@ type osInterface interface {
 	Chtimes(fname string, atime, mtime time.Time) error
 	Geteuid() int
 	Chown(fname string, uid, gid int) error
-
-	// Errno
-	IsESTALE(err error) bool
 }
 
 type osReadFile interface {

--- a/repo/blob/filesystem/osinterface_realos_other.go
+++ b/repo/blob/filesystem/osinterface_realos_other.go
@@ -4,6 +4,6 @@
 package filesystem
 
 //nolint:revive
-func (realOS) IsESTALE(err error) bool {
+func (realOS) IsStale(err error) bool {
 	return false
 }

--- a/repo/blob/filesystem/osinterface_realos_unix.go
+++ b/repo/blob/filesystem/osinterface_realos_unix.go
@@ -10,7 +10,5 @@ import (
 )
 
 func (realOS) IsStale(err error) bool {
-	var errno syscall.Errno
-
-	return errors.As(err, &errno) && errno == syscall.ESTALE
+	return errors.Is(err, syscall.ESTALE)
 }

--- a/repo/blob/filesystem/osinterface_realos_unix.go
+++ b/repo/blob/filesystem/osinterface_realos_unix.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (realOS) IsESTALE(err error) bool {
+func (realOS) IsStale(err error) bool {
 	var errno syscall.Errno
 
 	return errors.As(err, &errno) && errno == syscall.ESTALE


### PR DESCRIPTION
Renames `IsESTALE(error)` to `IsStale(error)` to make it consistent with the conventions in the Go ecosystem.

Uses `errors.Is()` instead of `==` comparison. It is more robust.