### PR TITLE
fix(ci): Potential fix for TestLogFileMaxTotalSize

### DIFF
--- a/internal/logfile/logfile_test.go
+++ b/internal/logfile/logfile_test.go
@@ -189,8 +189,8 @@ func TestLogFileMaxTotalSize(t *testing.T) {
 
 			env.RunAndExpectSuccess(t, "snap", "ls", "--file-log-level=debug", "--log-dir", tmpLogDir, fmt.Sprintf("%s=%v", flag, size1MB/2))
 			size2 := getTotalDirSize(t, logSubdir)
-			require.Less(t, size1, size0/2)
-			require.Less(t, size2, size1/2)
+			require.LessOrEqual(t, size1, size0/2)
+			require.LessOrEqual(t, size2, size1/2)
 			require.Greater(t, size2, size1/4)
 		})
 	}


### PR DESCRIPTION
Hi, 

there were a couple failed runs for logfile_test. In edge cases both sizes were the same and therefore the test failed. 
An analysis of the test output revealed that the test itself works as intented. 

Further analysis will be carried out to find the root cause. 
For now it should fix #3128 

Feedback is welcomed.

Cheers, 