### PR TITLE
feat(snapshots): added ability to use cron expressions to schedule snapshots

### DIFF
--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -172,8 +172,6 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 }
 
 func TestSetSchedulingPolicyFromFlags(t *testing.T) {
-	var psf policySchedulingFlags
-
 	ctx := testlogging.Context(t)
 
 	for _, tc := range []struct {
@@ -418,6 +416,8 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			changeCount := 0
+
+			var psf policySchedulingFlags
 
 			psf.policySetInterval = tc.intervalArg
 			psf.policySetTimesOfDay = tc.timesOfDayArg

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -301,6 +301,16 @@ func appendSchedulingPolicyRows(rows []policyTableRow, p *policy.Policy, def *po
 		hasAny = true
 	}
 
+	if len(p.SchedulingPolicy.Cron) > 0 {
+		rows = append(rows, policyTableRow{"  Crontab expressions:", "", definitionPointToString(p.Target(), def.SchedulingPolicy.Cron)})
+
+		for _, cron := range p.SchedulingPolicy.Cron {
+			rows = append(rows, policyTableRow{"    " + cron, "", ""})
+		}
+
+		hasAny = true
+	}
+
 	if !hasAny {
 		rows = append(rows, policyTableRow{"    None.", "", ""})
 	}

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/klauspost/compress v1.16.7
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.11.8
-	github.com/kopia/htmluibuild v0.0.0-20230714030926-ff7ed652d883
+	github.com/kopia/htmluibuild v0.0.0-20230716183504-d78b44b3a9bd
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.61

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hanwen/go-fuse/v2 v2.3.0
+	github.com/hashicorp/cronexpr v1.1.2
 	github.com/klauspost/compress v1.16.7
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.11.8

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hanwen/go-fuse/v2 v2.3.0 h1:t5ivNIH2PK+zw4OBul/iJjsoG9K6kXo4nMDoBpciC8A=
 github.com/hanwen/go-fuse/v2 v2.3.0/go.mod h1:xKwi1cF7nXAOBCXujD5ie0ZKsxc8GGSA1rlMJc+8IJs=
+github.com/hashicorp/cronexpr v1.1.2 h1:wG/ZYIKT+RT3QkOdgYc+xsKWVRgnxJ1OJtjjy84fJ9A=
+github.com/hashicorp/cronexpr v1.1.2/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.11.8 h1:s8RpUW5TK4hjr+djiOpbZJB4ksx+TdYbRH7vHQpwPOY=
 github.com/klauspost/reedsolomon v1.11.8/go.mod h1:4bXRN+cVzMdml6ti7qLouuYi32KHJ5MGv0Qd8a47h6A=
-github.com/kopia/htmluibuild v0.0.0-20230714030926-ff7ed652d883 h1:LX3CQvH12mNYXt+rBUqxwbwAieb9QmDrMXjKVAuMxvQ=
-github.com/kopia/htmluibuild v0.0.0-20230714030926-ff7ed652d883/go.mod h1:eWer4rx9P8lJo2eKc+Q7AZ1dE1x1hJNdkbDFPzMu1Hw=
+github.com/kopia/htmluibuild v0.0.0-20230716183504-d78b44b3a9bd h1:Vskpc00T65HkkDSWbkiXOG5yYsgWg5LN48daUfGZ+u0=
+github.com/kopia/htmluibuild v0.0.0-20230716183504-d78b44b3a9bd/go.mod h1:eWer4rx9P8lJo2eKc+Q7AZ1dE1x1hJNdkbDFPzMu1Hw=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/server/api_policies.go
+++ b/internal/server/api_policies.go
@@ -89,6 +89,10 @@ func handlePolicyResolve(ctx context.Context, rc requestContext) (interface{}, *
 	resp.Effective, resp.Definition = policy.MergePolicies(policies, target)
 	resp.UpcomingSnapshotTimes = []time.Time{}
 
+	if err := policy.ValidateSchedulingPolicy(policies[0].SchedulingPolicy); err != nil {
+		resp.SchedulingError = err.Error()
+	}
+
 	now := clock.Now().Local()
 
 	for i := 0; i < req.NumUpcomingSnapshotTimes; i++ {

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -269,6 +269,7 @@ type ResolvePolicyResponse struct {
 	Definition            *policy.Definition `json:"definition"`
 	Defined               *policy.Policy     `json:"defined"`
 	UpcomingSnapshotTimes []time.Time        `json:"upcomingSnapshotTimes"`
+	SchedulingError       string             `json:"schedulingError,omitempty"`
 }
 
 // ResolvePathRequest contains request to resolve a particular path to ResolvePathResponse.

--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -130,6 +130,7 @@ func (p *SchedulingPolicy) NextSnapshotTime(previousSnapshotTime, now time.Time)
 		ce, err := cronexpr.Parse(stripCronComment(e))
 		if err != nil {
 			// ignore invalid crontab entries, nothing we can do at this point
+			// we already validated cron expressions them when they were added to the policy.
 			continue
 		}
 
@@ -213,5 +214,5 @@ func ValidateSchedulingPolicy(p SchedulingPolicy) error {
 }
 
 func stripCronComment(s string) string {
-	return strings.TrimSpace(strings.Split(s, "#")[0])
+	return strings.TrimSpace(strings.SplitN(s, "#", 2)[0]) //nolint:gomnd
 }

--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 
+	"github.com/hashicorp/cronexpr"
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/repo"
@@ -59,12 +61,14 @@ type SchedulingPolicy struct {
 	TimesOfDay         []TimeOfDay `json:"timeOfDay,omitempty"`
 	NoParentTimesOfDay bool        `json:"noParentTimeOfDay,omitempty"`
 	Manual             bool        `json:"manual,omitempty"`
+	Cron               []string    `json:"cron,omitempty"`
 }
 
 // SchedulingPolicyDefinition specifies which policy definition provided the value of a particular field.
 type SchedulingPolicyDefinition struct {
 	IntervalSeconds snapshot.SourceInfo `json:"intervalSeconds,omitempty"`
 	TimesOfDay      snapshot.SourceInfo `json:"timeOfDay,omitempty"`
+	Cron            snapshot.SourceInfo `json:"cron,omitempty"`
 	Manual          snapshot.SourceInfo `json:"manual,omitempty"`
 }
 
@@ -122,6 +126,24 @@ func (p *SchedulingPolicy) NextSnapshotTime(previousSnapshotTime, now time.Time)
 		}
 	}
 
+	for _, e := range p.Cron {
+		ce, err := cronexpr.Parse(stripCronComment(e))
+		if err != nil {
+			// ignore invalid crontab entries, nothing we can do at this point
+			continue
+		}
+
+		nt := ce.Next(now)
+		if nt.IsZero() {
+			continue
+		}
+
+		if !ok || nt.Before(nextSnapshotTime) {
+			nextSnapshotTime = nt
+			ok = true
+		}
+	}
+
 	return nextSnapshotTime, ok
 }
 
@@ -136,6 +158,8 @@ func (p *SchedulingPolicy) Merge(src SchedulingPolicy, def *SchedulingPolicyDefi
 			p.TimesOfDay = SortAndDedupeTimesOfDay(append(append([]TimeOfDay(nil), src.TimesOfDay...), p.TimesOfDay...))
 		}
 	}
+
+	mergeStringList(&p.Cron, src.Cron, &def.Cron, si)
 
 	if src.NoParentTimesOfDay {
 		// prevent future merges
@@ -177,5 +201,17 @@ func ValidateSchedulingPolicy(p SchedulingPolicy) error {
 		return errors.New("invalid scheduling policy: manual cannot be combined with other scheduling policies")
 	}
 
+	for _, e := range p.Cron {
+		if e2 := stripCronComment(e); e2 != "" {
+			if _, err := cronexpr.Parse(e2); err != nil {
+				return errors.Errorf("invalid cron expression %q", e)
+			}
+		}
+	}
+
 	return nil
+}
+
+func stripCronComment(s string) string {
+	return strings.TrimSpace(strings.Split(s, "#")[0])
 }

--- a/snapshot/policy/scheduling_policy_test.go
+++ b/snapshot/policy/scheduling_policy_test.go
@@ -173,6 +173,26 @@ func TestNextSnapshotTime(t *testing.T) {
 			wantTime:             time.Time{},
 			wantOK:               false,
 		},
+		{
+			pol: policy.SchedulingPolicy{
+				Cron: []string{"0 23 * * *"},
+			},
+			previousSnapshotTime: time.Date(2020, time.January, 1, 19, 0, 0, 0, time.Local),
+			now:                  time.Date(2020, time.January, 1, 10, 0, 0, 0, time.Local),
+			// matches 23:00
+			wantTime: time.Date(2020, time.January, 1, 23, 0, 0, 0, time.Local),
+			wantOK:   true,
+		},
+		{
+			pol: policy.SchedulingPolicy{
+				Cron: []string{"5 3 * Feb Thu"},
+			},
+			previousSnapshotTime: time.Date(2020, time.January, 1, 19, 0, 0, 0, time.Local),
+			now:                  time.Date(2020, time.January, 1, 1, 0, 0, 0, time.Local),
+			// matches next Thursday in February, 3:05
+			wantTime: time.Date(2020, time.February, 6, 3, 5, 0, 0, time.Local),
+			wantOK:   true,
+		},
 	}
 
 	for i, tc := range cases {

--- a/snapshot/policy/scheduling_policy_test.go
+++ b/snapshot/policy/scheduling_policy_test.go
@@ -177,8 +177,7 @@ func TestNextSnapshotTime(t *testing.T) {
 			pol: policy.SchedulingPolicy{
 				Cron: []string{"0 23 * * *"},
 			},
-			previousSnapshotTime: time.Date(2020, time.January, 1, 19, 0, 0, 0, time.Local),
-			now:                  time.Date(2020, time.January, 1, 10, 0, 0, 0, time.Local),
+			now: time.Date(2020, time.January, 1, 10, 0, 0, 0, time.Local),
 			// matches 23:00
 			wantTime: time.Date(2020, time.January, 1, 23, 0, 0, 0, time.Local),
 			wantOK:   true,
@@ -187,8 +186,7 @@ func TestNextSnapshotTime(t *testing.T) {
 			pol: policy.SchedulingPolicy{
 				Cron: []string{"5 3 * Feb Thu"},
 			},
-			previousSnapshotTime: time.Date(2020, time.January, 1, 19, 0, 0, 0, time.Local),
-			now:                  time.Date(2020, time.January, 1, 1, 0, 0, 0, time.Local),
+			now: time.Date(2020, time.January, 1, 1, 0, 0, 0, time.Local),
 			// matches next Thursday in February, 3:05
 			wantTime: time.Date(2020, time.February, 6, 3, 5, 0, 0, time.Local),
 			wantOK:   true,


### PR DESCRIPTION
We use `github.com/hashicorp/cronexpr` to parse and evaluate expressions, as documented in https://github.com/hashicorp/cronexpr#implementation

https://github.com/kopia/htmlui/assets/249880/cde6b575-d077-4a0d-8f43-ff5cd2babde9

Fixes #671
Related #1723