### PR TITLE
chore(infra): run golangci_lint in Go version from go.mod

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,4 @@
 run:
-  go: '1.19'
   skip-dirs:
     - test/testdata_etc
 


### PR DESCRIPTION
Reverts to default behavior from golangci_lint