### PR TITLE
fix(ci): add test for theme selection

### DIFF
--- a/tests/htmlui_e2e_test/htmlui_e2e_test.go
+++ b/tests/htmlui_e2e_test/htmlui_e2e_test.go
@@ -115,13 +115,13 @@ func createTestSnapshot(t *testing.T, ctx context.Context, sp *testutil.ServerPa
 	require.NoError(t, os.WriteFile(filepath.Join(snap1Path, "some-file.txt"), []byte("content"), 0o644))
 	f, err := os.Create(filepath.Join(snap1Path, "big.file"))
 
-	// assert that no error occured
+	// assert that no error occurred
 	assert.Nil(t, err)
 
 	// truncate file to 10 mb
 	err = f.Truncate(1e7)
 
-	// assert that no error occured
+	// assert that no error occurred
 	assert.Nil(t, err)
 
 	// create test repository
@@ -278,7 +278,7 @@ func TestChangeTheme(t *testing.T) {
 			chromedp.Click("a[data-testid='tab-preferences']", chromedp.BySearch),
 
 			chromedp.Nodes("html", &nodes),
-			tc.captureScreenshot("intial-theme"),
+			tc.captureScreenshot("initial-theme"),
 		))
 
 		// ensure we start with light mode
@@ -324,6 +324,9 @@ func TestByteRepresentation(t *testing.T) {
 		repoPath := testutil.TempDirectory(t)
 		snap1Path := testutil.TempDirectory(t)
 
+		var base2 string
+		var base10 string
+
 		// create a test snaphot
 		createTestSnapshot(t, ctx, sp, tc, repoPath, snap1Path)
 
@@ -339,6 +342,8 @@ func TestByteRepresentation(t *testing.T) {
 
 			tc.log("clicking on snapshots tab"),
 			chromedp.Click("a[data-testid='tab-snapshots']", chromedp.BySearch),
+			// getting text from the third column of the first row indicating the size of the snapshot
+			chromedp.Text(`#root > div > table > tbody > tr:nth-child(1) > td:nth-child(3)`, &base2, chromedp.ByQuery),
 			tc.captureScreenshot("snapshot-base-2"),
 
 			tc.log("clicking on preferences tab"),
@@ -350,13 +355,20 @@ func TestByteRepresentation(t *testing.T) {
 
 			tc.log("clicking on snapshots tab"),
 			chromedp.Click("a[data-testid='tab-snapshots']", chromedp.BySearch),
+			// getting text from the third column of the first row indicating the size of the snapshot
+			chromedp.Text(`#root > div > table > tbody > tr:nth-child(1) > td:nth-child(3)`, &base10, chromedp.BySearch),
 			tc.captureScreenshot("snapshot-base-10"),
 		))
+
+		// check result of base-2 representation
+		require.Equal(t, "9.5 MiB", base2, "Expected 9.5 MiB as a result.")
+		// check result of base-10 representation
+		require.Equal(t, "10 MB", base10, "Expected 10 MB as a result.")
 	})
 }
 
 func TestPagination(t *testing.T) {
-	t.Skip("Fix me")
+	t.Skip("Test needs proper ID for pagination button")
 	runInBrowser(t, func(ctx context.Context, sp *testutil.ServerParameters, tc *TestContext) {
 		repoPath := testutil.TempDirectory(t)
 		snap1Path := testutil.TempDirectory(t)

--- a/tests/htmlui_e2e_test/htmlui_e2e_test.go
+++ b/tests/htmlui_e2e_test/htmlui_e2e_test.go
@@ -111,56 +111,77 @@ func runInBrowser(t *testing.T, run func(ctx context.Context, sp *testutil.Serve
 	}
 }
 
+func createTestSnapshot(t *testing.T, ctx context.Context, sp *testutil.ServerParameters, tc *TestContext, repoPath string, snap1Path string) {
+	require.NoError(t, os.WriteFile(filepath.Join(snap1Path, "some-file.txt"), []byte("content"), 0o644))
+	f, err := os.Create(filepath.Join(snap1Path, "big.file"))
+
+	// assert that no error occured
+	assert.Nil(t, err)
+
+	// truncate file to 10 mb
+	err = f.Truncate(1e7)
+
+	// assert that no error occured
+	assert.Nil(t, err)
+
+	// create test repository
+	require.NoError(t, chromedp.Run(ctx,
+		chromedp.Navigate(sp.BaseURL),
+		chromedp.WaitVisible("button[data-testid='provider-filesystem']"),
+		tc.captureScreenshot("initial"),
+
+		tc.log("configuring filesystem provider"),
+		chromedp.Click("button[data-testid='provider-filesystem']"),
+		tc.captureScreenshot("filesystem-setup"),
+
+		tc.log("entering repo path: "+repoPath),
+		chromedp.SendKeys("input[data-testid='control-path']", repoPath+"\n"),
+
+		tc.log("entering password"),
+		chromedp.SendKeys("input[data-testid='control-password']", "password1"),
+		chromedp.SendKeys("input[data-testid='control-confirmPassword']", "password1\n"),
+
+		tc.log("waiting for snapshot list"),
+		chromedp.WaitVisible(`a[data-testid='new-snapshot']`),
+		tc.captureScreenshot("snapshot-list"),
+
+		tc.log("clicking new snapshot"),
+		chromedp.Click(`a[data-testid='new-snapshot']`),
+
+		tc.log("entering path:"+snap1Path),
+		chromedp.SendKeys(`input[name='path']`, snap1Path+"\t"),
+		chromedp.Sleep(2*time.Second),
+
+		tc.log("clicking estimate"),
+		chromedp.Click(`button[data-testid='estimate-now']`),
+		tc.captureScreenshot("estimate-clicked"),
+		chromedp.Sleep(time.Second),
+		tc.captureScreenshot("estimate-1s"),
+
+		tc.log("clicking snapshot now"),
+		chromedp.Click(`button[data-testid='snapshot-now']`),
+		tc.captureScreenshot("snapshot-clicked"),
+
+		chromedp.Navigate(sp.BaseURL),
+		chromedp.Click("a[data-testid='tab-snapshots']"),
+
+		tc.log("waiting for snapshot list"),
+		chromedp.WaitVisible(`a[data-testid='new-snapshot']`),
+		tc.captureScreenshot("snapshot-list"),
+	))
+}
+
 func TestEndToEndTest(t *testing.T) {
 	runInBrowser(t, func(ctx context.Context, sp *testutil.ServerParameters, tc *TestContext) {
 		repoPath := testutil.TempDirectory(t)
 		downloadDir := testutil.TempDirectory(t)
 		snap1Path := testutil.TempDirectory(t)
 
-		require.NoError(t, os.WriteFile(filepath.Join(snap1Path, "some-file.txt"), []byte("content"), 0o644))
+		// create a test snaphot
+		createTestSnapshot(t, ctx, sp, tc, repoPath, snap1Path)
 
 		// navigate to the base page, wait unti we're redirected to 'Repository' page
 		require.NoError(t, chromedp.Run(ctx,
-			chromedp.Navigate(sp.BaseURL),
-			chromedp.WaitVisible("button[data-testid='provider-filesystem']"),
-			tc.captureScreenshot("initial"),
-
-			tc.log("configuring filesystem provider"),
-			chromedp.Click("button[data-testid='provider-filesystem']"),
-			tc.captureScreenshot("filesystem-setup"),
-
-			tc.log("entering repo path: "+repoPath),
-			chromedp.SendKeys("input[data-testid='control-path']", repoPath+"\n"),
-
-			tc.log("entering password"),
-			chromedp.SendKeys("input[data-testid='control-password']", "password1"),
-			chromedp.SendKeys("input[data-testid='control-confirmPassword']", "password1\n"),
-
-			tc.log("waiting for snapshot list"),
-			chromedp.WaitVisible(`a[data-testid='new-snapshot']`),
-			tc.captureScreenshot("snapshot-list"),
-
-			tc.log("clicking new snapshot"),
-			chromedp.Click(`a[data-testid='new-snapshot']`),
-
-			tc.log("entering path:"+snap1Path),
-			chromedp.SendKeys(`input[name='path']`, snap1Path+"\t"),
-			chromedp.Sleep(2*time.Second),
-
-			tc.log("clicking estimate"),
-			chromedp.Click(`button[data-testid='estimate-now']`),
-			tc.captureScreenshot("estimate-clicked"),
-			chromedp.Sleep(time.Second),
-			tc.captureScreenshot("estimate-1s"),
-
-			tc.log("clicking Snapshot Now"),
-			chromedp.Click(`button[data-testid='snapshot-now']`),
-			tc.captureScreenshot("snapshot-clicked"),
-
-			tc.log("waiting for snapshot list"),
-			chromedp.WaitVisible(`a[data-testid='new-snapshot']`),
-			tc.captureScreenshot("snapshot-list"),
-
 			tc.log("clicking on snapshot source"),
 			chromedp.Click(`a[href*='/snapshots/single-source']`),
 			tc.captureScreenshot("snapshot-source"),
@@ -176,7 +197,7 @@ func TestEndToEndTest(t *testing.T) {
 			chromedp.Click(`a[href*='/api/v1/objects/']`),
 			tc.waitForDownload(5*time.Second),
 
-			tc.log("navigating to Repository page"),
+			tc.log("navigating to repository page"),
 			chromedp.Click("a[data-testid='tab-repo']"),
 			tc.captureScreenshot("repository"),
 
@@ -224,7 +245,7 @@ func TestConnectDisconnectReconnect(t *testing.T) {
 			chromedp.WaitVisible(`a[data-testid='new-snapshot']`),
 			tc.captureScreenshot("snapshot-list"),
 
-			tc.log("navigating to Repository page"),
+			tc.log("navigating to repository page"),
 			chromedp.Click("a[data-testid='tab-repo']"),
 			tc.captureScreenshot("repository"),
 
@@ -245,31 +266,102 @@ func TestConnectDisconnectReconnect(t *testing.T) {
 }
 
 func TestChangeTheme(t *testing.T) {
-	t.Skip("fix me")
-
 	runInBrowser(t, func(ctx context.Context, sp *testutil.ServerParameters, tc *TestContext) {
 		var nodes []*cdp.Node
 
 		require.NoError(t, chromedp.Run(ctx,
+			tc.log("navigating to base-url"),
 			chromedp.Navigate(sp.BaseURL),
+			chromedp.WaitVisible("button[data-testid='provider-filesystem']"),
+
+			tc.log("clicking on preference tab"),
+			chromedp.Click("a[data-testid='tab-preferences']", chromedp.BySearch),
+
 			chromedp.Nodes("html", &nodes),
+			tc.captureScreenshot("intial-theme"),
 		))
 
 		// ensure we start with light mode
-		if nodes[0].AttributeValue("class") == "dark" {
+		if nodes[0].AttributeValue("class") != "light" {
 			require.NoError(t, chromedp.Run(ctx,
-				chromedp.Click("button[data-testid='toggle-dark-mode']"),
+				tc.log("selecting light-theme before starting the test"),
+				chromedp.SetValue(`//select[@class="select_theme, form-select form-select-sm"]`, "light", chromedp.BySearch),
 			))
 		}
 
+		// select the theme, wait one second, take screenshot and select next theme
 		require.NoError(t, chromedp.Run(ctx,
 			chromedp.WaitVisible("html.light"),
-			chromedp.Click("button[data-testid='toggle-dark-mode']"),
+			tc.log("selecting pastel theme"),
+			chromedp.SetValue(`//select[@class="select_theme, form-select form-select-sm"]`, "pastel", chromedp.BySearch),
+			chromedp.Sleep(time.Second),
+			chromedp.WaitVisible("html.pastel"),
+			tc.captureScreenshot("theme-pastel"),
+
+			tc.log("selecting dark theme"),
+			chromedp.SetValue(`//select[@class="select_theme, form-select form-select-sm"]`, "dark", chromedp.BySearch),
 			chromedp.WaitVisible("html.dark"),
-			chromedp.Click("button[data-testid='toggle-dark-mode']"),
+			chromedp.Sleep(time.Second),
+			tc.captureScreenshot("theme-dark"),
+
+			tc.log("selecting ocean theme"),
+			chromedp.SetValue(`//select[@class="select_theme, form-select form-select-sm"]`, "ocean", chromedp.BySearch),
+			chromedp.WaitVisible("html.ocean"),
+			chromedp.Sleep(time.Second),
+			tc.captureScreenshot("theme-ocean"),
+
+			tc.log("selecting light theme"),
+			chromedp.SetValue(`//select[@class="select_theme, form-select form-select-sm"]`, "light", chromedp.BySearch),
 			chromedp.WaitVisible("html.light"),
-			chromedp.Click("button[data-testid='toggle-dark-mode']"),
-			chromedp.WaitVisible("html.dark"),
+			chromedp.Sleep(time.Second),
+			tc.captureScreenshot("theme-light"),
 		))
+	})
+}
+
+func TestByteRepresentation(t *testing.T) {
+	runInBrowser(t, func(ctx context.Context, sp *testutil.ServerParameters, tc *TestContext) {
+		repoPath := testutil.TempDirectory(t)
+		snap1Path := testutil.TempDirectory(t)
+
+		// create a test snaphot
+		createTestSnapshot(t, ctx, sp, tc, repoPath, snap1Path)
+
+		// begin test
+		require.NoError(t, chromedp.Run(ctx,
+			tc.log("navigating to preferences tab"),
+			chromedp.Click("a[data-testid='tab-preferences']", chromedp.BySearch),
+			tc.captureScreenshot("initial"),
+
+			tc.log("selecting representation to base-2"),
+			chromedp.SetValue(`//select[@id="bytesBaseInput"]`, "true", chromedp.BySearch),
+			tc.captureScreenshot("base-2"),
+
+			tc.log("clicking on snapshots tab"),
+			chromedp.Click("a[data-testid='tab-snapshots']", chromedp.BySearch),
+			tc.captureScreenshot("snapshot-base-2"),
+
+			tc.log("clicking on preferences tab"),
+			chromedp.Click("a[data-testid='tab-preferences']", chromedp.BySearch),
+
+			tc.log("selecting representation to base-10"),
+			chromedp.SetValue(`//select[@id="bytesBaseInput"]`, "false", chromedp.BySearch),
+			tc.captureScreenshot("base-10"),
+
+			tc.log("clicking on snapshots tab"),
+			chromedp.Click("a[data-testid='tab-snapshots']", chromedp.BySearch),
+			tc.captureScreenshot("snapshot-base-10"),
+		))
+	})
+}
+
+func TestPagination(t *testing.T) {
+	t.Skip("Fix me")
+	runInBrowser(t, func(ctx context.Context, sp *testutil.ServerParameters, tc *TestContext) {
+		repoPath := testutil.TempDirectory(t)
+		snap1Path := testutil.TempDirectory(t)
+
+		// create a test snaphot
+		createTestSnapshot(t, ctx, sp, tc, repoPath, snap1Path)
 	})
 }

--- a/tests/htmlui_e2e_test/htmlui_e2e_test.go
+++ b/tests/htmlui_e2e_test/htmlui_e2e_test.go
@@ -112,7 +112,7 @@ func runInBrowser(t *testing.T, run func(ctx context.Context, sp *testutil.Serve
 }
 
 //nolint:thelper
-func createTestSnapshot(t *testing.T, ctx context.Context, sp *testutil.ServerParameters, tc *TestContext, repoPath string, snap1Path string) {
+func createTestSnapshot(t *testing.T, ctx context.Context, sp *testutil.ServerParameters, tc *TestContext, repoPath, snap1Path string) {
 	require.NoError(t, os.WriteFile(filepath.Join(snap1Path, "some-file.txt"), []byte("content"), 0o644))
 	f, err := os.Create(filepath.Join(snap1Path, "big.file"))
 

--- a/tests/htmlui_e2e_test/htmlui_e2e_test.go
+++ b/tests/htmlui_e2e_test/htmlui_e2e_test.go
@@ -111,6 +111,7 @@ func runInBrowser(t *testing.T, run func(ctx context.Context, sp *testutil.Serve
 	}
 }
 
+//nolint:thelper
 func createTestSnapshot(t *testing.T, ctx context.Context, sp *testutil.ServerParameters, tc *TestContext, repoPath string, snap1Path string) {
 	require.NoError(t, os.WriteFile(filepath.Join(snap1Path, "some-file.txt"), []byte("content"), 0o644))
 	f, err := os.Create(filepath.Join(snap1Path, "big.file"))


### PR DESCRIPTION
Dear all, 

this PR contains:

- Added test for changing themes
- Encapsulated the creation of a test repository in a function
- Added test for changing the byte representation
- Added test for changing the pagination

The PR is currently a draft. While the test for selecting different themes works, the tests for testing pagination and byte representation still needs to be finished. I was not able to extract the text within the cell, where the size of the snapshot is located. 

The idea was to get the size in both byte representations and compare them. 
Feedback is welcomed. 

Cheers, 