### PR TITLE
fix(cli): preserve error exit code when '--json' output is specified

### DIFF
--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -349,10 +349,9 @@ func (c *commandSnapshotCreate) reportSnapshotStatus(ctx context.Context, manife
 
 	if c.jo.jsonOutput {
 		c.out.printStdout("%s\n", c.jo.jsonIndentedBytes(manifest, "  "))
-		return nil
+	} else {
+		log(ctx).Infof("Created%v snapshot with root %v and ID %v in %v", maybePartial, manifest.RootObjectID(), snapID, manifest.EndTime.Sub(manifest.StartTime).Truncate(time.Second))
 	}
-
-	log(ctx).Infof("Created%v snapshot with root %v and ID %v in %v", maybePartial, manifest.RootObjectID(), snapID, manifest.EndTime.Sub(manifest.StartTime).Truncate(time.Second))
 
 	if ds := manifest.RootEntry.DirSummary; ds != nil {
 		if ds.IgnoredErrorCount > 0 {

--- a/tests/end_to_end_test/restore_fail_test.go
+++ b/tests/end_to_end_test/restore_fail_test.go
@@ -51,8 +51,8 @@ func TestRestoreFail(t *testing.T) {
 
 	beforeBlobList := e.RunAndExpectSuccess(t, "blob", "list")
 
-	_, errOut := e.RunAndExpectSuccessWithErrOut(t, "snapshot", "create", sourceDir)
-	parsed := parseSnapshotResult(t, errOut)
+	out, errOut := e.RunAndExpectSuccessWithErrOut(t, "snapshot", "create", sourceDir)
+	parsed := parseSnapshotResultFromLog(t, out, errOut)
 
 	afterBlobList := e.RunAndExpectSuccess(t, "blob", "list")
 

--- a/tests/end_to_end_test/snapshot_fail_test.go
+++ b/tests/end_to_end_test/snapshot_fail_test.go
@@ -76,6 +76,8 @@ func cond(c bool, a, b int) int {
 }
 
 func testSnapshotFailText(t *testing.T, isFailFast bool, snapshotCreateFlags []string, snapshotCreateEnv map[string]string) {
+	t.Helper()
+
 	testSnapshotFail(t, isFailFast, snapshotCreateFlags, snapshotCreateEnv, parseSnapshotResultFromLog)
 }
 


### PR DESCRIPTION
Changes kopia's behavior to match the exit code that would have been returned when the `--json` flag was not specified.

`kopia snapshot create my/path --json` terminates with a 0 status code in cases where
`kopia snapshot create my/path` terminates with a non-zero exit code. One such case is when there are permissions errors reading files or directories to snapshot.

