### PR TITLE
refactor(general): Cleaner error checking in retention tests

### DIFF
--- a/internal/blobtesting/object_locking_map.go
+++ b/internal/blobtesting/object_locking_map.go
@@ -14,6 +14,8 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 )
 
+var ErrBlobLocked = errors.New("cannot alter object before retention period expires")
+
 type entry struct {
 	value          []byte
 	mtime          time.Time
@@ -60,7 +62,7 @@ func (s *objectLockingMap) getLatestForMutationLocked(id blob.ID) (*entry, error
 	}
 
 	if !e.retentionTime.IsZero() && e.retentionTime.After(s.timeNow()) {
-		return nil, errors.New("cannot alter object before retention period expires")
+		return nil, errors.WithStack(ErrBlobLocked)
 	}
 
 	return e, nil

--- a/repo/blob/storage_extend_test.go
+++ b/repo/blob/storage_extend_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/cache"
 	"github.com/kopia/kopia/internal/faketime"
 	"github.com/kopia/kopia/internal/repotesting"
@@ -59,7 +60,7 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetention(t *testing.T) {
 
 	// Verify that file is locked
 	_, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour)
-	assert.EqualErrorf(t, err, "cannot alter object before retention period expires", "Altering locked object should fail")
+	assert.ErrorIs(t, err, blobtesting.ErrBlobLocked, "Altering locked object should fail")
 
 	ta.Advance(7 * 24 * time.Hour)
 
@@ -82,7 +83,7 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetention(t *testing.T) {
 	ta.Advance(1 * time.Hour)
 
 	_, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour)
-	assert.EqualErrorf(t, err, "cannot alter object before retention period expires", "Altering locked object should fail")
+	assert.ErrorIs(t, err, blobtesting.ErrBlobLocked, "Altering locked object should fail")
 
 	ta.Advance(2 * time.Hour)
 

--- a/repo/maintenance/blob_retain_test.go
+++ b/repo/maintenance/blob_retain_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/cache"
@@ -46,9 +47,7 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTime(t *testing.T) {
 	env.RepositoryWriter.Flush(ctx)
 
 	blobsBefore, err := blob.ListAllBlobs(ctx, env.RepositoryWriter.BlobStorage(), "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if got, want := len(blobsBefore), 4; got != want {
 		t.Fatalf("unexpected number of blobs after writing: %v", blobsBefore)
@@ -59,14 +58,12 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTime(t *testing.T) {
 
 	ta.Advance(7 * 24 * time.Hour)
 
-	if _, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour); err != nil {
-		t.Fatalf("Altering expired object failed")
-	}
+	_, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour)
+	require.NoError(t, err, "Altering expired object failed")
 
 	// extend retention time of all blobs
-	if _, err = maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter, maintenance.ExtendBlobRetentionTimeOptions{}); err != nil {
-		t.Fatal(err)
-	}
+	_, err = maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter, maintenance.ExtendBlobRetentionTimeOptions{})
+	require.NoError(t, err)
 
 	_, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour)
 	assert.ErrorIs(t, err, blobtesting.ErrBlobLocked, "Altering locked object should fail")
@@ -96,9 +93,7 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTimeDisabled(t *testing
 	env.RepositoryWriter.Flush(ctx)
 
 	blobsBefore, err := blob.ListAllBlobs(ctx, env.RepositoryWriter.BlobStorage(), "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if got, want := len(blobsBefore), 4; got != want {
 		t.Fatalf("unexpected number of blobs after writing: %v", blobsBefore)
@@ -109,16 +104,13 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTimeDisabled(t *testing
 
 	ta.Advance(7 * 24 * time.Hour)
 
-	if _, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour); err != nil {
-		t.Fatalf("Altering expired object failed")
-	}
+	_, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour)
+	require.NoError(t, err, "Altering expired object failed")
 
 	// extend retention time of all blobs
-	if _, err = maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter, maintenance.ExtendBlobRetentionTimeOptions{}); err != nil {
-		t.Fatal(err)
-	}
+	_, err = maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter, maintenance.ExtendBlobRetentionTimeOptions{})
+	require.NoError(t, err)
 
-	if _, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour); err != nil {
-		t.Fatalf("Altering expired object failed")
-	}
+	_, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour)
+	require.NoError(t, err, "Altering expired object failed")
 }

--- a/repo/maintenance/blob_retain_test.go
+++ b/repo/maintenance/blob_retain_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/cache"
 	"github.com/kopia/kopia/internal/faketime"
 	"github.com/kopia/kopia/internal/repotesting"
@@ -68,7 +69,7 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTime(t *testing.T) {
 	}
 
 	_, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour)
-	assert.EqualErrorf(t, err, "cannot alter object before retention period expires", "Altering locked object should fail")
+	assert.ErrorIs(t, err, blobtesting.ErrBlobLocked, "Altering locked object should fail")
 }
 
 func (s *formatSpecificTestSuite) TestExtendBlobRetentionTimeDisabled(t *testing.T) {


### PR DESCRIPTION
Two minor cleanups for tests around retention:
* define an error and use `assert.ErrorIs` rather than comparing error messages when a blobtesting backend is used
* switch to `require.NoError` instead of an `if err != nil`/`t.Fatal` block