### PR TITLE
fix(ci): avoid hung CI jobs while notarizing the kopia app on MacOS 

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -36,6 +36,7 @@ else
 # notarize.
 unexport CSC_LINK
 unexport CSC_KEY_PASSWORD
+unexport KOPIA_UI_NOTARIZE
 
 endif
 endif

--- a/app/Makefile
+++ b/app/Makefile
@@ -27,18 +27,17 @@ else
 
 # Running as part of a pull_request event on GH, or outside a GH workflow, then
 # don't build installer and don't publish
-ifeq ($(FORCE_KOPIA_UI_SIGN),)
+ifneq ($(FORCE_KOPIA_UI_SIGN),)
+electron_builder_flags+=--dir
+
+else
 
 # unset CSC_LINK completely, otherwise electron builder hangs attempting to
 # notarize.
 unexport CSC_LINK
 unexport CSC_KEY_PASSWORD
 
-else
-electron_builder_flags+=--dir
-
 endif
-
 endif
 
 # empty CSC_LINK, unset completely since empty value confuses electron builder.

--- a/app/Makefile
+++ b/app/Makefile
@@ -25,9 +25,16 @@ endif
 
 else
 
-# not running on Travis, or Travis in PR mode, don't build installer and don't publish
+# Running as part of a pull_request event on GH, or outside a GH workflow, then
+# don't build installer and don't publish
 ifneq ($(FORCE_KOPIA_UI_SIGN),)
 electron_builder_flags+=--dir
+
+# unset CSC_LINK completely, otherwise electron builder hangs attempting to
+# notarize.
+unexport CSC_LINK
+unexport CSC_KEY_PASSWORD
+
 endif
 
 endif

--- a/app/Makefile
+++ b/app/Makefile
@@ -27,13 +27,15 @@ else
 
 # Running as part of a pull_request event on GH, or outside a GH workflow, then
 # don't build installer and don't publish
-ifneq ($(FORCE_KOPIA_UI_SIGN),)
-electron_builder_flags+=--dir
+ifeq ($(FORCE_KOPIA_UI_SIGN),)
 
 # unset CSC_LINK completely, otherwise electron builder hangs attempting to
 # notarize.
 unexport CSC_LINK
 unexport CSC_KEY_PASSWORD
+
+else
+electron_builder_flags+=--dir
 
 endif
 


### PR DESCRIPTION
This happens on PR from branches in the kopia repo.