### PR TITLE
fix(ui): Task summary should show fatal errors

### DIFF
--- a/snapshot/snapshotfs/upload_progress.go
+++ b/snapshot/snapshotfs/upload_progress.go
@@ -257,15 +257,17 @@ func (p *CountingUploadProgress) Snapshot() UploadCounters {
 	defer p.mu.Unlock()
 
 	return UploadCounters{
-		TotalCachedFiles: atomic.LoadInt32(&p.counters.TotalCachedFiles),
-		TotalHashedFiles: atomic.LoadInt32(&p.counters.TotalHashedFiles),
-		TotalCachedBytes: atomic.LoadInt64(&p.counters.TotalCachedBytes),
-		TotalHashedBytes: atomic.LoadInt64(&p.counters.TotalHashedBytes),
-		EstimatedBytes:   atomic.LoadInt64(&p.counters.EstimatedBytes),
-		EstimatedFiles:   atomic.LoadInt32(&p.counters.EstimatedFiles),
-		CurrentDirectory: p.counters.CurrentDirectory,
-		LastErrorPath:    p.counters.LastErrorPath,
-		LastError:        p.counters.LastError,
+		TotalCachedFiles:  atomic.LoadInt32(&p.counters.TotalCachedFiles),
+		TotalHashedFiles:  atomic.LoadInt32(&p.counters.TotalHashedFiles),
+		TotalCachedBytes:  atomic.LoadInt64(&p.counters.TotalCachedBytes),
+		TotalHashedBytes:  atomic.LoadInt64(&p.counters.TotalHashedBytes),
+		EstimatedBytes:    atomic.LoadInt64(&p.counters.EstimatedBytes),
+		EstimatedFiles:    atomic.LoadInt32(&p.counters.EstimatedFiles),
+		IgnoredErrorCount: atomic.LoadInt32(&p.counters.IgnoredErrorCount),
+		FatalErrorCount:   atomic.LoadInt32(&p.counters.FatalErrorCount),
+		CurrentDirectory:  p.counters.CurrentDirectory,
+		LastErrorPath:     p.counters.LastErrorPath,
+		LastError:         p.counters.LastError,
 	}
 }
 
@@ -292,7 +294,7 @@ func (p *CountingUploadProgress) UITaskCounters(final bool) map[string]uitask.Co
 		"Excluded Files":       uitask.SimpleCounter(int64(atomic.LoadInt32(&p.counters.TotalExcludedFiles))),
 		"Excluded Directories": uitask.SimpleCounter(int64(atomic.LoadInt32(&p.counters.TotalExcludedDirs))),
 
-		"Errors": uitask.ErrorCounter(int64(atomic.LoadInt32(&p.counters.IgnoredErrorCount))),
+		"Errors": uitask.ErrorCounter(int64(atomic.LoadInt32(&p.counters.FatalErrorCount))),
 	}
 
 	if !final {


### PR DESCRIPTION
Hi, 

currently, the task summary shows the total number of ignored errors. Since the user is interested in non ignored errors, the summary should show fatal errors (see https://kopia.discourse.group/t/kopiaui-bug-on-log/2171/2)

Fatal errors are already shown when browsing the snapshot (indicated by a warning sign). However, the task summary showed ignored errors causing inconsistencies between both views. 

<img width="410" alt="image" src="https://github.com/kopia/kopia/assets/37236531/9c459e87-06dd-43b9-aa44-1e9dd4afdfda">

<img width="1274" alt="image" src="https://github.com/kopia/kopia/assets/37236531/62eb238e-e392-41e3-a902-f33e756f7a4e">


This PR contains the following fix:

- Store and send the total number of fatal errors

It would also be possible to extend the task summary to show ignored and fatal errors separately.

Feedback is welcomed. 

Cheers, 