### PR TITLE
fix(general): change cache full logging frequency & message

### DIFF
--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -233,7 +233,7 @@ func (c *PersistentCache) Put(ctx context.Context, key string, data gather.Bytes
 		// snapshots/restores from getting affected by the cache's storage use.
 		if c.isCacheFullLocked() {
 			// Limit warnings to one per minute max.
-			if clock.Now().Sub(c.lastCacheWarning) > time.Minute {
+			if clock.Now().Sub(c.lastCacheWarning) > 10*time.Minute {
 				c.lastCacheWarning = clock.Now()
 
 				log(ctx).Warnf("Cache is full, unable to add %v into cache.", key)

--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -236,7 +236,7 @@ func (c *PersistentCache) Put(ctx context.Context, key string, data gather.Bytes
 			if clock.Now().Sub(c.lastCacheWarning) > 10*time.Minute {
 				c.lastCacheWarning = clock.Now()
 
-				log(ctx).Warnf("Cache is full, unable to add %v into cache.", key)
+				log(ctx).Warnf("Cache is full, unable to add item into '%s' cache.", c.description)
 			}
 
 			return


### PR DESCRIPTION
Followups to #3085

Change cache full logging frequency to once every 10 minutes. Addresses concerns about too many messages in the logs in #3085 

Avoid logging cache key. Instead log the cache description, which provides information about the types of contents being cached.
