### PR TITLE
refactor(cli): break down observability.startMetrics()

### DIFF
--- a/cli/observability_flags.go
+++ b/cli/observability_flags.go
@@ -90,23 +90,25 @@ func (c *observabilityFlags) startMetrics(ctx context.Context) error {
 
 // Starts observability listener when a listener address is specified.
 func (c *observabilityFlags) maybeStartListener(ctx context.Context) {
-	if c.metricsListenAddr != "" {
-		m := mux.NewRouter()
-		initPrometheus(m)
-
-		if c.enablePProf {
-			m.HandleFunc("/debug/pprof/", pprof.Index)
-			m.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-			m.HandleFunc("/debug/pprof/profile", pprof.Profile)
-			m.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-			m.HandleFunc("/debug/pprof/trace", pprof.Trace)
-			m.HandleFunc("/debug/pprof/{cmd}", pprof.Index) // special handling for Gorilla mux, see https://stackoverflow.com/questions/30560859/cant-use-go-tool-pprof-with-an-existing-server/71032595#71032595
-		}
-
-		log(ctx).Infof("starting prometheus metrics on %v", c.metricsListenAddr)
-
-		go http.ListenAndServe(c.metricsListenAddr, m) //nolint:errcheck,gosec
+	if c.metricsListenAddr == "" {
+		return
 	}
+
+	m := mux.NewRouter()
+	initPrometheus(m)
+
+	if c.enablePProf {
+		m.HandleFunc("/debug/pprof/", pprof.Index)
+		m.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		m.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		m.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		m.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		m.HandleFunc("/debug/pprof/{cmd}", pprof.Index) // special handling for Gorilla mux, see https://stackoverflow.com/questions/30560859/cant-use-go-tool-pprof-with-an-existing-server/71032595#71032595
+	}
+
+	log(ctx).Infof("starting prometheus metrics on %v", c.metricsListenAddr)
+
+	go http.ListenAndServe(c.metricsListenAddr, m) //nolint:errcheck,gosec
 }
 
 func (c *observabilityFlags) maybeStartMetricsPusher(ctx context.Context) error {

--- a/cli/observability_flags.go
+++ b/cli/observability_flags.go
@@ -150,9 +150,14 @@ func (c *observabilityFlags) maybeStartMetricsPusher(ctx context.Context) error 
 }
 
 func (c *observabilityFlags) maybeStartTraceExporter() error {
-	se, err := c.getSpanExporter()
+	if !c.enableJaeger {
+		return nil
+	}
+
+	// Create the Jaeger exporter
+	se, err := jaeger.New(jaeger.WithCollectorEndpoint())
 	if err != nil {
-		return err
+		return errors.Wrap(err, "unable to create Jaeger exporter")
 	}
 
 	r := resource.NewWithAttributes(
@@ -173,20 +178,6 @@ func (c *observabilityFlags) maybeStartTraceExporter() error {
 	}
 
 	return nil
-}
-
-func (c *observabilityFlags) getSpanExporter() (trace.SpanExporter, error) {
-	if c.enableJaeger {
-		// Create the Jaeger exporter
-		exp, err := jaeger.New(jaeger.WithCollectorEndpoint())
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to create Jaeger exporter")
-		}
-
-		return exp, nil
-	}
-
-	return nil, nil
 }
 
 func (c *observabilityFlags) stopMetrics(ctx context.Context) {

--- a/cli/observability_flags.go
+++ b/cli/observability_flags.go
@@ -160,13 +160,13 @@ func (c *observabilityFlags) maybeStartTraceExporter() error {
 		return errors.Wrap(err, "unable to create Jaeger exporter")
 	}
 
-	r := resource.NewWithAttributes(
-		semconv.SchemaURL,
-		semconv.ServiceNameKey.String("kopia"),
-		semconv.ServiceVersionKey.String(repo.BuildVersion),
-	)
-
 	if se != nil {
+		r := resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceNameKey.String("kopia"),
+			semconv.ServiceVersionKey.String(repo.BuildVersion),
+		)
+
 		tp := trace.NewTracerProvider(
 			trace.WithBatcher(se),
 			trace.WithResource(r),


### PR DESCRIPTION
Motivation: reduce the function complexity for the linter, so additional functionality can be added to `startMetrics()`

No functional changes.

Breaks down `observability.startMetrics()` into:
- `maybeStartListener`
- `maybeStartMetricsPusher`
- `maybeStartTraceExporter`