### PR TITLE
feat(cli): save observability metric before exiting the process

### DIFF
--- a/cli/observability_flags_test.go
+++ b/cli/observability_flags_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync"
 	"testing"
 
@@ -76,4 +77,20 @@ func TestMetricsPushFlags(t *testing.T) {
 		"--metrics-push-addr="+server.URL,
 		"--metrics-push-grouping=a=s",
 	)
+}
+
+func TestMetricsSaveToOutputDirFlags(t *testing.T) {
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+	tmp1 := testutil.TempDirectory(t)
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", tmp1)
+
+	tmp2 := testutil.TempDirectory(t)
+
+	env.RunAndExpectSuccess(t, "repo", "status", "--metrics-directory", tmp2)
+
+	entries, err := os.ReadDir(tmp2)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "a metrics output file should have been created")
 }


### PR DESCRIPTION
Objective: to facilitate capturing metrics for relatively short-lived kopia executions.

Motivation: Currently, kopia allows a. exposing metrics via a Prometheus exporter; and b. pushing metrics to a Prometheus gateway. In certain scenarios, such as short lived executions, it is not possible to reliably scrape the metrics from the exporter endpoint. And, while the pusher approach would work, it requires starting a separate push gateway.

This change allows saving the metrics to a local file before kopia exists by specifying the metrics output directory. For example,

```
kopia --metrics-directory /tmp/kopia-metrics/ snapshot create ....
```

In this case, after kopia exists, the `/tmp/kopia-metrics/` directory will contain a file with a named of the form `<date>-<time>-<command_subcommand>.prom`

