### PR TITLE
fix(infra): add timeout for make.yml build.Build step

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -82,6 +82,7 @@ jobs:
       if: ${{ contains(matrix.os, 'windows') }}
     - name: Build 
       run: make ci-build
+      timeout-minutes: 40
       env:
         # Apple ID and app-specific password for notarizaton, used by Electron Builder
         APPLEID: ${{ secrets.APPLEID }}


### PR DESCRIPTION
Currently, on MacOS, this step hangs when attempting to notarize the newly built binary. The job eventually times out after 360 min.

This is a temporary workaround that will terminate the job sooner to avoid wasting runner cycles. The chose timeout value is ~2x the maximum typical elapsed time for this specific step.
In all platforms this step finishes in less than 20 minutes.

The actual cause of the notarization timeout needs to be investigated.

Ref: #488 #3168 #3175