### PR TITLE
fix(general): cache storage config blob

### DIFF
--- a/repo/format/format_set_parameters.go
+++ b/repo/format/format_set_parameters.go
@@ -38,6 +38,11 @@ func (m *Manager) SetParameters(
 		return errors.Wrap(err, "unable to write blobcfg blob")
 	}
 
+	// At this point the new blobcfg is persisted in the blob layer. Setting this
+	// here also ensures the call below properly sets retention on the kopia
+	// repository blob.
+	m.blobCfgBlob = blobcfg
+
 	if err := m.j.WriteKopiaRepositoryBlob(ctx, m.blobs, m.blobCfgBlob); err != nil {
 		return errors.Wrap(err, "unable to write format blob")
 	}


### PR DESCRIPTION
Fix minor issue with caching the storage blob config blob settings in-memory which could cause other blob PUTs after a reconfiguration to have incorrect settings

Most of PR is tests similar to the retention extension tests to ensure changing repo settings works as expected