### PR TITLE
feat(server): add server support for unix domain sockets

### DIFF
--- a/cli/command_server_control_test.go
+++ b/cli/command_server_control_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -160,6 +161,60 @@ func TestServerControl(t *testing.T) {
 	env.RunAndExpectFailure(t, "server", "flush", "--address", sp.BaseURL, "--server-control-password", sp.ServerControlPassword)
 	env.RunAndExpectFailure(t, "server", "refresh", "--address", sp.BaseURL, "--server-control-password", sp.ServerControlPassword)
 	env.RunAndExpectFailure(t, "server", "shutdown", "--address", sp.BaseURL, "--server-control-password", sp.ServerControlPassword)
+}
+
+func TestServerControlUDS(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+	dir0 := testutil.TempDirectory(t)
+	dir1 := testutil.TempDirectory(t)
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir, "--override-username=another-user", "--override-hostname=another-host")
+	env.RunAndExpectSuccess(t, "snap", "create", dir0)
+
+	env.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", env.RepoDir, "--override-username=test-user", "--override-hostname=test-host")
+
+	serverStarted := make(chan struct{})
+	serverStopped := make(chan struct{})
+
+	var sp testutil.ServerParameters
+
+	go func() {
+		wait, _ := env.RunAndProcessStderr(t, sp.ProcessOutput,
+			"server", "start", "--insecure", "--random-server-control-password", "--address="+"unix:"+dir1+"/sock")
+
+		close(serverStarted)
+
+		wait()
+
+		close(serverStopped)
+	}()
+
+	select {
+	case <-serverStarted:
+		t.Logf("server started on %v", sp.BaseURL)
+
+	case <-time.After(5 * time.Second):
+		t.Fatalf("server did not start in time")
+	}
+
+	lines := env.RunAndExpectSuccess(t, "server", "status", "--address", sp.BaseURL, "--server-control-password", sp.ServerControlPassword, "--remote")
+	require.Len(t, lines, 1)
+	require.Contains(t, lines, "REMOTE: another-user@another-host:"+dir0)
+
+	env.RunAndExpectSuccess(t, "server", "shutdown", "--address", sp.BaseURL, "--server-control-password", sp.ServerControlPassword)
+
+	select {
+	case <-serverStopped:
+		t.Logf("server shut down")
+
+	case <-time.After(15 * time.Second):
+		t.Fatalf("server did not shutdown in time")
+	}
 }
 
 func hasLine(lines []string, lookFor string) bool {

--- a/cli/command_server_control_test.go
+++ b/cli/command_server_control_test.go
@@ -171,7 +171,8 @@ func TestServerControlUDS(t *testing.T) {
 	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
 
 	dir0 := testutil.TempDirectory(t)
-	dir1 := testutil.TempDirectory(t)
+	// the socket path must be < 108 bytes (linux) or 104 bytes (Mac), so can't use long tempdir
+	dir1 := testutil.TempDirectoryShort(t)
 
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir, "--override-username=another-user", "--override-hostname=another-host")
 	env.RunAndExpectSuccess(t, "snap", "create", dir0)

--- a/cli/command_server_tls.go
+++ b/cli/command_server_tls.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -34,7 +35,16 @@ func (c *commandServerStart) generateServerCertificate(ctx context.Context) (*x5
 }
 
 func (c *commandServerStart) startServerWithOptionalTLS(ctx context.Context, httpServer *http.Server) error {
-	l, err := net.Listen("tcp", httpServer.Addr)
+	var l net.Listener
+
+	var err error
+
+	if strings.HasPrefix(httpServer.Addr, "unix:") {
+		l, err = net.Listen("unix", strings.TrimPrefix(httpServer.Addr, "unix:"))
+	} else {
+		l, err = net.Listen("tcp", httpServer.Addr)
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "listen error")
 	}
@@ -86,10 +96,15 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 		return err
 	}
 
+	udsPfx := ""
+	if listener.Addr().Network() == "unix" {
+		udsPfx = "unix+"
+	}
+
 	switch {
 	case c.serverStartTLSCertFile != "" && c.serverStartTLSKeyFile != "":
 		// PEM files provided
-		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: https://%v\n", httpServer.Addr)
+		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttps://%v\n", udsPfx, httpServer.Addr)
 		c.showServerUIPrompt(ctx)
 
 		return errors.Wrap(httpServer.ServeTLS(listener, c.serverStartTLSCertFile, c.serverStartTLSKeyFile), "error starting TLS server")
@@ -125,7 +140,7 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 			fmt.Fprintf(c.out.stderr(), "SERVER CERTIFICATE: %v\n", base64.StdEncoding.EncodeToString(b.Bytes()))
 		}
 
-		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: https://%v\n", httpServer.Addr)
+		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttps://%v\n", udsPfx, httpServer.Addr)
 		c.showServerUIPrompt(ctx)
 
 		return errors.Wrap(httpServer.ServeTLS(listener, "", ""), "error starting TLS server")
@@ -135,7 +150,7 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 			return errors.Errorf("TLS not configured. To start server without encryption pass --insecure")
 		}
 
-		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: http://%v\n", httpServer.Addr)
+		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttp://%v\n", udsPfx, httpServer.Addr)
 		c.showServerUIPrompt(ctx)
 
 		return errors.Wrap(httpServer.Serve(listener), "error starting server")

--- a/internal/testutil/tmpdir.go
+++ b/internal/testutil/tmpdir.go
@@ -68,6 +68,27 @@ func TempDirectory(tb testing.TB) string {
 	return d
 }
 
+// TempDirectoryShort returns a short temporary directory and cleans it up before test
+// completes.
+func TempDirectoryShort(tb testing.TB) string {
+	tb.Helper()
+
+	d, err := os.MkdirTemp("", "kopia-test")
+	if err != nil {
+		tb.Fatal(errors.Wrap(err, "unable to create temp directory"))
+	}
+
+	tb.Cleanup(func() {
+		if !tb.Failed() {
+			os.RemoveAll(d) //nolint:errcheck
+		} else {
+			tb.Logf("temporary files left in %v", d)
+		}
+	})
+
+	return d
+}
+
 // TempLogDirectory returns a temporary directory used for storing logs.
 // If KOPIA_LOGS_DIR is provided.
 func TempLogDirectory(t *testing.T) string {

--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -806,12 +806,17 @@ func openGRPCAPIRepository(ctx context.Context, si *APIServerInfo, password stri
 		return nil, errors.Wrap(err, "unable to parse server URL")
 	}
 
-	if u.Scheme != "kopia" && u.Scheme != "https" {
-		return nil, errors.Errorf("invalid server address, must be 'https://host:port'")
+	if u.Scheme != "kopia" && u.Scheme != "https" && u.Scheme != "unix+https" {
+		return nil, errors.Errorf("invalid server address, must be 'https://host:port' or 'unix+https://<path>")
+	}
+
+	uri := u.Hostname() + ":" + u.Port()
+	if u.Scheme == "unix+https" {
+		uri = "unix:" + u.Path
 	}
 
 	conn, err := grpc.Dial(
-		u.Hostname()+":"+u.Port(),
+		uri,
 		grpc.WithPerRPCCredentials(grpcCreds{par.cliOpts.Hostname, par.cliOpts.Username, password}),
 		grpc.WithTransportCredentials(transportCreds),
 		grpc.WithDefaultCallOptions(

--- a/site/content/docs/Repository Server/_index.md
+++ b/site/content/docs/Repository Server/_index.md
@@ -296,3 +296,29 @@ kopia server start --address 0.0.0.0:51515 --tls-cert-file ~/my.cert --tls-key-f
 ```
 
 You can now connect to your kopia server via reverse proxy with your domain: `mydomain.com:443`.
+
+Alternatively here is an example nginx/kopia configuration using unix domain sockets:
+
+```shell
+
+upstream socket {
+    server unix:///tmp/kopia.sock;
+}
+server {
+  listen 443 ssl http2;
+  server_name mydomain.com;
+
+  ssl_certificate_key /path/to/your/key.key;
+  ssl_certificate /path/to/your/cert.crt;
+
+  client_max_body_size 0;  # Allow unlimited upload size
+
+  location / {
+   grpc_pass grpcs://socket; # Adapt if your kopia is running on another server
+  }
+}
+```
+
+```shell
+kopia server start --address unix:/tmp/kopia.sock --tls-cert-file ~/my.cert --tls-key-file ~/my.key
+```


### PR DESCRIPTION
Enable using unix domain sockets with kopia server.

unix sockets can be useful to allow connecting services without going throgh the network interface.  They tend to be faster than using tcp sockets, and can be restricted via file-access permissions.

I'm using unix sockets in a container solution using rootless containers with networking disabled via podman + systemd socket-activated-sockets.  This means that the reverse-proxy (nginx) doesn't need any network interface, as it speaks to the outside world through a socket-activated-socket, and speaks to other services via unix sockets.

The patch also implements the ability to use unixsockets for client connections, but  I'm not sure what the use of that is other than enabling testing

