### PR TITLE
test(repository): More precise check for retention in tests

### DIFF
--- a/internal/blobtesting/object_locking_map.go
+++ b/internal/blobtesting/object_locking_map.go
@@ -213,8 +213,11 @@ func (s *objectLockingMap) ExtendBlobRetention(ctx context.Context, id blob.ID, 
 		return blob.ErrBlobNotFound
 	}
 
-	// Use the clock instead of mtime since that aligns with how the S3 blob
-	// storage acts.
+	// Update the retention time from now to the given retention period in the
+	// future. Note that we do not bump the existing time on the element `e.mtime`
+	// by the given delta because we'd like to align with the S3 storage's current
+	// time and the S3 storage code extends retention periods based off the
+	// current time, not object mod time.
 	if !e.retentionTime.IsZero() {
 		e.retentionTime = s.timeNow().Add(opts.RetentionPeriod)
 	}

--- a/internal/blobtesting/object_locking_map.go
+++ b/internal/blobtesting/object_locking_map.go
@@ -20,6 +20,7 @@ type entry struct {
 	value          []byte
 	mtime          time.Time
 	retentionTime  time.Time
+	retentionMode  blob.RetentionMode
 	isDeleteMarker bool
 }
 
@@ -129,6 +130,18 @@ func (s *objectLockingMap) GetMetadata(ctx context.Context, id blob.ID) (blob.Me
 	}, nil
 }
 
+func (s *objectLockingMap) GetRetention(ctx context.Context, id blob.ID) (blob.RetentionMode, time.Time, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	e, err := s.getLatestByID(id)
+	if err != nil {
+		return "", time.Time{}, errors.Wrap(err, "getting blob")
+	}
+
+	return e.retentionMode, e.retentionTime, nil
+}
+
 // PutBlob works the same as map-storage PutBlob except that if the latest
 // version is a delete-marker then it will return ErrBlobNotFound. The
 // PutOptions retention parameters will be respected when storing the object.
@@ -153,6 +166,7 @@ func (s *objectLockingMap) PutBlob(ctx context.Context, id blob.ID, data blob.By
 
 	if opts.HasRetentionOptions() {
 		e.retentionTime = e.mtime.Add(opts.RetentionPeriod)
+		e.retentionMode = opts.RetentionMode
 	}
 
 	s.data[id] = append(s.data[id], e)
@@ -293,7 +307,7 @@ func (s *objectLockingMap) FlushCaches(ctx context.Context) error {
 
 // NewVersionedMapStorage returns an implementation of Storage backed by the
 // contents of an internal in-memory map used primarily for testing.
-func NewVersionedMapStorage(timeNow func() time.Time) blob.Storage {
+func NewVersionedMapStorage(timeNow func() time.Time) RetentionStorage {
 	if timeNow == nil {
 		timeNow = clock.Now
 	}

--- a/internal/blobtesting/object_locking_map.go
+++ b/internal/blobtesting/object_locking_map.go
@@ -213,8 +213,10 @@ func (s *objectLockingMap) ExtendBlobRetention(ctx context.Context, id blob.ID, 
 		return blob.ErrBlobNotFound
 	}
 
+	// Use the clock instead of mtime since that aligns with how the S3 blob
+	// storage acts.
 	if !e.retentionTime.IsZero() {
-		e.retentionTime = e.mtime.Add(opts.RetentionPeriod)
+		e.retentionTime = s.timeNow().Add(opts.RetentionPeriod)
 	}
 
 	return nil

--- a/internal/blobtesting/storage.go
+++ b/internal/blobtesting/storage.go
@@ -1,0 +1,17 @@
+package blobtesting
+
+import (
+	"context"
+	"time"
+
+	"github.com/kopia/kopia/repo/blob"
+)
+
+// RetentionStorage allows for better testing of retention and object
+// locking-related code by allowing callers to get the retention parameters of
+// the blob and attempt "modifying" the blob with TouchBlob.
+type RetentionStorage interface {
+	blob.Storage
+	TouchBlob(ctx context.Context, id blob.ID, threshold time.Duration) (time.Time, error)
+	GetRetention(context.Context, blob.ID) (blob.RetentionMode, time.Time, error)
+}

--- a/repo/maintenance/blob_retain_test.go
+++ b/repo/maintenance/blob_retain_test.go
@@ -113,7 +113,7 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTimeDisabled(t *testing
 	}
 
 	// Need to continue using TouchBlob because the environment only supports the
-	// locking map if a retention time is given.
+	// locking map if no retention time is given.
 	lastBlobIdx := len(blobsBefore) - 1
 	st := env.RootStorage().(cache.Storage)
 

--- a/repo/maintenance/blob_retain_test.go
+++ b/repo/maintenance/blob_retain_test.go
@@ -22,9 +22,13 @@ import (
 const blockFormatHash = "HMAC-SHA256"
 
 func (s *formatSpecificTestSuite) TestExtendBlobRetentionTime(t *testing.T) {
+	mode := blob.Governance
+	period := time.Hour * 24
+
 	// set up fake clock which is initially synchronized to wall clock time
 	// and moved at the same speed but which can be moved forward.
 	ta := faketime.NewClockTimeWithOffset(0)
+	earliestExpiry := ta.NowFunc()().Add(period)
 
 	ctx, env := repotesting.NewEnvironment(t, s.formatVersion, repotesting.Options{
 		OpenOptions: func(o *repo.Options) {
@@ -35,8 +39,8 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTime(t *testing.T) {
 			nro.BlockFormat.MasterKey = testMasterKey
 			nro.BlockFormat.Hash = blockFormatHash
 			nro.BlockFormat.HMACSecret = testHMACSecret
-			nro.RetentionMode = blob.Governance
-			nro.RetentionPeriod = time.Hour * 24
+			nro.RetentionMode = mode
+			nro.RetentionPeriod = period
 		},
 	})
 	w := env.RepositoryWriter.NewObjectWriter(ctx, object.WriterOptions{})
@@ -54,19 +58,28 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTime(t *testing.T) {
 	}
 
 	lastBlobIdx := len(blobsBefore) - 1
-	st := env.RootStorage().(cache.Storage)
+	st := env.RootStorage().(blobtesting.RetentionStorage)
 
+	gotMode, expiry, err := st.GetRetention(ctx, blobsBefore[lastBlobIdx].BlobID)
+	require.NoError(t, err, "getting blob retention info")
+
+	assert.Equal(t, mode, gotMode)
+	assert.WithinDuration(t, earliestExpiry, expiry, time.Minute)
+
+	// Advance the clock and get a new earliestExpiry so we can attempt extending
+	// retention and then check our blob again.
 	ta.Advance(7 * 24 * time.Hour)
-
-	_, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour)
-	require.NoError(t, err, "Altering expired object failed")
+	earliestExpiry = ta.NowFunc()().Add(period)
 
 	// extend retention time of all blobs
 	_, err = maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter, maintenance.ExtendBlobRetentionTimeOptions{})
 	require.NoError(t, err)
 
-	_, err = st.TouchBlob(ctx, blobsBefore[lastBlobIdx].BlobID, time.Hour)
-	assert.ErrorIs(t, err, blobtesting.ErrBlobLocked, "Altering locked object should fail")
+	gotMode, expiry, err = st.GetRetention(ctx, blobsBefore[lastBlobIdx].BlobID)
+	require.NoError(t, err, "getting blob retention info")
+
+	assert.Equal(t, mode, gotMode)
+	assert.WithinDuration(t, earliestExpiry, expiry, time.Minute)
 }
 
 func (s *formatSpecificTestSuite) TestExtendBlobRetentionTimeDisabled(t *testing.T) {
@@ -99,6 +112,8 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTimeDisabled(t *testing
 		t.Fatalf("unexpected number of blobs after writing: %v", blobsBefore)
 	}
 
+	// Need to continue using TouchBlob because the environment only supports the
+	// locking map if a retention time is given.
 	lastBlobIdx := len(blobsBefore) - 1
 	st := env.RootStorage().(cache.Storage)
 


### PR DESCRIPTION
Store and return information about retention in the blobtesting storage used for retention tests. This allows more precise checks on when a blob expires and the retention mode applied to the blob

closes #3218