### PR TITLE
fix(repository): Disable manifest manager compaction when in read-only mode

### DIFF
--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -112,6 +112,12 @@ type SharedManager struct {
 	metricsStruct
 }
 
+// IsReadOnly returns whether this instance of the SharedManager only supports
+// reads or if it also supports mutations to the index.
+func (sm *SharedManager) IsReadOnly() bool {
+	return sm.st.IsReadOnly()
+}
+
 // LoadIndexBlob return index information loaded from the specified blob.
 func (sm *SharedManager) LoadIndexBlob(ctx context.Context, ibid blob.ID, d *gather.WriteBuffer) ([]Info, error) {
 	err := sm.st.GetBlob(ctx, ibid, 0, -1, d)

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -357,7 +357,7 @@ func loadManifestContent(ctx context.Context, b contentManager, contentID conten
 	return man, errors.Wrapf(err, "unable to parse manifest %q", contentID)
 }
 
-func newCommittedManager(b contentManager, readOnly bool) *committedManifestManager {
+func newCommittedManager(b contentManager) *committedManifestManager {
 	debugID := ""
 	if os.Getenv("KOPIA_DEBUG_MANIFEST_MANAGER") != "" {
 		debugID = fmt.Sprintf("%x", rand.Int63()) //nolint:gosec
@@ -368,6 +368,5 @@ func newCommittedManager(b contentManager, readOnly bool) *committedManifestMana
 		debugID:             debugID,
 		committedEntries:    map[ID]*manifestEntry{},
 		committedContentIDs: map[content.ID]bool{},
-		readOnly:            readOnly,
 	}
 }

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -33,13 +33,6 @@ type committedManifestManager struct {
 	committedEntries map[ID]*manifestEntry
 	// +checklocks:cmmu
 	committedContentIDs map[content.ID]bool
-
-	// readOnly denotes whether this instance of the manifest manager only
-	// supports reads or supports reads and writes. This is important because the
-	// manifest manager attempts to compact manifest blobs automatically, and that
-	// may not be possible if kopia was opened at a specific point in time (i.e.
-	// S3 object locking/versioned bucket with --point-in-time flag).
-	readOnly bool
 }
 
 func (m *committedManifestManager) getCommittedEntryOrNil(ctx context.Context, id ID) (*manifestEntry, error) {
@@ -225,7 +218,7 @@ func (m *committedManifestManager) maybeCompactLocked(ctx context.Context) error
 
 	// Don't attempt to compact manifests if the repo was opened in read only mode
 	// since we'll just end up failing.
-	if m.readOnly || len(m.committedContentIDs) < autoCompactionContentCount {
+	if m.b.IsReadOnly() || len(m.committedContentIDs) < autoCompactionContentCount {
 		return nil
 	}
 

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -48,6 +48,7 @@ type contentManager interface {
 	DisableIndexFlush(ctx context.Context)
 	EnableIndexFlush(ctx context.Context)
 	Flush(ctx context.Context) error
+	IsReadOnly() bool
 }
 
 // ID is a unique identifier of a single manifest.

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -263,7 +263,8 @@ func copyLabels(m map[string]string) map[string]string {
 
 // ManagerOptions are optional parameters for Manager creation.
 type ManagerOptions struct {
-	TimeNow func() time.Time // Time provider
+	TimeNow  func() time.Time // Time provider
+	ReadOnly bool
 }
 
 // NewManager returns new manifest manager for the provided content manager.
@@ -279,7 +280,7 @@ func NewManager(ctx context.Context, b contentManager, options ManagerOptions, m
 		b:              b,
 		pendingEntries: map[ID]*manifestEntry{},
 		timeNow:        timeNow,
-		committed:      newCommittedManager(b),
+		committed:      newCommittedManager(b, options.ReadOnly),
 	}
 
 	return m, nil

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -264,8 +264,7 @@ func copyLabels(m map[string]string) map[string]string {
 
 // ManagerOptions are optional parameters for Manager creation.
 type ManagerOptions struct {
-	TimeNow  func() time.Time // Time provider
-	ReadOnly bool
+	TimeNow func() time.Time // Time provider
 }
 
 // NewManager returns new manifest manager for the provided content manager.
@@ -281,7 +280,7 @@ func NewManager(ctx context.Context, b contentManager, options ManagerOptions, m
 		b:              b,
 		pendingEntries: map[ID]*manifestEntry{},
 		timeNow:        timeNow,
-		committed:      newCommittedManager(b, options.ReadOnly),
+		committed:      newCommittedManager(b),
 	}
 
 	return m, nil

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -10,11 +10,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/blob/readonly"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/content/index"
 	"github.com/kopia/kopia/repo/encryption"
@@ -306,10 +308,14 @@ func sortIDs(s []ID) {
 	})
 }
 
-func newManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.DataMap) *Manager {
+func newContentManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.DataMap, readOnly bool) contentManager {
 	t.Helper()
 
 	st := blobtesting.NewMapStorage(data, nil, nil)
+
+	if readOnly {
+		st = readonly.NewWrapper(st)
+	}
 
 	fop, err := format.NewFormattingOptionsProvider(&format.ContentFormat{
 		Hash:       hashing.DefaultAlgorithm,
@@ -326,6 +332,14 @@ func newManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.Da
 	require.NoError(t, err)
 
 	t.Cleanup(func() { bm.CloseShared(ctx) })
+
+	return bm
+}
+
+func newManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.DataMap) *Manager {
+	t.Helper()
+
+	bm := newContentManagerForTesting(ctx, t, data, false)
 
 	mm, err := NewManager(ctx, bm, ManagerOptions{}, nil)
 	require.NoError(t, err)
@@ -380,4 +394,35 @@ func TestManifestAutoCompaction(t *testing.T) {
 		require.NoError(t, mgr.Flush(ctx))
 		require.NoError(t, mgr.b.Flush(ctx))
 	}
+}
+
+func TestManifestAutoCompactionWithReadOnly(t *testing.T) {
+	ctx := testlogging.Context(t)
+	data := blobtesting.DataMap{}
+
+	bm := newContentManagerForTesting(ctx, t, data, false)
+
+	mgr, err := NewManager(ctx, bm, ManagerOptions{}, nil)
+	require.NoError(t, err, "getting initial manifest manager")
+
+	for i := 0; i < 100; i++ {
+		item1 := map[string]int{"foo": 1, "bar": 2}
+		labels1 := map[string]string{"type": "item", "color": "red"}
+
+		_, err = mgr.Put(ctx, labels1, item1)
+		require.NoError(t, err, "adding item to manifest manager")
+
+		require.NoError(t, mgr.Flush(ctx))
+		require.NoError(t, mgr.b.Flush(ctx))
+	}
+
+	// Opening another instance of the manager should cause the manifest manager
+	// to attempt to compact things.
+	bm = newContentManagerForTesting(ctx, t, data, true)
+
+	mgr, err = NewManager(ctx, bm, ManagerOptions{ReadOnly: true}, nil)
+	require.NoError(t, err, "getting other instance of manifest manager")
+
+	_, err = mgr.Find(ctx, map[string]string{"color": "red"})
+	assert.NoError(t, err, "forcing reload of manifest manager")
 }

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -420,7 +420,7 @@ func TestManifestAutoCompactionWithReadOnly(t *testing.T) {
 	// to attempt to compact things.
 	bm = newContentManagerForTesting(ctx, t, data, true)
 
-	mgr, err = NewManager(ctx, bm, ManagerOptions{ReadOnly: true}, nil)
+	mgr, err = NewManager(ctx, bm, ManagerOptions{}, nil)
 	require.NoError(t, err, "getting other instance of manifest manager")
 
 	_, err = mgr.Find(ctx, map[string]string{"color": "red"})

--- a/repo/open.go
+++ b/repo/open.go
@@ -335,7 +335,7 @@ func openWithConfig(ctx context.Context, st blob.Storage, cliOpts ClientOptions,
 		return nil, errors.Wrap(ferr, "unable to open object manager")
 	}
 
-	manifests, ferr := manifest.NewManager(ctx, cm, manifest.ManagerOptions{TimeNow: cmOpts.TimeNow, ReadOnly: cliOpts.ReadOnly}, mr)
+	manifests, ferr := manifest.NewManager(ctx, cm, manifest.ManagerOptions{TimeNow: cmOpts.TimeNow}, mr)
 	if ferr != nil {
 		return nil, errors.Wrap(ferr, "unable to open manifests")
 	}

--- a/repo/open.go
+++ b/repo/open.go
@@ -335,7 +335,7 @@ func openWithConfig(ctx context.Context, st blob.Storage, cliOpts ClientOptions,
 		return nil, errors.Wrap(ferr, "unable to open object manager")
 	}
 
-	manifests, ferr := manifest.NewManager(ctx, cm, manifest.ManagerOptions{TimeNow: cmOpts.TimeNow}, mr)
+	manifests, ferr := manifest.NewManager(ctx, cm, manifest.ManagerOptions{TimeNow: cmOpts.TimeNow, ReadOnly: cliOpts.ReadOnly}, mr)
 	if ferr != nil {
 		return nil, errors.Wrap(ferr, "unable to open manifests")
 	}


### PR DESCRIPTION
Add a new field to the manifest manager that denotes whether it should act in read-only mode or not. The main difference between read-only and normal modes for the manager is that manifest compaction is disabled in read-only mode

This allows kopia to successfully read manifest information in the repo when either the repo was opened in read-only mode or the repo uses a versioned S3 bucket and was opened at a specific point in time with the `--point-in-time` flag

The value of this new field is taken from the local client options `ReadOnly` parameter. Client options can be provided during `repository.Open` calls to kopia giving the user control over this if needed

closes #3219