### PR TITLE
feat(providers): improve performance of SFTP uploads

### DIFF
--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -174,3 +174,8 @@ func (b *WriteBuffer) Dup() *WriteBuffer {
 func NewWriteBuffer() *WriteBuffer {
 	return &WriteBuffer{}
 }
+
+// NewWriteBufferMaxContiguous creates new write buffer that will allocate large chunks.
+func NewWriteBufferMaxContiguous() *WriteBuffer {
+	return &WriteBuffer{alloc: maxContiguousAllocator}
+}

--- a/internal/gather/gather_write_buffer_test.go
+++ b/internal/gather/gather_write_buffer_test.go
@@ -107,3 +107,24 @@ func TestGatherWriteBufferAllocatorSelector(t *testing.T) {
 	w.MakeContiguous(maxContiguousAllocator.chunkSize + 1)
 	require.Nil(t, w.alloc)
 }
+
+func TestGatherWriteBufferMax(t *testing.T) {
+	b := NewWriteBufferMaxContiguous()
+	defer b.Close()
+
+	// write 1Mx5 bytes
+	for i := 0; i < 1000000; i++ {
+		b.Append([]byte("hello"))
+	}
+
+	// make sure we have 1 contiguous buffer
+	require.Equal(t, 1, len(b.Bytes().Slices))
+
+	// write 10Mx5 bytes
+	for i := 0; i < 10000000; i++ {
+		b.Append([]byte("hello"))
+	}
+
+	// 51M requires 4x16MB buffers
+	require.Equal(t, 4, len(b.Bytes().Slices))
+}

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/kopia/kopia/internal/connection"
 	"github.com/kopia/kopia/internal/dirutil"
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/ospath"
 	"github.com/kopia/kopia/repo/blob"
@@ -194,6 +195,16 @@ func (s *sftpImpl) PutBlobInPath(ctx context.Context, dirPath, fullPath string, 
 		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "do-not-recreate")
 	}
 
+	// SFTP client Write() does not do any buffering leading to sub-optimal
+	// performance of gather writes, so we copy the data to a contiguous
+	// temporary buffer first.
+	contig := gather.NewWriteBufferMaxContiguous()
+	defer contig.Close()
+
+	if _, err := data.WriteTo(contig); err != nil {
+		return errors.Wrap(err, "can't write to comtiguous buffer")
+	}
+
 	//nolint:wrapcheck
 	return s.rec.UsingConnectionNoResult(ctx, "PutBlobInPath", func(conn connection.Connection) error {
 		randSuffix := make([]byte, tempFileRandomSuffixLen)
@@ -208,7 +219,7 @@ func (s *sftpImpl) PutBlobInPath(ctx context.Context, dirPath, fullPath string, 
 			return errors.Wrap(err, "cannot create temporary file")
 		}
 
-		if _, err = data.WriteTo(f); err != nil {
+		if _, err = contig.Bytes().WriteTo(f); err != nil {
 			return errors.Wrap(err, "can't write temporary file")
 		}
 


### PR DESCRIPTION
This improves the performance of gather writes (p and q blobs) in particular on high-latency links by reducing round-trips.

Tested by uploading Kopia working directory
(3 GB, files:32157 dirs:6051) to SFTP server on LAN (TrueNAS) over WiFi:

Before: 2m4s (~24 MB/s)
After: 1m13s (~41 MB/s)