### PR TITLE
feat(repository): added hard size limit to the on-disk cache

### DIFF
--- a/cli/command_cache_info.go
+++ b/cli/command_cache_info.go
@@ -46,10 +46,16 @@ func (c *commandCacheInfo) run(ctx context.Context, _ repo.Repository) error {
 		return errors.Wrap(err, "unable to scan cache directory")
 	}
 
-	path2Limit := map[string]int64{
+	path2SoftLimit := map[string]int64{
 		"contents":        opts.MaxCacheSizeBytes,
 		"metadata":        opts.MaxMetadataCacheSizeBytes,
 		"server-contents": opts.MaxCacheSizeBytes,
+	}
+
+	path2HardLimit := map[string]int64{
+		"contents":        opts.ContentCacheSizeLimitBytes,
+		"metadata":        opts.MetadataCacheSizeLimitBytes,
+		"server-contents": opts.ContentCacheSizeLimitBytes,
 	}
 
 	path2SweepAgeSeconds := map[string]time.Duration{
@@ -72,12 +78,24 @@ func (c *commandCacheInfo) run(ctx context.Context, _ repo.Repository) error {
 		}
 
 		maybeLimit := ""
-		if l, ok := path2Limit[ent.Name()]; ok {
-			maybeLimit = fmt.Sprintf(" (limit %v, min sweep age %v)", units.BytesString(l), path2SweepAgeSeconds[ent.Name()])
+
+		if l, ok := path2SoftLimit[ent.Name()]; ok {
+			var hardLimit string
+
+			if hl := path2HardLimit[ent.Name()]; hl > 0 {
+				hardLimit = units.BytesString(hl)
+			} else {
+				hardLimit = "none"
+			}
+
+			maybeLimit = fmt.Sprintf(" (soft limit: %v, hard limit: %v, min sweep age: %v)",
+				units.BytesString(l),
+				hardLimit,
+				path2SweepAgeSeconds[ent.Name()])
 		}
 
 		if ent.Name() == "blob-list" {
-			maybeLimit = fmt.Sprintf(" (duration %v)", opts.MaxListCacheDuration.DurationOrDefault(0))
+			maybeLimit = fmt.Sprintf(" (duration: %v)", opts.MaxListCacheDuration.DurationOrDefault(0))
 		}
 
 		c.out.printStdout("%v: %v files %v%v\n", subdir, fileCount, units.BytesString(totalFileSize), maybeLimit)

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -25,10 +25,21 @@ type mapStorage struct {
 	keyTime map[blob.ID]time.Time
 	// +checklocks:mutex
 	timeNow func() time.Time
-	mutex   sync.RWMutex
+	// +checklocks:mutex
+	totalBytes int64
+	// +checklocks:mutex
+	limit int64
+	mutex sync.RWMutex
 }
 
 func (s *mapStorage) GetCapacity(ctx context.Context) (blob.Capacity, error) {
+	if s.limit >= 0 {
+		return blob.Capacity{
+			SizeB: uint64(s.limit),
+			FreeB: uint64(s.limit - s.totalBytes),
+		}, nil
+	}
+
 	return blob.Capacity{}, blob.ErrNotAVolume
 }
 
@@ -104,7 +115,13 @@ func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, o
 
 	data.WriteTo(&b)
 
+	if s.limit >= 0 && s.totalBytes+int64(b.Len()) > s.limit {
+		return errors.Errorf("exceeded limit, unable to add %v bytes, currently using %v/%v", b.Len(), s.totalBytes, s.limit)
+	}
+
+	s.totalBytes -= int64(len(s.data[id]))
 	s.data[id] = b.Bytes()
+	s.totalBytes += int64(b.Len())
 
 	if opts.GetModTime != nil {
 		*opts.GetModTime = s.keyTime[id]
@@ -117,6 +134,7 @@ func (s *mapStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	s.totalBytes -= int64(len(s.data[id]))
 	delete(s.data, id)
 	delete(s.keyTime, id)
 
@@ -196,6 +214,12 @@ func (s *mapStorage) FlushCaches(ctx context.Context) error {
 // NewMapStorage returns an implementation of Storage backed by the contents of given map.
 // Used primarily for testing.
 func NewMapStorage(data DataMap, keyTime map[blob.ID]time.Time, timeNow func() time.Time) blob.Storage {
+	return NewMapStorageWithLimit(data, keyTime, timeNow, -1)
+}
+
+// NewMapStorageWithLimit returns an implementation of Storage backed by the contents of given map.
+// Used primarily for testing.
+func NewMapStorageWithLimit(data DataMap, keyTime map[blob.ID]time.Time, timeNow func() time.Time, limit int64) blob.Storage {
 	if keyTime == nil {
 		keyTime = make(map[blob.ID]time.Time)
 	}
@@ -204,5 +228,11 @@ func NewMapStorage(data DataMap, keyTime map[blob.ID]time.Time, timeNow func() t
 		timeNow = clock.Now
 	}
 
-	return &mapStorage{data: data, keyTime: keyTime, timeNow: timeNow}
+	totalBytes := int64(0)
+
+	for _, v := range data {
+		totalBytes += int64(len(v))
+	}
+
+	return &mapStorage{data: data, keyTime: keyTime, timeNow: timeNow, limit: limit, totalBytes: totalBytes}
 }

--- a/internal/blobtesting/map_test.go
+++ b/internal/blobtesting/map_test.go
@@ -3,6 +3,9 @@ package blobtesting
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -16,4 +19,47 @@ func TestMapStorage(t *testing.T) {
 	}
 
 	VerifyStorage(testlogging.Context(t), t, r, blob.PutOptions{})
+}
+
+func TestMapStorageWithLimit(t *testing.T) {
+	ctx := testlogging.Context(t)
+	data := DataMap{}
+
+	r := NewMapStorageWithLimit(data, nil, nil, 10)
+	verifyCapacityAndFreeSpace(t, r, 10, 10)
+	require.NoError(t, r.PutBlob(ctx, "foo", gather.FromSlice([]byte("foo")), blob.PutOptions{}))
+	verifyCapacityAndFreeSpace(t, r, 10, 7)
+	require.NoError(t, r.PutBlob(ctx, "bar", gather.FromSlice([]byte("bar")), blob.PutOptions{}))
+	verifyCapacityAndFreeSpace(t, r, 10, 4)
+	require.NoError(t, r.PutBlob(ctx, "baz", gather.FromSlice([]byte("baz")), blob.PutOptions{}))
+	verifyCapacityAndFreeSpace(t, r, 10, 1)
+
+	// we're at 9/10 bytes, can't add 3 more
+	require.ErrorContains(t, r.PutBlob(ctx, "qux", gather.FromSlice([]byte("qux")), blob.PutOptions{}), "exceeded limit")
+	// remove 3 bytes
+	require.NoError(t, r.DeleteBlob(ctx, "baz"))
+	verifyCapacityAndFreeSpace(t, r, 10, 4)
+	// can add 4 bytes again
+	require.NoError(t, r.PutBlob(ctx, "qux", gather.FromSlice([]byte("qux1")), blob.PutOptions{}))
+	verifyCapacityAndFreeSpace(t, r, 10, 0)
+	// can't add any more bytes since we're at 10/10 bytes
+	require.ErrorContains(t, r.PutBlob(ctx, "aaa", gather.FromSlice([]byte("1")), blob.PutOptions{}), "exceeded limit")
+	// adding zero bytes won't fail in this situation.
+	require.NoError(t, r.PutBlob(ctx, "bbb", gather.FromSlice([]byte{}), blob.PutOptions{}), "exceeded limit")
+	verifyCapacityAndFreeSpace(t, r, 10, 0)
+
+	r = NewMapStorageWithLimit(DataMap{
+		"foo": []byte("foo"),
+	}, nil, nil, 20)
+	verifyCapacityAndFreeSpace(t, r, 20, 17)
+}
+
+func verifyCapacityAndFreeSpace(t *testing.T, r blob.Storage, wantSize, wantFree int64) {
+	t.Helper()
+
+	c, err := r.GetCapacity(testlogging.Context(t))
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(wantSize), c.SizeB)
+	require.Equal(t, uint64(wantFree), c.FreeB)
 }

--- a/internal/cache/content_cache_test.go
+++ b/internal/cache/content_cache_test.go
@@ -80,7 +80,7 @@ func TestCacheExpiration(t *testing.T) {
 	err = cc.GetContent(ctx, "00000d", "content-4k", 0, -1, &tmp) // 4k
 	require.NoError(t, err)
 
-	// 00000a and 00000b will be removed from cache because it's the oldest.
+	// 00000a and 00000b will be removed from cache because they are the oldest.
 	// to verify, let's remove content-4k from the underlying storage and make sure we can still read
 	// 00000c and 00000d from the cache but not 00000a nor 00000b
 	require.NoError(t, underlyingStorage.DeleteBlob(ctx, "content-4k"))
@@ -97,9 +97,8 @@ func TestCacheExpiration(t *testing.T) {
 
 	for _, tc := range cases {
 		got := cc.GetContent(ctx, tc.contentID, "content-4k", 0, -1, &tmp)
-		if assert.ErrorIs(t, got, tc.expectedError, "tc.contentID: %v", tc.contentID) {
-			t.Logf("got correct error %v when reading content %v", tc.expectedError, tc.contentID)
-		}
+		require.ErrorIs(t, got, tc.expectedError, "tc.contentID: %v", tc.contentID)
+		t.Logf("got correct error %v when reading content %v", tc.expectedError, tc.contentID)
 	}
 }
 

--- a/internal/cache/mutex_map.go
+++ b/internal/cache/mutex_map.go
@@ -1,0 +1,107 @@
+package cache
+
+import (
+	"sync"
+)
+
+// manages a map of RWMutexes indexed by string keys
+// mutexes are allocated on demand and released when no longer needed.
+type mutexMap struct {
+	mu sync.Mutex
+
+	// +checklocks:mu
+	entries map[string]*mutexMapEntry
+}
+
+type mutexMapEntry struct {
+	mut      *sync.RWMutex
+	refCount int
+}
+
+func (m *mutexMap) exclusiveLock(key string) {
+	if m != nil {
+		m.getMutexAndAddRef(key).Lock()
+	}
+}
+
+func (m *mutexMap) tryExclusiveLock(key string) bool {
+	if m != nil {
+		if !m.getMutexAndAddRef(key).TryLock() {
+			m.getMutexAndReleaseRef(key)
+			return false
+		}
+
+		return true
+	}
+
+	return true
+}
+
+func (m *mutexMap) exclusiveUnlock(key string) {
+	if m != nil {
+		m.getMutexAndReleaseRef(key).Unlock()
+	}
+}
+
+func (m *mutexMap) sharedLock(key string) {
+	if m != nil {
+		m.getMutexAndAddRef(key).RLock()
+	}
+}
+
+func (m *mutexMap) trySharedLock(key string) bool {
+	if m != nil {
+		if !m.getMutexAndAddRef(key).TryRLock() {
+			m.getMutexAndReleaseRef(key)
+			return false
+		}
+
+		return true
+	}
+
+	return true
+}
+
+func (m *mutexMap) sharedUnlock(key string) {
+	if m != nil {
+		m.getMutexAndReleaseRef(key).RUnlock()
+	}
+}
+
+func (m *mutexMap) getMutexAndAddRef(key string) *sync.RWMutex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ent := m.entries[key]
+	if ent == nil {
+		ent = &mutexMapEntry{
+			mut: &sync.RWMutex{},
+		}
+
+		m.entries[key] = ent
+	}
+
+	ent.refCount++
+
+	return ent.mut
+}
+
+func (m *mutexMap) getMutexAndReleaseRef(key string) *sync.RWMutex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ent := m.entries[key]
+	ent.refCount--
+
+	if ent.refCount == 0 {
+		delete(m.entries, key)
+	}
+
+	return ent.mut
+}
+
+func newMutexMap() *mutexMap {
+	return &mutexMap{
+		entries: make(map[string]*mutexMapEntry),
+	}
+}

--- a/internal/cache/mutex_map_test.go
+++ b/internal/cache/mutex_map_test.go
@@ -1,0 +1,62 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMutexMap_ExclusiveLock(t *testing.T) {
+	m := newMutexMap()
+
+	require.Len(t, m.entries, 0)
+	m.exclusiveLock("foo")
+	require.Len(t, m.entries, 1)
+	require.False(t, m.tryExclusiveLock("foo"))
+	require.True(t, m.tryExclusiveLock("bar"))
+	require.False(t, m.trySharedLock("bar"))
+	require.Len(t, m.entries, 2)
+	m.exclusiveUnlock("foo")
+	require.Len(t, m.entries, 1)
+	require.True(t, m.tryExclusiveLock("foo"))
+	require.Len(t, m.entries, 2)
+	m.exclusiveUnlock("foo")
+	require.Len(t, m.entries, 1)
+	m.exclusiveUnlock("bar")
+	require.Len(t, m.entries, 0)
+}
+
+func TestMutexMap_SharedLock(t *testing.T) {
+	m := newMutexMap()
+
+	require.Len(t, m.entries, 0)
+	m.sharedLock("foo")
+	require.Len(t, m.entries, 1)
+	m.sharedLock("foo")
+	require.Len(t, m.entries, 1)
+	require.True(t, m.trySharedLock("foo"))
+	require.Len(t, m.entries, 1)
+
+	// exclusive lock can't be acquired while shared lock is held
+	require.False(t, m.tryExclusiveLock("foo"))
+	m.sharedUnlock("foo")
+	require.False(t, m.tryExclusiveLock("foo"))
+	m.sharedUnlock("foo")
+	require.False(t, m.tryExclusiveLock("foo"))
+	m.sharedUnlock("foo")
+
+	// now exclusive lock can be acquired
+	require.True(t, m.tryExclusiveLock("foo"))
+}
+
+func TestMutexMap_Nil(t *testing.T) {
+	var m *mutexMap
+
+	// make sure all operations are no-ops on nil map
+	m.exclusiveUnlock("foo")
+	m.sharedUnlock("bar")
+	m.exclusiveLock("foo")
+	m.sharedLock("bar")
+	require.True(t, m.tryExclusiveLock("foo"))
+	require.True(t, m.trySharedLock("bar"))
+}

--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -29,9 +29,13 @@ const (
 
 // PersistentCache provides persistent on-disk cache.
 type PersistentCache struct {
+	fetchMutexes *mutexMap
+
 	listCacheMutex sync.Mutex
 	// +checklocks:listCacheMutex
 	listCache contentMetadataHeap
+	// +checklocks:listCacheMutex
+	pendingWriteBytes int64
 
 	cacheStorage      Storage
 	storageProtection cacheprot.StorageProtection
@@ -49,27 +53,6 @@ func (c *PersistentCache) CacheStorage() Storage {
 	return c.cacheStorage
 }
 
-// GetFetchingMutex returns a RWMutex used to lock a blob or content during loading.
-func (c *PersistentCache) GetFetchingMutex(id blob.ID) *sync.RWMutex {
-	if c == nil {
-		// special case - also works on non-initialized cache pointer.
-		return &sync.RWMutex{}
-	}
-
-	c.listCacheMutex.Lock()
-	defer c.listCacheMutex.Unlock()
-
-	if _, entry := c.listCache.LookupByID(id); entry != nil {
-		return &entry.contentDownloadMutex
-	}
-
-	heap.Push(&c.listCache, blob.Metadata{BlobID: id})
-
-	_, entry := c.listCache.LookupByID(id)
-
-	return &entry.contentDownloadMutex
-}
-
 // GetOrLoad is utility function gets the provided item from the cache or invokes the provided fetch function.
 // The function also appends and verifies HMAC checksums using provided secret on all cached items to ensure data integrity.
 func (c *PersistentCache) GetOrLoad(ctx context.Context, key string, fetch func(output *gather.WriteBuffer) error, output *gather.WriteBuffer) error {
@@ -84,9 +67,8 @@ func (c *PersistentCache) GetOrLoad(ctx context.Context, key string, fetch func(
 
 	output.Reset()
 
-	mut := c.GetFetchingMutex(blob.ID(key))
-	mut.Lock()
-	defer mut.Unlock()
+	c.fetchMutexes.exclusiveLock(key)
+	defer c.fetchMutexes.exclusiveUnlock(key)
 
 	// check again while holding the mutex
 	if c.GetFull(ctx, key, output) {
@@ -115,36 +97,12 @@ func (c *PersistentCache) getPartialCacheHit(ctx context.Context, key string, le
 	// cache hit
 	c.reportHitBytes(int64(output.Length()))
 
-	// cache hit
+	mtime, err := c.cacheStorage.TouchBlob(ctx, blob.ID(key), c.sweep.TouchThreshold)
 	c.listCacheMutex.Lock()
 	defer c.listCacheMutex.Unlock()
 
-	// Touching the blobs when cache is full can lead to cache never
-	// getting cleaned up if all the blobs fall under MinSweepAge.
-	//
-	// This can happen when the user is restoring large files (at
-	// comparable sizes to the cache size limitation) and MinSweepAge is
-	// sufficiently large. For large files which span over multiple
-	// blobs, every blob becomes least-recently-used.
-	//
-	// So, we'll avoid this until our cache usage drops to acceptable
-	// limits.
-	if c.isCacheFullLocked() {
-		c.listCacheCleanupLocked(ctx)
-
-		if c.isCacheFullLocked() {
-			return
-		}
-	}
-
-	// unlock for the expensive operation
-	c.listCacheMutex.Unlock()
-	mtime, err := c.cacheStorage.TouchBlob(ctx, blob.ID(key), c.sweep.TouchThreshold)
-	c.listCacheMutex.Lock()
-
 	if err == nil {
-		// insert or update the metadata
-		heap.Push(&c.listCache, blob.Metadata{
+		c.listCache.AddOrUpdate(blob.Metadata{
 			BlobID:    blob.ID(key),
 			Length:    length,
 			Timestamp: mtime,
@@ -152,18 +110,17 @@ func (c *PersistentCache) getPartialCacheHit(ctx context.Context, key string, le
 	}
 }
 
-func (c *PersistentCache) getPartialDeleteInvalidBlob(ctx context.Context, key string) {
-	// delete invalid blob
-	c.reportMalformedData()
-
+func (c *PersistentCache) deleteInvalidBlob(ctx context.Context, key string) {
 	if err := c.cacheStorage.DeleteBlob(ctx, blob.ID(key)); err != nil && !errors.Is(err, blob.ErrBlobNotFound) {
 		log(ctx).Errorf("unable to delete %v entry %v: %v", c.description, key, err)
-	} else {
-		c.listCacheMutex.Lock()
-		if i, entry := c.listCache.LookupByID(blob.ID(key)); entry != nil {
-			heap.Remove(&c.listCache, i)
-		}
-		c.listCacheMutex.Unlock()
+		return
+	}
+
+	c.listCacheMutex.Lock()
+	defer c.listCacheMutex.Unlock()
+
+	if i, ok := c.listCache.index[blob.ID(key)]; ok {
+		heap.Remove(&c.listCache, i)
 	}
 }
 
@@ -178,19 +135,21 @@ func (c *PersistentCache) GetPartial(ctx context.Context, key string, offset, le
 	defer tmp.Close()
 
 	if err := c.cacheStorage.GetBlob(ctx, blob.ID(key), offset, length, &tmp); err == nil {
-		prot := c.storageProtection
+		sp := c.storageProtection
+
 		if length >= 0 {
-			// only full items have protection.
-			prot = cacheprot.NoProtection()
+			// do not perform integrity check on partial reads
+			sp = cacheprot.NoProtection()
 		}
 
-		if err := prot.Verify(key, tmp.Bytes(), output); err == nil {
+		if err := sp.Verify(key, tmp.Bytes(), output); err == nil {
 			c.getPartialCacheHit(ctx, key, length, output)
 
 			return true
 		}
 
-		c.getPartialDeleteInvalidBlob(ctx, key)
+		c.reportMalformedData()
+		c.deleteInvalidBlob(ctx, key)
 	}
 
 	// cache miss
@@ -204,48 +163,33 @@ func (c *PersistentCache) GetPartial(ctx context.Context, key string, offset, le
 	return false
 }
 
-// +checklocks:c.listCacheMutex
-func (c *PersistentCache) isCacheFullLocked() bool {
-	return c.listCache.DataSize() > c.sweep.MaxSizeBytes
-}
-
 // Put adds the provided key-value pair to the cache.
 func (c *PersistentCache) Put(ctx context.Context, key string, data gather.Bytes) {
 	if c == nil {
 		return
 	}
 
-	var (
-		protected gather.WriteBuffer
-		mtime     time.Time
-	)
-
-	defer protected.Close()
-
 	c.listCacheMutex.Lock()
 	defer c.listCacheMutex.Unlock()
 
-	// opportunistically cleanup cache before the PUT if we can
-	if c.isCacheFullLocked() {
-		c.listCacheCleanupLocked(ctx)
-		// Do not add more things to cache if it remains full after cleanup. We
-		// MUST NOT go over the specified limit for the cache space to avoid
-		// snapshots/restores from getting affected by the cache's storage use.
-		if c.isCacheFullLocked() {
-			// Limit warnings to one per minute max.
-			if clock.Now().Sub(c.lastCacheWarning) > 10*time.Minute {
-				c.lastCacheWarning = clock.Now()
-
-				log(ctx).Warnf("Cache is full, unable to add item into '%s' cache.", c.description)
-			}
-
-			return
-		}
-	}
+	// make sure the cache has enough room for the new item including any protection overhead.
+	l := data.Length() + c.storageProtection.OverheadBytes()
+	c.pendingWriteBytes += int64(l)
+	c.sweepLocked(ctx)
 
 	// LOCK RELEASED for expensive operations
 	c.listCacheMutex.Unlock()
+
+	var protected gather.WriteBuffer
+	defer protected.Close()
+
 	c.storageProtection.Protect(key, data, &protected)
+
+	if protected.Length() != l {
+		log(ctx).Panicf("protection overhead mismatch, assumed %v got %v", l, protected.Length())
+	}
+
+	var mtime time.Time
 
 	if err := c.cacheStorage.PutBlob(ctx, blob.ID(key), protected.Bytes(), blob.PutOptions{GetModTime: &mtime}); err != nil {
 		c.reportStoreError()
@@ -256,13 +200,14 @@ func (c *PersistentCache) Put(ctx context.Context, key string, data gather.Bytes
 	c.listCacheMutex.Lock()
 	// LOCK RE-ACQUIRED
 
-	c.listCache.Push(blob.Metadata{
+	c.pendingWriteBytes -= int64(protected.Length())
+	c.listCache.AddOrUpdate(blob.Metadata{
 		BlobID:    blob.ID(key),
 		Length:    int64(protected.Bytes().Length()),
 		Timestamp: mtime,
 	})
 
-	c.listCacheCleanupLocked(ctx)
+	c.sweepLocked(ctx)
 }
 
 // Close closes the instance of persistent cache possibly waiting for at least one sweep to complete.
@@ -274,16 +219,11 @@ func (c *PersistentCache) Close(ctx context.Context) {
 	releasable.Released("persistent-cache", c)
 }
 
-type blobCacheEntry struct {
-	metadata             blob.Metadata
-	contentDownloadMutex sync.RWMutex
-}
-
 // A contentMetadataHeap implements heap.Interface and holds blob.Metadata.
 type contentMetadataHeap struct {
-	data     []*blobCacheEntry
-	index    map[blob.ID]int
-	dataSize int64
+	data           []blob.Metadata
+	index          map[blob.ID]int
+	totalDataBytes int64
 }
 
 func newContentMetadataHeap() contentMetadataHeap {
@@ -293,86 +233,92 @@ func newContentMetadataHeap() contentMetadataHeap {
 func (h contentMetadataHeap) Len() int { return len(h.data) }
 
 func (h contentMetadataHeap) Less(i, j int) bool {
-	return h.data[i].metadata.Timestamp.Before(h.data[j].metadata.Timestamp)
+	return h.data[i].Timestamp.Before(h.data[j].Timestamp)
 }
 
 func (h contentMetadataHeap) Swap(i, j int) {
-	h.index[h.data[i].metadata.BlobID], h.index[h.data[j].metadata.BlobID] = h.index[h.data[j].metadata.BlobID], h.index[h.data[i].metadata.BlobID]
+	iBlobID := h.data[i].BlobID
+	jBlobID := h.data[j].BlobID
+
+	h.index[iBlobID], h.index[jBlobID] = h.index[jBlobID], h.index[iBlobID]
 	h.data[i], h.data[j] = h.data[j], h.data[i]
 }
 
-func (h *contentMetadataHeap) Push(x interface{}) {
+func (h *contentMetadataHeap) Push(x any) {
 	bm := x.(blob.Metadata) //nolint:forcetypeassert
+
+	h.index[bm.BlobID] = len(h.data)
+	h.data = append(h.data, bm)
+	h.totalDataBytes += bm.Length
+}
+
+func (h *contentMetadataHeap) AddOrUpdate(bm blob.Metadata) {
 	if i, exists := h.index[bm.BlobID]; exists {
 		// only accept newer timestamps
-		if h.data[i].metadata.Timestamp.IsZero() || bm.Timestamp.After(h.data[i].metadata.Timestamp) {
-			h.dataSize += bm.Length - h.data[i].metadata.Length
-			h.data[i] = &blobCacheEntry{metadata: bm}
+		if bm.Timestamp.After(h.data[i].Timestamp) {
+			h.totalDataBytes += bm.Length - h.data[i].Length
+			h.data[i] = bm
 			heap.Fix(h, i)
 		}
 	} else {
-		h.index[bm.BlobID] = len(h.data)
-		h.data = append(h.data, &blobCacheEntry{metadata: bm})
-		h.dataSize += bm.Length
+		heap.Push(h, bm)
 	}
 }
 
-func (h *contentMetadataHeap) Pop() interface{} {
+func (h *contentMetadataHeap) Pop() any {
 	old := h.data
 	n := len(old)
 	item := old[n-1]
 	h.data = old[0 : n-1]
-	h.dataSize -= item.metadata.Length
-	delete(h.index, item.metadata.BlobID)
+	h.totalDataBytes -= item.Length
+	delete(h.index, item.BlobID)
 
-	return item.metadata
+	return item
 }
-
-func (h *contentMetadataHeap) LookupByID(id blob.ID) (int, *blobCacheEntry) {
-	i, ok := h.index[id]
-	if !ok {
-		return -1, nil
-	}
-
-	return i, h.data[i]
-}
-
-func (h contentMetadataHeap) DataSize() int64 { return h.dataSize }
 
 // +checklocks:c.listCacheMutex
-func (c *PersistentCache) listCacheCleanupLocked(ctx context.Context) {
+func (c *PersistentCache) aboveSoftLimit(extraBytes int64) bool {
+	return c.listCache.totalDataBytes+extraBytes+c.pendingWriteBytes > c.sweep.MaxSizeBytes
+}
+
+// +checklocks:c.listCacheMutex
+func (c *PersistentCache) aboveHardLimit(extraBytes int64) bool {
+	if c.sweep.LimitBytes <= 0 {
+		return false
+	}
+
+	return c.listCache.totalDataBytes+extraBytes+c.pendingWriteBytes > c.sweep.LimitBytes
+}
+
+// +checklocks:c.listCacheMutex
+func (c *PersistentCache) sweepLocked(ctx context.Context) {
 	var (
 		unsuccessfulDeletes     []blob.Metadata
-		unsuccessfulDeletesSize int64
+		unsuccessfulDeleteBytes int64
 		now                     = c.timeNow()
 	)
 
-	// if there are blobs pending to be deleted ...
-	for c.listCache.DataSize() > 0 &&
-		// ... and everything including what we couldn't delete is still bigger than the threshold
-		(c.listCache.DataSize()+unsuccessfulDeletesSize) > c.sweep.MaxSizeBytes {
-		oldest := heap.Pop(&c.listCache).(blob.Metadata) //nolint:forcetypeassert
+	for len(c.listCache.data) > 0 && (c.aboveSoftLimit(unsuccessfulDeleteBytes) || c.aboveHardLimit(unsuccessfulDeleteBytes)) {
+		// examine the oldest cache item without removing it from the heap.
+		oldest := c.listCache.data[0]
 
-		// stop here if the oldest item is below the specified minimal age
-		if age := now.Sub(oldest.Timestamp); age < c.sweep.MinSweepAge {
-			heap.Push(&c.listCache, oldest)
+		if age := now.Sub(oldest.Timestamp); age < c.sweep.MinSweepAge && !c.aboveHardLimit(unsuccessfulDeleteBytes) {
+			// the oldest item is below the specified minimal sweep age and we're below the hard limit, stop here
 			break
 		}
 
-		// unlock before the expensive operation
-		c.listCacheMutex.Unlock()
-		delerr := c.cacheStorage.DeleteBlob(ctx, oldest.BlobID)
-		c.listCacheMutex.Lock()
+		heap.Pop(&c.listCache)
 
-		if delerr != nil {
-			log(ctx).Errorf("unable to remove %v: %v", oldest.BlobID, delerr)
+		if delerr := c.cacheStorage.DeleteBlob(ctx, oldest.BlobID); delerr != nil {
+			log(ctx).Warnw("unable to remove cache item", "cache", c.description, "item", oldest.BlobID, "err", delerr)
+
 			// accumulate unsuccessful deletes to be pushed back into the heap
 			// later so we do not attempt deleting the same blob multiple times
 			//
 			// after this we keep draining from the heap until we bring down
 			// c.listCache.DataSize() to zero
 			unsuccessfulDeletes = append(unsuccessfulDeletes, oldest)
-			unsuccessfulDeletesSize += oldest.Length
+			unsuccessfulDeleteBytes += oldest.Length
 		}
 	}
 
@@ -409,9 +355,7 @@ func (c *PersistentCache) initialScan(ctx context.Context) error {
 		return errors.Wrapf(err, "error listing %v", c.description)
 	}
 
-	if c.isCacheFullLocked() {
-		c.listCacheCleanupLocked(ctx)
-	}
+	c.sweepLocked(ctx)
 
 	dur := timer.Elapsed()
 
@@ -420,17 +364,18 @@ func (c *PersistentCache) initialScan(ctx context.Context) error {
 	inUsePercent := int64(hundredPercent)
 
 	if c.sweep.MaxSizeBytes != 0 {
-		inUsePercent = hundredPercent * c.listCache.DataSize() / c.sweep.MaxSizeBytes
+		inUsePercent = hundredPercent * c.listCache.totalDataBytes / c.sweep.MaxSizeBytes
 	}
 
 	log(ctx).Debugw(
 		"finished initial cache scan",
 		"cache", c.description,
 		"duration", dur,
-		"totalRetainedSize", c.listCache.DataSize(),
+		"totalRetainedSize", c.listCache.totalDataBytes,
 		"tooRecentBytes", tooRecentBytes,
 		"tooRecentCount", tooRecentCount,
 		"maxSizeBytes", c.sweep.MaxSizeBytes,
+		"limitBytes", c.sweep.LimitBytes,
 		"inUsePercent", inUsePercent,
 	)
 
@@ -439,8 +384,17 @@ func (c *PersistentCache) initialScan(ctx context.Context) error {
 
 // SweepSettings encapsulates settings that impact cache item sweep/expiration.
 type SweepSettings struct {
-	MaxSizeBytes   int64
-	MinSweepAge    time.Duration
+	// soft limit, the cache will be limited to this size, except for items newer than MinSweepAge.
+	MaxSizeBytes int64
+
+	// hard limit, if non-zero the cache will be limited to this size, regardless of MinSweepAge.
+	LimitBytes int64
+
+	// items older than this will never be removed from the cache except when the cache is above
+	// HardMaxSizeBytes.
+	MinSweepAge time.Duration
+
+	// on each use, items will be touched if they have not been touched in this long.
 	TouchThreshold time.Duration
 }
 
@@ -465,6 +419,7 @@ func NewPersistentCache(ctx context.Context, description string, cacheStorage St
 	}
 
 	c := &PersistentCache{
+		fetchMutexes:      newMutexMap(),
 		cacheStorage:      cacheStorage,
 		sweep:             sweep,
 		description:       description,

--- a/internal/cache/persistent_lru_cache_test.go
+++ b/internal/cache/persistent_lru_cache_test.go
@@ -25,7 +25,7 @@ func TestPersistentLRUCache(t *testing.T) {
 
 	const maxSizeBytes = 1000
 
-	cs := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil).(cache.Storage)
+	cs := blobtesting.NewMapStorageWithLimit(blobtesting.DataMap{}, nil, nil, maxSizeBytes).(cache.Storage)
 
 	pc, err := cache.NewPersistentCache(ctx, "testing", cs, cacheprot.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{
 		MaxSizeBytes:   maxSizeBytes,
@@ -148,11 +148,13 @@ func TestPersistentLRUCache_GetDeletesInvalidBlob(t *testing.T) {
 
 	data := blobtesting.DataMap{}
 
-	st := blobtesting.NewMapStorage(data, nil, nil)
+	const maxSizeBytes = 1000
+
+	st := blobtesting.NewMapStorageWithLimit(data, nil, nil, maxSizeBytes)
 	fs := blobtesting.NewFaultyStorage(st)
 	fc := faultyCache{fs}
 
-	pc, err := cache.NewPersistentCache(ctx, "test", fc, cacheprot.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{MaxSizeBytes: 100}, nil, clock.Now)
+	pc, err := cache.NewPersistentCache(ctx, "test", fc, cacheprot.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{MaxSizeBytes: maxSizeBytes}, nil, clock.Now)
 	require.NoError(t, err)
 
 	pc.Put(ctx, "key", gather.FromSlice([]byte{1, 2, 3}))
@@ -204,17 +206,19 @@ func TestPersistentLRUCache_SweepMinSweepAge(t *testing.T) {
 
 	data := blobtesting.DataMap{}
 
-	st := blobtesting.NewMapStorage(data, nil, nil)
+	const maxSizeBytes = 1000
+
+	st := blobtesting.NewMapStorageWithLimit(data, nil, nil, maxSizeBytes)
 	fs := blobtesting.NewFaultyStorage(st)
 	fc := faultyCache{fs}
 
 	pc, err := cache.NewPersistentCache(ctx, "test", fc, cacheprot.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{
-		MaxSizeBytes: 1000,
+		MaxSizeBytes: maxSizeBytes,
 		MinSweepAge:  10 * time.Second,
 	}, nil, clock.Now)
 	require.NoError(t, err)
 	pc.Put(ctx, "key", gather.FromSlice([]byte{1, 2, 3}))
-	pc.Put(ctx, "key2", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3}, 1e6)))
+	pc.Put(ctx, "key2", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3}, 10)))
 	time.Sleep(1 * time.Second)
 
 	// simulate error during final sweep
@@ -232,12 +236,14 @@ func TestPersistentLRUCache_SweepIgnoresErrors(t *testing.T) {
 
 	data := blobtesting.DataMap{}
 
-	st := blobtesting.NewMapStorage(data, nil, nil)
+	const maxSizeBytes = 1000
+
+	st := blobtesting.NewMapStorageWithLimit(data, nil, nil, maxSizeBytes)
 	fs := blobtesting.NewFaultyStorage(st)
 	fc := faultyCache{fs}
 
 	pc, err := cache.NewPersistentCache(ctx, "test", fc, cacheprot.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{
-		MaxSizeBytes: 1000,
+		MaxSizeBytes: maxSizeBytes,
 	}, nil, clock.Now)
 	require.NoError(t, err)
 
@@ -245,7 +251,7 @@ func TestPersistentLRUCache_SweepIgnoresErrors(t *testing.T) {
 	fs.AddFault(blobtesting.MethodDeleteBlob).ErrorInstead(errors.Errorf("some delete error")).Repeat(1e6)
 
 	pc.Put(ctx, "key", gather.FromSlice([]byte{1, 2, 3}))
-	pc.Put(ctx, "key2", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3}, 1e6)))
+	pc.Put(ctx, "key2", gather.FromSlice(bytes.Repeat([]byte{1, 2, 3}, 10)))
 	time.Sleep(500 * time.Millisecond)
 
 	// simulate error during sweep
@@ -264,12 +270,14 @@ func TestPersistentLRUCache_Sweep1(t *testing.T) {
 
 	data := blobtesting.DataMap{}
 
-	st := blobtesting.NewMapStorage(data, nil, nil)
+	const maxSizeBytes = 1
+
+	st := blobtesting.NewMapStorageWithLimit(data, nil, nil, maxSizeBytes)
 	fs := blobtesting.NewFaultyStorage(st)
 	fc := faultyCache{fs}
 
 	pc, err := cache.NewPersistentCache(ctx, "test", fc, cacheprot.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{
-		MaxSizeBytes: 1,
+		MaxSizeBytes: maxSizeBytes,
 		MinSweepAge:  0 * time.Second,
 	}, nil, clock.Now)
 	require.NoError(t, err)
@@ -290,13 +298,6 @@ func TestPersistentLRUCacheNil(t *testing.T) {
 	// no-op
 	pc.Close(ctx)
 	pc.Put(ctx, "key", gather.FromSlice([]byte{1, 2, 3}))
-
-	m1 := pc.GetFetchingMutex("dummy")
-	m2 := pc.GetFetchingMutex("dummy")
-
-	require.NotNil(t, m1)
-	require.NotNil(t, m2)
-	require.NotSame(t, m1, m2)
 
 	var tmp gather.WriteBuffer
 

--- a/repo/content/caching_options.go
+++ b/repo/content/caching_options.go
@@ -19,14 +19,16 @@ func (s DurationSeconds) DurationOrDefault(def time.Duration) time.Duration {
 
 // CachingOptions specifies configuration of local cache.
 type CachingOptions struct {
-	CacheDirectory            string          `json:"cacheDirectory,omitempty"`
-	MaxCacheSizeBytes         int64           `json:"maxCacheSize,omitempty"`
-	MaxMetadataCacheSizeBytes int64           `json:"maxMetadataCacheSize,omitempty"`
-	MaxListCacheDuration      DurationSeconds `json:"maxListCacheDuration,omitempty"`
-	MinMetadataSweepAge       DurationSeconds `json:"minMetadataSweepAge,omitempty"`
-	MinContentSweepAge        DurationSeconds `json:"minContentSweepAge,omitempty"`
-	MinIndexSweepAge          DurationSeconds `json:"minIndexSweepAge,omitempty"`
-	HMACSecret                []byte          `json:"-"`
+	CacheDirectory              string          `json:"cacheDirectory,omitempty"`
+	MaxCacheSizeBytes           int64           `json:"maxCacheSize,omitempty"`
+	ContentCacheSizeLimitBytes  int64           `json:"contentCacheSizeLimitBytes,omitempty"`
+	MaxMetadataCacheSizeBytes   int64           `json:"maxMetadataCacheSize,omitempty"`
+	MetadataCacheSizeLimitBytes int64           `json:"metadataCacheSizeLimitBytes,omitempty"`
+	MaxListCacheDuration        DurationSeconds `json:"maxListCacheDuration,omitempty"`
+	MinMetadataSweepAge         DurationSeconds `json:"minMetadataSweepAge,omitempty"`
+	MinContentSweepAge          DurationSeconds `json:"minContentSweepAge,omitempty"`
+	MinIndexSweepAge            DurationSeconds `json:"minIndexSweepAge,omitempty"`
+	HMACSecret                  []byte          `json:"-"`
 }
 
 // CloneOrDefault returns a clone of the caching options or empty options for nil.

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -421,6 +421,7 @@ func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *Ca
 		HMACSecret:         caching.HMACSecret,
 		Sweep: cache.SweepSettings{
 			MaxSizeBytes: caching.MaxCacheSizeBytes,
+			LimitBytes:   caching.ContentCacheSizeLimitBytes,
 			MinSweepAge:  caching.MinContentSweepAge.DurationOrDefault(DefaultDataCacheSweepAge),
 		},
 	}, mr)
@@ -440,6 +441,7 @@ func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *Ca
 		FetchFullBlobs:     true,
 		Sweep: cache.SweepSettings{
 			MaxSizeBytes: metadataCacheSize,
+			LimitBytes:   caching.MetadataCacheSizeLimitBytes,
 			MinSweepAge:  caching.MinMetadataSweepAge.DurationOrDefault(DefaultMetadataCacheSweepAge),
 		},
 	}, mr)
@@ -452,10 +454,13 @@ func (sm *SharedManager) setupReadManagerCaches(ctx context.Context, caching *Ca
 		return errors.Wrap(err, "unable to initialize index blob cache storage")
 	}
 
-	indexBlobCache, err := cache.NewPersistentCache(ctx, "index-blobs", indexBlobStorage, cacheprot.ChecksumProtection(caching.HMACSecret), cache.SweepSettings{
-		MaxSizeBytes: metadataCacheSize,
-		MinSweepAge:  caching.MinMetadataSweepAge.DurationOrDefault(DefaultMetadataCacheSweepAge),
-	}, mr, sm.timeNow)
+	indexBlobCache, err := cache.NewPersistentCache(ctx, "index-blobs",
+		indexBlobStorage,
+		cacheprot.ChecksumProtection(caching.HMACSecret),
+		cache.SweepSettings{
+			MaxSizeBytes: metadataCacheSize,
+			MinSweepAge:  caching.MinMetadataSweepAge.DurationOrDefault(DefaultMetadataCacheSweepAge),
+		}, mr, sm.timeNow)
 	if err != nil {
 		return errors.Wrap(err, "unable to create index blob cache")
 	}

--- a/repo/open.go
+++ b/repo/open.go
@@ -155,6 +155,7 @@ func getContentCacheOrNil(ctx context.Context, opt *content.CachingOptions, pass
 
 	pc, err := cache.NewPersistentCache(ctx, "cache-storage", cs, prot, cache.SweepSettings{
 		MaxSizeBytes: opt.MaxCacheSizeBytes,
+		LimitBytes:   opt.ContentCacheSizeLimitBytes,
 		MinSweepAge:  opt.MinContentSweepAge.DurationOrDefault(content.DefaultDataCacheSweepAge),
 	}, mr, timeNow)
 	if err != nil {


### PR DESCRIPTION
Before this change the cache size limit was only "soft", since "minSweepAge" would take priority over size. This is useful for metadata caching where we want to keep all recently used metadata to speed up incremental snapshots, but sometimes we want to enforce hard limits on the cache size.

This PR adds support for optional hard limits and refactors cache code for better readability.