### PR TITLE
refactor(providers): Create default provider that has common functions

### DIFF
--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -18,7 +18,7 @@ import (
 type DataMap map[blob.ID][]byte
 
 type mapStorage struct {
-	blob.UnsupportedBlobRetention
+	blob.DefaultProviderImplementation
 	// +checklocks:mutex
 	data DataMap
 	// +checklocks:mutex

--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -28,14 +28,6 @@ type mapStorage struct {
 	mutex   sync.RWMutex
 }
 
-func (s *mapStorage) GetCapacity(ctx context.Context) (blob.Capacity, error) {
-	return blob.Capacity{}, blob.ErrNotAVolume
-}
-
-func (s *mapStorage) IsReadOnly() bool {
-	return false
-}
-
 func (s *mapStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -166,10 +158,6 @@ func (s *mapStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback fun
 	return nil
 }
 
-func (s *mapStorage) Close(ctx context.Context) error {
-	return nil
-}
-
 func (s *mapStorage) TouchBlob(ctx context.Context, blobID blob.ID, threshold time.Duration) (time.Time, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -191,10 +179,6 @@ func (s *mapStorage) ConnectionInfo() blob.ConnectionInfo {
 
 func (s *mapStorage) DisplayName() string {
 	return "Map"
-}
-
-func (s *mapStorage) FlushCaches(ctx context.Context) error {
-	return nil
 }
 
 // NewMapStorage returns an implementation of Storage backed by the contents of given map.

--- a/internal/blobtesting/object_locking_map.go
+++ b/internal/blobtesting/object_locking_map.go
@@ -32,6 +32,7 @@ type versionedEntries map[blob.ID][]*entry
 // marker. This struct manages the retention time of each blob through the
 // PutBlob options.
 type objectLockingMap struct {
+	blob.DefaultProviderImplementation
 	// +checklocks:mutex
 	data    versionedEntries
 	timeNow func() time.Time // +checklocksignore
@@ -67,14 +68,6 @@ func (s *objectLockingMap) getLatestForMutationLocked(id blob.ID) (*entry, error
 	}
 
 	return e, nil
-}
-
-func (s *objectLockingMap) GetCapacity(ctx context.Context) (blob.Capacity, error) {
-	return blob.Capacity{}, blob.ErrNotAVolume
-}
-
-func (s *objectLockingMap) IsReadOnly() bool {
-	return false
 }
 
 // GetBlob works the same as map-storage GetBlob except that if the latest
@@ -266,11 +259,6 @@ func (s *objectLockingMap) ListBlobs(ctx context.Context, prefix blob.ID, callba
 	return nil
 }
 
-// Close is a no-op for this implementation.
-func (s *objectLockingMap) Close(ctx context.Context) error {
-	return nil
-}
-
 // TouchBlob updates the mtime of the latest version of the object. If it is a
 // delete-marker or if it does not exist then this becomes a no-op. If the
 // latest version has retention parameters set then they are respected.
@@ -307,11 +295,6 @@ func (s *objectLockingMap) ConnectionInfo() blob.ConnectionInfo {
 // DisplayName gets the identifier of this storage for display purposes.
 func (s *objectLockingMap) DisplayName() string {
 	return "VersionedMap"
-}
-
-// FlushCaches is a no-op for this implementation.
-func (s *objectLockingMap) FlushCaches(ctx context.Context) error {
-	return nil
 }
 
 // NewVersionedMapStorage returns an implementation of Storage backed by the

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -34,14 +34,6 @@ type azStorage struct {
 	container string
 }
 
-func (az *azStorage) GetCapacity(ctx context.Context) (blob.Capacity, error) {
-	return blob.Capacity{}, blob.ErrNotAVolume
-}
-
-func (az *azStorage) IsReadOnly() bool {
-	return false
-}
-
 func (az *azStorage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	if offset < 0 {
 		return errors.Wrap(blob.ErrInvalidRange, "invalid offset")
@@ -232,14 +224,6 @@ func (az *azStorage) ConnectionInfo() blob.ConnectionInfo {
 
 func (az *azStorage) DisplayName() string {
 	return fmt.Sprintf("Azure: %v", az.Options.Container)
-}
-
-func (az *azStorage) Close(ctx context.Context) error {
-	return nil
-}
-
-func (az *azStorage) FlushCaches(ctx context.Context) error {
-	return nil
 }
 
 // New creates new Azure Blob Storage-backed storage with specified options:

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -28,7 +28,7 @@ const (
 
 type azStorage struct {
 	Options
-	blob.UnsupportedBlobRetention
+	blob.DefaultProviderImplementation
 
 	service   *azblob.Client
 	container string

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -32,14 +32,6 @@ type b2Storage struct {
 	bucket *backblaze.Bucket
 }
 
-func (s *b2Storage) GetCapacity(ctx context.Context) (blob.Capacity, error) {
-	return blob.Capacity{}, blob.ErrNotAVolume
-}
-
-func (s *b2Storage) IsReadOnly() bool {
-	return false
-}
-
 func (s *b2Storage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	fileName := s.getObjectNameString(id)
 
@@ -249,14 +241,6 @@ func (s *b2Storage) ConnectionInfo() blob.ConnectionInfo {
 
 func (s *b2Storage) DisplayName() string {
 	return fmt.Sprintf("B2: %v", s.BucketName)
-}
-
-func (s *b2Storage) Close(ctx context.Context) error {
-	return nil
-}
-
-func (s *b2Storage) FlushCaches(ctx context.Context) error {
-	return nil
 }
 
 func (s *b2Storage) String() string {

--- a/repo/blob/b2/b2_storage.go
+++ b/repo/blob/b2/b2_storage.go
@@ -26,7 +26,7 @@ const (
 
 type b2Storage struct {
 	Options
-	blob.UnsupportedBlobRetention
+	blob.DefaultProviderImplementation
 
 	cli    *backblaze.B2
 	bucket *backblaze.Bucket

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -34,7 +34,7 @@ const (
 
 type fsStorage struct {
 	sharded.Storage
-	blob.UnsupportedBlobRetention
+	blob.DefaultProviderImplementation
 }
 
 type fsImpl struct {

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -336,14 +336,6 @@ func (fs *fsStorage) DisplayName() string {
 	return fmt.Sprintf("Filesystem: %v", fs.RootPath)
 }
 
-func (fs *fsStorage) Close(ctx context.Context) error {
-	return nil
-}
-
-func (fs *fsStorage) FlushCaches(ctx context.Context) error {
-	return nil
-}
-
 // New creates new filesystem-backed storage in a specified directory.
 func New(ctx context.Context, opts *Options, isCreate bool) (blob.Storage, error) {
 	var err error

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -38,14 +38,6 @@ type gcsStorage struct {
 	bucket        *gcsclient.BucketHandle
 }
 
-func (gcs *gcsStorage) GetCapacity(ctx context.Context) (blob.Capacity, error) {
-	return blob.Capacity{}, blob.ErrNotAVolume
-}
-
-func (gcs *gcsStorage) IsReadOnly() bool {
-	return false
-}
-
 func (gcs *gcsStorage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	if offset < 0 {
 		return blob.ErrInvalidRange
@@ -211,10 +203,6 @@ func (gcs *gcsStorage) DisplayName() string {
 
 func (gcs *gcsStorage) Close(ctx context.Context) error {
 	return errors.Wrap(gcs.storageClient.Close(), "error closing GCS storage")
-}
-
-func (gcs *gcsStorage) FlushCaches(ctx context.Context) error {
-	return nil
 }
 
 func tokenSourceFromCredentialsFile(ctx context.Context, fn string, scopes ...string) (oauth2.TokenSource, error) {

--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -32,7 +32,7 @@ const (
 
 type gcsStorage struct {
 	Options
-	blob.UnsupportedBlobRetention
+	blob.DefaultProviderImplementation
 
 	storageClient *gcsclient.Client
 	bucket        *gcsclient.BucketHandle

--- a/repo/blob/gdrive/gdrive_storage.go
+++ b/repo/blob/gdrive/gdrive_storage.go
@@ -45,7 +45,7 @@ var log = logging.Module("gdrive")
 
 type gdriveStorage struct {
 	Options
-	blob.UnsupportedBlobRetention
+	blob.DefaultProviderImplementation
 
 	client      *drive.FilesService
 	about       *drive.AboutService

--- a/repo/blob/gdrive/gdrive_storage.go
+++ b/repo/blob/gdrive/gdrive_storage.go
@@ -73,10 +73,6 @@ func (gdrive *gdriveStorage) GetCapacity(ctx context.Context) (blob.Capacity, er
 	}, nil
 }
 
-func (gdrive *gdriveStorage) IsReadOnly() bool {
-	return false
-}
-
 func (gdrive *gdriveStorage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	if offset < 0 {
 		return blob.ErrInvalidRange
@@ -328,10 +324,6 @@ func (gdrive *gdriveStorage) ConnectionInfo() blob.ConnectionInfo {
 
 func (gdrive *gdriveStorage) DisplayName() string {
 	return fmt.Sprintf("Google Drive: %v", gdrive.folderID)
-}
-
-func (gdrive *gdriveStorage) Close(ctx context.Context) error {
-	return nil
 }
 
 func (gdrive *gdriveStorage) FlushCaches(ctx context.Context) error {

--- a/repo/blob/readonly/readonly_storage.go
+++ b/repo/blob/readonly/readonly_storage.go
@@ -15,7 +15,7 @@ var ErrReadonly = errors.Errorf("storage is read-only")
 // readonlyStorage prevents all mutations on the underlying storage.
 type readonlyStorage struct {
 	base blob.Storage
-	blob.UnsupportedBlobRetention
+	blob.DefaultProviderImplementation
 }
 
 func (s readonlyStorage) GetCapacity(ctx context.Context) (blob.Capacity, error) {

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -30,18 +30,11 @@ const (
 
 type s3Storage struct {
 	Options
+	blob.DefaultProviderImplementation
 
 	cli *minio.Client
 
 	storageConfig *StorageConfig
-}
-
-func (s *s3Storage) GetCapacity(ctx context.Context) (blob.Capacity, error) {
-	return blob.Capacity{}, blob.ErrNotAVolume
-}
-
-func (s *s3Storage) IsReadOnly() bool {
-	return false
 }
 
 func (s *s3Storage) GetBlob(ctx context.Context, b blob.ID, offset, length int64, output blob.OutputBuffer) error {
@@ -300,20 +293,12 @@ func (s *s3Storage) ConnectionInfo() blob.ConnectionInfo {
 	}
 }
 
-func (s *s3Storage) Close(ctx context.Context) error {
-	return nil
-}
-
 func (s *s3Storage) String() string {
 	return fmt.Sprintf("s3://%v/%v", s.BucketName, s.Prefix)
 }
 
 func (s *s3Storage) DisplayName() string {
 	return fmt.Sprintf("S3: %v %v", s.Endpoint, s.BucketName)
-}
-
-func (s *s3Storage) FlushCaches(ctx context.Context) error {
-	return nil
 }
 
 func getCustomTransport(opt *Options) (*http.Transport, error) {

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -40,7 +40,7 @@ const (
 // sftpStorage implements blob.Storage on top of sftp.
 type sftpStorage struct {
 	sharded.Storage
-	blob.UnsupportedBlobRetention
+	blob.DefaultProviderImplementation
 }
 
 type sftpImpl struct {

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -360,10 +360,6 @@ func writeKnownHostsDataStringToTempFile(data string) (string, error) {
 	return tf.Name(), nil
 }
 
-func (s *sftpStorage) FlushCaches(ctx context.Context) error {
-	return nil
-}
-
 // getHostKeyCallback returns a HostKeyCallback that validates the connected host based on KnownHostsFile or KnownHostsData.
 func getHostKeyCallback(opt *Options) (ssh.HostKeyCallback, error) {
 	if opt.KnownHostsData != "" {

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -44,11 +44,6 @@ type Storage struct {
 	parameters *Parameters
 }
 
-// IsReadOnly implements blob.Storage.
-func (s *Storage) IsReadOnly() bool {
-	return false
-}
-
 // GetBlob implements blob.Storage.
 func (s *Storage) GetBlob(ctx context.Context, blobID blob.ID, offset, length int64, output blob.OutputBuffer) error {
 	dirPath, filePath, err := s.GetShardedPathAndFilePath(ctx, blobID)

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -138,11 +138,16 @@ type ExtendOptions struct {
 	RetentionPeriod time.Duration
 }
 
-// UnsupportedBlobRetention provides a default implementation for ExtendBlobRetention.
-type UnsupportedBlobRetention struct{}
+// DefaultProviderImplementation provides a default implementation for
+// common functions that are mostly provider independent and have a sensible
+// default.
+//
+// Storage providers should imbed this struct and override functions that they
+// have different return values for.
+type DefaultProviderImplementation struct{}
 
 // ExtendBlobRetention provides a common implementation for unsupported blob retention storage.
-func (s *UnsupportedBlobRetention) ExtendBlobRetention(context.Context, ID, ExtendOptions) error {
+func (s DefaultProviderImplementation) ExtendBlobRetention(context.Context, ID, ExtendOptions) error {
 	return ErrUnsupportedObjectLock
 }
 

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -151,6 +151,26 @@ func (s DefaultProviderImplementation) ExtendBlobRetention(context.Context, ID, 
 	return ErrUnsupportedObjectLock
 }
 
+// IsReadOnly complies with the Storage interface.
+func (s DefaultProviderImplementation) IsReadOnly() bool {
+	return false
+}
+
+// Close complies with the Storage interface.
+func (s DefaultProviderImplementation) Close(context.Context) error {
+	return nil
+}
+
+// FlushCaches complies with the Storage interface.
+func (s DefaultProviderImplementation) FlushCaches(context.Context) error {
+	return nil
+}
+
+// GetCapacity complies with the Storage interface.
+func (s DefaultProviderImplementation) GetCapacity(context.Context) (Capacity, error) {
+	return Capacity{}, ErrNotAVolume
+}
+
 // HasRetentionOptions returns true when blob-retention settings have been
 // specified, otherwise returns false.
 func (o PutOptions) HasRetentionOptions() bool {

--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -45,10 +45,6 @@ type davStorageImpl struct {
 	cli *gowebdav.Client
 }
 
-func (d *davStorage) GetCapacity(ctx context.Context) (blob.Capacity, error) {
-	return blob.Capacity{}, blob.ErrNotAVolume
-}
-
 func (d *davStorageImpl) GetBlobFromPath(ctx context.Context, dirPath, path string, offset, length int64, output blob.OutputBuffer) error {
 	_ = dirPath
 
@@ -240,14 +236,6 @@ func (d *davStorage) ConnectionInfo() blob.ConnectionInfo {
 func (d *davStorage) DisplayName() string {
 	o := d.Storage.Impl.(*davStorageImpl).Options //nolint:forcetypeassert
 	return fmt.Sprintf("WebDAV: %v", o.URL)
-}
-
-func (d *davStorage) Close(ctx context.Context) error {
-	return nil
-}
-
-func (d *davStorage) FlushCaches(ctx context.Context) error {
-	return nil
 }
 
 func isRetriable(err error) bool {

--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -36,7 +36,7 @@ const (
 // may be accessed using WebDAV or File interchangeably.
 type davStorage struct {
 	sharded.Storage
-	blob.UnsupportedBlobRetention
+	blob.DefaultProviderImplementation
 }
 
 type davStorageImpl struct {


### PR DESCRIPTION
Create a stub struct that has default implementations of trivial functions that providers are expected to implement. This allows for easier additions in the future as the new struct can be modified instead of all provider implementations. Providers that desire different functionality can just override specific functions

Reviewing by commit should help isolate individual sets of changes