### PR TITLE
chore(ci): add govulncheck step to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,11 @@ jobs:
         go-version: '1.20'
       id: go
       if: ${{ !contains(matrix.os, 'ARMHF') }}
+    - id: govulncheck
+      uses: golang/govulncheck-action@7da72f730e37eeaad891fcff0a532d27ed737cd4
+      with:
+        repo-checkout: false
+        cache: false
     - name: Lint
       run: make lint
     - name: Check Locks


### PR DESCRIPTION
Sample output:

```
Run govulncheck -C . ./...
  govulncheck -C . ./...
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    UNIX_SHELL_ON_WINDOWS: true
    ENABLE_UNICODE_FILENAMES: 
    ENABLE_LONG_FILENAMES: 
Scanning your code and 636 packages across 105 dependent modules for known vulnerabilities...

No vulnerabilities found.
```