### PR TITLE
feat(server): fixed server logging to file & console

### DIFF
--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -62,6 +62,7 @@ type commandServerStart struct {
 	uiTitlePrefix                       string
 	uiPreferencesFile                   string
 	asyncRepoConnect                    bool
+	persistentLogs                      bool
 
 	shutdownGracePeriod time.Duration
 
@@ -108,6 +109,7 @@ func (c *commandServerStart) setup(svc advancedAppServices, parent commandParent
 	cmd.Flag("tls-print-server-cert", "Print server certificate").Hidden().BoolVar(&c.serverStartTLSPrintFullServerCert)
 
 	cmd.Flag("async-repo-connect", "Connect to repository asynchronously").Hidden().BoolVar(&c.asyncRepoConnect)
+	cmd.Flag("persistent-logs", "Persist logs in a file").Default("true").BoolVar(&c.persistentLogs)
 	cmd.Flag("ui-title-prefix", "UI title prefix").Hidden().Envar(svc.EnvName("KOPIA_UI_TITLE_PREFIX")).StringVar(&c.uiTitlePrefix)
 	cmd.Flag("ui-preferences-file", "Path to JSON file storing UI preferences").StringVar(&c.uiPreferencesFile)
 
@@ -149,6 +151,7 @@ func (c *commandServerStart) serverStartOptions(ctx context.Context) (*server.Op
 		PasswordPersist:      c.svc.passwordPersistenceStrategy(),
 		UIPreferencesFile:    uiPreferencesFile,
 		UITitlePrefix:        c.uiTitlePrefix,
+		PersistentLogs:       c.persistentLogs,
 
 		DisableCSRFTokenChecks: c.disableCSRFTokenChecks,
 	}, nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -865,6 +865,7 @@ type Options struct {
 	UIPreferencesFile      string // name of the JSON file storing UI preferences
 	ServerControlUser      string // name of the user allowed to access the server control API
 	DisableCSRFTokenChecks bool
+	PersistentLogs         bool
 	UITitlePrefix          string
 }
 
@@ -1047,7 +1048,7 @@ func New(ctx context.Context, options *Options) (*Server, error) {
 		grpcServerState:      makeGRPCServerState(options.MaxConcurrency),
 		authenticator:        options.Authenticator,
 		authorizer:           options.Authorizer,
-		taskmgr:              uitask.NewManager(),
+		taskmgr:              uitask.NewManager(options.PersistentLogs),
 		mounts:               map[object.ID]mount.Controller{},
 		authCookieSigningKey: []byte(options.AuthCookieSigningKey),
 	}

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -593,7 +593,9 @@ func (sm *SharedManager) CloseShared(ctx context.Context) error {
 func (sm *SharedManager) AlsoLogToContentLog(ctx context.Context) context.Context {
 	sm.repoLogManager.Enable()
 
-	return logging.AlsoLogTo(ctx, sm.log)
+	return logging.WithAdditionalLogger(ctx, func(module string) logging.Logger {
+		return sm.log
+	})
 }
 
 func (sm *SharedManager) shouldRefreshIndexes() bool {

--- a/repo/logging/broadcast.go
+++ b/repo/logging/broadcast.go
@@ -9,9 +9,21 @@ import (
 func Broadcast(logger ...Logger) Logger {
 	var cores []zapcore.Core
 
+	var singleName string
+
 	for _, l := range logger {
-		cores = append(cores, l.Desugar().Core())
+		dl := l.Desugar()
+
+		if singleName == "" {
+			singleName = dl.Name()
+		}
+
+		if dl.Name() != singleName {
+			singleName = "-"
+		}
+
+		cores = append(cores, dl.Core())
 	}
 
-	return zap.New(zapcore.NewTee(cores...)).Sugar()
+	return zap.New(zapcore.NewTee(cores...)).Sugar().Named(singleName)
 }

--- a/repo/logging/ctx.go
+++ b/repo/logging/ctx.go
@@ -34,6 +34,15 @@ func WithLogger(ctx context.Context, l LoggerFactory) context.Context {
 	})
 }
 
+// WithAdditionalLogger returns a context where all logging is emitted the original output plus the provided logger factory.
+func WithAdditionalLogger(ctx context.Context, fact LoggerFactory) context.Context {
+	originalLogFactory := loggerFactoryFromContext(ctx)
+
+	return WithLogger(ctx, func(module string) Logger {
+		return Broadcast(originalLogFactory(module), fact(module))
+	})
+}
+
 // loggerFactoryFromContext returns a LoggerFactory associated with current context.
 func loggerFactoryFromContext(ctx context.Context) LoggerFactory {
 	v := ctx.Value(loggerCacheKey)
@@ -42,13 +51,4 @@ func loggerFactoryFromContext(ctx context.Context) LoggerFactory {
 	}
 
 	return v.(*loggerCache).getLogger //nolint:forcetypeassert
-}
-
-// AlsoLogTo returns a context where all logging is emitted the original output plus the provided loggers.
-func AlsoLogTo(ctx context.Context, loggers ...Logger) context.Context {
-	originalLogFactory := loggerFactoryFromContext(ctx)
-
-	return WithLogger(ctx, func(module string) Logger {
-		return Broadcast(append([]Logger{originalLogFactory(module)}, loggers...)...)
-	})
 }

--- a/repo/logging/logging_test.go
+++ b/repo/logging/logging_test.go
@@ -82,6 +82,23 @@ func TestNonNullWriterModule(t *testing.T) {
 	require.Equal(t, "A\nS\t{\"b\":123}\nB\nC\nW\n", buf.String())
 }
 
+func TestWithAdditionalLogger(t *testing.T) {
+	var buf, buf2 bytes.Buffer
+
+	ctx := logging.WithLogger(context.Background(), logging.ToWriter(&buf))
+	ctx = logging.WithAdditionalLogger(ctx, logging.ToWriter(&buf2))
+	l := logging.Module("mod1")(ctx)
+
+	l.Debugf("A")
+	l.Debugw("S", "b", 123)
+	l.Infof("B")
+	l.Errorf("C")
+	l.Warnf("W")
+
+	require.Equal(t, "A\nS\t{\"b\":123}\nB\nC\nW\n", buf.String())
+	require.Equal(t, "A\nS\t{\"b\":123}\nB\nC\nW\n", buf2.String())
+}
+
 func BenchmarkLogger(b *testing.B) {
 	mod1 := logging.Module("mod1")
 	ctx := logging.WithLogger(context.Background(), testlogging.PrintfFactory(b.Logf))


### PR DESCRIPTION
Previously some logs from a running server were only kept in memory (including storage activity logs) which was confusing to many folks.

This changes the behavior so that logs are sent to their regular (console/file) file locations in addition to the UI tasks.

Old behavior can be restored by adding `--no-persistent-logs` to server.
