### PR TITLE
fix(cli): added output to indicate completion of snapshot verification

### DIFF
--- a/cli/command_snapshot_verify.go
+++ b/cli/command_snapshot_verify.go
@@ -69,6 +69,7 @@ func (c *commandSnapshotVerify) run(ctx context.Context, rep repo.Repository) er
 	}
 
 	v := snapshotfs.NewVerifier(ctx, rep, opts)
+	defer v.ShowFinalStats(ctx)
 
 	//nolint:wrapcheck
 	return v.InParallel(ctx, func(tw *snapshotfs.TreeWalker) error {

--- a/snapshot/snapshotfs/snapshot_verifier.go
+++ b/snapshot/snapshotfs/snapshot_verifier.go
@@ -49,6 +49,13 @@ func (v *Verifier) ShowStats(ctx context.Context) {
 	verifierLog(ctx).Infof("Processed %v objects.", processed)
 }
 
+// ShowFinalStats logs final verification statistics.
+func (v *Verifier) ShowFinalStats(ctx context.Context) {
+	processed := v.processed.Load()
+
+	verifierLog(ctx).Infof("Finished processing %v objects.", processed)
+}
+
 // VerifyFile verifies a single file object (using content check, blob map check or full read).
 func (v *Verifier) VerifyFile(ctx context.Context, oid object.ID, entryPath string) error {
 	verifierLog(ctx).Debugf("verifying object %v", oid)


### PR DESCRIPTION
This should address user confusion for very small repositories that are very quickly verified printing only `Processed 0 objects.`