### PR TITLE
chore(ci): use 'with.go-version-file' in actions/setup-go

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
     - name: Run Tests

--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
     - name: Compat Test

--- a/.github/workflows/endurance-test.yml
+++ b/.github/workflows/endurance-test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
     - name: Endurance Tests

--- a/.github/workflows/htmlui-tests.yml
+++ b/.github/workflows/htmlui-tests.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
     - name: Run Tests

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
     - name: Download dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
       if: ${{ !contains(matrix.os, 'ARMHF') }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
       if: ${{ !contains(matrix.os, 'ARMHF') }}

--- a/.github/workflows/providers-core.yml
+++ b/.github/workflows/providers-core.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
     - name: Install Dependencies

--- a/.github/workflows/providers-extra.yml
+++ b/.github/workflows/providers-extra.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
     - name: Install Dependencies

--- a/.github/workflows/race-detector.yml
+++ b/.github/workflows/race-detector.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
     - name: Unit Tests

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
     - name: Stress Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
         check-latest: true
       id: go
       if: ${{ !contains(matrix.os, 'ARMHF') }}


### PR DESCRIPTION
This simplifies managing the Go version used in CI, as it will only require updating the `go.mod` file when upgrading the Go toolchain.