### PR TITLE
feat(server): Add socket-activation support

### DIFF
--- a/cli/command_server_control_linux_test.go
+++ b/cli/command_server_control_linux_test.go
@@ -1,0 +1,104 @@
+//go:build linux
+// +build linux
+
+package cli_test
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestServerControlSocketActivated(t *testing.T) {
+	var port int
+
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+	dir0 := testutil.TempDirectory(t)
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir, "--override-username=another-user", "--override-hostname=another-host")
+	env.RunAndExpectSuccess(t, "snap", "create", dir0)
+
+	env.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", env.RepoDir, "--override-username=test-user", "--override-hostname=test-host")
+
+	serverStarted := make(chan struct{})
+	serverStopped := make(chan struct{})
+
+	var sp testutil.ServerParameters
+
+	go func() {
+		os.Setenv("LISTEN_FDS", "1")
+		os.Setenv("LISTEN_PID", strconv.Itoa(os.Getpid()))
+
+		in2, err := syscall.Dup(3)
+		if err != nil {
+			close(serverStarted)
+			return
+		}
+
+		defer func() {
+			syscall.Close(3)
+			syscall.Dup3(in2, 3, 0)
+			syscall.Close(in2)
+		}()
+
+		syscall.Close(3)
+
+		l1, err := net.Listen("tcp", ":0")
+		if err != nil {
+			close(serverStarted)
+			return
+		}
+
+		port = l1.Addr().(*net.TCPAddr).Port
+
+		t.Logf("Activating socket on %v, PID: %v", port, os.Getpid())
+
+		wait, _ := env.RunAndProcessStderr(t, sp.ProcessOutput,
+			"server", "start", "--insecure", "--random-server-control-password", "--address=127.0.0.1:0")
+
+		close(serverStarted)
+		os.Unsetenv("LISTEN_FDS")
+		os.Unsetenv("LISTEN_PID")
+
+		wait()
+
+		close(serverStopped)
+	}()
+
+	select {
+	case <-serverStarted:
+		if sp.BaseURL == "" {
+			t.Fatalf("Failed to start server")
+		}
+
+		t.Logf("server started on %v", sp.BaseURL)
+
+	case <-time.After(5 * time.Second):
+		t.Fatalf("server did not start in time")
+	}
+
+	require.Contains(t, sp.BaseURL, ":"+strconv.Itoa(port))
+
+	lines := env.RunAndExpectSuccess(t, "server", "status", "--address", "http://127.0.0.1:"+strconv.Itoa(port), "--server-control-password", sp.ServerControlPassword, "--remote")
+	require.Len(t, lines, 1)
+	require.Contains(t, lines, "REMOTE: another-user@another-host:"+dir0)
+
+	env.RunAndExpectSuccess(t, "server", "shutdown", "--address", sp.BaseURL, "--server-control-password", sp.ServerControlPassword)
+
+	select {
+	case <-serverStopped:
+		t.Logf("server shut down")
+
+	case <-time.After(15 * time.Second):
+		t.Fatalf("server did not shutdown in time")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/chmduquesne/rollinghash v4.0.0+incompatible
 	github.com/chromedp/cdproto v0.0.0-20230802225258-3cf4e6d46a89
 	github.com/chromedp/chromedp v0.9.2
+	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/fatih/color v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XP
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
+github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.2.0 h1:ozqKHaLK0W/ii4KVbbvluM91W2H3Sh0BncbUNPS7jLE=
 github.com/danieljoos/wincred v1.2.0/go.mod h1:FzQLLMKBFdvu+osBrnFODiv32YGwCfx0SkRa/eYHgec=
@@ -119,6 +121,7 @@ github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.2.1 h1:F2aeBZrm2NDsc7vbovKrWSogd4wvfAxg0FQ89/iqOTk=
 github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=

--- a/site/content/docs/Repository Server/_index.md
+++ b/site/content/docs/Repository Server/_index.md
@@ -322,3 +322,28 @@ server {
 ```shell
 kopia server start --address unix:/tmp/kopia.sock --tls-cert-file ~/my.cert --tls-key-file ~/my.key
 ```
+
+## Kopia with systemd
+
+Kopia can be run as a socket-activated systemd service.  While socket-activation is not typically needed
+for Kopia, it can be usefull when run in a rootless Podman container, or to control the permissions
+of the unix-domain-socket when run behind a reverse proxy.
+
+Kopia will automatically detect socket-activation when present and ignore the --address switch.
+
+When using socket-activation with Kopia server, it is generally deriable to enable both the socket and
+the service so that the service starts immediately instead of on-demand (so that the maintenance can run).
+
+An example kopia.socket file using unix domain sockets and permission control may look like:
+
+```
+[Unit]
+Description=Kopia
+
+[Socket]
+ListenStream=%t/kopia/kopia.sock
+SocketMode=0666
+
+[Install]
+WantedBy=sockets.target
+```


### PR DESCRIPTION
I'm not sure how much interest there is in this, but the attached patch adds systemd socket-activation support for Kopia.  Normally socket-activation is used for on-demand application startup, but that probably isn't an ideal setup for Kopia as it could prevent the running of maintenance tasks.  However socket activation has a few other uses:

* Allows configuring permissions of a unix-domain-socket
* Allows exposing ports when running in a rootless podman container without the need for slirp4netns (socket-activation does not work with Docker as far as I know)
* Can be used to allow running of privileged ports as non-root user (additional setup required)

My personal use is the 1st one, as it provides a race-free way to ensure my reverse-proxy can access the unix-domain-socket I use for Kopia.

The test is a little ugly, as the `go-systemd/activation` module provides no means of changing the starting FD when scanning for socket-activated sockets, which requires that we enable activation on fd 3 which may already be in use when the test runs. 