### PR TITLE
feat(ui): Allow specifying whether local or all snapshots are shown by default

### DIFF
--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -289,7 +289,8 @@ type CLIInfo struct {
 
 // UIPreferences represents JSON object storing UI preferences.
 type UIPreferences struct {
-	BytesStringBase2 bool   `json:"bytesStringBase2"` // If `true`, display storage values in base-2 (default is base-10)
-	Theme            string `json:"theme"`            // 'dark', 'light' or ''
-	PageSize         int    `json:"pageSize"`         // A page size; the actual possible values will only be provided by the frontend
+	BytesStringBase2       bool   `json:"bytesStringBase2"`       // If `true`, display storage values in base-2 (default is base-10)
+	DefaultSnapshotViewAll bool   `json:"defaultSnapshotViewAll"` // If `true` default to showing all snapshots (default is local snapshots)
+	Theme                  string `json:"theme"`                  // 'dark', 'light' or ''
+	PageSize               int    `json:"pageSize"`               // A page size; the actual possible values will only be provided by the frontend
 }


### PR DESCRIPTION
When I connect to the server http page, I prefer to see all snapshots shown by default.  every time I switch away and come back I need to reselect 'All' instead of 'Local'.  This just makes the default a preference option.

Requires https://github.com/kopia/htmlui/pull/186
