### PR TITLE
feat(server): introduced generic scheduler

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,192 @@
+// Package scheduler implements a simple scheduler that triggers the next item when its due time is
+// reached based on the list of upcoming items.
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/ctxutil"
+	"github.com/kopia/kopia/repo/logging"
+)
+
+var log = logging.Module("scheduler")
+
+// GetItemsFunc is a callback that returns items for the scheduler to consider.
+type GetItemsFunc func(ctx context.Context, now time.Time) []Item
+
+// Item describes an item that can be scheduled with a function that is invoked the next time the item is due.
+type Item struct {
+	Description string
+	NextTime    time.Time
+	Trigger     func()
+}
+
+// Scheduler manages triggering of arbitrary events by periodically determining the first
+// of a set of upcoming events and waiting until it's due and invoking the trigger function.
+type Scheduler struct {
+	TimeNow func() time.Time
+	Debug   bool
+
+	refreshRequested chan string
+	getItems         GetItemsFunc
+	closed           chan struct{}
+	wg               sync.WaitGroup
+}
+
+// Options the scheduler.
+type Options struct {
+	TimeNow        func() time.Time
+	Debug          bool
+	RefreshChannel chan string
+}
+
+// Start runs a new scheduler that will call getItems() to get the list of items to schedule.
+func Start(ctx context.Context, getItems GetItemsFunc, opts Options) *Scheduler {
+	timeNow := opts.TimeNow
+
+	if timeNow == nil {
+		timeNow = clock.Now
+	}
+
+	s := &Scheduler{
+		TimeNow:          timeNow,
+		refreshRequested: opts.RefreshChannel,
+		closed:           make(chan struct{}),
+		getItems:         getItems,
+		Debug:            opts.Debug,
+	}
+
+	s.wg.Add(1)
+
+	go func() {
+		defer s.wg.Done()
+
+		s.run(ctxutil.Detach(ctx))
+	}()
+
+	return s
+}
+
+const sleepTimeWhenNoUpcomingSnapshots = 8 * time.Hour
+
+func (s *Scheduler) upcomingItems(ctx context.Context, now time.Time) (nextTriggerTime time.Time, toTrigger []Item) {
+	allsm := s.getItems(ctx, now)
+
+	for _, t := range allsm {
+		if nextTriggerTime.IsZero() || t.NextTime.Before(nextTriggerTime) {
+			nextTriggerTime = t.NextTime
+			toTrigger = nil
+		}
+
+		if t.NextTime.Equal(nextTriggerTime) {
+			toTrigger = append(toTrigger, t)
+		}
+	}
+
+	if s.Debug {
+		log(ctx).Debugf(">>>> scheduling %v items (now %v)", len(allsm), now.Format(time.RFC3339))
+
+		for _, it := range allsm {
+			log(ctx).Debugf("  %v %v", it.NextTime.Format(time.RFC3339), it.Description)
+		}
+	}
+
+	return nextTriggerTime, toTrigger
+}
+
+func sleepTimeOrDefault(now, t time.Time, def time.Duration) time.Duration {
+	if t.IsZero() {
+		return def
+	}
+
+	// note this may negative if the getItems returns items in the past.
+	return t.Sub(now)
+}
+
+// Stop stops the scheduler.
+func (s *Scheduler) Stop() {
+	close(s.closed)
+	s.wg.Wait()
+}
+
+func (s *Scheduler) run(ctx context.Context) {
+	var timer *time.Timer
+
+	for {
+		now := s.TimeNow()
+		nextTriggerTime, toTrigger := s.upcomingItems(ctx, now)
+
+		sleepTimeUntilNextTrigger := sleepTimeOrDefault(now, nextTriggerTime, sleepTimeWhenNoUpcomingSnapshots)
+		if sleepTimeUntilNextTrigger < 0 {
+			sleepTimeUntilNextTrigger = 0
+		}
+
+		if s.Debug && sleepTimeUntilNextTrigger > 0 {
+			log(ctx).Debugf("sleeping for %v until %v (%v)",
+				sleepTimeUntilNextTrigger,
+				nextTriggerTime.Format(time.RFC3339),
+				TriggerNames(toTrigger),
+			)
+		}
+
+		// stop previous timer, if any
+		if timer != nil {
+			timer.Stop()
+		}
+
+		timer = time.NewTimer(sleepTimeUntilNextTrigger)
+
+		select {
+		case <-s.closed:
+			// stopping, just exit
+			return
+
+		case <-timer.C:
+			for _, sm := range toTrigger {
+				log(ctx).Debugf("triggering %v", sm.Description)
+
+				sm.Trigger()
+			}
+
+		case reason := <-s.refreshRequested:
+			if s.Debug {
+				log(ctx).Debugw("schedule re-evaluation requested", "reason", reason)
+			}
+		}
+	}
+}
+
+// TriggerNames returns a human-readable description of the items that are about to be triggered.
+func TriggerNames(toTrigger []Item) string {
+	var result []string
+
+	for _, t := range toTrigger {
+		result = append(result, t.Description)
+	}
+
+	if len(result) == 0 {
+		return "no triggers"
+	}
+
+	if len(result) == 1 {
+		return result[0]
+	}
+
+	s := fmt.Sprintf("%v triggers: ", len(result))
+
+	var suffix string
+
+	const maxItems = 5
+
+	if len(result) > maxItems {
+		suffix = " [...]"
+		result = result[:maxItems]
+	}
+
+	return s + strings.Join(result, ", ") + suffix
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,184 @@
+package scheduler_test
+
+import (
+	"context"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/faketime"
+	"github.com/kopia/kopia/internal/scheduler"
+	"github.com/kopia/kopia/internal/testlogging"
+)
+
+var baseTime = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func TestScheduler(t *testing.T) {
+	ch := make(chan string, 1000)
+
+	// times of upcoming events
+	it1 := scheduler.Item{"it1", baseTime.Add(100 * time.Millisecond), reportTriggered(t, ch, "it1")}
+	it2a := scheduler.Item{"it2", baseTime.Add(200 * time.Millisecond), reportTriggered(t, ch, "it2")}
+	it2b := scheduler.Item{"it2", baseTime.Add(200 * time.Millisecond), reportTriggered(t, ch, "it2")}
+	it3a := scheduler.Item{"it3", baseTime.Add(300 * time.Millisecond), reportTriggered(t, ch, "it3")}
+	it3b := scheduler.Item{"it3", baseTime.Add(300 * time.Millisecond), reportTriggered(t, ch, "it3")}
+	it4 := scheduler.Item{"it4", baseTime.Add(30 * time.Hour), reportTriggered(t, ch, "it4")}
+
+	items := []scheduler.Item{it1, it2a, it2b, it3a, it3b, it4}
+
+	// verify that the item order does not matter by shuffling the items.
+	rand.Shuffle(len(items), func(i, j int) { items[i], items[j] = items[j], items[i] })
+
+	ctx := testlogging.Context(t)
+
+	ft := faketime.NewClockTimeWithOffset(baseTime.Sub(clock.Now()))
+
+	refresh := make(chan string)
+	s := scheduler.Start(ctx, func(ctx context.Context, now time.Time) []scheduler.Item {
+		var result []scheduler.Item
+
+		for _, it := range items {
+			if it.NextTime.After(now) {
+				result = append(result, it)
+			}
+		}
+
+		return result
+	}, scheduler.Options{
+		TimeNow:        ft.NowFunc(),
+		Debug:          true,
+		RefreshChannel: refresh,
+	})
+
+	defer s.Stop()
+
+	// ensure that the first few items are triggered in order.
+	require.Equal(t, "it1", <-ch)
+	require.Equal(t, "it2", <-ch)
+	require.Equal(t, "it2", <-ch)
+	require.Equal(t, "it3", <-ch)
+	require.Equal(t, "it3", <-ch)
+
+	// it4 is far into the future, make sure nothing is triggered immediately
+	select {
+	case v := <-ch:
+		t.Fatalf("unexpected item: %v", v)
+
+	case <-time.After(1 * time.Second):
+	}
+
+	// now change the set of items returned by adding it5 which comes before it4
+	it5 := scheduler.Item{"it5", ft.NowFunc()().Add(time.Second), reportTriggered(t, ch, "it5")}
+	items = []scheduler.Item{it1, it2a, it2b, it3a, it3b, it4, it5}
+
+	refresh <- "x"
+
+	require.Equal(t, "it5", <-ch)
+}
+
+// reportTriggered returns a function that reports the item to the provided channel and logs it.
+func reportTriggered(t *testing.T, ch chan string, name string) func() {
+	t.Helper()
+
+	return func() {
+		ch <- name
+	}
+}
+
+func TestSchedulerWillTriggerItemsInThePast(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	var cnt atomic.Int32
+
+	s := scheduler.Start(ctx, func(ctx context.Context, now time.Time) []scheduler.Item {
+		if v := cnt.Add(1); v <= 3 {
+			return []scheduler.Item{{
+				"it1",
+				now.Add(-100 * time.Millisecond),
+				func() {
+					t.Logf("zzz %v", v)
+				},
+			}}
+		}
+
+		return nil
+	}, scheduler.Options{})
+
+	defer s.Stop() // times of upcoming events
+
+	for cnt.Load() < 3 {
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestSchedulerRefresh(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	var cnt atomic.Int32
+
+	refresh := make(chan string)
+	triggered := make(chan struct{})
+
+	s := scheduler.Start(ctx, func(ctx context.Context, now time.Time) []scheduler.Item {
+		t.Logf("now=%v", now)
+		switch cnt.Add(1) {
+		case 1:
+			return []scheduler.Item{{
+				"it1",
+				now.Add(time.Hour),
+				func() {
+					t.Error("this should not happen")
+				},
+			}}
+		case 2:
+			return []scheduler.Item{{
+				"it1",
+				now,
+				func() {
+					close(triggered)
+				},
+			}}
+		}
+
+		return nil
+	}, scheduler.Options{
+		RefreshChannel: refresh,
+	})
+
+	defer s.Stop() // times of upcoming events
+
+	select {
+	case <-time.After(time.Second):
+		// nothing
+	case <-triggered:
+		t.Error("triggered too early")
+	}
+
+	refresh <- "x"
+
+	select {
+	case <-time.After(time.Second):
+		t.Error("did not trigger")
+	case <-triggered: // success
+	}
+}
+
+func TestTriggerNames(t *testing.T) {
+	cases := []struct {
+		items []scheduler.Item
+		want  string
+	}{
+		{nil, "no triggers"},
+		{[]scheduler.Item{{Description: "x"}}, "x"},
+		{[]scheduler.Item{{Description: "x"}, {Description: "y"}}, "2 triggers: x, y"},
+		{[]scheduler.Item{{Description: "a"}, {Description: "b"}, {Description: "c"}, {Description: "d"}, {Description: "e"}, {Description: "f"}}, "6 triggers: a, b, c, d, e [...]"},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, scheduler.TriggerNames(tc.items))
+	}
+}


### PR DESCRIPTION
This is a generic scheduler that executes a loop consisting of:

- determining upcoming set of events
- waiting until the appropriate time
- triggering the events

(Note this is part of #3265 after addressing comments made on that review, only limited to scheduler)