### PR TITLE
feat(cli): add more info to "snapshot create" json

### DIFF
--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -286,6 +286,19 @@ func (c *commandSnapshotCreate) snapshotSingleSource(ctx context.Context, fsEntr
 	manifest.Tags = tags
 	manifest.UpdatePins(c.pins, nil)
 
+	progress := c.svc.getProgress()
+
+	manifest.Progress = map[string]int64{
+		"uploadedBytes":     progress.uploadedBytes.Load(),
+		"cachedBytes":       progress.cachedBytes.Load(),
+		"hashedBytes":       progress.hashedBytes.Load(),
+		"cachedFiles":       int64(progress.cachedFiles.Load()),
+		"hashedFiles":       int64(progress.hashedFiles.Load()),
+		"uploadedFiles":     int64(progress.uploadedFiles.Load()),
+		"ignoredErrorCount": int64(progress.ignoredErrorCount.Load()),
+		"fatalErrorCount":   int64(progress.fatalErrorCount.Load()),
+	}
+
 	startTimeOverride, _ := parseTimestamp(c.snapshotCreateStartTime)
 	endTimeOverride, _ := parseTimestamp(c.snapshotCreateEndTime)
 
@@ -336,7 +349,7 @@ func (c *commandSnapshotCreate) snapshotSingleSource(ctx context.Context, fsEntr
 		}
 	}
 
-	c.svc.getProgress().Finish()
+	progress.Finish()
 
 	return c.reportSnapshotStatus(ctx, manifest)
 }

--- a/snapshot/manifest.go
+++ b/snapshot/manifest.go
@@ -18,9 +18,10 @@ type Manifest struct {
 	ID     manifest.ID `json:"id"`
 	Source SourceInfo  `json:"source"`
 
-	Description string          `json:"description"`
-	StartTime   fs.UTCTimestamp `json:"startTime"`
-	EndTime     fs.UTCTimestamp `json:"endTime"`
+	Description string           `json:"description"`
+	StartTime   fs.UTCTimestamp  `json:"startTime"`
+	EndTime     fs.UTCTimestamp  `json:"endTime"`
+	Progress    map[string]int64 `json:"progress"`
 
 	Stats            Stats  `json:"stats,omitempty"`
 	IncompleteReason string `json:"incomplete,omitempty"`


### PR DESCRIPTION
I'd like to expose how many bytes were uploaded to the json of `kopia snapshot create --json`. I tested my diff and it works as expected.

I think this diff is rather hacky. I am motivated to improve this diff, if you let me know what you would like me to change. I wasn't sure how to cleanly implement this and I am also new to Go.