### PR TITLE
chore(ci): auto-delete old RPM and DEB packages

### DIFF
--- a/tools/apt-publish.sh
+++ b/tools/apt-publish.sh
@@ -3,7 +3,7 @@ set -e
 GS_PREFIX=gs://$PACKAGES_HOST/apt
 GPG_KEY_ID=7FB99DFD47809F0D5339D7D92273699AFD56A556
 PKGDIR=$1
-RETAIN_UNSTABLE_DEB_COUNT=2
+RETAIN_UNSTABLE_DEB_COUNT=3
 
 if [ -z "$PACKAGES_HOST" ]; then
   echo Not publishing APT package because PACKAGES_HOST is not set.
@@ -46,9 +46,7 @@ for d in $distributions; do
   mkdir -pv $WORK_DIR/dists/$d
   gsutil -m rsync -r -d $GS_PREFIX/dists/$d $WORK_DIR/dists/$d
   for a in $architectures; do
-    if [ "$d" == "unstable" ]; then
-      delete_old_deb $WORK_DIR/dists/$d/main/binary-$a || echo Unable to delete old deb
-    fi
+    delete_old_deb $WORK_DIR/dists/$d/main/binary-$a || echo Unable to delete old deb
   done
 done
 

--- a/tools/rpm-publish.sh
+++ b/tools/rpm-publish.sh
@@ -2,7 +2,7 @@
 set -e
 GS_PREFIX=gs://$PACKAGES_HOST/rpm
 PKGDIR=$1
-RETAIN_UNSTABLE_RPM_COUNT=2
+RETAIN_UNSTABLE_RPM_COUNT=3
 
 delete_old_rpms() {
   ls -tp1 $1/*.rpm | tail -n +$RETAIN_UNSTABLE_RPM_COUNT | xargs -I {} rm -v -- {}
@@ -46,12 +46,10 @@ for d in $distributions; do
 done
 
 for d in $distributions; do
-  if [ "$d" == "unstable" ]; then
-    # for unstable, keep only last few RPM versions.
-    for a in $architectures; do
-      delete_old_rpms $WORK_DIR/$d/$a
-    done
-  fi
+  # keep only last few RPM versions.
+  for a in $architectures; do
+    delete_old_rpms $WORK_DIR/$d/$a
+  done
 done
 
 rpm_files=$(find $1 -name '*.rpm')


### PR DESCRIPTION
This was previously done in `unstable` track, now doing it everywhere. At the same time bumped the count 2=>3.