### PR TITLE
feat(cli): Added option to allow running missed snapshots on Kopia start

### DIFF
--- a/cli/command_policy_set_scheduling.go
+++ b/cli/command_policy_set_scheduling.go
@@ -16,12 +16,14 @@ type policySchedulingFlags struct {
 	policySetTimesOfDay []string
 	policySetCron       string
 	policySetManual     bool
+	policySetRunMissed  bool
 }
 
 func (c *policySchedulingFlags) setup(cmd *kingpin.CmdClause) {
 	cmd.Flag("snapshot-interval", "Interval between snapshots").DurationListVar(&c.policySetInterval)
 	cmd.Flag("snapshot-time", "Comma-separated times of day when to take snapshot (HH:mm,HH:mm,...) or 'inherit' to remove override").StringsVar(&c.policySetTimesOfDay)
 	cmd.Flag("snapshot-time-crontab", "Semicolon-separated crontab-compatible expressions (or 'inherit')").StringVar(&c.policySetCron)
+	cmd.Flag("run-missed", "Run missed time-of-day snapshots (has no effect on interval snapshots)").BoolVar(&c.policySetRunMissed)
 	cmd.Flag("manual", "Only create snapshots manually").BoolVar(&c.policySetManual)
 }
 
@@ -91,6 +93,8 @@ func (c *policySchedulingFlags) setScheduleFromFlags(ctx context.Context, sp *po
 		}
 	}
 
+	c.setRunMissedFromFlags(ctx, sp, changeCount)
+
 	if sp.Manual {
 		*changeCount++
 
@@ -100,6 +104,21 @@ func (c *policySchedulingFlags) setScheduleFromFlags(ctx context.Context, sp *po
 	}
 
 	return nil
+}
+
+// Update RunMissed policy flag if changed.
+func (c *policySchedulingFlags) setRunMissedFromFlags(ctx context.Context, sp *policy.SchedulingPolicy, changeCount *int) {
+	if (c.policySetRunMissed && !sp.RunMissed) || (!c.policySetRunMissed && sp.RunMissed) {
+		*changeCount++
+
+		sp.RunMissed = c.policySetRunMissed
+
+		if sp.RunMissed {
+			log(ctx).Infof(" - missed time-of-day snapshots will run immediately\n")
+		} else {
+			log(ctx).Infof(" - missed time-of-day snapshots will run at next scheduled time\n")
+		}
+	}
 }
 
 // splitCronExpressions splits the provided string into a list of cron expressions.

--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -171,6 +171,7 @@ func TestSetErrorHandlingPolicyFromFlags(t *testing.T) {
 	}
 }
 
+//nolint:maintidx
 func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 	ctx := testlogging.Context(t)
 
@@ -181,6 +182,7 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 		timesOfDayArg  []string
 		cronArg        string
 		manualArg      bool
+		runMissedArg   bool
 		expResult      *policy.SchedulingPolicy
 		expErrMsg      string
 		expChangeCount int
@@ -412,6 +414,43 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 			},
 			expChangeCount: 1,
 		},
+		{
+			name: "Set RunMissed",
+			startingPolicy: &policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{Hour: 12, Minute: 0}},
+			},
+			runMissedArg: true,
+			expResult: &policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{Hour: 12, Minute: 0}},
+				RunMissed:  true,
+			},
+			expChangeCount: 1,
+		},
+		{
+			name: "Clear RunMissed",
+			startingPolicy: &policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{Hour: 12, Minute: 0}},
+				RunMissed:  true,
+			},
+			expResult: &policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{Hour: 12, Minute: 0}},
+				RunMissed:  false,
+			},
+			expChangeCount: 1,
+		},
+		{
+			name: "RunMissed unchanged",
+			startingPolicy: &policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{Hour: 12, Minute: 0}},
+				RunMissed:  true,
+			},
+			expResult: &policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{Hour: 12, Minute: 0}},
+				RunMissed:  true,
+			},
+			runMissedArg:   true,
+			expChangeCount: 0,
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -422,6 +461,7 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 			psf.policySetInterval = tc.intervalArg
 			psf.policySetTimesOfDay = tc.timesOfDayArg
 			psf.policySetManual = tc.manualArg
+			psf.policySetRunMissed = tc.runMissedArg
 			psf.policySetCron = tc.cronArg
 
 			err := psf.setSchedulingPolicyFromFlags(ctx, tc.startingPolicy, &changeCount)

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -292,7 +292,8 @@ func appendSchedulingPolicyRows(rows []policyTableRow, p *policy.Policy, def *po
 	}
 
 	if len(p.SchedulingPolicy.TimesOfDay) > 0 {
-		rows = append(rows, policyTableRow{"  Snapshot times:", "", definitionPointToString(p.Target(), def.SchedulingPolicy.TimesOfDay)})
+		rows = append(rows, policyTableRow{"  Run missed snapshots:", boolToString(p.SchedulingPolicy.RunMissed), definitionPointToString(p.Target(), def.SchedulingPolicy.RunMissed)},
+			policyTableRow{"  Snapshot times:", "", definitionPointToString(p.Target(), def.SchedulingPolicy.TimesOfDay)})
 
 		for _, tod := range p.SchedulingPolicy.TimesOfDay {
 			rows = append(rows, policyTableRow{"    " + tod.String(), "", ""})

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.16.7
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.11.8
-	github.com/kopia/htmluibuild v0.0.1-0.20230917144530-09072f5d10be
+	github.com/kopia/htmluibuild v0.0.1-0.20230917154246-98806054261e
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.63

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.11.8 h1:s8RpUW5TK4hjr+djiOpbZJB4ksx+TdYbRH7vHQpwPOY=
 github.com/klauspost/reedsolomon v1.11.8/go.mod h1:4bXRN+cVzMdml6ti7qLouuYi32KHJ5MGv0Qd8a47h6A=
-github.com/kopia/htmluibuild v0.0.1-0.20230917144530-09072f5d10be h1:8MTOmcSrien26eEVNT/uooE9jqQk80Dg/6msiQ5nLVo=
-github.com/kopia/htmluibuild v0.0.1-0.20230917144530-09072f5d10be/go.mod h1:cSImbrlwvv2phvj5RfScL2v08ghX6xli0PcK6f+t8S0=
+github.com/kopia/htmluibuild v0.0.1-0.20230917154246-98806054261e h1:XogFUFI4mcT5qyywKiGY5WqLi7l4b/eMi7BlEzgLTd0=
+github.com/kopia/htmluibuild v0.0.1-0.20230917154246-98806054261e/go.mod h1:cSImbrlwvv2phvj5RfScL2v08ghX6xli0PcK6f+t8S0=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/snapshot/policy/scheduling_policy_test.go
+++ b/snapshot/policy/scheduling_policy_test.go
@@ -191,6 +191,50 @@ func TestNextSnapshotTime(t *testing.T) {
 			wantTime: time.Date(2020, time.February, 6, 3, 5, 0, 0, time.Local),
 			wantOK:   true,
 		},
+		{
+			// Run immediately since last run was missed and RunMissed is set
+			pol: policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{11, 55}},
+				RunMissed:  true,
+			},
+			now:                  time.Date(2020, time.January, 2, 11, 55, 30, 0, time.Local),
+			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 55, 0, 0, time.Local),
+			wantTime:             time.Date(2020, time.January, 2, 11, 55, 30, 0, time.Local),
+			wantOK:               true,
+		},
+		{
+			// Don't run immediately even though RunMissed is set, because next run is upcoming
+			pol: policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{11, 55}},
+				RunMissed:  true,
+			},
+			now:                  time.Date(2020, time.January, 3, 11, 30, 0, 0, time.Local),
+			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 55, 0, 0, time.Local),
+			wantTime:             time.Date(2020, time.January, 3, 11, 55, 0, 0, time.Local),
+			wantOK:               true,
+		},
+		{
+			// Don't run immediately even though RunMissed is set because last run was not missed
+			pol: policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{11, 55}},
+				RunMissed:  true,
+			},
+			now:                  time.Date(2020, time.January, 2, 11, 30, 0, 0, time.Local),
+			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 55, 0, 0, time.Local),
+			wantTime:             time.Date(2020, time.January, 2, 11, 55, 0, 0, time.Local),
+			wantOK:               true,
+		},
+		{
+			// Don't run immediately even though RunMissed is set because last run was not missed
+			pol: policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{10, 0}},
+				RunMissed:  true,
+			},
+			now:                  time.Date(2020, time.January, 2, 11, 0, 0, 0, time.Local),
+			previousSnapshotTime: time.Date(2020, time.January, 2, 10, 0, 0, 0, time.Local),
+			wantTime:             time.Date(2020, time.January, 3, 10, 0, 0, 0, time.Local),
+			wantOK:               true,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
This PR adds a configuration option to create an immediate snapshot if a previous time-of-day snapshot was missed.  Today, interval snapshots will automatically be taken immediately if they were missed, but a time-of-day snapshot will not be taken until the next schedule.

 made this a configuration item instead of just enabling it because it may be that some users would prefer to miss a snasphot and take the next one off-hours rather than doing it immediately on startup.

This implements https://github.com/kopia/kopia/issues/3197

This is associated wit the htmlui patch: https://github.com/kopia/htmlui/pull/190
