### PR TITLE
feat(server): improve scheduler algorithm to run missed snapshots 

### DIFF
--- a/cli/command_policy_set_scheduling.go
+++ b/cli/command_policy_set_scheduling.go
@@ -23,7 +23,7 @@ func (c *policySchedulingFlags) setup(cmd *kingpin.CmdClause) {
 	cmd.Flag("snapshot-interval", "Interval between snapshots").DurationListVar(&c.policySetInterval)
 	cmd.Flag("snapshot-time", "Comma-separated times of day when to take snapshot (HH:mm,HH:mm,...) or 'inherit' to remove override").StringsVar(&c.policySetTimesOfDay)
 	cmd.Flag("snapshot-time-crontab", "Semicolon-separated crontab-compatible expressions (or 'inherit')").StringVar(&c.policySetCron)
-	cmd.Flag("run-missed", "Run missed time-of-day snapshots ('true', 'false', 'inherit')").EnumVar(&c.policySetRunMissed, booleanEnumValues...)
+	cmd.Flag("run-missed", "Run missed time-of-day or cron snapshots ('true', 'false', 'inherit')").EnumVar(&c.policySetRunMissed, booleanEnumValues...)
 	cmd.Flag("manual", "Only create snapshots manually").BoolVar(&c.policySetManual)
 }
 

--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -191,14 +191,16 @@ func (p *SchedulingPolicy) getNextCronSnapshot(now time.Time) (time.Time, bool) 
 func (p *SchedulingPolicy) checkMissedSnapshot(now, previousSnapshotTime, nextSnapshotTime time.Time) bool {
 	const halfhour = 30 * time.Minute
 
+	momentAfterSnapshot := previousSnapshotTime.Add(time.Second)
+
 	if !p.RunMissed.OrDefault(false) {
 		return false
 	}
 
 	nextSnapshot := nextSnapshotTime
 	// We add a second to ensure that the next possible snapshot is > the last snaphot
-	todSnapshot, todOk := p.getNextTimeOfDaySnapshot(previousSnapshotTime.Add(time.Second))
-	cronSnapshot, cronOk := p.getNextCronSnapshot(previousSnapshotTime.Add(time.Second))
+	todSnapshot, todOk := p.getNextTimeOfDaySnapshot(momentAfterSnapshot)
+	cronSnapshot, cronOk := p.getNextCronSnapshot(momentAfterSnapshot)
 
 	if !todOk && !cronOk {
 		return false

--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -196,6 +196,7 @@ func (p *SchedulingPolicy) checkMissedSnapshot(now, previousSnapshotTime, nextSn
 	}
 
 	nextSnapshot := nextSnapshotTime
+	// We add a second to ensure that the next possible snapshot is > the last snaphot
 	todSnapshot, todOk := p.getNextTimeOfDaySnapshot(previousSnapshotTime.Add(time.Second))
 	cronSnapshot, cronOk := p.getNextCronSnapshot(previousSnapshotTime.Add(time.Second))
 

--- a/snapshot/policy/scheduling_policy_test.go
+++ b/snapshot/policy/scheduling_policy_test.go
@@ -234,6 +234,17 @@ func TestNextSnapshotTime(t *testing.T) {
 			wantOK:               true,
 		},
 		{
+			name: "Run immediately because one of the TimeOfDays was missed",
+			pol: policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{11, 1}, {4, 1}},
+				RunMissed:  true,
+			},
+			now:                  time.Date(2020, time.January, 2, 10, 0, 0, 0, time.Local),
+			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 1, 0, 0, time.Local),
+			wantTime:             time.Date(2020, time.January, 2, 10, 0, 0, 0, time.Local),
+			wantOK:               true,
+		},
+		{
 			name: "Don't run immediately even though RunMissed is set because last run was not missed",
 			pol: policy.SchedulingPolicy{
 				TimesOfDay: []policy.TimeOfDay{{11, 55}},

--- a/snapshot/policy/scheduling_policy_test.go
+++ b/snapshot/policy/scheduling_policy_test.go
@@ -229,8 +229,8 @@ func TestNextSnapshotTime(t *testing.T) {
 				RunMissed:  policy.NewOptionalBool(true),
 			},
 			now:                  time.Date(2020, time.January, 3, 11, 30, 0, 0, time.Local),
-			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 55, 0, 0, time.Local),
-			wantTime:             time.Date(2020, time.January, 3, 11, 55, 0, 0, time.Local),
+			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 54, 0, 0, time.Local),
+			wantTime:             time.Date(2020, time.January, 3, 11, 54, 0, 0, time.Local),
 			wantOK:               true,
 		},
 		{
@@ -251,8 +251,20 @@ func TestNextSnapshotTime(t *testing.T) {
 				RunMissed:  policy.NewOptionalBool(true),
 			},
 			now:                  time.Date(2020, time.January, 2, 11, 0, 0, 0, time.Local),
-			previousSnapshotTime: time.Date(2020, time.January, 2, 10, 0, 0, 0, time.Local),
-			wantTime:             time.Date(2020, time.January, 3, 10, 0, 0, 0, time.Local),
+			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 55, 0, 0, time.Local),
+			wantTime:             time.Date(2020, time.January, 2, 11, 0, 0, 0, time.Local),
+			wantOK:               true,
+		},
+		{
+			name: "Run immediately because Cron was missed",
+			pol: policy.SchedulingPolicy{
+				TimesOfDay: []policy.TimeOfDay{{11, 55}},
+				Cron:       []string{"0 * * * *"}, // Every hour
+				RunMissed:  true,
+			},
+			now:                  time.Date(2020, time.January, 2, 11, 0, 0, 0, time.Local),
+			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 55, 0, 0, time.Local),
+			wantTime:             time.Date(2020, time.January, 2, 11, 0, 0, 0, time.Local),
 			wantOK:               true,
 		},
 	}

--- a/snapshot/policy/scheduling_policy_test.go
+++ b/snapshot/policy/scheduling_policy_test.go
@@ -229,15 +229,15 @@ func TestNextSnapshotTime(t *testing.T) {
 				RunMissed:  policy.NewOptionalBool(true),
 			},
 			now:                  time.Date(2020, time.January, 3, 11, 30, 0, 0, time.Local),
-			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 54, 0, 0, time.Local),
-			wantTime:             time.Date(2020, time.January, 3, 11, 54, 0, 0, time.Local),
+			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 55, 0, 0, time.Local),
+			wantTime:             time.Date(2020, time.January, 3, 11, 55, 0, 0, time.Local),
 			wantOK:               true,
 		},
 		{
 			name: "Run immediately because one of the TimeOfDays was missed",
 			pol: policy.SchedulingPolicy{
 				TimesOfDay: []policy.TimeOfDay{{11, 1}, {4, 1}},
-				RunMissed:  true,
+				RunMissed:  policy.NewOptionalBool(true),
 			},
 			now:                  time.Date(2020, time.January, 2, 10, 0, 0, 0, time.Local),
 			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 1, 0, 0, time.Local),
@@ -271,7 +271,7 @@ func TestNextSnapshotTime(t *testing.T) {
 			pol: policy.SchedulingPolicy{
 				TimesOfDay: []policy.TimeOfDay{{11, 55}},
 				Cron:       []string{"0 * * * *"}, // Every hour
-				RunMissed:  true,
+				RunMissed:  policy.NewOptionalBool(true),
 			},
 			now:                  time.Date(2020, time.January, 2, 11, 0, 0, 0, time.Local),
 			previousSnapshotTime: time.Date(2020, time.January, 1, 11, 55, 0, 0, time.Local),


### PR DESCRIPTION
The current algorithm assumes a singe snapshot per-day.  It doesn't work well with either >1 time-of-day snapshots or with cron snapshots.

This PR calculates the next snapshot time that should have happened based on the previous snapshot.  If that time is before now, then we missed a snapshot and should do a catchup snapshot.

I kept the heuristic of not running a snapshot if the next snapshot would occur within the next 30 minutes.  I'm no longer sure if that is a good policy or not.

Fixes #3319