### PR TITLE
docs(site): Add description of title-checker when submitting a PR

### DIFF
--- a/site/content/docs/Contribution guidelines/_index.md
+++ b/site/content/docs/Contribution guidelines/_index.md
@@ -29,3 +29,9 @@ toc_hide: true
   - `make ci-tests`
   - `make lint-all` (if developing cross-platform code)
   - `make goreleaser`
+* When creating a PR, the title should match the pattern `<type>`(`<domain>`): `<description>` where:
+  - `<type>` is one of: `feat`, `fix`, `breaking`, `build`, `chore`, `docs`, `style`, `refactor`, `test`.
+  - `<domain>` is one of: `kopiaui`, `cli`, `ui`, `repository`, `snapshots`, `server`, `providers`, `deps`, `deps-dev`, `site`, `ci`, `infra`, `general`.
+  - `<description>` is a clear description of a PR.
+  - Follow the pattern precisely, as the title-checker cares about capitalization parentheses, and spaces.
+  - For example: `feat(cli): Add new policy rule --new-feature-x to enable using feature x`.


### PR DESCRIPTION
I've run into the title checker on almost every one of my PRs, despite trying to get it right each time.  So I've documented it in the hopes to make it easier to get right in one attempt.