### PR TITLE
fix(kopiaui): Fix missing window when external displays are detached

### DIFF
--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -51,12 +51,14 @@ function isWithinBounds(winBounds) {
       isFactorEqual = false
       break;
     }
+    /*
     //Check if window bounds lie within at least one display's workarea
     if ((winBounds.x >= workArea.x && winBounds.y >= workArea.y)
       && (winBounds.x < (workArea.x + winBounds.width)
-      && winBounds.y < (workArea.y + winBounds.height))) {
+        && winBounds.y < (workArea.y + winBounds.height))) {
       isWithinBounds = true
     }
+    */
     prevFactor = factor
   }
   return isFactorEqual && isWithinBounds
@@ -93,9 +95,9 @@ function showRepoWindow(repositoryID) {
   let winBounds = store.get('winBounds')
   let maximized = store.get('maximized')
   // Assign the bounds if all factors are equal and window lies within bounds, else use default
-//  if (isWithinBounds(winBounds)) {
-//    Object.assign(windowOptions, winBounds);
-//  }
+  if (isWithinBounds(winBounds)) {
+    Object.assign(windowOptions, winBounds);
+  }
 
   // Create the browser window
   let repositoryWindow = new BrowserWindow(windowOptions)

--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -97,6 +97,7 @@ function showRepoWindow(repositoryID) {
     Object.assign(windowOptions, winBounds);
   }
 
+  //Create the browser window
   let repositoryWindow = new BrowserWindow(windowOptions)
   // If the window was maximized, maximize it
   if (maximized) {

--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -83,7 +83,7 @@ function showRepoWindow(repositoryID) {
 
     autoHideMenuBar: true,
     resizable: true,
-    show: false,
+    //show: false,
     webPreferences: {
       preload: path.join(resourcesPath(), 'preload.js'),
     },
@@ -100,11 +100,11 @@ function showRepoWindow(repositoryID) {
   //Create the browser window
   let repositoryWindow = new BrowserWindow(windowOptions)
   // If the window was maximized, maximize it
-  if (maximized) {
-    repositoryWindow.maximize()
-  }
+  //if (maximized) {
+  //  repositoryWindow.maximize()
+  //}
   // Show the window
-  repositoryWindow.show()
+  //repositoryWindow.show()
   const webContentsID = repositoryWindow.webContents.id;
 
   repositoryWindows[repositoryID] = repositoryWindow

--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -90,12 +90,12 @@ function showRepoWindow(repositoryID) {
   };
 
   // The bounds of the windows
-  let winBounds = store.get('winBounds')
-  let maximized = store.get('maximized')
+  //let winBounds = store.get('winBounds')
+  //let maximized = store.get('maximized')
   // Assign the bounds if all factors are equal and window lies within bounds, else use default
-  if (isWithinBounds(winBounds)) {
-    Object.assign(windowOptions, winBounds);
-  }
+  //if (isWithinBounds(winBounds)) {
+  //  Object.assign(windowOptions, winBounds);
+  //}
 
   //Create the browser window
   let repositoryWindow = new BrowserWindow(windowOptions)

--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -93,9 +93,9 @@ function showRepoWindow(repositoryID) {
   let winBounds = store.get('winBounds')
   let maximized = store.get('maximized')
   // Assign the bounds if all factors are equal and window lies within bounds, else use default
-  if (isWithinBounds(winBounds)) {
-    Object.assign(windowOptions, winBounds);
-  }
+//  if (isWithinBounds(winBounds)) {
+//    Object.assign(windowOptions, winBounds);
+//  }
 
   // Create the browser window
   let repositoryWindow = new BrowserWindow(windowOptions)

--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -52,9 +52,9 @@ function isWithinBounds(winBounds) {
       break;
     }
     //Check if window bounds lie within at least one display's workarea
-    if (winBounds.x >= workArea.x && winBounds.y >= workArea.y
-      && winBounds.x < (workArea.x + workArea.width)
-      && winBounds.y < (workArea.y + workArea.height)) {
+    if ((winBounds.x >= workArea.x && winBounds.y >= workArea.y)
+      && (winBounds.x < (workArea.x + winBounds.width)
+      && winBounds.y < (workArea.y + winBounds.height))) {
       isWithinBounds = true
     }
     prevFactor = factor
@@ -83,30 +83,28 @@ function showRepoWindow(repositoryID) {
 
     autoHideMenuBar: true,
     resizable: true,
-    //show: false,
+    show: false,
     webPreferences: {
       preload: path.join(resourcesPath(), 'preload.js'),
     },
   };
 
   // The bounds of the windows
-  //let winBounds = store.get('winBounds')
-  //let maximized = store.get('maximized')
+  let winBounds = store.get('winBounds')
+  let maximized = store.get('maximized')
   // Assign the bounds if all factors are equal and window lies within bounds, else use default
-  //if (isWithinBounds(winBounds)) {
-  //  Object.assign(windowOptions, winBounds);
-  //}
+  if (isWithinBounds(winBounds)) {
+    Object.assign(windowOptions, winBounds);
+  }
 
-  //Create the browser window
+  // Create the browser window
   let repositoryWindow = new BrowserWindow(windowOptions)
-  // If the window was maximized, maximize it
-  //if (maximized) {
-  //  repositoryWindow.maximize()
-  //}
-  // Show the window
-  //repositoryWindow.show()
-  const webContentsID = repositoryWindow.webContents.id;
 
+  // If the window was maximized, maximize it
+  if (maximized) {
+    repositoryWindow.maximize()
+  }
+  const webContentsID = repositoryWindow.webContents.id;
   repositoryWindows[repositoryID] = repositoryWindow
   repoIDForWebContents[webContentsID] = repositoryID
 
@@ -132,7 +130,11 @@ function showRepoWindow(repositoryID) {
   repositoryWindow.on('close', function () {
     store.set('winBounds', repositoryWindow.getBounds())
     store.set('maximized', repositoryWindow.isMaximized())
-  });
+  })
+
+  repositoryWindow.once('ready-to-show', function () {
+    repositoryWindow.show()
+  })
 
   /**
    * Delete references to the repository window
@@ -147,7 +149,6 @@ function showRepoWindow(repositoryID) {
     if (deleteConfigIfDisconnected(repositoryID)) {
       s.stopServer();
     }
-
     updateDockIcon();
   })
 }


### PR DESCRIPTION
This PR contains the following fix:

- Fixed missing window in cases where external displays are detached
- Maximize the window now works as expected

This PR is an **emergency fix** for #3315. If an external display is detached after the kopia-ui window has been closed on this display, the ui won't open anymore. 

The logic now checks if the scaling factors of attached displays are the same (covers https://github.com/electron/electron/issues/10862). Additionally it checks, whether the window bounds lie within a display's working area. Both conditions has to be true, so that the stored window bounds are restored. 

If not, the window will default to the center of the primary screen with it's default width and height. 

Please review. 

Cheers,