### PR TITLE
fix(cli): Fix --manual interatcion with --run-missed

### DIFF
--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -451,6 +451,18 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 			},
 			expChangeCount: 0,
 		},
+		{
+			name: "Set global manual",
+			startingPolicy: &policy.SchedulingPolicy{
+				RunMissed: policy.NewOptionalBool(true),
+			},
+			expResult: &policy.SchedulingPolicy{
+				Manual:    true,
+				RunMissed: policy.NewOptionalBool(true),
+			},
+			manualArg:      true,
+			expChangeCount: 1,
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -471,6 +483,7 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			require.NoError(t, policy.ValidateSchedulingPolicy(*tc.startingPolicy))
 			require.Equal(t, tc.expResult, tc.startingPolicy)
 			require.Equal(t, tc.expChangeCount, changeCount)
 		})

--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -223,7 +223,7 @@ func SetManual(ctx context.Context, rep repo.RepositoryWriter, sourceInfo snapsh
 
 // ValidateSchedulingPolicy returns an error if manual field is set along with scheduling fields.
 func ValidateSchedulingPolicy(p SchedulingPolicy) error {
-	if p.Manual && !reflect.DeepEqual(p, SchedulingPolicy{Manual: true}) {
+	if p.Manual && !reflect.DeepEqual(p, SchedulingPolicy{Manual: true, RunMissed: p.RunMissed}) {
 		return errors.New("invalid scheduling policy: manual cannot be combined with other scheduling policies")
 	}
 


### PR DESCRIPTION
As discovered while debugging #3344 when RunMissed was converted to a tri-state, the validation checks when setting --manual on the --global policy fail.

This is a small PR to address that and add an appropriate test for it.