### PR TITLE
fix(cli): Convert policy set --manual to use a tri-state

### DIFF
--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -451,6 +451,18 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 			},
 			expChangeCount: 0,
 		},
+		{
+			name: "Set global manual",
+			startingPolicy: &policy.SchedulingPolicy{
+				RunMissed: policy.NewOptionalBool(true),
+			},
+			expResult: &policy.SchedulingPolicy{
+				Manual:    true,
+				RunMissed: policy.NewOptionalBool(true),
+			},
+			manualArg:      true,
+			expChangeCount: 1,
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -471,6 +483,7 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			require.NoError(t, policy.ValidateSchedulingPolicy(*tc.startingPolicy))
 			require.Equal(t, tc.expResult, tc.startingPolicy)
 			require.Equal(t, tc.expChangeCount, changeCount)
 		})

--- a/cli/command_policy_set_test.go
+++ b/cli/command_policy_set_test.go
@@ -181,7 +181,7 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 		intervalArg    []time.Duration
 		timesOfDayArg  []string
 		cronArg        string
-		manualArg      bool
+		manualArg      string
 		runMissedArg   string
 		expResult      *policy.SchedulingPolicy
 		expErrMsg      string
@@ -196,9 +196,9 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 		{
 			name:           "Manual flag set to true, no starting policy",
 			startingPolicy: &policy.SchedulingPolicy{},
-			manualArg:      true,
+			manualArg:      "true",
 			expResult: &policy.SchedulingPolicy{
-				Manual: true,
+				Manual: policy.NewOptionalBool(true),
 			},
 			expChangeCount: 1,
 		},
@@ -235,7 +235,7 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 			intervalArg: []time.Duration{
 				time.Hour * 1,
 			},
-			manualArg:      true,
+			manualArg:      "true",
 			expResult:      &policy.SchedulingPolicy{},
 			expErrMsg:      "cannot set manual field when scheduling snapshots",
 			expChangeCount: 0,
@@ -246,7 +246,7 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 			timesOfDayArg: []string{
 				"12:00",
 			},
-			manualArg:      true,
+			manualArg:      "true",
 			expResult:      &policy.SchedulingPolicy{},
 			expErrMsg:      "cannot set manual field when scheduling snapshots",
 			expChangeCount: 0,
@@ -255,7 +255,7 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 			name:           "Manual and cron set, no starting policy",
 			startingPolicy: &policy.SchedulingPolicy{},
 			cronArg:        "* * * * *",
-			manualArg:      true,
+			manualArg:      "true",
 			expResult:      &policy.SchedulingPolicy{},
 			expErrMsg:      "cannot set manual field when scheduling snapshots",
 			expChangeCount: 0,
@@ -265,9 +265,9 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 			startingPolicy: &policy.SchedulingPolicy{
 				IntervalSeconds: 3600,
 			},
-			manualArg: true,
+			manualArg: "true",
 			expResult: &policy.SchedulingPolicy{
-				Manual: true,
+				Manual: policy.NewOptionalBool(true),
 			},
 			expChangeCount: 2,
 		},
@@ -281,9 +281,9 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 					},
 				},
 			},
-			manualArg: true,
+			manualArg: "true",
 			expResult: &policy.SchedulingPolicy{
-				Manual: true,
+				Manual: policy.NewOptionalBool(true),
 			},
 			expChangeCount: 2,
 		},
@@ -298,29 +298,30 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 					},
 				},
 			},
-			manualArg: true,
+			manualArg: "true",
 			expResult: &policy.SchedulingPolicy{
-				Manual: true,
+				Manual: policy.NewOptionalBool(true),
 			},
 			expChangeCount: 3,
 		},
 		{
 			name: "Interval set, starting policy with manual",
 			startingPolicy: &policy.SchedulingPolicy{
-				Manual: true,
+				Manual: policy.NewOptionalBool(true),
 			},
 			intervalArg: []time.Duration{
 				time.Hour * 1,
 			},
 			expResult: &policy.SchedulingPolicy{
 				IntervalSeconds: 3600,
+				Manual:          policy.NewOptionalBool(false),
 			},
 			expChangeCount: 2,
 		},
 		{
 			name: "Times of day set, starting policy with manual",
 			startingPolicy: &policy.SchedulingPolicy{
-				Manual: true,
+				Manual: policy.NewOptionalBool(true),
 			},
 			timesOfDayArg: []string{
 				"12:00",
@@ -332,6 +333,7 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 						Minute: 0,
 					},
 				},
+				Manual: policy.NewOptionalBool(false),
 			},
 			expChangeCount: 2,
 		},
@@ -457,10 +459,10 @@ func TestSetSchedulingPolicyFromFlags(t *testing.T) {
 				RunMissed: policy.NewOptionalBool(true),
 			},
 			expResult: &policy.SchedulingPolicy{
-				Manual:    true,
+				Manual:    policy.NewOptionalBool(true),
 				RunMissed: policy.NewOptionalBool(true),
 			},
-			manualArg:      true,
+			manualArg:      "true",
 			expChangeCount: 1,
 		},
 	} {

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -325,7 +325,11 @@ func appendSchedulingPolicyRows(rows []policyTableRow, p *policy.Policy, def *po
 		rows = append(rows, policyTableRow{"    None.", "", ""})
 	}
 
-	rows = append(rows, policyTableRow{"  Manual snapshot:", boolToString(p.SchedulingPolicy.Manual), definitionPointToString(p.Target(), def.SchedulingPolicy.Manual)})
+	rows = append(rows, policyTableRow{
+		"  Manual snapshot:",
+		boolToString(p.SchedulingPolicy.Manual.OrDefault(false)),
+		definitionPointToString(p.Target(), def.SchedulingPolicy.Manual),
+	})
 
 	return rows
 }

--- a/snapshot/policy/policy_merge_test.go
+++ b/snapshot/policy/policy_merge_test.go
@@ -332,3 +332,24 @@ func TestPolicyMergeTimesOfDayIncludingParents(t *testing.T) {
 
 	require.Equal(t, want.String(), result.String())
 }
+
+func TestPolicyMergeManual(t *testing.T) {
+	p0 := &policy.Policy{
+		SchedulingPolicy: policy.SchedulingPolicy{
+			Manual: policy.NewOptionalBool(true),
+		},
+	}
+
+	p1 := &policy.Policy{
+		SchedulingPolicy: policy.SchedulingPolicy{
+			Manual: policy.NewOptionalBool(false),
+		},
+	}
+
+	result, _ := policy.MergePolicies([]*policy.Policy{p1, p0}, p0.Target())
+
+	want := *policy.DefaultPolicy
+	want.SchedulingPolicy.Manual = policy.NewOptionalBool(false)
+
+	require.Equal(t, want.String(), result.String())
+}

--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -223,7 +223,7 @@ func SetManual(ctx context.Context, rep repo.RepositoryWriter, sourceInfo snapsh
 
 // ValidateSchedulingPolicy returns an error if manual field is set along with scheduling fields.
 func ValidateSchedulingPolicy(p SchedulingPolicy) error {
-	if p.Manual && !reflect.DeepEqual(p, SchedulingPolicy{Manual: true}) {
+	if p.Manual && !reflect.DeepEqual(p, SchedulingPolicy{Manual: true, RunMissed: p.RunMissed}) {
 		return errors.New("invalid scheduling policy: manual cannot be combined with other scheduling policies")
 	}
 

--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -60,7 +60,7 @@ type SchedulingPolicy struct {
 	IntervalSeconds    int64         `json:"intervalSeconds,omitempty"`
 	TimesOfDay         []TimeOfDay   `json:"timeOfDay,omitempty"`
 	NoParentTimesOfDay bool          `json:"noParentTimeOfDay,omitempty"`
-	Manual             bool          `json:"manual,omitempty"`
+	Manual             *OptionalBool `json:"manual,omitempty"`
 	Cron               []string      `json:"cron,omitempty"`
 	RunMissed          *OptionalBool `json:"runMissed,omitempty"`
 }
@@ -90,7 +90,7 @@ func (p *SchedulingPolicy) SetInterval(d time.Duration) {
 // NextSnapshotTime computes next snapshot time given previous
 // snapshot time and current wall clock time.
 func (p *SchedulingPolicy) NextSnapshotTime(previousSnapshotTime, now time.Time) (time.Time, bool) {
-	if p.Manual {
+	if p.Manual.OrDefault(false) {
 		return time.Time{}, false
 	}
 
@@ -191,13 +191,13 @@ func (p *SchedulingPolicy) Merge(src SchedulingPolicy, def *SchedulingPolicyDefi
 		p.NoParentTimesOfDay = src.NoParentTimesOfDay
 	}
 
-	mergeBool(&p.Manual, src.Manual, &def.Manual, si)
+	mergeOptionalBool(&p.Manual, src.Manual, &def.Manual, si)
 	mergeOptionalBool(&p.RunMissed, src.RunMissed, &def.RunMissed, si)
 }
 
 // IsManualSnapshot returns the SchedulingPolicy manual value from the given policy tree.
 func IsManualSnapshot(policyTree *Tree) bool {
-	return policyTree.EffectivePolicy().SchedulingPolicy.Manual
+	return policyTree.EffectivePolicy().SchedulingPolicy.Manual.OrDefault(false)
 }
 
 // SetManual sets the manual setting in the SchedulingPolicy on the given source.
@@ -212,7 +212,7 @@ func SetManual(ctx context.Context, rep repo.RepositoryWriter, sourceInfo snapsh
 		return errors.Wrap(err, "could not get defined policy for source")
 	}
 
-	p.SchedulingPolicy.Manual = true
+	p.SchedulingPolicy.Manual = NewOptionalBool(true)
 
 	if err := SetPolicy(ctx, rep, sourceInfo, p); err != nil {
 		return errors.Wrapf(err, "can't save policy for %v", sourceInfo)
@@ -223,7 +223,7 @@ func SetManual(ctx context.Context, rep repo.RepositoryWriter, sourceInfo snapsh
 
 // ValidateSchedulingPolicy returns an error if manual field is set along with scheduling fields.
 func ValidateSchedulingPolicy(p SchedulingPolicy) error {
-	if p.Manual && !reflect.DeepEqual(p, SchedulingPolicy{Manual: true, RunMissed: p.RunMissed}) {
+	if p.Manual.OrDefault(false) && !reflect.DeepEqual(p, SchedulingPolicy{Manual: NewOptionalBool(true), RunMissed: p.RunMissed}) {
 		return errors.New("invalid scheduling policy: manual cannot be combined with other scheduling policies")
 	}
 

--- a/snapshot/policy/scheduling_policy_test.go
+++ b/snapshot/policy/scheduling_policy_test.go
@@ -182,7 +182,7 @@ func TestNextSnapshotTime(t *testing.T) {
 			pol: policy.SchedulingPolicy{
 				IntervalSeconds: 43200,
 				TimesOfDay:      []policy.TimeOfDay{{19, 0}, {20, 0}},
-				Manual:          true,
+				Manual:          policy.NewOptionalBool(true),
 			},
 			previousSnapshotTime: time.Date(2020, time.January, 1, 19, 0, 0, 0, time.Local),
 			now:                  time.Date(2020, time.January, 1, 10, 0, 0, 0, time.Local),

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -564,7 +564,7 @@ func TestSnapshotCreateAllWithManualSnapshot(t *testing.T) {
 	sourceSnapshotCount := len(e.RunAndExpectSuccess(t, "snapshot", "list", "-a"))
 
 	// set manual field in the scheduling policy for `sharedTestDataDir1`
-	e.RunAndExpectSuccess(t, "policy", "set", "--manual", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "policy", "set", "--manual=true", sharedTestDataDir1)
 
 	// make sure the policy is visible in the policy list, includes global policy
 	e.RunAndVerifyOutputLineCount(t, 2, "policy", "list")
@@ -757,7 +757,7 @@ func TestSnapshotCreateAllSnapshotPath(t *testing.T) {
 	// all non-global policies should be manual
 	for _, p := range plist {
 		if (p.Target != snapshot.SourceInfo{}) {
-			require.True(t, p.Policy.SchedulingPolicy.Manual)
+			require.True(t, p.Policy.SchedulingPolicy.Manual.OrDefault(false))
 		}
 	}
 


### PR DESCRIPTION
As per issue #3344, If Manual is set to true in a more-general policy, it cannot be reset to false in a lower policy.  This is due to manual being a bool, and there being no way to distinguish between 'inherit' and 'false'

This PR converts Manual into an OptionalBool so that it can hold values of true, false, and inherit, and can thus override both from false->true and from true->false

There is an included test to validate as well.

This PR includes #3348 as inheritance cannot be properly tested until that issue is addressed.  I recommend committing #3348 1st, and then this PR