### PR TITLE
refactor(snapshots): Minor reorder of defer funcs for streaming files

### DIFF
--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -342,13 +342,12 @@ func (u *Uploader) uploadStreamingFileInternal(ctx context.Context, relativePath
 		return nil, errors.Wrap(err, "unable to get streaming file reader")
 	}
 
-	defer reader.Close() //nolint:errcheck
-
 	var streamSize int64
 
 	u.Progress.HashingFile(relativePath)
 
 	defer func() {
+		reader.Close() //nolint:errcheck
 		u.Progress.FinishedHashingFile(relativePath, streamSize)
 		u.Progress.FinishedFile(relativePath, ret)
 	}()


### PR DESCRIPTION
Reorder streaming file upload defer functions slightly so the reader is closed prior to calling FinishedFile. This allows folks who hook into those callbacks to make stronger assumptions about the ordering/state of things if needed.