### PR TITLE
fix(cli): Don't return error when parameters unchanged

### DIFF
--- a/cli/command_repository_set_parameters.go
+++ b/cli/command_repository_set_parameters.go
@@ -228,8 +228,6 @@ func (c *commandRepositorySetParameters) run(ctx context.Context, rep repo.Direc
 	requiredFeatures = c.addRemoveUpdateRequiredFeatures(requiredFeatures, &anyChange)
 
 	if !anyChange {
-		log(ctx).Infof("no changes from set-parameters")
-
 		return nil
 	}
 

--- a/cli/command_repository_set_parameters.go
+++ b/cli/command_repository_set_parameters.go
@@ -228,6 +228,7 @@ func (c *commandRepositorySetParameters) run(ctx context.Context, rep repo.Direc
 	requiredFeatures = c.addRemoveUpdateRequiredFeatures(requiredFeatures, &anyChange)
 
 	if !anyChange {
+		log(ctx).Info("no changes")
 		return nil
 	}
 

--- a/cli/command_repository_set_parameters.go
+++ b/cli/command_repository_set_parameters.go
@@ -228,7 +228,9 @@ func (c *commandRepositorySetParameters) run(ctx context.Context, rep repo.Direc
 	requiredFeatures = c.addRemoveUpdateRequiredFeatures(requiredFeatures, &anyChange)
 
 	if !anyChange {
-		return errors.Errorf("no changes")
+		log(ctx).Infof("no changes from set-parameters")
+
+		return nil
 	}
 
 	if blobcfg.IsRetentionEnabled() {

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -207,19 +207,20 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersDowngrade(t *testin
 			require.Contains(t, out, "Format version:      1")
 			require.Contains(t, out, "Epoch Manager:       disabled")
 			env.RunAndExpectFailure(t, "index", "epoch", "list")
-			_, out := env.RunAndExpectSuccessWithErrOut(t, "repository", "set-parameters", "--index-version=1")
+			// setting the current version again is ok
+			_, out = env.RunAndExpectSuccessWithErrOut(t, "repository", "set-parameters", "--index-version=1")
 			require.Contains(t, out, "no changes")
 		case format.FormatVersion2:
 			require.Contains(t, out, "Format version:      2")
 			require.Contains(t, out, "Epoch Manager:       enabled")
 			env.RunAndExpectSuccess(t, "index", "epoch", "list")
-			_, out := env.RunAndExpectFailure(t, "repository", "set-parameters", "--index-version=1")
+			_, out = env.RunAndExpectFailure(t, "repository", "set-parameters", "--index-version=1")
 			require.Contains(t, out, "index format version can only be upgraded")
 		default:
 			require.Contains(t, out, "Format version:      3")
 			require.Contains(t, out, "Epoch Manager:       enabled")
 			env.RunAndExpectSuccess(t, "index", "epoch", "list")
-			_, out := env.RunAndExpectFailure(t, "repository", "set-parameters", "--index-version=1")
+			_, out = env.RunAndExpectFailure(t, "repository", "set-parameters", "--index-version=1")
 			require.Contains(t, out, "index format version can only be upgraded")
 		}
 	}

--- a/cli/command_repository_set_parameters_test.go
+++ b/cli/command_repository_set_parameters_test.go
@@ -35,8 +35,10 @@ func (s *formatSpecificTestSuite) TestRepositorySetParameters(t *testing.T) {
 	require.Contains(t, out, "Max pack length:     21 MB")
 	require.Contains(t, out, fmt.Sprintf("Format version:      %d", s.formatVersion))
 
+	_, out = env.RunAndExpectSuccessWithErrOut(t, "repository", "set-parameters")
+	require.Contains(t, out, "no changes")
+
 	// failure cases
-	env.RunAndExpectFailure(t, "repository", "set-parameters")
 	env.RunAndExpectFailure(t, "repository", "set-parameters", "--index-version=33")
 	env.RunAndExpectFailure(t, "repository", "set-parameters", "--max-pack-size-mb=9")
 	env.RunAndExpectFailure(t, "repository", "set-parameters", "--max-pack-size-mb=121")
@@ -72,6 +74,10 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersRetention(t *testin
 	// clear retention settings
 	_, out = env.RunAndExpectSuccessWithErrOut(t, "repository", "set-parameters", "--retention-mode", "none")
 	require.Contains(t, out, "disabling blob retention")
+
+	// 2nd time also succeeds but disabling is skipped due to already being disabled. !anyChanges returns no error.
+	_, out = env.RunAndExpectSuccessWithErrOut(t, "repository", "set-parameters", "--retention-mode", "none")
+	require.Contains(t, out, "no changes")
 
 	out = env.RunAndExpectSuccess(t, "repository", "status")
 	require.NotContains(t, out, "Blob retention mode")
@@ -201,20 +207,24 @@ func (s *formatSpecificTestSuite) TestRepositorySetParametersDowngrade(t *testin
 			require.Contains(t, out, "Format version:      1")
 			require.Contains(t, out, "Epoch Manager:       disabled")
 			env.RunAndExpectFailure(t, "index", "epoch", "list")
+			_, out := env.RunAndExpectSuccessWithErrOut(t, "repository", "set-parameters", "--index-version=1")
+			require.Contains(t, out, "no changes")
 		case format.FormatVersion2:
 			require.Contains(t, out, "Format version:      2")
 			require.Contains(t, out, "Epoch Manager:       enabled")
 			env.RunAndExpectSuccess(t, "index", "epoch", "list")
+			_, out := env.RunAndExpectFailure(t, "repository", "set-parameters", "--index-version=1")
+			require.Contains(t, out, "index format version can only be upgraded")
 		default:
 			require.Contains(t, out, "Format version:      3")
 			require.Contains(t, out, "Epoch Manager:       enabled")
 			env.RunAndExpectSuccess(t, "index", "epoch", "list")
+			_, out := env.RunAndExpectFailure(t, "repository", "set-parameters", "--index-version=1")
+			require.Contains(t, out, "index format version can only be upgraded")
 		}
 	}
 
 	checkStatusForVersion()
-
-	env.RunAndExpectFailure(t, "repository", "set-parameters", "--index-version=1")
 
 	checkStatusForVersion()
 


### PR DESCRIPTION
Currently there is an [inconsistency](https://github.com/search?q=repo%3Akopia%2Fkopia%20%22no%20change%22&type=code) between what to do when `!anyChanges`...some return an error while others log it and return nil. I'm not sure if in any of the commands it makes sense to return an error in such cases (I would guess always nil) but in the case of SetParameters I think it's not needed. People want a desired state and they have the desired state so all is good; similar to how DeleteBlob returns nil when the blob doesn't exist

At least one path where it is reached is setting `retentionMode` to `none` but retention is already disabled; whereas it's not the case if you set it to `COMPLIANCE` although the value is also not changed. ~~Maybe the logging should also be removed due to this (it only logs in 1 or a couple edge cases)~~

https://github.com/kopia/kopia/blob/b7f3e17c9febe120c5c122ba33753eb86ca63251/cli/command_repository_set_parameters.go#L210-L214