### PR TITLE
feat(repository): Add support for Azure immutability protection

### DIFF
--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -49,7 +49,7 @@ func (c *commandRepositoryCreate) setup(svc advancedAppServices, parent commandP
 	cmd.Flag("object-splitter", "The splitter to use for new objects in the repository").Default(splitter.DefaultAlgorithm).EnumVar(&c.createSplitter, splitter.SupportedAlgorithms()...)
 	cmd.Flag("create-only", "Create repository, but don't connect to it.").Short('c').BoolVar(&c.createOnly)
 	cmd.Flag("format-version", "Force a particular repository format version (1, 2 or 3, 0==default)").IntVar(&c.createFormatVersion)
-	cmd.Flag("retention-mode", "Set the blob retention-mode for supported storage backends.").EnumVar(&c.retentionMode, blob.Governance.String(), blob.Compliance.String())
+	cmd.Flag("retention-mode", "Set the blob retention-mode for supported storage backends.").EnumVar(&c.retentionMode, blob.Governance.String(), blob.Compliance.String(), blob.Locked.String())
 	cmd.Flag("retention-period", "Set the blob retention-period for supported storage backends.").DurationVar(&c.retentionPeriod)
 
 	c.co.setup(svc, cmd)

--- a/cli/command_repository_set_parameters.go
+++ b/cli/command_repository_set_parameters.go
@@ -43,7 +43,7 @@ func (c *commandRepositorySetParameters) setup(svc appServices, parent commandPa
 
 	cmd.Flag("max-pack-size-mb", "Set max pack file size").PlaceHolder("MB").IntVar(&c.maxPackSizeMB)
 	cmd.Flag("index-version", "Set version of index format used for writing").IntVar(&c.indexFormatVersion)
-	cmd.Flag("retention-mode", "Set the blob retention-mode for supported storage backends.").EnumVar(&c.retentionMode, "none", blob.Governance.String(), blob.Compliance.String())
+	cmd.Flag("retention-mode", "Set the blob retention-mode for supported storage backends.").EnumVar(&c.retentionMode, "none", blob.Governance.String(), blob.Compliance.String(), blob.Locked.String())
 	cmd.Flag("retention-period", "Set the blob retention-period for supported storage backends.").DurationVar(&c.retentionPeriod)
 
 	cmd.Flag("upgrade", "Upgrade repository to the latest stable format").BoolVar(&c.upgradeRepositoryFormat)

--- a/repo/blob/azure/azure_storage_test.go
+++ b/repo/blob/azure/azure_storage_test.go
@@ -7,8 +7,10 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
-	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	legacyazblob "github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/azure"
+	"github.com/kopia/kopia/repo/content"
 )
 
 const (
@@ -46,30 +49,30 @@ func getEnvOrSkip(t *testing.T, name string) string {
 func createContainer(t *testing.T, container, storageAccount, storageKey string) {
 	t.Helper()
 
-	credential, err := azblob.NewSharedKeyCredential(storageAccount, storageKey)
+	credential, err := legacyazblob.NewSharedKeyCredential(storageAccount, storageKey)
 	if err != nil {
 		t.Fatalf("failed to create Azure credentials: %v", err)
 	}
 
-	p := azblob.NewPipeline(credential, azblob.PipelineOptions{})
+	p := legacyazblob.NewPipeline(credential, legacyazblob.PipelineOptions{})
 
 	u, err := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net", storageAccount))
 	if err != nil {
 		t.Fatalf("failed to parse container URL: %v", err)
 	}
 
-	serviceURL := azblob.NewServiceURL(*u, p)
+	serviceURL := legacyazblob.NewServiceURL(*u, p)
 	containerURL := serviceURL.NewContainerURL(container)
 
-	_, err = containerURL.Create(context.Background(), azblob.Metadata{}, azblob.PublicAccessNone)
+	_, err = containerURL.Create(context.Background(), legacyazblob.Metadata{}, legacyazblob.PublicAccessNone)
 	if err == nil {
 		return
 	}
 
 	// return if already exists
-	var stgErr azblob.StorageError
+	var stgErr legacyazblob.StorageError
 	if errors.As(err, &stgErr) {
-		if stgErr.ServiceCode() == azblob.ServiceCodeContainerAlreadyExists {
+		if stgErr.ServiceCode() == legacyazblob.ServiceCodeContainerAlreadyExists {
 			return
 		}
 	}
@@ -269,4 +272,126 @@ func TestAzureStorageInvalidCreds(t *testing.T) {
 	if err == nil {
 		t.Errorf("unexpected success connecting to Azure blob storage, wanted error")
 	}
+}
+
+// TestAzureStorageImmutabilityProtection runs through the behavior of Azure immutability protection.
+func TestAzureStorageImmutabilityProtection(t *testing.T) {
+	t.Parallel()
+	testutil.ProviderTest(t)
+
+	// must be with ImmutableStorage with Versioning enabled
+	container := getEnvOrSkip(t, testContainerEnv)
+	storageAccount := getEnvOrSkip(t, testStorageAccountEnv)
+	storageKey := getEnvOrSkip(t, testStorageKeyEnv)
+
+	// create container if does not exist
+	createContainer(t, container, storageAccount, storageKey)
+
+	data := make([]byte, 8)
+	rand.Read(data)
+
+	ctx := testlogging.Context(t)
+
+	// use context that gets canceled after opening storage to ensure it's not used beyond New().
+	newctx, cancel := context.WithCancel(ctx)
+	prefix := fmt.Sprintf("test-%v-%x-", clock.Now().Unix(), data)
+	st, err := azure.New(newctx, &azure.Options{
+		Container:      container,
+		StorageAccount: storageAccount,
+		StorageKey:     storageKey,
+		Prefix:         prefix,
+	}, false)
+
+	cancel()
+	require.NoError(t, err)
+
+	defer st.Close(ctx)
+
+	const (
+		blobName  = "sExample"
+		dummyBlob = blob.ID(blobName)
+	)
+
+	blobNameFullPath := prefix + blobName
+
+	putOpts := blob.PutOptions{
+		RetentionMode:   blob.Locked,
+		RetentionPeriod: 3 * time.Second,
+	}
+	// non-nil blob to distinguish against delete marker version
+	err = st.PutBlob(ctx, dummyBlob, gather.FromSlice([]byte("x")), putOpts)
+	require.NoError(t, err)
+	cli := getAzureCLI(t, storageAccount, storageKey)
+
+	count := getBlobCount(ctx, t, st, content.BlobIDPrefixSession)
+	require.Equal(t, 1, count)
+
+	currentTime := clock.Now().UTC()
+
+	blobRetention := getBlobRetention(ctx, t, cli, container, blobNameFullPath)
+	if !blobRetention.After(currentTime) {
+		t.Fatalf("blob retention period not in the future: %v", blobRetention)
+		t.FailNow()
+	}
+
+	extendOpts := blob.ExtendOptions{
+		RetentionMode:   blob.Locked,
+		RetentionPeriod: 4 * time.Second,
+	}
+	err = st.ExtendBlobRetention(ctx, dummyBlob, extendOpts)
+	require.NoError(t, err)
+
+	extendedRetention := getBlobRetention(ctx, t, cli, container, blobNameFullPath)
+	if !extendedRetention.After(blobRetention) {
+		t.Fatalf("blob retention period not extended. was %v, now %v", blobRetention, extendedRetention)
+		t.FailNow()
+	}
+
+	err = st.DeleteBlob(ctx, dummyBlob)
+	require.NoError(t, err)
+
+	count = getBlobCount(ctx, t, st, content.BlobIDPrefixSession)
+	require.Equal(t, 0, count)
+}
+
+func getBlobCount(ctx context.Context, t *testing.T, st blob.Storage, prefix blob.ID) int {
+	t.Helper()
+
+	var count int
+
+	err := st.ListBlobs(ctx, prefix, func(bm blob.Metadata) error {
+		count++
+		return nil
+	})
+	require.NoError(t, err)
+
+	return count
+}
+
+func getBlobRetention(ctx context.Context, t *testing.T, cli *azblob.Client, container string, blobName string) time.Time {
+	t.Helper()
+
+	props, err := cli.ServiceClient().
+		NewContainerClient(container).
+		NewBlobClient(blobName).
+		GetProperties(ctx, nil)
+	require.NoError(t, err)
+
+	return *props.ImmutabilityPolicyExpiresOn
+}
+
+// getAzureCLI returns a separate client to verify things the Storage interface doesn't support.
+func getAzureCLI(t *testing.T, storageAccount, storageKey string) *azblob.Client {
+	t.Helper()
+
+	cred, err := azblob.NewSharedKeyCredential(storageAccount, storageKey)
+	require.NoError(t, err)
+
+	storageHostname := fmt.Sprintf("%v.blob.core.windows.net", storageAccount)
+	cli, err := azblob.NewClientWithSharedKeyCredential(
+		fmt.Sprintf("https://%s/", storageHostname), cred, nil,
+	)
+	require.NoError(t, err)
+
+	return cli
 }

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -133,6 +133,8 @@ func (s *s3Storage) getVersionMetadata(ctx context.Context, b blob.ID, version s
 
 func (s *s3Storage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
 	switch {
+	case opts.HasRetentionOptions() && !opts.RetentionMode.IsValidS3():
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob retention mode is not valid for S3")
 	case opts.DoNotRecreate:
 		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "do-not-recreate")
 	case !opts.SetModTime.IsZero():

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -276,6 +276,14 @@ func TestS3StorageRetentionLockedBucket(t *testing.T) {
 			RetentionPeriod: time.Nanosecond,
 		})
 	})
+
+	t.Run("invalid mode", func(t *testing.T) {
+		options.Prefix = ""
+		testPutBlobWithInvalidRetention(t, options, blob.PutOptions{
+			RetentionMode:   blob.Locked, // Azure mode
+			RetentionPeriod: time.Hour * 24,
+		})
+	})
 }
 
 func TestTokenExpiration(t *testing.T) {

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
@@ -107,6 +108,9 @@ const (
 
 	// Compliance - compliance mode.
 	Compliance RetentionMode = "COMPLIANCE"
+
+	// Locked - Locked policy mode for Azure.
+	Locked RetentionMode = RetentionMode(blob.ImmutabilityPolicyModeLocked)
 )
 
 func (r RetentionMode) String() string {
@@ -115,7 +119,17 @@ func (r RetentionMode) String() string {
 
 // IsValid - check whether this retention mode is valid or not.
 func (r RetentionMode) IsValid() bool {
+	return r.IsValidS3() || r.IsValidAzure()
+}
+
+// IsValidS3 - check whether this retention mode is valid for S3.
+func (r RetentionMode) IsValidS3() bool {
 	return r == Governance || r == Compliance
+}
+
+// IsValidAzure - check whether this retention mode is valid for Azure.
+func (r RetentionMode) IsValidAzure() bool {
+	return r == Locked
 }
 
 // PutOptions represents put-options for a single BLOB in a storage.


### PR DESCRIPTION
Adds the option to set retention for Azure. They'd need to set the mode to Locked and run the command `kopia maintenance set --extend-object-locks` true like on S3.

Only includes `Locked` since `Unlocked` is not recommended. `PutBlob` with an invalid type (e.g. Locked for S3) will fail. The same validation check could also be done on [ExtendBlobRetention ](https://github.com/kopia/kopia/pull/3405) or it can be left to fail naturally...technically `PutBlob` can also be left to fail naturally rather than having the guard clause like `opts.HasRetentionOptions() && !opts.RetentionMode.IsValidAzure()`...instead put on Azure CLI would just fail like "COMPLIANCE is unknown retention type"