### PR TITLE
docs(cli): add missing -File for powershell vss script policy setup

### DIFF
--- a/site/content/docs/Advanced/Actions/_index.md
+++ b/site/content/docs/Advanced/Actions/_index.md
@@ -245,8 +245,8 @@ if (([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::
 To install the actions:
 
 ```shell
-kopia policy set <target_dir> --before-folder-action "powershell -WindowStyle Hidden <path_to_script>\before.ps1"
-kopia policy set <target_dir> --after-folder-action  "powershell -WindowStyle Hidden <path_to_script>\after.ps1"
+kopia policy set <target_dir> --before-folder-action "powershell -WindowStyle Hidden -File <path_to_script>\before.ps1"
+kopia policy set <target_dir> --after-folder-action  "powershell -WindowStyle Hidden -File <path_to_script>\after.ps1"
 ```
 
 ### Contributions Welcome


### PR DESCRIPTION
Hello,

Thanks a lot for sharing this super tool (never seen a more efficient backup tool). While setting up VSS following the smart suggestion, I had an issue which I fixed adding a -File to the powershell command...
I hope it is not related to different powershell versions (I’m refering to [V2.0](https://learn.microsoft.com/en-us/previous-versions//dd315276(v=technet.10)?redirectedfrom=MSDN))... If you know more than me about this, please discard this fix.