### PR TITLE
docs(providers): fix documentation for S3 permissions

### DIFF
--- a/site/content/docs/Advanced/Ransomware Protection/_index.md
+++ b/site/content/docs/Advanced/Ransomware Protection/_index.md
@@ -46,7 +46,6 @@ Some cloud storage solutions provide the ability to generate restricted access k
                         "s3:DeleteBucket",
                         "s3:DeleteBucketPolicy",
                         "s3:DeleteBucketWebsite",
-                        "s3:DeleteObject",
                         "s3:DeleteObjectVersion"
                     ],
                     "Resource": [


### PR DESCRIPTION
DeleteObject needs to be allowed. This is needed for kopia to work correctly.

The assumption is that S3 versioning is enabled.