### PR TITLE
refactor(general): minor cleanups

### DIFF
--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -256,22 +256,6 @@ func (e *Manager) AdvanceDeletionWatermark(ctx context.Context, ts time.Time) er
 	return nil
 }
 
-// ForceAdvanceEpoch advances current epoch unconditionally.
-func (e *Manager) ForceAdvanceEpoch(ctx context.Context) error {
-	cs, err := e.committedState(ctx, 0)
-	if err != nil {
-		return err
-	}
-
-	e.Invalidate()
-
-	if err := e.advanceEpoch(ctx, cs); err != nil {
-		return errors.Wrap(err, "error advancing epoch")
-	}
-
-	return nil
-}
-
 // Refresh refreshes information about current epoch.
 func (e *Manager) Refresh(ctx context.Context) error {
 	e.mu.Lock()

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -944,8 +944,6 @@ func (bm *WriteManager) MetadataCache() cache.ContentCache {
 type ManagerOptions struct {
 	TimeNow                func() time.Time // Time provider
 	DisableInternalLog     bool
-	RetentionMode          string
-	RetentionPeriod        time.Duration
 	PermissiveCacheLoading bool
 }
 


### PR DESCRIPTION
Unexport `epoch.Manager.forceAdvanceEpoch`. It is only used in tests.

Remove unused `RetentionMode` and `RetentionPeriod` fields from
`content.ManagerOptions` struct.