### PR TITLE
fix(cli): print errors during processing in red

### DIFF
--- a/cli/cli_progress.go
+++ b/cli/cli_progress.go
@@ -94,7 +94,7 @@ func (p *cliProgress) Error(path string, err error, isIgnored bool) {
 		p.output(warningColor, fmt.Sprintf("Ignored error when processing \"%v\": %v\n", path, err))
 	} else {
 		p.fatalErrorCount.Add(1)
-		p.output(warningColor, fmt.Sprintf("Error when processing \"%v\": %v\n", path, err))
+		p.output(errorColor, fmt.Sprintf("Error when processing \"%v\": %v\n", path, err))
 	}
 }
 


### PR DESCRIPTION
My backup had a fatal error. The end of the log looked like this:

```
Created snapshot with root k5ab05dd5a8aaf9da8a6a822abd0afabb and ID 04caa6e10f4e2866a74492a4162ea943 in 2m44s
WARN Ignored 943 error(s) while snapshotting root@tower:/.
 ERROR Found 1 fatal error(s) while snapshotting root@tower:/.
```

Note that "WARN" is yellow and "ERROR" is red.

Since I got a fatal error, I wanted to check what the fatal error was in the log. Because "ERROR" in the lines above is red, I expected the fatal error in the kopia log to also be red, but it was yellow like the non-fatal errors. This was unexpected to me.

Also note that I have lots of `! Ignored error when processing` in the kopia log because I also backup Docker containers, so right now it is not easy to find the fatal error among the non-fatal errors because non-fatal and fatal errors have the same color.

NB: Not sure if this is a "fix:" or "chore:" in conventional commits. I guess it depends on what you define as the interface.