### PR TITLE
fix(providers): change versioning check for Azure storage

### DIFF
--- a/repo/blob/azure/azure_pit.go
+++ b/repo/blob/azure/azure_pit.go
@@ -175,13 +175,13 @@ func (az *azPointInTimeStorage) isAzureDeleteMarker(it *azblobmodels.BlobItem) b
 
 // maybePointInTimeStore wraps s with a point-in-time store when s is versioned
 // and a point-in-time value is specified. Otherwise, s is returned.
-func maybePointInTimeStore(ctx context.Context, s *azStorage, pointInTime *time.Time) (blob.Storage, error) {
+func maybePointInTimeStore(s *azStorage, pointInTime *time.Time) blob.Storage {
 	if pit := s.Options.PointInTime; pit == nil || pit.IsZero() {
-		return s, nil
+		return s
 	}
 
 	return readonly.NewWrapper(&azPointInTimeStorage{
 		azStorage:   *s,
 		pointInTime: *pointInTime,
-	}), nil
+	})
 }

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -417,7 +417,10 @@ func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error)
 		service:   service,
 	}
 
-	st := maybePointInTimeStore(raw, opt.PointInTime)
+	st, err := maybePointInTimeStore(ctx, raw, opt.PointInTime)
+	if err != nil {
+		return nil, err
+	}
 
 	az := retrying.NewWrapper(st)
 

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -417,10 +417,7 @@ func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error)
 		service:   service,
 	}
 
-	st, err := maybePointInTimeStore(ctx, raw, opt.PointInTime)
-	if err != nil {
-		return nil, err
-	}
+	st := maybePointInTimeStore(raw, opt.PointInTime)
 
 	az := retrying.NewWrapper(st)
 

--- a/repo/blob/azure/azure_versioned_test.go
+++ b/repo/blob/azure/azure_versioned_test.go
@@ -54,6 +54,8 @@ func TestGetBlobVersions(t *testing.T) {
 	// required for PIT versioning check
 	err = st.PutBlob(ctx, format.KopiaRepositoryBlobID, gather.FromSlice([]byte(nil)), blob.PutOptions{})
 	require.NoError(t, err)
+	err = st.DeleteBlob(ctx, format.KopiaRepositoryBlobID) // blob can be deleted and still work
+	require.NoError(t, err)
 
 	const (
 		originalData = "original"

--- a/repo/blob/azure/azure_versioned_test.go
+++ b/repo/blob/azure/azure_versioned_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kopia/kopia/repo/format"
 )
 
-func TestGetBlobVersionsWithVersioningDisabled(t *testing.T) {
+func TestGetBlobVersionsFailsWhenVersioningDisabled(t *testing.T) {
 	t.Parallel()
 	testutil.ProviderTest(t)
 


### PR DESCRIPTION
It is unusable if `kopia.respository` is deleted. This changes it to work with deleted or not