### PR TITLE
fix(cli): Ensure scrubber checks all fields recursively for sensitive tags

### DIFF
--- a/internal/scrubber/scrub_sensitive.go
+++ b/internal/scrubber/scrub_sensitive.go
@@ -31,10 +31,16 @@ func ScrubSensitiveData(v reflect.Value) reflect.Value {
 					if !fv.IsNil() {
 						fv = ScrubSensitiveData(fv.Elem()).Addr()
 					}
+
 				case reflect.Struct:
 					fv = ScrubSensitiveData(fv)
+
 				case reflect.Interface:
-					fv = ScrubSensitiveData(fv.Elem())
+					if !fv.IsNil() {
+						fv = ScrubSensitiveData(fv.Elem())
+					}
+
+				default: // Set the field as-is.
 				}
 
 				res.Field(i).Set(fv)

--- a/internal/scrubber/scrub_sensitive.go
+++ b/internal/scrubber/scrub_sensitive.go
@@ -26,6 +26,17 @@ func ScrubSensitiveData(v reflect.Value) reflect.Value {
 					res.Field(i).SetString(strings.Repeat("*", fv.Len()))
 				}
 			} else if sf.IsExported() {
+				switch fv.Kind() {
+				case reflect.Pointer:
+					if !fv.IsNil() {
+						fv = ScrubSensitiveData(fv.Elem()).Addr()
+					}
+				case reflect.Struct:
+					fv = ScrubSensitiveData(fv)
+				case reflect.Interface:
+					fv = ScrubSensitiveData(fv.Elem())
+				}
+
 				res.Field(i).Set(fv)
 			}
 		}

--- a/internal/scrubber/scrub_sensitive_test.go
+++ b/internal/scrubber/scrub_sensitive_test.go
@@ -12,7 +12,9 @@ import (
 type S struct {
 	SomePassword1 string `kopia:"sensitive"`
 	NonPassword   string
-	Inner         *Q
+	InnerPtr      *Q
+	InnerIf       interface{}
+	InnerStruct   Q
 }
 
 type Q struct {
@@ -24,7 +26,15 @@ func TestScrubber(t *testing.T) {
 	input := &S{
 		SomePassword1: "foo",
 		NonPassword:   "bar",
-		Inner: &Q{
+		InnerPtr: &Q{
+			SomePassword1: "foo",
+			NonPassword:   "bar",
+		},
+		InnerStruct: Q{
+			SomePassword1: "foo",
+			NonPassword:   "bar",
+		},
+		InnerIf: Q{
 			SomePassword1: "foo",
 			NonPassword:   "bar",
 		},
@@ -33,8 +43,16 @@ func TestScrubber(t *testing.T) {
 	want := &S{
 		SomePassword1: "***",
 		NonPassword:   "bar",
-		Inner: &Q{
-			SomePassword1: "foo",
+		InnerPtr: &Q{
+			SomePassword1: "***",
+			NonPassword:   "bar",
+		},
+		InnerStruct: Q{
+			SomePassword1: "***",
+			NonPassword:   "bar",
+		},
+		InnerIf: Q{
+			SomePassword1: "***",
 			NonPassword:   "bar",
 		},
 	}

--- a/internal/scrubber/scrub_sensitive_test.go
+++ b/internal/scrubber/scrub_sensitive_test.go
@@ -15,6 +15,8 @@ type S struct {
 	InnerPtr      *Q
 	InnerIf       interface{}
 	InnerStruct   Q
+	NilPtr        *Q
+	NilIf         interface{}
 }
 
 type Q struct {
@@ -38,6 +40,8 @@ func TestScrubber(t *testing.T) {
 			SomePassword1: "foo",
 			NonPassword:   "bar",
 		},
+		NilPtr: nil,
+		NilIf:  nil,
 	}
 
 	want := &S{
@@ -55,6 +59,8 @@ func TestScrubber(t *testing.T) {
 			SomePassword1: "***",
 			NonPassword:   "bar",
 		},
+		NilPtr: nil,
+		NilIf:  nil,
 	}
 
 	output := scrubber.ScrubSensitiveData(reflect.ValueOf(input)).Interface()


### PR DESCRIPTION
Add recursive checks to ensure that sub-structures with sensitive fields also get scrubbed by `ScrubSensitiveData`.