### PR TITLE
refactor(general): move index cleanup out to refreshAttempt

### DIFF
--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -460,6 +460,8 @@ func (e *Manager) refreshLocked(ctx context.Context) error {
 
 func (e *Manager) maybeCompactAndCleanupLocked(ctx context.Context, p *Parameters) error {
 	if !e.allowWritesOnLoad() {
+		e.log.Debug("not performing epoch index cleanup")
+
 		return nil
 	}
 

--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -962,7 +962,7 @@ func (e *Manager) getIndexesFromEpochInternal(ctx context.Context, cs CurrentSna
 		uncompactedBlobs = ue
 	}
 
-	if epochSettled {
+	if epochSettled && e.allowWritesOnLoad() {
 		e.backgroundWork.Add(1)
 
 		// we're starting background work, ignore parent cancellation signal.


### PR DESCRIPTION
Refactoring related to #3638 to simplify later PRs as much as possible.

These changes are mostly code movement except for a functional change noted below.

---

Changes

Move index compaction and cleanup out of `refreshAttemptLocked`, and perform it in `refreshLocked` after `refreshAttempLock` succeeds. See inline comments.

Refactor: Introduce an `allowWritesOnLoadHelper` to check whether or not writes can be performed when loading the indexes. Currently this is only a function of whether the storage is in read-only mode. In the near future, an explicit flag will be added to control this behavior.

_Functional change_: Avoid single epoch compaction when writes are disallowed, that is when using read-only storage. Currently, the epoch manager will attempt to perform single epoch compactions, when it is time to do so, even on read-only storage.

---

Ref:
- #3224
- #3225
- #3638
- #3639