### PR TITLE
refactor(cli): miscellaneous code simplifications

### DIFF
--- a/cli/command_snapshot_migrate.go
+++ b/cli/command_snapshot_migrate.go
@@ -72,12 +72,15 @@ func (c *commandSnapshotMigrate) run(ctx context.Context, destRepo repo.Reposito
 		mu.Lock()
 		defer mu.Unlock()
 
-		if !canceled {
-			canceled = true
-			for s, u := range activeUploaders {
-				log(ctx).Infof("canceling active uploader for %v", s)
-				u.Cancel()
-			}
+		if canceled {
+			return
+		}
+
+		canceled = true
+
+		for s, u := range activeUploaders {
+			log(ctx).Infof("canceling active uploader for %v", s)
+			u.Cancel()
 		}
 	})
 

--- a/internal/logfile/logfile_test.go
+++ b/internal/logfile/logfile_test.go
@@ -207,7 +207,7 @@ func verifyFileLogFormat(t *testing.T, fname string, re *regexp.Regexp) {
 	s := bufio.NewScanner(f)
 
 	for s.Scan() {
-		require.True(t, re.MatchString(s.Text()), "log line does not match the format: %v (re %v)", s.Text(), re.String())
+		require.True(t, re.MatchString(s.Text()), "log line does not match the format: %q (re %q)", s.Text(), re.String())
 	}
 }
 


### PR DESCRIPTION
- Simplification in `onTerminate` callback function for snapshot migrate command.
- Quote strings, via `%q`, in assertion failure message for clarity.

Proposed by @aaron-kasten 