### PR TITLE
fix(ci): fixed HTMLUI E2E test by switching to macOS runner

### DIFF
--- a/.github/workflows/htmlui-tests.yml
+++ b/.github/workflows/htmlui-tests.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   end-to-end-test:
     name: E2E Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - name: Check out repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/tests/htmlui_e2e_test/htmlui_e2e_test.go
+++ b/tests/htmlui_e2e_test/htmlui_e2e_test.go
@@ -335,6 +335,8 @@ func TestByteRepresentation(t *testing.T) {
 
 		// begin test
 		require.NoError(t, chromedp.Run(ctx,
+			tc.captureScreenshot("initial0"),
+
 			tc.log("navigating to preferences tab"),
 			chromedp.Click("a[data-testid='tab-preferences']", chromedp.BySearch),
 			tc.captureScreenshot("initial"),


### PR DESCRIPTION
The exact reason why Linux runner started suddenly failing is unknown, but it's not essential for this test to run on Linux since it's about UI.