### PR TITLE
refactor(cli): minor cleanups in server start

### DIFF
--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -249,7 +249,7 @@ func (c *commandServerStart) run(ctx context.Context) error {
 	httpServer.Handler = handler
 
 	if c.serverStartShutdownWhenStdinClosed {
-		log(ctx).Infof("Server will close when stdin is closed...")
+		log(ctx).Info("Server will close when stdin is closed...")
 
 		ctxutil.GoDetached(ctx, func(ctx context.Context) {
 			// consume all stdin and close the server when it closes

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -253,7 +253,7 @@ func (c *commandServerStart) run(ctx context.Context) error {
 
 		ctxutil.GoDetached(ctx, func(ctx context.Context) {
 			// consume all stdin and close the server when it closes
-			io.ReadAll(os.Stdin) //nolint:errcheck
+			io.Copy(io.Discard, os.Stdin) //nolint:errcheck
 			shutdownHTTPServer(ctx, httpServer)
 		})
 	}


### PR DESCRIPTION
Discard content when server reads `stdin` to avoid allocating a buffer, in the rare case that a large amount of data is streamed to the server's standard input.

nit: use `log.Info` variant for message with no parameters.