### PR TITLE
refactor(general): perform index compaction during repo maintenance

### DIFF
--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -50,6 +50,7 @@ const (
 	TaskEpochDeleteSupersededIndexes = "delete-superseded-epoch-indexes"
 	TaskEpochCleanupMarkers          = "cleanup-epoch-markers"
 	TaskEpochGenerateRange           = "generate-epoch-range-index"
+	TaskEpochCompactSingle           = "compact-single-epoch"
 )
 
 // shouldRun returns Mode if repository is due for periodic maintenance.
@@ -350,6 +351,14 @@ func runTaskEpochMaintenanceQuick(ctx context.Context, runParams RunParameters, 
 
 	if !hasEpochManager {
 		return nil
+	}
+
+	err := ReportRun(ctx, runParams.rep, TaskEpochCompactSingle, s, func() error {
+		log(ctx).Infof("Compacting an eligible uncompacted epoch...")
+		return errors.Wrap(em.MaybeCompactSingleEpoch(ctx), "error compacting single epoch")
+	})
+	if err != nil {
+		return err
 	}
 
 	return runTaskEpochAdvance(ctx, em, runParams, s)

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/epoch"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/content/index"
@@ -45,6 +46,7 @@ const (
 	TaskIndexCompaction              = "index-compaction"
 	TaskExtendBlobRetentionTimeFull  = "extend-blob-retention-time"
 	TaskCleanupLogs                  = "cleanup-logs"
+	TaskEpochAdvance                 = "advance-epoch"
 	TaskEpochDeleteSupersededIndexes = "delete-superseded-epoch-indexes"
 	TaskEpochCleanupMarkers          = "cleanup-epoch-markers"
 )
@@ -295,6 +297,10 @@ func runQuickMaintenance(ctx context.Context, runParams RunParameters, safety Sa
 		notDeletingOrphanedBlobs(ctx, s, safety)
 	}
 
+	if err := runTaskEpochMaintenanceQuick(ctx, runParams, s); err != nil {
+		return errors.Wrap(err, "error running quick epoch maintenance tasks")
+	}
+
 	// consolidate many smaller indexes into fewer larger ones.
 	if err := runTaskIndexCompactionQuick(ctx, runParams, s, safety); err != nil {
 		return errors.Wrap(err, "error performing index compaction")
@@ -328,6 +334,26 @@ func runTaskCleanupLogs(ctx context.Context, runParams RunParameters, s *Schedul
 	})
 }
 
+func runTaskEpochAdvance(ctx context.Context, em *epoch.Manager, runParams RunParameters, s *Schedule) error {
+	return ReportRun(ctx, runParams.rep, TaskEpochAdvance, s, func() error {
+		log(ctx).Infof("Cleaning up no-longer-needed epoch markers...")
+		return errors.Wrap(em.MaybeAdvanceWriteEpoch(ctx), "error advancing epoch marker")
+	})
+}
+
+func runTaskEpochMaintenanceQuick(ctx context.Context, runParams RunParameters, s *Schedule) error {
+	em, hasEpochManager, emerr := runParams.rep.ContentManager().EpochManager(ctx)
+	if emerr != nil {
+		return errors.Wrap(emerr, "epoch manager")
+	}
+
+	if !hasEpochManager {
+		return nil
+	}
+
+	return runTaskEpochAdvance(ctx, em, runParams, s)
+}
+
 func runTaskEpochMaintenanceFull(ctx context.Context, runParams RunParameters, s *Schedule) error {
 	em, hasEpochManager, emerr := runParams.rep.ContentManager().EpochManager(ctx)
 	if emerr != nil {
@@ -336,6 +362,10 @@ func runTaskEpochMaintenanceFull(ctx context.Context, runParams RunParameters, s
 
 	if !hasEpochManager {
 		return nil
+	}
+
+	if err := runTaskEpochAdvance(ctx, em, runParams, s); err != nil {
+		return err
 	}
 
 	// clean up epoch markers

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -374,6 +374,14 @@ func runTaskEpochMaintenanceFull(ctx context.Context, runParams RunParameters, s
 		return nil
 	}
 
+	// compact a single epoch
+	if err := ReportRun(ctx, runParams.rep, TaskEpochCompactSingle, s, func() error {
+		log(ctx).Infof("Compacting an eligible uncompacted epoch...")
+		return errors.Wrap(em.MaybeCompactSingleEpoch(ctx), "error compacting single epoch")
+	}); err != nil {
+		return err
+	}
+
 	if err := runTaskEpochAdvance(ctx, em, runParams, s); err != nil {
 		return err
 	}


### PR DESCRIPTION
Perform index epoch compaction and cleanup during repository maintenance.

- [x] Advance epoch on quick maintenance #3709
- [x] Advance epoch on full maintenance
- [x] Compact a single epoch on quick maintenance #3728
- [x] Compact a single epoch on full maintenance
- [x] Range compaction on full maintenance #3727
- [x] Cleanup watermark and epoch markers on full maintenance #3726


Ref:
- #3638
- #3639

Followup to:
- #3603
- #3645

Related helpers and changes:
- #3721
- #3735
