### PR TITLE
fix(server): do not make blocking calls inside server status API

### DIFF
--- a/internal/server/grpc_session.go
+++ b/internal/server/grpc_session.go
@@ -551,10 +551,7 @@ func (s *Server) handleInitialSessionHandshake(srv grpcapi.KopiaRepository_Sessi
 		return repo.WriteSessionOptions{}, errors.Errorf("missing initialization request")
 	}
 
-	scc, err := dr.ContentReader().SupportsContentCompression(srv.Context())
-	if err != nil {
-		return repo.WriteSessionOptions{}, errors.Wrap(err, "supports content compression")
-	}
+	scc := dr.ContentReader().SupportsContentCompression()
 
 	if err := s.send(srv, initializeReq.GetRequestId(), &grpcapi.SessionResponse{
 		Response: &grpcapi.SessionResponse_InitializeSession{

--- a/repo/api_server_repository.go
+++ b/repo/api_server_repository.go
@@ -157,8 +157,8 @@ func (r *apiServerRepository) Flush(ctx context.Context) error {
 	return nil
 }
 
-func (r *apiServerRepository) SupportsContentCompression(ctx context.Context) (bool, error) {
-	return r.serverSupportsContentCompression, nil
+func (r *apiServerRepository) SupportsContentCompression() bool {
+	return r.serverSupportsContentCompression
 }
 
 func (r *apiServerRepository) NewWriter(ctx context.Context, opt WriteSessionOptions) (context.Context, RepositoryWriter, error) {

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -768,13 +768,10 @@ func (bm *WriteManager) getOrCreatePendingPackInfoLocked(ctx context.Context, pr
 }
 
 // SupportsContentCompression returns true if content manager supports content-compression.
-func (bm *WriteManager) SupportsContentCompression(ctx context.Context) (bool, error) {
-	mp, mperr := bm.format.GetMutableParameters(ctx)
-	if mperr != nil {
-		return false, errors.Wrap(mperr, "mutable parameters")
-	}
+func (bm *WriteManager) SupportsContentCompression() bool {
+	mp := bm.format.GetCachedMutableParameters()
 
-	return mp.IndexVersion >= index.Version2, nil
+	return mp.IndexVersion >= index.Version2
 }
 
 // WriteContent saves a given content of data to a pack group with a provided name and returns a contentID

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -1830,7 +1830,7 @@ func (s *contentManagerSuite) TestAutoCompressionOfMetadata(t *testing.T) {
 	info, err := bm.ContentInfo(ctx, contentID)
 	require.NoError(t, err)
 
-	if scc, _ := bm.SupportsContentCompression(ctx); scc {
+	if bm.SupportsContentCompression() {
 		require.Equal(t, compression.HeaderZstdFastest, info.GetCompressionHeaderID())
 	} else {
 		require.Equal(t, NoCompression, info.GetCompressionHeaderID())

--- a/repo/content/content_reader.go
+++ b/repo/content/content_reader.go
@@ -9,7 +9,10 @@ import (
 
 // Reader defines content read API.
 type Reader interface {
-	SupportsContentCompression(ctx context.Context) (bool, error)
+	// returns true if the repository supports content compression.
+	// this may be slightly stale if the repository recently
+	// got upgraded, in which case it will return false which is safe.
+	SupportsContentCompression() bool
 	ContentFormat() format.Provider
 	GetContent(ctx context.Context, id ID) ([]byte, error)
 	ContentInfo(ctx context.Context, id ID) (Info, error)

--- a/repo/format/content_format.go
+++ b/repo/format/content_format.go
@@ -50,6 +50,11 @@ func (f *ContentFormat) GetMutableParameters(ctx context.Context) (MutableParame
 	return f.MutableParameters, nil
 }
 
+// GetCachedMutableParameters implements FormattingOptionsProvider.
+func (f *ContentFormat) GetCachedMutableParameters() MutableParameters {
+	return f.MutableParameters
+}
+
 // SupportsPasswordChange implements FormattingOptionsProvider.
 func (f *ContentFormat) SupportsPasswordChange() bool {
 	return f.EnablePasswordChange

--- a/repo/format/format_manager.go
+++ b/repo/format/format_manager.go
@@ -266,6 +266,18 @@ func (m *Manager) GetMutableParameters(ctx context.Context) (MutableParameters, 
 	return f.GetMutableParameters(ctx)
 }
 
+// GetCachedMutableParameters gets mutable paramers of the repository without blocking.
+func (m *Manager) GetCachedMutableParameters() MutableParameters {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.current == nil {
+		return MutableParameters{}
+	}
+
+	return m.current.GetCachedMutableParameters()
+}
+
 // UpgradeLockIntent returns the current lock intent.
 func (m *Manager) UpgradeLockIntent(ctx context.Context) (*UpgradeLockIntent, error) {
 	if err := m.maybeRefreshNotLocked(ctx); err != nil {

--- a/repo/format/format_provider.go
+++ b/repo/format/format_provider.go
@@ -59,6 +59,7 @@ type Provider interface {
 	// this is typically cached, but sometimes refreshes MutableParameters from
 	// the repository so the results should not be cached.
 	GetMutableParameters(ctx context.Context) (MutableParameters, error)
+	GetCachedMutableParameters() MutableParameters
 	SupportsPasswordChange() bool
 	GetMasterKey() []byte
 

--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -682,8 +682,8 @@ func (r *grpcInnerSession) GetContent(ctx context.Context, contentID content.ID)
 	return nil, errNoSessionResponse()
 }
 
-func (r *grpcRepositoryClient) SupportsContentCompression(ctx context.Context) (bool, error) {
-	return r.serverSupportsContentCompression, nil
+func (r *grpcRepositoryClient) SupportsContentCompression() bool {
+	return r.serverSupportsContentCompression
 }
 
 func (r *grpcRepositoryClient) doWriteAsync(ctx context.Context, contentID content.ID, data []byte, prefix content.IDPrefix, comp compression.HeaderID) error {

--- a/repo/object/object_manager.go
+++ b/repo/object/object_manager.go
@@ -35,7 +35,8 @@ type contentReader interface {
 
 type contentManager interface {
 	contentReader
-	SupportsContentCompression(ctx context.Context) (bool, error)
+
+	SupportsContentCompression() bool
 	WriteContent(ctx context.Context, data gather.Bytes, prefix content.IDPrefix, comp compression.HeaderID) (content.ID, error)
 }
 

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -79,8 +79,8 @@ func (f *fakeContentManager) WriteContent(ctx context.Context, data gather.Bytes
 	return contentID, nil
 }
 
-func (f *fakeContentManager) SupportsContentCompression(ctx context.Context) (bool, error) {
-	return f.supportsContentCompression, nil
+func (f *fakeContentManager) SupportsContentCompression() bool {
+	return f.supportsContentCompression
 }
 
 func (f *fakeContentManager) ContentInfo(ctx context.Context, contentID content.ID) (content.Info, error) {

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -188,13 +188,11 @@ func (w *objectWriter) prepareAndWriteContentChunk(chunkID int, data gather.Byte
 	comp := content.NoCompression
 	objectComp := w.compressor
 
-	scc, err := w.om.contentMgr.SupportsContentCompression(w.ctx)
-	if err != nil {
-		return errors.Wrap(err, "supports content compression")
-	}
+	// in super rare cases this may be stale, but if it is it will be false which is always safe.
+	supportsContentCompression := w.om.contentMgr.SupportsContentCompression()
 
 	// do not compress in this layer, instead pass comp to the content manager.
-	if scc && w.compressor != nil {
+	if supportsContentCompression && w.compressor != nil {
 		comp = w.compressor.HeaderID()
 		objectComp = nil
 	}


### PR DESCRIPTION
also reduce global server lock scope

This API call is frequently invoked by KopiaUI. This should improve #2226 and #2453  by never blocking in the critical API call. 
