### PR TITLE
feat(general): Add alternate key derivation algorithms

### DIFF
--- a/cli/command_user_add_set.go
+++ b/cli/command_user_add_set.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/internal/user"
 	"github.com/kopia/kopia/repo"
 )
@@ -74,7 +75,7 @@ func (c *commandServerUserAddSet) runServerUserAddSet(ctx context.Context, rep r
 	if p := c.userSetPassword; p != "" {
 		changed = true
 
-		if err := up.SetPassword(p); err != nil {
+		if err := up.SetPassword(p, crypto.DefaultKeyDerivationAlgorithm); err != nil {
 			return errors.Wrap(err, "error setting password")
 		}
 	}
@@ -107,7 +108,7 @@ func (c *commandServerUserAddSet) runServerUserAddSet(ctx context.Context, rep r
 
 		changed = true
 
-		if err := up.SetPassword(pwd); err != nil {
+		if err := up.SetPassword(pwd, crypto.DefaultKeyDerivationAlgorithm); err != nil {
 			return errors.Wrap(err, "error setting password")
 		}
 	}

--- a/internal/auth/authn_repo.go
+++ b/internal/auth/authn_repo.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/internal/user"
 	"github.com/kopia/kopia/repo"
 )
@@ -51,7 +52,7 @@ func (ac *repositoryUserAuthenticator) IsValid(ctx context.Context, rep repo.Rep
 
 	// IsValidPassword can be safely called on nil and the call will take as much time as for a valid user
 	// thus not revealing anything about whether the user exists.
-	return ac.userProfiles[username].IsValidPassword(password)
+	return ac.userProfiles[username].IsValidPassword(password, crypto.DefaultKeyDerivationAlgorithm)
 }
 
 func (ac *repositoryUserAuthenticator) Refresh(ctx context.Context) error {

--- a/internal/auth/authn_repo_test.go
+++ b/internal/auth/authn_repo_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/auth"
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/user"
 	"github.com/kopia/kopia/repo"
@@ -22,7 +23,7 @@ func TestRepositoryAuthenticator(t *testing.T) {
 				Username: "user1@host1",
 			}
 
-			p.SetPassword("password1")
+			p.SetPassword("password1", crypto.DefaultKeyDerivationAlgorithm)
 
 			return user.SetUserProfile(ctx, w, p)
 		}))

--- a/internal/crypto/key_derivation_nontest.go
+++ b/internal/crypto/key_derivation_nontest.go
@@ -38,12 +38,3 @@ var keyDerivers = map[string]KeyDeriver{}
 func Register(name string, keyDeriver KeyDeriver) {
 	keyDerivers[name] = keyDeriver
 }
-
-// DeriveKeyFromPassword derives encryption key using the provided password and per-repository unique ID.
-func DeriveKeyFromPassword(password string, salt []byte, algorithm string) ([]byte, error) {
-	kdFunc, ok := keyDerivationFunctions[algorithm]
-	if !ok {
-		return nil, errors.Errorf("unsupported key algorithm: %v", algorithm)
-	}
-	return kdFunc(password, salt, MasterKeyLength)
-}

--- a/internal/crypto/key_derivation_nontest.go
+++ b/internal/crypto/key_derivation_nontest.go
@@ -8,9 +8,12 @@ import (
 )
 
 const (
+	// MasterKeyLength describes the length of the master key.
 	MasterKeyLength = 32
 
+	// ScryptAlgorithm is the key for the scrypt algorithm.
 	ScryptAlgorithm = "scrypt-65536-8-1"
+	// Pbkdf2Algorithm is the key for the pbkdf algorithm.
 	Pbkdf2Algorithm = "pbkdf2"
 )
 
@@ -19,8 +22,10 @@ const DefaultKeyDerivationAlgorithm = ScryptAlgorithm
 
 type keyDerivationFunc func(password string, salt []byte) ([]byte, error)
 
+//nolint:gochecknoglobals
 var keyDerivers = map[string]keyDerivationFunc{}
 
+// RegisterKeyDerivationFunc registers various key derivation functions.
 func RegisterKeyDerivationFunc(name string, keyDeriver keyDerivationFunc) {
 	keyDerivers[name] = keyDeriver
 }
@@ -31,5 +36,6 @@ func DeriveKeyFromPassword(password string, salt []byte, algorithm string) ([]by
 	if !ok {
 		return nil, errors.Errorf("unsupported key algorithm: %v", algorithm)
 	}
+
 	return kdFunc(password, salt)
 }

--- a/internal/crypto/key_derivation_nontest.go
+++ b/internal/crypto/key_derivation_nontest.go
@@ -17,12 +17,26 @@ const (
 // DefaultKeyDerivationAlgorithm is the key derivation algorithm for new configurations.
 const DefaultKeyDerivationAlgorithm = ScryptAlgorithm
 
+type KeyDeriver interface {
+	IsValidSalt(salt []byte) error
+
+	DeriveKeyFromPassword(password string, salt []byte) ([]byte, error)
+}
+
+func CreateKeyDeriver(algorithm string) (KeyDeriver, error) {
+	keyDeriver, ok := keyDerivers[algorithm]
+	if !ok {
+		return nil, errors.Errorf("unsupported key derivation algorithm: %v", algorithm)
+	}
+	return keyDeriver, nil
+}
+
 type keyDerivationFunc func(password string, salt []byte, keyLen int) ([]byte, error)
 
-var keyDerivationFunctions = map[string]keyDerivationFunc{}
+var keyDerivers = map[string]KeyDeriver{}
 
-func Register(name string, newKDFunc keyDerivationFunc) {
-	keyDerivationFunctions[name] = newKDFunc
+func Register(name string, keyDeriver KeyDeriver) {
+	keyDerivers[name] = keyDeriver
 }
 
 // DeriveKeyFromPassword derives encryption key using the provided password and per-repository unique ID.

--- a/internal/crypto/key_derivation_testing.go
+++ b/internal/crypto/key_derivation_testing.go
@@ -12,6 +12,9 @@ import (
 // DefaultKeyDerivationAlgorithm is the key derivation algorithm for new configurations.
 const DefaultKeyDerivationAlgorithm = "testing-only-insecure"
 
+// MasterKeyLength describes the length of the master key.
+const MasterKeyLength = 32
+
 // DeriveKeyFromPassword derives encryption key using the provided password and per-repository unique ID.
 func DeriveKeyFromPassword(password string, salt []byte, algorithm string) ([]byte, error) {
 	const masterKeySize = 32

--- a/internal/crypto/pbkdf.go
+++ b/internal/crypto/pbkdf.go
@@ -1,13 +1,16 @@
+//go:build !testing
+// +build !testing
+
 package crypto
 
 import (
 	"crypto/sha256"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/pbkdf2"
 )
 
-// The NIST recommended iterations for PBKDF2 with SHA256 hash is 600,000
+// The NIST recommended iterations for PBKDF2 with SHA256 hash is 600,000.
 const pbkdf2Sha256Iterations = 1<<20 - 1<<18 // 786,432
 
 // The NIST recommended minimum size for a salt for pbkdf2 is 16 bytes.
@@ -20,8 +23,9 @@ const minPbkdfSha256SaltSize = 32 // size in bytes == 256 bits
 func init() {
 	RegisterKeyDerivationFunc(Pbkdf2Algorithm, func(password string, salt []byte) ([]byte, error) {
 		if len(salt) < minPbkdfSha256SaltSize {
-			return nil, fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSha256SaltSize)
+			return nil, errors.Errorf("required salt size is atleast %d bytes", minPbkdfSha256SaltSize)
 		}
+
 		return pbkdf2.Key([]byte(password), salt, pbkdf2Sha256Iterations, MasterKeyLength, sha256.New), nil
 	})
 }

--- a/internal/crypto/pbkdf.go
+++ b/internal/crypto/pbkdf.go
@@ -1,0 +1,16 @@
+package crypto
+
+import (
+	"crypto/sha256"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// The recommended iterations for PBKDF2 with SHA256 hash is 600,000
+const pbkdf2Sha256Iterations = 1<<20 - 1<<18 // 786,432
+
+func init() {
+	Register(Pbkdf2Algorithm, func(password string, salt []byte, keyLen int) ([]byte, error) {
+		return pbkdf2.Key([]byte(password), salt, pbkdf2Sha256Iterations, keyLen, sha256.New), nil
+	})
+}

--- a/internal/crypto/pbkdf.go
+++ b/internal/crypto/pbkdf.go
@@ -2,15 +2,30 @@ package crypto
 
 import (
 	"crypto/sha256"
+	"fmt"
 
 	"golang.org/x/crypto/pbkdf2"
 )
 
-// The recommended iterations for PBKDF2 with SHA256 hash is 600,000
+// The NIST recommended iterations for PBKDF2 with SHA256 hash is 600,000
 const pbkdf2Sha256Iterations = 1<<20 - 1<<18 // 786,432
 
+// The NIST recommended minimum size for a salt to be used for pbkdf2
+const minPbkdfSaltSize = 16 // size in bytes == 128 bits
+
+type pbkdf2sha256 struct{}
+
+func (p pbkdf2sha256) IsValidSalt(salt []byte) error {
+	if len(salt) < minPbkdfSaltSize {
+		return fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSaltSize)
+	}
+	return nil
+}
+
+func (p pbkdf2sha256) DeriveKeyFromPassword(password string, salt []byte) ([]byte, error) {
+	return pbkdf2.Key([]byte(password), salt, pbkdf2Sha256Iterations, MasterKeyLength, sha256.New), nil
+}
+
 func init() {
-	Register(Pbkdf2Algorithm, func(password string, salt []byte, keyLen int) ([]byte, error) {
-		return pbkdf2.Key([]byte(password), salt, pbkdf2Sha256Iterations, keyLen, sha256.New), nil
-	})
+	Register(Pbkdf2Algorithm, pbkdf2sha256{})
 }

--- a/internal/crypto/pbkdf.go
+++ b/internal/crypto/pbkdf.go
@@ -13,19 +13,11 @@ const pbkdf2Sha256Iterations = 1<<20 - 1<<18 // 786,432
 // The NIST recommended minimum size for a salt to be used for pbkdf2
 const minPbkdfSaltSize = 16 // size in bytes == 128 bits
 
-type pbkdf2sha256 struct{}
-
-func (p pbkdf2sha256) IsValidSalt(salt []byte) error {
-	if len(salt) < minPbkdfSaltSize {
-		return fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSaltSize)
-	}
-	return nil
-}
-
-func (p pbkdf2sha256) DeriveKeyFromPassword(password string, salt []byte) ([]byte, error) {
-	return pbkdf2.Key([]byte(password), salt, pbkdf2Sha256Iterations, MasterKeyLength, sha256.New), nil
-}
-
 func init() {
-	Register(Pbkdf2Algorithm, pbkdf2sha256{})
+	RegisterKeyDerivationFunc(Pbkdf2Algorithm, func(password string, salt []byte) ([]byte, error) {
+		if len(salt) < minPbkdfSaltSize {
+			return nil, fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSaltSize)
+		}
+		return pbkdf2.Key([]byte(password), salt, pbkdf2Sha256Iterations, MasterKeyLength, sha256.New), nil
+	})
 }

--- a/internal/crypto/pbkdf.go
+++ b/internal/crypto/pbkdf.go
@@ -10,13 +10,17 @@ import (
 // The NIST recommended iterations for PBKDF2 with SHA256 hash is 600,000
 const pbkdf2Sha256Iterations = 1<<20 - 1<<18 // 786,432
 
-// The NIST recommended minimum size for a salt to be used for pbkdf2
-const minPbkdfSaltSize = 16 // size in bytes == 128 bits
+// The NIST recommended minimum size for a salt for pbkdf2 is 16 bytes.
+// However, A good rule of thumb is to use a salt that is the same size
+// as the output of the hash function. For example, the output of SHA256
+// is 256 bits (32 bytes), so the salt should be at least 32 random bytes
+// https://crackstation.net/hashing-security.htm
+const minPbkdfSha256SaltSize = 32 // size in bytes == 256 bits
 
 func init() {
 	RegisterKeyDerivationFunc(Pbkdf2Algorithm, func(password string, salt []byte) ([]byte, error) {
-		if len(salt) < minPbkdfSaltSize {
-			return nil, fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSaltSize)
+		if len(salt) < minPbkdfSha256SaltSize {
+			return nil, fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSha256SaltSize)
 		}
 		return pbkdf2.Key([]byte(password), salt, pbkdf2Sha256Iterations, MasterKeyLength, sha256.New), nil
 	})

--- a/internal/crypto/scrypt.go
+++ b/internal/crypto/scrypt.go
@@ -1,8 +1,10 @@
+//go:build !testing
+// +build !testing
+
 package crypto
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/scrypt"
 )
 
@@ -17,8 +19,10 @@ const minScryptSha256SaltSize = 32 // size in bytes == 256 bits
 func init() {
 	RegisterKeyDerivationFunc(ScryptAlgorithm, func(password string, salt []byte) ([]byte, error) {
 		if len(salt) < minScryptSha256SaltSize {
-			return nil, fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSha256SaltSize)
+			return nil, errors.Errorf("required salt size is atleast %d bytes", minPbkdfSha256SaltSize)
 		}
+
+		//nolint:wrapcheck,gomnd
 		return scrypt.Key([]byte(password), salt, 65536, 8, 1, MasterKeyLength)
 	})
 }

--- a/internal/crypto/scrypt.go
+++ b/internal/crypto/scrypt.go
@@ -7,12 +7,17 @@ import (
 )
 
 // The recommended minimum size for a salt to be used for scrypt
-const minScryptSaltSize = 16 // size in bytes == 128 bits
+// A good rule of thumb is to use a salt that is the same size
+// as the output of the hash function. For example, the output of SHA256
+// is 256 bits (32 bytes), so the salt should be at least 32 random bytes.
+// Scrypt uses a SHA256 hash function.
+// https://crackstation.net/hashing-security.htm
+const minScryptSha256SaltSize = 32 // size in bytes == 256 bits
 
 func init() {
 	RegisterKeyDerivationFunc(ScryptAlgorithm, func(password string, salt []byte) ([]byte, error) {
-		if len(salt) < minScryptSaltSize {
-			return nil, fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSaltSize)
+		if len(salt) < minScryptSha256SaltSize {
+			return nil, fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSha256SaltSize)
 		}
 		return scrypt.Key([]byte(password), salt, 65536, 8, 1, MasterKeyLength)
 	})

--- a/internal/crypto/scrypt.go
+++ b/internal/crypto/scrypt.go
@@ -1,0 +1,11 @@
+package crypto
+
+import (
+	"golang.org/x/crypto/scrypt"
+)
+
+func init() {
+	Register(ScryptAlgorithm, func(password string, salt []byte, keyLen int) ([]byte, error) {
+		return scrypt.Key([]byte(password), salt, 65536, 8, 1, keyLen)
+	})
+}

--- a/internal/crypto/scrypt.go
+++ b/internal/crypto/scrypt.go
@@ -4,8 +4,22 @@ import (
 	"golang.org/x/crypto/scrypt"
 )
 
+// The recommended minimum size for a salt to be used for pbkdf2
+const minScryptSaltSize = 16 // size in bytes == 128 bits
+
+type scrypt6553681 struct{}
+
+func (s scrypt6553681) IsValidSalt(salt []byte) error {
+	if len(salt) < minScryptSaltSize {
+		return fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSaltSize)
+	}
+	return nil
+}
+
+func (s scrypt6553681) DeriveKeyFromPassword(password string, salt []byte) ([]byte, error) {
+	return scrypt.Key([]byte(password), salt, 65536, 8, 1, MasterKeyLength)
+}
+
 func init() {
-	Register(ScryptAlgorithm, func(password string, salt []byte, keyLen int) ([]byte, error) {
-		return scrypt.Key([]byte(password), salt, 65536, 8, 1, keyLen)
-	})
+	Register(ScryptAlgorithm, scrypt6553681{})
 }

--- a/internal/crypto/scrypt.go
+++ b/internal/crypto/scrypt.go
@@ -1,10 +1,12 @@
 package crypto
 
 import (
+	"fmt"
+
 	"golang.org/x/crypto/scrypt"
 )
 
-// The recommended minimum size for a salt to be used for pbkdf2
+// The recommended minimum size for a salt to be used for scrypt
 const minScryptSaltSize = 16 // size in bytes == 128 bits
 
 type scrypt6553681 struct{}

--- a/internal/crypto/scrypt.go
+++ b/internal/crypto/scrypt.go
@@ -9,19 +9,11 @@ import (
 // The recommended minimum size for a salt to be used for scrypt
 const minScryptSaltSize = 16 // size in bytes == 128 bits
 
-type scrypt6553681 struct{}
-
-func (s scrypt6553681) IsValidSalt(salt []byte) error {
-	if len(salt) < minScryptSaltSize {
-		return fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSaltSize)
-	}
-	return nil
-}
-
-func (s scrypt6553681) DeriveKeyFromPassword(password string, salt []byte) ([]byte, error) {
-	return scrypt.Key([]byte(password), salt, 65536, 8, 1, MasterKeyLength)
-}
-
 func init() {
-	Register(ScryptAlgorithm, scrypt6553681{})
+	RegisterKeyDerivationFunc(ScryptAlgorithm, func(password string, salt []byte) ([]byte, error) {
+		if len(salt) < minScryptSaltSize {
+			return nil, fmt.Errorf("required salt size is atleast %d bytes", minPbkdfSaltSize)
+		}
+		return scrypt.Key([]byte(password), salt, 65536, 8, 1, MasterKeyLength)
+	})
 }

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -14,23 +14,23 @@ type Profile struct {
 }
 
 // SetPassword changes the password for a user profile.
-func (p *Profile) SetPassword(password string) error {
-	return p.setPasswordV1(password)
+func (p *Profile) SetPassword(password string, keyDerivationAlgorithm string) error {
+	return p.setPasswordV1(password, keyDerivationAlgorithm)
 }
 
 // IsValidPassword determines whether the password is valid for a given user.
-func (p *Profile) IsValidPassword(password string) bool {
+func (p *Profile) IsValidPassword(password string, keyDerivationAlgorithm string) bool {
 	if p == nil {
 		// if the user is invalid, return false but use the same amount of time as when we
 		// compare against valid user to avoid revealing whether the user account exists.
-		isValidPasswordV1(password, dummyV1HashThatNeverMatchesAnyPassword)
+		isValidPasswordV1(password, dummyV1HashThatNeverMatchesAnyPassword, keyDerivationAlgorithm)
 
 		return false
 	}
 
 	switch p.PasswordHashVersion {
 	case hashVersion1:
-		return isValidPasswordV1(password, p.PasswordHash)
+		return isValidPasswordV1(password, p.PasswordHash, keyDerivationAlgorithm)
 
 	default:
 		return false

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"io"
-	"log"
 
 	"github.com/pkg/errors"
 
@@ -21,21 +20,22 @@ const (
 //nolint:gochecknoglobals
 var dummyV1HashThatNeverMatchesAnyPassword = make([]byte, crypto.MasterKeyLength+v1SaltLength)
 
-func (p *Profile) setPasswordV1(password string) error {
+func (p *Profile) setPasswordV1(password string, keyDerivationAlgorithm string) error {
 	salt := make([]byte, v1SaltLength)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
 		return errors.Wrap(err, "error generating salt")
 	}
 
 	var err error
+
 	p.PasswordHashVersion = 1
-	p.PasswordHash, err = computePasswordHashV1(password, salt)
+	p.PasswordHash, err = computePasswordHashV1(password, salt, keyDerivationAlgorithm)
 
 	return err
 }
 
-func computePasswordHashV1(password string, salt []byte) ([]byte, error) {
-	key, err := crypto.DeriveKeyFromPassword(password, salt, crypto.DefaultKeyDerivationAlgorithm)
+func computePasswordHashV1(password string, salt []byte, keyDerivationAlgorithm string) ([]byte, error) {
+	key, err := crypto.DeriveKeyFromPassword(password, salt, keyDerivationAlgorithm)
 	if err != nil {
 		return nil, errors.Wrap(err, "error deriving key from password")
 	}
@@ -45,16 +45,16 @@ func computePasswordHashV1(password string, salt []byte) ([]byte, error) {
 	return payload, nil
 }
 
-func isValidPasswordV1(password string, hashedPassword []byte) bool {
+func isValidPasswordV1(password string, hashedPassword []byte, keyDerivationAlgorithm string) bool {
 	if len(hashedPassword) != v1SaltLength+crypto.MasterKeyLength {
 		return false
 	}
 
 	salt := hashedPassword[0:v1SaltLength]
 
-	h, err := computePasswordHashV1(password, salt)
+	h, err := computePasswordHashV1(password, salt, keyDerivationAlgorithm)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	return subtle.ConstantTimeCompare(h, hashedPassword) != 0

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -6,22 +6,19 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/scrypt"
+
+	"github.com/kopia/kopia/internal/crypto"
 )
 
 // parameters for v1 hashing.
 const (
 	hashVersion1 = 1
 
-	v1ScryptN    = 65536
-	v1ScryptR    = 8
-	v1ScryptP    = 1
 	v1SaltLength = 32
-	v1KeyLength  = 32
 )
 
 //nolint:gochecknoglobals
-var dummyV1HashThatNeverMatchesAnyPassword = make([]byte, v1KeyLength+v1SaltLength)
+var dummyV1HashThatNeverMatchesAnyPassword = make([]byte, crypto.MasterKeyLength+v1SaltLength)
 
 func (p *Profile) setPasswordV1(password string) error {
 	salt := make([]byte, v1SaltLength)
@@ -36,9 +33,9 @@ func (p *Profile) setPasswordV1(password string) error {
 }
 
 func computePasswordHashV1(password string, salt []byte) []byte {
-	key, err := scrypt.Key([]byte(password), salt, v1ScryptN, v1ScryptR, v1ScryptP, v1KeyLength)
+	key, err := crypto.DeriveKeyFromPassword(password, salt, crypto.DefaultKeyDerivationAlgorithm)
 	if err != nil {
-		panic("unexpected scrypt error")
+		panic("unexpected key derivation error")
 	}
 
 	payload := append(append([]byte(nil), salt...), key...)
@@ -47,7 +44,7 @@ func computePasswordHashV1(password string, salt []byte) []byte {
 }
 
 func isValidPasswordV1(password string, hashedPassword []byte) bool {
-	if len(hashedPassword) != v1SaltLength+v1KeyLength {
+	if len(hashedPassword) != v1SaltLength+crypto.MasterKeyLength {
 		return false
 	}
 

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -37,7 +37,7 @@ func (p *Profile) setPasswordV1(password string) error {
 func computePasswordHashV1(password string, salt []byte) ([]byte, error) {
 	key, err := crypto.DeriveKeyFromPassword(password, salt, crypto.DefaultKeyDerivationAlgorithm)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error deriving key from password")
 	}
 
 	payload := append(append([]byte(nil), salt...), key...)

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -34,15 +34,7 @@ func (p *Profile) setPasswordV1(password string) error {
 }
 
 func computePasswordHashV1(password string, salt []byte) ([]byte, error) {
-	kd, err := crypto.CreateKeyDeriver(crypto.DefaultKeyDerivationAlgorithm)
-	if err != nil {
-		return nil, err
-	}
-	err = kd.IsValidSalt(salt)
-	if err != nil {
-		return nil, err
-	}
-	key, err := kd.DeriveKeyFromPassword(password, salt)
+	key, err := crypto.DeriveKeyFromPassword(password, salt, crypto.DefaultKeyDerivationAlgorithm)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -59,7 +59,10 @@ func isValidPasswordV1(password string, hashedPassword []byte) bool {
 
 	salt := hashedPassword[0:v1SaltLength]
 
-	h := computePasswordHashV1(password, salt)
+	h, err := computePasswordHashV1(password, salt)
+	if err != nil {
+		return false
+	}
 
 	return subtle.ConstantTimeCompare(h, hashedPassword) != 0
 }

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"io"
+	"log"
 
 	"github.com/pkg/errors"
 
@@ -53,7 +54,7 @@ func isValidPasswordV1(password string, hashedPassword []byte) bool {
 
 	h, err := computePasswordHashV1(password, salt)
 	if err != nil {
-		return false
+		log.Fatal(err)
 	}
 
 	return subtle.ConstantTimeCompare(h, hashedPassword) != 0

--- a/internal/user/user_profile_test.go
+++ b/internal/user/user_profile_test.go
@@ -3,31 +3,42 @@ package user_test
 import (
 	"testing"
 
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/internal/user"
 )
 
 func TestUserProfile(t *testing.T) {
 	p := &user.Profile{}
 
-	if p.IsValidPassword("bar") {
+	if p.IsValidPassword("bar", crypto.DefaultKeyDerivationAlgorithm) {
 		t.Fatalf("password unexpectedly valid!")
 	}
 
-	p.SetPassword("foo")
+	p.SetPassword("foo", crypto.DefaultKeyDerivationAlgorithm)
 
-	if !p.IsValidPassword("foo") {
+	if !p.IsValidPassword("foo", crypto.DefaultKeyDerivationAlgorithm) {
 		t.Fatalf("password not valid!")
 	}
 
-	if p.IsValidPassword("bar") {
+	if p.IsValidPassword("bar", crypto.DefaultKeyDerivationAlgorithm) {
 		t.Fatalf("password unexpectedly valid!")
 	}
+}
+
+func TestBadKeyDerivationAlgorithmPanic(t *testing.T) {
+	defer func() { _ = recover() }()
+	func() {
+		p := &user.Profile{}
+		p.SetPassword("foo", crypto.DefaultKeyDerivationAlgorithm)
+		p.IsValidPassword("foo", "bad algorithm")
+	}()
+	t.Errorf("should have panicked")
 }
 
 func TestNilUserProfile(t *testing.T) {
 	var p *user.Profile
 
-	if p.IsValidPassword("bar") {
+	if p.IsValidPassword("bar", crypto.DefaultKeyDerivationAlgorithm) {
 		t.Fatalf("password unexpectedly valid!")
 	}
 }
@@ -40,7 +51,7 @@ func TestInvalidPasswordHash(t *testing.T) {
 
 	for _, tc := range cases {
 		p := &user.Profile{PasswordHash: tc}
-		if p.IsValidPassword("some-password") {
+		if p.IsValidPassword("some-password", crypto.DefaultKeyDerivationAlgorithm) {
 			t.Fatalf("password unexpectedly valid for %v", tc)
 		}
 	}

--- a/repo/format/format_blob.go
+++ b/repo/format/format_blob.go
@@ -72,7 +72,15 @@ func ParseKopiaRepositoryJSON(b []byte) (*KopiaRepositoryJSON, error) {
 
 // DeriveFormatEncryptionKeyFromPassword derives encryption key using the provided password and per-repository unique ID.
 func (f *KopiaRepositoryJSON) DeriveFormatEncryptionKeyFromPassword(password string) ([]byte, error) {
-	res, err := crypto.DeriveKeyFromPassword(password, f.UniqueID, f.KeyDerivationAlgorithm)
+	kd, err := crypto.CreateKeyDeriver(f.KeyDerivationAlgorithm)
+	if err != nil {
+		return nil, err
+	}
+	err = kd.IsValidSalt(f.UniqueID)
+	if err != nil {
+		return nil, err
+	}
+	res, err := kd.DeriveKeyFromPassword(password, f.UniqueID)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to derive format encryption key")
 	}

--- a/repo/format/format_blob.go
+++ b/repo/format/format_blob.go
@@ -72,15 +72,7 @@ func ParseKopiaRepositoryJSON(b []byte) (*KopiaRepositoryJSON, error) {
 
 // DeriveFormatEncryptionKeyFromPassword derives encryption key using the provided password and per-repository unique ID.
 func (f *KopiaRepositoryJSON) DeriveFormatEncryptionKeyFromPassword(password string) ([]byte, error) {
-	kd, err := crypto.CreateKeyDeriver(f.KeyDerivationAlgorithm)
-	if err != nil {
-		return nil, err
-	}
-	err = kd.IsValidSalt(f.UniqueID)
-	if err != nil {
-		return nil, err
-	}
-	res, err := kd.DeriveKeyFromPassword(password, f.UniqueID)
+	res, err := crypto.DeriveKeyFromPassword(password, f.UniqueID, f.KeyDerivationAlgorithm)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to derive format encryption key")
 	}

--- a/repo/open.go
+++ b/repo/open.go
@@ -153,7 +153,7 @@ func getContentCacheOrNil(ctx context.Context, opt *content.CachingOptions, pass
 	saltWithPurpose := append([]byte("content-cache-protection"), opt.HMACSecret...)
 
 	//nolint:gomnd
-	cacheEncryptionKey, err := crypto.DeriveKeyFromPassword(password, saltWithPurpose, crypto.DefaultKeyDerivationAlgorithm)
+	cacheEncryptionKey, err := kd.DeriveKeyFromPassword(password, saltWithPurpose)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to derive cache encryption key from password")
 	}

--- a/repo/open.go
+++ b/repo/open.go
@@ -143,7 +143,6 @@ func getContentCacheOrNil(ctx context.Context, opt *content.CachingOptions, pass
 	// derive content cache key from the password & HMAC secret
 	saltWithPurpose := append([]byte("content-cache-protection"), opt.HMACSecret...)
 
-	//nolint:gomnd
 	cacheEncryptionKey, err := crypto.DeriveKeyFromPassword(password, saltWithPurpose, crypto.DefaultKeyDerivationAlgorithm)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to derive cache encryption key from password")

--- a/repo/open.go
+++ b/repo/open.go
@@ -140,11 +140,20 @@ func getContentCacheOrNil(ctx context.Context, opt *content.CachingOptions, pass
 		return nil, errors.Wrap(err, "error opening storage")
 	}
 
+	kd, err := crypto.CreateKeyDeriver(crypto.DefaultKeyDerivationAlgorithm)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to initialize key deriver")
+	}
+
+	if err := kd.IsValidSalt(opt.HMACSecret); err != nil {
+		return nil, errors.Wrap(err, "invalid salt")
+	}
+
 	// derive content cache key from the password & HMAC secret
-	salt := append([]byte("content-cache-protection"), opt.HMACSecret...)
+	saltWithPurpose := append([]byte("content-cache-protection"), opt.HMACSecret...)
 
 	//nolint:gomnd
-	cacheEncryptionKey, err := crypto.DeriveKeyFromPassword(password, salt, crypto.DefaultKeyDerivationAlgorithm)
+	cacheEncryptionKey, err := crypto.DeriveKeyFromPassword(password, saltWithPurpose, crypto.DefaultKeyDerivationAlgorithm)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to derive cache encryption key from password")
 	}

--- a/repo/open.go
+++ b/repo/open.go
@@ -140,20 +140,11 @@ func getContentCacheOrNil(ctx context.Context, opt *content.CachingOptions, pass
 		return nil, errors.Wrap(err, "error opening storage")
 	}
 
-	kd, err := crypto.CreateKeyDeriver(crypto.DefaultKeyDerivationAlgorithm)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to initialize key deriver")
-	}
-
-	if err := kd.IsValidSalt(opt.HMACSecret); err != nil {
-		return nil, errors.Wrap(err, "invalid salt")
-	}
-
 	// derive content cache key from the password & HMAC secret
 	saltWithPurpose := append([]byte("content-cache-protection"), opt.HMACSecret...)
 
 	//nolint:gomnd
-	cacheEncryptionKey, err := kd.DeriveKeyFromPassword(password, saltWithPurpose)
+	cacheEncryptionKey, err := crypto.DeriveKeyFromPassword(password, saltWithPurpose, crypto.DefaultKeyDerivationAlgorithm)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to derive cache encryption key from password")
 	}

--- a/repo/open.go
+++ b/repo/open.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/scrypt"
 
 	"github.com/kopia/kopia/internal/cache"
 	"github.com/kopia/kopia/internal/cacheprot"
@@ -141,11 +140,11 @@ func getContentCacheOrNil(ctx context.Context, opt *content.CachingOptions, pass
 		return nil, errors.Wrap(err, "error opening storage")
 	}
 
-	// derive content cache key from the password & HMAC secret using scrypt.
+	// derive content cache key from the password & HMAC secret
 	salt := append([]byte("content-cache-protection"), opt.HMACSecret...)
 
 	//nolint:gomnd
-	cacheEncryptionKey, err := scrypt.Key([]byte(password), salt, 65536, 8, 1, 32)
+	cacheEncryptionKey, err := crypto.DeriveKeyFromPassword(password, salt, crypto.DefaultKeyDerivationAlgorithm)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to derive cache encryption key from password")
 	}


### PR DESCRIPTION
This PR adds the ability to select a different key derivation algorithm instead of `scrypt`. We add the `pbkdf2` algorithm as an example. However, the default is still `scrypt` and we are not yet using the `pbkdf2` algorithm to generate keys yet.