### PR TITLE
Pprof extensions c 1c

### DIFF
--- a/internal/pproflogging/pproflogging.go
+++ b/internal/pproflogging/pproflogging.go
@@ -82,9 +82,9 @@ type Writer interface {
 // ProfileConfigs configuration flags for all requested profiles.
 type ProfileConfigs struct {
 	mu sync.Mutex
-	//+checklocks:mu
+	// +checklocks:mu
 	wrt Writer
-	//+checklocks:mu
+	// +checklocks:mu
 	pcm map[ProfileName]*ProfileConfig
 }
 

--- a/internal/pproflogging/pproflogging.go
+++ b/internal/pproflogging/pproflogging.go
@@ -81,8 +81,10 @@ type Writer interface {
 
 // ProfileConfigs configuration flags for all requested profiles.
 type ProfileConfigs struct {
-	mu  sync.Mutex
+	mu sync.Mutex
+	//+checklocks:mu
 	wrt Writer
+	//+checklocks:mu
 	pcm map[ProfileName]*ProfileConfig
 }
 
@@ -112,7 +114,6 @@ func newProfileConfigs(wrt Writer) *ProfileConfigs {
 }
 
 // SetWriter set the destination for the PPROF dump.
-// +checklocksignore.
 func (p *ProfileConfigs) SetWriter(wrt Writer) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -121,7 +122,6 @@ func (p *ProfileConfigs) SetWriter(wrt Writer) {
 }
 
 // GetProfileConfig return a profile configuration by name.
-// +checklocksignore.
 func (p *ProfileConfigs) GetProfileConfig(nm ProfileName) *ProfileConfig {
 	if p == nil {
 		return nil

--- a/internal/pproflogging/pproflogging.go
+++ b/internal/pproflogging/pproflogging.go
@@ -41,7 +41,7 @@ const (
 
 const (
 	// EnvVarKopiaDebugPprof environment variable that contains the pprof dump configuration.
-	EnvVarKopiaDebugPprof = "KOPIA_DEBUG_PPROF"
+	EnvVarKopiaDebugPprof = "KOPIA_PPROF_LOGGING_CONFIG"
 )
 
 // flags used to configure profiling in EnvVarKopiaDebugPprof.

--- a/internal/pproflogging/pproflogging.go
+++ b/internal/pproflogging/pproflogging.go
@@ -113,26 +113,6 @@ func newProfileConfigs(wrt Writer) *ProfileConfigs {
 	return q
 }
 
-// SetWriter set the destination for the PPROF dump.
-func (p *ProfileConfigs) SetWriter(wrt Writer) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	p.wrt = wrt
-}
-
-// GetProfileConfig return a profile configuration by name.
-func (p *ProfileConfigs) GetProfileConfig(nm ProfileName) *ProfileConfig {
-	if p == nil {
-		return nil
-	}
-
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	return p.pcm[nm]
-}
-
 // LoadProfileConfig configure PPROF profiling from the config in ppconfigss.
 func LoadProfileConfig(ctx context.Context, ppconfigss string) (map[ProfileName]*ProfileConfig, error) {
 	// if empty, then don't bother configuring but emit a log message - use might be expecting them to be configured

--- a/internal/pproflogging/pproflogging.go
+++ b/internal/pproflogging/pproflogging.go
@@ -168,9 +168,7 @@ func parseProfileConfigs(bufSizeB int, ppconfigs string) (map[ProfileName]*Profi
 		profileFlagNameValuePairs := strings.SplitN(profileOptionWithFlags, "=", pair)
 		flagValue := ""
 
-		if len(profileFlagNameValuePairs) == 0 {
-			return nil, ErrEmptyConfiguration
-		} else if len(profileFlagNameValuePairs) > 1 {
+		if len(profileFlagNameValuePairs) > 1 {
 			// only <key>=<value? allowed
 			flagValue = profileFlagNameValuePairs[1]
 		}

--- a/internal/pproflogging/pproflogging_test.go
+++ b/internal/pproflogging/pproflogging_test.go
@@ -1,6 +1,7 @@
 package pproflogging
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -196,6 +197,18 @@ func TestDebug_newProfileConfigs(t *testing.T) {
 			require.Equal(t, tc.expect, v)
 		})
 	}
+}
+
+func TestDebug_DumpPem(t *testing.T) {
+	saveLockEnv(t)
+	defer restoreUnlockEnv(t)
+
+	ctx := context.Background()
+	wrt := bytes.Buffer{}
+	// DumpPem dump a PEM version of the byte slice, bs, into writer, wrt.
+	err := DumpPem(ctx, []byte("this is a sample PEM"), "test", &wrt)
+	require.NoError(t, err)
+	require.Equal(t, "-----BEGIN test-----\ndGhpcyBpcyBhIHNhbXBsZSBQRU0=\n-----END test-----\n\n", wrt.String())
 }
 
 func TestDebug_LoadProfileConfigs(t *testing.T) {

--- a/internal/pproflogging/pproflogging_test.go
+++ b/internal/pproflogging/pproflogging_test.go
@@ -1,18 +1,38 @@
 package pproflogging
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+var (
+	mu     sync.Mutex
+	oldEnv string
 )
 
 func TestDebug_parseProfileConfigs(t *testing.T) {
+	saveLockEnv(t)
+	defer restoreUnlockEnv(t)
+
 	tcs := []struct {
-		in     string
-		key    ProfileName
-		expect []string
+		in            string
+		key           ProfileName
+		expect        []string
+		expectError   error
+		expectMissing bool
 	}{
+		{
+			in:     "foo",
+			key:    "foo",
+			expect: nil,
+		},
 		{
 			in:  "foo=bar",
 			key: "foo",
@@ -67,13 +87,39 @@ func TestDebug_parseProfileConfigs(t *testing.T) {
 			key:    "third",
 			expect: nil,
 		},
+		{
+			in:            "=",
+			key:           "",
+			expectMissing: true,
+			expectError:   ErrEmptyProfileName,
+		},
+		{
+			in:            ":",
+			key:           "",
+			expectMissing: true,
+			expectError:   ErrEmptyProfileName,
+		},
+		{
+			in:     ",",
+			key:    ",",
+			expect: nil,
+		},
+		{
+			in:            "=,:",
+			key:           "",
+			expectMissing: true,
+			expectError:   ErrEmptyProfileName,
+		},
 	}
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("%d %s", i, tc.in), func(t *testing.T) {
-			pbs := parseProfileConfigs(1<<10, tc.in)
+			pbs, err := parseProfileConfigs(1<<10, tc.in)
+			require.ErrorIs(t, tc.expectError, err)
 			pb, ok := pbs[tc.key] // no negative testing for missing keys (see newProfileConfigs)
-			require.True(t, ok)
-			require.NotNil(t, pb)                 // always not nil
+			require.Equalf(t, !tc.expectMissing, ok, "key %q for set %q expect missing %t", tc.key, maps.Keys(pbs), tc.expectMissing)
+			if tc.expectMissing {
+				return
+			}
 			require.Equal(t, 1<<10, pb.buf.Cap()) // bufsize is always 1024
 			require.Equal(t, 0, pb.buf.Len())
 			require.Equal(t, tc.expect, pb.flags)
@@ -82,6 +128,9 @@ func TestDebug_parseProfileConfigs(t *testing.T) {
 }
 
 func TestDebug_newProfileConfigs(t *testing.T) {
+	saveLockEnv(t)
+	defer restoreUnlockEnv(t)
+
 	tcs := []struct {
 		in     string
 		key    string
@@ -123,4 +172,131 @@ func TestDebug_newProfileConfigs(t *testing.T) {
 			require.Equal(t, tc.expect, v)
 		})
 	}
+}
+
+func TestDebug_LoadProfileConfigs(t *testing.T) {
+	// save environment and restore after testing
+	saveLockEnv(t)
+	defer restoreUnlockEnv(t)
+
+	ctx := context.Background()
+
+	tcs := []struct {
+		inArgs                       string
+		profileKey                   ProfileName
+		profileFlagKey               string
+		expectProfileFlagValue       string
+		expectProfileFlagExists      bool
+		expectConfigurationCount     int
+		expectError                  error
+		expectProfileConfigNotExists bool
+	}{
+		{
+			inArgs:                       "",
+			expectConfigurationCount:     0,
+			profileKey:                   "",
+			expectError:                  nil,
+			expectProfileConfigNotExists: true,
+		},
+		{
+			inArgs:                   "block=rate=10:cpu:mutex=10",
+			expectConfigurationCount: 3,
+			profileKey:               "block",
+			profileFlagKey:           "rate",
+			expectProfileFlagExists:  true,
+			expectProfileFlagValue:   "10",
+			expectError:              nil,
+		},
+		{
+			inArgs:                   "block=rate=10:cpu:mutex=10",
+			expectConfigurationCount: 3,
+			profileKey:               "cpu",
+			profileFlagKey:           "rate",
+			expectProfileFlagExists:  false,
+		},
+		{
+			inArgs:                   "block=rate=10:cpu:mutex=10",
+			expectConfigurationCount: 3,
+			profileKey:               "mutex",
+			profileFlagKey:           "10",
+			expectProfileFlagExists:  true,
+		},
+	}
+
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("%d: %q", i, tc.inArgs), func(t *testing.T) {
+			pmp, err := LoadProfileConfig(ctx, tc.inArgs)
+			require.ErrorIs(t, tc.expectError, err)
+			if err != nil {
+				return
+			}
+			val, ok := pmp[tc.profileKey]
+			require.Equalf(t, tc.expectProfileConfigNotExists, !ok, "expecting key %q to %t exist", tc.profileKey, !tc.expectProfileConfigNotExists)
+			if tc.expectProfileConfigNotExists {
+				return
+			}
+			flagValue, ok := val.GetValue(tc.profileFlagKey)
+			require.Equal(t, tc.expectProfileFlagExists, ok, "expecting key %q to %t exist", tc.profileKey, tc.expectProfileFlagExists)
+			if tc.expectProfileFlagExists {
+				return
+			}
+			require.Equal(t, tc.expectProfileFlagValue, flagValue)
+		})
+	}
+}
+
+// +checklocksignore
+//
+//nolint:gocritic
+func saveLockEnv(t *testing.T) {
+	t.Helper()
+
+	mu.Lock()
+	oldEnv = os.Getenv(EnvVarKopiaDebugPprof)
+}
+
+// +checklocksignore
+//
+//nolint:gocritic
+func restoreUnlockEnv(t *testing.T) {
+	t.Helper()
+
+	t.Setenv(EnvVarKopiaDebugPprof, oldEnv)
+	mu.Unlock()
+}
+
+func TestWriter(t *testing.T) {
+	eww := &ErrorWriter{mx: 5, err: io.EOF}
+	n, err := eww.WriteString("Hello World")
+	require.ErrorIs(t, io.EOF, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "Hello", string(eww.bs))
+}
+
+type ErrorWriter struct {
+	bs  []byte
+	mx  int
+	err error
+}
+
+func (p *ErrorWriter) Write(bs []byte) (int, error) {
+	lbs := len(bs)
+	lpbs := len(p.bs)
+	n := lbs
+
+	if lbs+lpbs > p.mx {
+		n = p.mx - lpbs
+	}
+
+	p.bs = append(p.bs, bs[:n]...)
+	if n < lbs {
+		return n, p.err
+	}
+
+	return n, nil
+}
+
+//nolint:gocritic
+func (p *ErrorWriter) WriteString(s string) (int, error) {
+	return p.Write([]byte(s))
 }


### PR DESCRIPTION
This is a continuation of https://github.com/kopia/kopia/pull/3454

This is one of 8 PRs in a PR train:
`aaron-kasten/kopia:pprof-extensions-c-1a`
`aaron-kasten/kopia:pprof-extensions-c-1b`
`aaron-kasten/kopia:pprof-extensions-c-1c`
`aaron-kasten/kopia:pprof-extensions-c-1d`
`aaron-kasten/kopia:pprof-extensions-c-1e`
`aaron-kasten/kopia:pprof-extensions-c-1f`
`aaron-kasten/kopia:pprof-extensions-c-1g`

Usage
=====

pprof dumps are configured using the `KOPIA_DEBUG_PPROF` environment variable.  The variable is a list of pprof profile names (see `pprof.Lookup`) separated by `,`.  Optional parameters can be set with '=', delimited by ':'.

example:

`export KOPIA_DEBUG_PPROF=cpu,heap=debug=1,mutex=debug=1:rate=1000`

The above setting will produce CPU, heap and mutex profiles.  The block profile will have its debug parameter set to 1 and its sample rate set to 1000



Once run, profile data will be output in the Kopia logs on termination.  Profile dumps are generated as base64 output (PEM) to the log on termination.

You should consider captureing logs to a file when running the Kopia command:

```
$ kopia --log-file ./myout.log snapshot create . &
[1] 77308
```

Once the logs are captured, a dump can created by terminating the command:

```
$ kill %1
```

The following signals (on Linux and macos) can be used to dump profiles: SIGTERM, SIGINT, and SIGUSR1.

Captured standard-output should look similar to:

```
saving PEM buffers for output
2021/11/16 19:38:59 Shutting down...
dumping PEM for "PPROF MEM"
-----BEGIN PPROF MEM-----
H4sIAAAAAAAE/7R8CXxURfIw3ZOEJkTTGUUK8Hg8FZMoM8kDBHTXlUtFPBDwWteN
w+RlGJnMG2cmIO7uf4PcN8qtcsqNXCIgghgQBMUL8RYVFPHAAw/UVdTvV9VvzswE
.
.
.
sOBRWRMwE4RCnvDAimrjlBhatdcTCGSqZ9kAbk+k2i4YRBLMVXsCvgQzQXNwKGzh
l3HYSLE3drEgweOQCN7Jjnq8A43CtKt5Rt5tgyoj1u1G/m2DIkMiXk8gcPv/CwAA
//8psEjOrZ4AAA==
-----END PPROF MEM-----
```

The captured output can then be converted to a pprof binary by using `kats`.  The Kopia `kats` tool can be used to convert the PEM file into a binary:

```
$ ./go/bin/kats dump.b64
writing PEM "PPROF MEM" to file "pprof_mem.bin"
```

When successful, kats will output the file found in the capture file.

kats expects that there is a well formed PEM record in the capture file.

```
 ./go/bin/kats --help
 Usage of ./go/bin/kats:
  -verbose
    	verbose outout
```

Once successful, the binary can be used in PPROF:

```
$ go tool pprof ./pprof_mem.bin
File: pprof_mem.bin
Type: inuse_space
Time: Nov 16, 2021 at 11:38am (PST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) tree
Showing nodes accounting for 35248.89kB, 100% of 35248.89kB total
Showing top 80 nodes out of 127
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
   16384kB 46.48% 46.48%    16384kB 46.48%                | kopia/tracing.StartProfileBuffers
----------------------------------------------------------+-------------
                                         2561.41kB   100% |   encoding/json.(*decodeState).object
 2561.41kB  7.27% 53.75%  2561.41kB  7.27%                | reflect.mapassign
```

Configuration Options
=====

TBDThis PR adds the ability to dump pprof data to logs for debugging. 

This is a continuation of https://github.com/kopia/kopia/pull/3454

This is one of 4 PRs in a PR train:
`aaron-kasten/kopia:pprof-extensions-A`
`aaron-kasten/kopia:pprof-extensions-B`
`aaron-kasten/kopia:pprof-extensions-C`
`aaron-kasten/kopia:pprof-extensions-D`

Usage
=====

pprof dumps are configured using the `KOPIA_DEBUG_PPROF` environment variable.  The variable is a list of pprof profile names (see `pprof.Lookup`) separated by `,`.  Optional parameters can be set with '=', delimited by ':'.

example:

`export KOPIA_DEBUG_PPROF=cpu,heap=debug=1,mutex=debug=1:rate=1000`

The above setting will produce CPU, heap and mutex profiles.  The block profile will have its debug parameter set to 1 and its sample rate set to 1000



Once run, profile data will be output in the Kopia logs on termination.  Profile dumps are generated as base64 output (PEM) to the log on termination.

You should consider captureing logs to a file when running the Kopia command:

```
$ kopia --log-file ./myout.log snapshot create . &
[1] 77308
```

Once the logs are captured, a dump can created by terminating the command:

```
$ kill %1
```

The following signals (on Linux and macos) can be used to dump profiles: SIGTERM, SIGINT, and SIGUSR1.

Captured standard-output should look similar to:

```
saving PEM buffers for output
2021/11/16 19:38:59 Shutting down...
dumping PEM for "PPROF MEM"
-----BEGIN PPROF MEM-----
H4sIAAAAAAAE/7R8CXxURfIw3ZOEJkTTGUUK8Hg8FZMoM8kDBHTXlUtFPBDwWteN
w+RlGJnMG2cmIO7uf4PcN8qtcsqNXCIgghgQBMUL8RYVFPHAAw/UVdTvV9VvzswE
.
.
.
sOBRWRMwE4RCnvDAimrjlBhatdcTCGSqZ9kAbk+k2i4YRBLMVXsCvgQzQXNwKGzh
l3HYSLE3drEgweOQCN7Jjnq8A43CtKt5Rt5tgyoj1u1G/m2DIkMiXk8gcPv/CwAA
//8psEjOrZ4AAA==
-----END PPROF MEM-----
```

The captured output can then be converted to a pprof binary by using `kats`.  The Kopia `kats` tool can be used to convert the PEM file into a binary:

```
$ ./go/bin/kats dump.b64
writing PEM "PPROF MEM" to file "pprof_mem.bin"
```

When successful, kats will output the file found in the capture file.

kats expects that there is a well formed PEM record in the capture file.

```
 ./go/bin/kats --help
 Usage of ./go/bin/kats:
  -verbose
    	verbose outout
```

Once successful, the binary can be used in PPROF:

```
$ go tool pprof ./pprof_mem.bin
File: pprof_mem.bin
Type: inuse_space
Time: Nov 16, 2021 at 11:38am (PST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) tree
Showing nodes accounting for 35248.89kB, 100% of 35248.89kB total
Showing top 80 nodes out of 127
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
   16384kB 46.48% 46.48%    16384kB 46.48%                | kopia/tracing.StartProfileBuffers
----------------------------------------------------------+-------------
                                         2561.41kB   100% |   encoding/json.(*decodeState).object
 2561.41kB  7.27% 53.75%  2561.41kB  7.27%                | reflect.mapassign
```

Configuration Options
=====

TBD