### PR TITLE
refactor(general): add epoch.Manager.MaybeAdvanceEpoch helper

### DIFF
--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -723,6 +723,25 @@ func (e *Manager) refreshAttemptLocked(ctx context.Context) error {
 	return nil
 }
 
+// MaybeAdvanceWriteEpoch writes a new write epoch marker when a new write
+// epoch should be started, otherwise it does not do anything.
+func (e *Manager) MaybeAdvanceWriteEpoch(ctx context.Context) error {
+	p, err := e.getParameters(ctx)
+	if err != nil {
+		return err
+	}
+
+	e.mu.Lock()
+	cs := e.lastKnownState
+	e.mu.Unlock()
+
+	if shouldAdvance(cs.UncompactedEpochSets[cs.WriteEpoch], p.MinEpochDuration, p.EpochAdvanceOnCountThreshold, p.EpochAdvanceOnTotalSizeBytesThreshold) {
+		return errors.Wrap(e.advanceEpochMarker(ctx, cs), "error advancing epoch")
+	}
+
+	return nil
+}
+
 func (e *Manager) advanceEpochMarker(ctx context.Context, cs CurrentSnapshot) error {
 	blobID := blob.ID(fmt.Sprintf("%v%v", string(EpochMarkerIndexBlobPrefix), cs.WriteEpoch+1))
 

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -529,6 +529,43 @@ func TestSlowWrite_MovesToNextEpochTwice(t *testing.T) {
 	require.Contains(t, err.Error(), "slow index write")
 }
 
+func TestMaybeAdvanceEpoch_Empty(t *testing.T) {
+	t.Parallel()
+
+	te := newTestEnv(t)
+	ctx := testlogging.Context(t)
+
+	// check current epoch via the epoch manager
+	cs, err := te.mgr.Current(ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, 0, cs.WriteEpoch)
+
+	// load current epoch directly from storage
+	var cs0 CurrentSnapshot
+
+	err = te.mgr.loadWriteEpoch(ctx, &cs0)
+
+	require.NoError(t, err)
+	require.Equal(t, 0, cs0.WriteEpoch)
+
+	// this should be a no-op
+	err = te.mgr.MaybeAdvanceWriteEpoch(ctx)
+
+	require.NoError(t, err)
+
+	// check current epoch again
+	cs, err = te.mgr.Current(ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, 0, cs.WriteEpoch)
+
+	err = te.mgr.loadWriteEpoch(ctx, &cs0)
+
+	require.NoError(t, err)
+	require.Equal(t, 0, cs0.WriteEpoch)
+}
+
 func TestForceAdvanceEpoch(t *testing.T) {
 	te := newTestEnv(t)
 


### PR DESCRIPTION
Adds `epoch.Manager.MaybeAdvanceEpoch helper` and tests.
The helper is not yet invoked in maintenance, a separate change
will add all the epoch management cleanup tasks to maintenance.

Ref:
- #3638
- #3645
- #3651