### PR TITLE
fix(server): Return internal server errors for Content Get errors

### DIFF
--- a/internal/server/api_content.go
+++ b/internal/server/api_content.go
@@ -28,11 +28,17 @@ func handleContentGet(ctx context.Context, rc requestContext) (interface{}, *api
 	}
 
 	data, err := dr.ContentReader().GetContent(ctx, cid)
-	if errors.Is(err, content.ErrContentNotFound) {
-		return nil, notFoundError("content not found")
-	}
 
-	return data, nil
+	switch {
+	case err == nil:
+		return data, nil
+
+	case errors.Is(err, content.ErrContentNotFound):
+		return nil, notFoundError("content not found")
+
+	default:
+		return nil, internalServerError(err)
+	}
 }
 
 func handleContentInfo(ctx context.Context, rc requestContext) (interface{}, *apiError) {


### PR DESCRIPTION
The Content Get handler of the API server currently only returns `content not found` error responses. Other errors are swallowed and returned as successful, along with a `nil` data payload.

Fix by handling other errors as internal errors instead, equivalent to the behavior of e.g. `handleContentInfo`.