### PR TITLE
fix(cli): Output error msg returned by API server payload when possible

### DIFF
--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -148,9 +149,30 @@ func (e HTTPStatusError) Error() string {
 	return e.ErrorMessage
 }
 
+// serverErrorResponse is a structure that can decode the Error field
+// of a serverapi.ErrorResponse received from the API server.
+type serverErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// respToErrorMessage will attempt to JSON decode the response body into
+// a structure resembling the serverapi.ErrorResponse struct. If successful,
+// the Error field will be included in the string output. Otherwise
+// only the response Status field will be returned.
+func respToErrorMessage(resp *http.Response) string {
+	errResp := serverErrorResponse{}
+
+	err := json.NewDecoder(resp.Body).Decode(&errResp)
+	if err != nil {
+		return resp.Status
+	}
+
+	return fmt.Sprintf("%s: %s", resp.Status, errResp.Error)
+}
+
 func decodeResponse(resp *http.Response, respPayload interface{}) error {
 	if resp.StatusCode != http.StatusOK {
-		return HTTPStatusError{resp.StatusCode, resp.Status}
+		return HTTPStatusError{resp.StatusCode, respToErrorMessage(resp)}
 	}
 
 	if respPayload == nil {

--- a/internal/server/api_snapshots_test.go
+++ b/internal/server/api_snapshots_test.go
@@ -116,8 +116,8 @@ func TestListAndDeleteSnapshots(t *testing.T) {
 		},
 	}, &serverapi.Empty{}))
 
-	badReq := apiclient.HTTPStatusError{HTTPStatusCode: 400, ErrorMessage: "400 Bad Request"}
-	serverError := apiclient.HTTPStatusError{HTTPStatusCode: 500, ErrorMessage: "500 Internal Server Error"}
+	badReq := apiclient.HTTPStatusError{HTTPStatusCode: 400, ErrorMessage: "400 Bad Request: unknown source"}
+	serverError := apiclient.HTTPStatusError{HTTPStatusCode: 500, ErrorMessage: "500 Internal Server Error: internal server error: source info does not match snapshot source"}
 
 	// make sure when deleting snapshot by ID the source must match
 	require.ErrorIs(t, cli.Post(ctx, "snapshots/delete", &serverapi.DeleteSnapshotsRequest{


### PR DESCRIPTION
Proposal to include the payload being returned by the API server in the case of an error in the error message logged to STDERR. If the error message payload is present in the response body, include it in the error message. Otherwise the error message will remain unchanged.

Simulated `"some error"` being thrown in a query to `/api/v1/contents/{contentID}`, resulting in an internal server error response:
Before:
![image](https://github.com/kopia/kopia/assets/12399758/2b861755-13d5-4480-bb0b-318d17a9fb04)

After:
![image](https://github.com/kopia/kopia/assets/12399758/0f2934d4-30c2-4717-a541-c4bf4a139e8e)