### PR TITLE
chore(server): Disable legacy API by default

### DIFF
--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -82,7 +82,7 @@ func (c *commandServerStart) setup(svc advancedAppServices, parent commandParent
 	cmd.Flag("html", "Server the provided HTML at the root URL").ExistingDirVar(&c.serverStartHTMLPath)
 	cmd.Flag("ui", "Start the server with HTML UI").Default("true").BoolVar(&c.serverStartUI)
 
-	cmd.Flag("legacy-api", "Start the legacy server API").Default("true").BoolVar(&c.serverStartLegacyRepositoryAPI)
+	cmd.Flag("legacy-api", "Start the legacy server API").Default("false").BoolVar(&c.serverStartLegacyRepositoryAPI)
 	cmd.Flag("grpc", "Start the GRPC server").Default("true").BoolVar(&c.serverStartGRPC)
 	cmd.Flag("control-api", "Start the control API").Default("true").BoolVar(&c.serverStartControlAPI)
 

--- a/tests/end_to_end_test/acl_test.go
+++ b/tests/end_to_end_test/acl_test.go
@@ -77,6 +77,7 @@ func verifyACL(t *testing.T, disableGRPC bool) {
 		"--server-control-password=admin-pwd",
 		"--tls-generate-cert",
 		"--tls-generate-rsa-key-size=2048", // use shorter key size to speed up generation
+		"--legacy-api",
 	)
 
 	t.Logf("detected server parameters %#v", sp)

--- a/tests/end_to_end_test/api_server_repository_test.go
+++ b/tests/end_to_end_test/api_server_repository_test.go
@@ -53,7 +53,7 @@ func TestAPIServerRepository_GRPC_RepositoryUsers(t *testing.T) {
 func TestAPIServerRepository_DisableGRPC_htpasswd(t *testing.T) {
 	t.Parallel()
 
-	testAPIServerRepository(t, []string{"--no-grpc"}, false, false)
+	testAPIServerRepository(t, []string{"--no-grpc", "--legacy-api"}, false, false)
 }
 
 //nolint:thelper


### PR DESCRIPTION
Disable legacy API by default in the `kopia server start` command. The `--legacy-api` flag can be provided to start the server with the API enabled.

#3716