### PR TITLE
feat(general): Ability to set key derivation algorithm

### DIFF
--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/internal/passwordpersist"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
@@ -58,6 +59,8 @@ type connectOptions struct {
 	connectDescription            string
 	connectEnableActions          bool
 
+	keyDerivationAlgorithm string
+
 	formatBlobCacheDuration time.Duration
 	disableFormatBlobCache  bool
 }
@@ -81,6 +84,7 @@ func (c *connectOptions) setup(svc appServices, cmd *kingpin.CmdClause) {
 	cmd.Flag("enable-actions", "Allow snapshot actions").BoolVar(&c.connectEnableActions)
 	cmd.Flag("repository-format-cache-duration", "Duration of kopia.repository format blob cache").Hidden().DurationVar(&c.formatBlobCacheDuration)
 	cmd.Flag("disable-repository-format-cache", "Disable caching of kopia.repository format blob").Hidden().BoolVar(&c.disableFormatBlobCache)
+	cmd.Flag("key-derivation-algorithm", "Key Derivation Algorithm").Default(crypto.DefaultKeyDerivationAlgorithm).StringVar(&c.keyDerivationAlgorithm)
 }
 
 func (c *connectOptions) getFormatBlobCacheDuration() time.Duration {
@@ -103,6 +107,7 @@ func (c *connectOptions) toRepoConnectOptions() *repo.ConnectOptions {
 			MinContentSweepAge:          content.DurationSeconds(c.contentMinSweepAge.Seconds()),
 			MinMetadataSweepAge:         content.DurationSeconds(c.metadataMinSweepAge.Seconds()),
 			MinIndexSweepAge:            content.DurationSeconds(c.indexMinSweepAge.Seconds()),
+			KeyDerivationAlgorithm:      c.keyDerivationAlgorithm,
 		},
 		ClientOptions: repo.ClientOptions{
 			Hostname:                c.connectHostname,

--- a/cli/command_repository_connect.go
+++ b/cli/command_repository_connect.go
@@ -84,7 +84,7 @@ func (c *connectOptions) setup(svc appServices, cmd *kingpin.CmdClause) {
 	cmd.Flag("enable-actions", "Allow snapshot actions").BoolVar(&c.connectEnableActions)
 	cmd.Flag("repository-format-cache-duration", "Duration of kopia.repository format blob cache").Hidden().DurationVar(&c.formatBlobCacheDuration)
 	cmd.Flag("disable-repository-format-cache", "Disable caching of kopia.repository format blob").Hidden().BoolVar(&c.disableFormatBlobCache)
-	cmd.Flag("key-derivation-algorithm", "Key Derivation Algorithm").Default(crypto.DefaultKeyDerivationAlgorithm).StringVar(&c.keyDerivationAlgorithm)
+	cmd.Flag("key-derivation-algorithm", "Key derivation algorithm").Default(crypto.DefaultKeyDerivationAlgorithm).EnumVar(&c.keyDerivationAlgorithm, crypto.AllowedKeyDerivationAlgorithms()...)
 }
 
 func (c *connectOptions) getFormatBlobCacheDuration() time.Duration {

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/ecc"
@@ -31,6 +32,7 @@ type commandRepositoryCreate struct {
 	createSplitter                string
 	createOnly                    bool
 	createFormatVersion           int
+	keyDerivationAlgorithm        string
 	retentionMode                 string
 	retentionPeriod               time.Duration
 
@@ -48,6 +50,7 @@ func (c *commandRepositoryCreate) setup(svc advancedAppServices, parent commandP
 	cmd.Flag("ecc-overhead-percent", "[EXPERIMENTAL] How much space overhead can be used for error correction, in percentage. Use 0 to disable ECC.").Default("0").IntVar(&c.createBlockECCOverheadPercent)
 	cmd.Flag("object-splitter", "The splitter to use for new objects in the repository").Default(splitter.DefaultAlgorithm).EnumVar(&c.createSplitter, splitter.SupportedAlgorithms()...)
 	cmd.Flag("create-only", "Create repository, but don't connect to it.").Short('c').BoolVar(&c.createOnly)
+	cmd.Flag("key-derivation-algorithm", "Key Derivation Algorithm").Default(crypto.DefaultKeyDerivationAlgorithm).StringVar(&c.keyDerivationAlgorithm)
 	cmd.Flag("format-version", "Force a particular repository format version (1, 2 or 3, 0==default)").IntVar(&c.createFormatVersion)
 	cmd.Flag("retention-mode", "Set the blob retention-mode for supported storage backends.").EnumVar(&c.retentionMode, blob.Governance.String(), blob.Compliance.String())
 	cmd.Flag("retention-period", "Set the blob retention-period for supported storage backends.").DurationVar(&c.retentionPeriod)

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -7,7 +7,6 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/pkg/errors"
 
-	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/ecc"
@@ -32,7 +31,6 @@ type commandRepositoryCreate struct {
 	createSplitter                string
 	createOnly                    bool
 	createFormatVersion           int
-	keyDerivationAlgorithm        string
 	retentionMode                 string
 	retentionPeriod               time.Duration
 
@@ -50,7 +48,6 @@ func (c *commandRepositoryCreate) setup(svc advancedAppServices, parent commandP
 	cmd.Flag("ecc-overhead-percent", "[EXPERIMENTAL] How much space overhead can be used for error correction, in percentage. Use 0 to disable ECC.").Default("0").IntVar(&c.createBlockECCOverheadPercent)
 	cmd.Flag("object-splitter", "The splitter to use for new objects in the repository").Default(splitter.DefaultAlgorithm).EnumVar(&c.createSplitter, splitter.SupportedAlgorithms()...)
 	cmd.Flag("create-only", "Create repository, but don't connect to it.").Short('c').BoolVar(&c.createOnly)
-	cmd.Flag("key-derivation-algorithm", "Key Derivation Algorithm").Default(crypto.DefaultKeyDerivationAlgorithm).StringVar(&c.keyDerivationAlgorithm)
 	cmd.Flag("format-version", "Force a particular repository format version (1, 2 or 3, 0==default)").IntVar(&c.createFormatVersion)
 	cmd.Flag("retention-mode", "Set the blob retention-mode for supported storage backends.").EnumVar(&c.retentionMode, blob.Governance.String(), blob.Compliance.String())
 	cmd.Flag("retention-period", "Set the blob retention-period for supported storage backends.").DurationVar(&c.retentionPeriod)
@@ -93,9 +90,9 @@ func (c *commandRepositoryCreate) newRepositoryOptionsFromFlags() *repo.NewRepos
 		ObjectFormat: format.ObjectFormat{
 			Splitter: c.createSplitter,
 		},
-
-		RetentionMode:   blob.RetentionMode(c.retentionMode),
-		RetentionPeriod: c.retentionPeriod,
+		KeyDerivationAlgorithm: c.co.keyDerivationAlgorithm,
+		RetentionMode:          blob.RetentionMode(c.retentionMode),
+		RetentionPeriod:        c.retentionPeriod,
 	}
 }
 

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -81,18 +81,18 @@ func (c *commandRepositoryCreate) newRepositoryOptionsFromFlags() *repo.NewRepos
 			MutableParameters: format.MutableParameters{
 				Version: format.Version(c.createFormatVersion),
 			},
-			Hash:               c.createBlockHashFormat,
-			Encryption:         c.createBlockEncryptionFormat,
-			ECC:                c.createBlockECCFormat,
-			ECCOverheadPercent: c.createBlockECCOverheadPercent,
+			Hash:                   c.createBlockHashFormat,
+			Encryption:             c.createBlockEncryptionFormat,
+			ECC:                    c.createBlockECCFormat,
+			ECCOverheadPercent:     c.createBlockECCOverheadPercent,
+			KeyDerivationAlgorithm: c.co.keyDerivationAlgorithm,
 		},
 
 		ObjectFormat: format.ObjectFormat{
 			Splitter: c.createSplitter,
 		},
-		KeyDerivationAlgorithm: c.co.keyDerivationAlgorithm,
-		RetentionMode:          blob.RetentionMode(c.retentionMode),
-		RetentionPeriod:        c.retentionPeriod,
+		RetentionMode:   blob.RetentionMode(c.retentionMode),
+		RetentionPeriod: c.retentionPeriod,
 	}
 }
 
@@ -131,6 +131,7 @@ func (c *commandRepositoryCreate) runCreateCommandWithStorage(ctx context.Contex
 
 	log(ctx).Infof("  block hash:          %v", options.BlockFormat.Hash)
 	log(ctx).Infof("  encryption:          %v", options.BlockFormat.Encryption)
+	log(ctx).Infof("  key derivation:      %v", options.BlockFormat.KeyDerivationAlgorithm)
 
 	if options.BlockFormat.ECC != "" && options.BlockFormat.ECCOverheadPercent > 0 {
 		log(ctx).Infof("  ecc:                 %v with %v%% overhead", options.BlockFormat.ECC, options.BlockFormat.ECCOverheadPercent)

--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -19,7 +19,6 @@ import (
 	htpasswd "github.com/tg123/go-htpasswd"
 
 	"github.com/kopia/kopia/internal/auth"
-	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/internal/ctxutil"
 	"github.com/kopia/kopia/internal/server"
 	"github.com/kopia/kopia/repo"
@@ -66,8 +65,6 @@ type commandServerStart struct {
 	persistentLogs                      bool
 	debugScheduler                      bool
 	minMaintenanceInterval              time.Duration
-
-	keyDerivationAlgorithm string
 
 	shutdownGracePeriod time.Duration
 
@@ -122,8 +119,6 @@ func (c *commandServerStart) setup(svc advancedAppServices, parent commandParent
 
 	cmd.Flag("log-server-requests", "Log server requests").Hidden().BoolVar(&c.logServerRequests)
 	cmd.Flag("disable-csrf-token-checks", "Disable CSRF token").Hidden().BoolVar(&c.disableCSRFTokenChecks)
-
-	cmd.Flag("key-derivation-algorithm", "Key Derivation Algorithm").Default(crypto.DefaultKeyDerivationAlgorithm).StringVar(&c.keyDerivationAlgorithm)
 
 	cmd.Flag("shutdown-grace-period", "Grace period for shutting down the server").Default("5s").DurationVar(&c.shutdownGracePeriod)
 
@@ -371,7 +366,7 @@ User accounts can be added using 'kopia server user add'.
 `)
 
 	// handle user accounts stored in the repository
-	authenticators = append(authenticators, auth.AuthenticateRepositoryUsers(c.keyDerivationAlgorithm))
+	authenticators = append(authenticators, auth.AuthenticateRepositoryUsers(c.co.keyDerivationAlgorithm))
 
 	return auth.CombineAuthenticators(authenticators...), nil
 }

--- a/cli/command_user_add_set.go
+++ b/cli/command_user_add_set.go
@@ -19,6 +19,8 @@ type commandServerUserAddSet struct {
 	userSetPasswordHashVersion int
 	userSetPasswordHash        string
 
+	keyDerivationAlgorithm string
+
 	isNew bool // true == 'add', false == 'update'
 	out   textOutput
 }
@@ -35,6 +37,7 @@ func (c *commandServerUserAddSet) setup(svc appServices, parent commandParent, i
 	}
 
 	cmd.Flag("ask-password", "Ask for user password").BoolVar(&c.userAskPassword)
+	cmd.Flag("key-derivation-algorithm", "Key Derivation Algorithm").Default(crypto.DefaultKeyDerivationAlgorithm).StringVar(&c.keyDerivationAlgorithm)
 	cmd.Flag("user-password", "Password").StringVar(&c.userSetPassword)
 	cmd.Flag("user-password-hash", "Password hash").StringVar(&c.userSetPasswordHash)
 	cmd.Flag("user-password-hash-version", "Password hash version").Default("1").IntVar(&c.userSetPasswordHashVersion)
@@ -75,7 +78,7 @@ func (c *commandServerUserAddSet) runServerUserAddSet(ctx context.Context, rep r
 	if p := c.userSetPassword; p != "" {
 		changed = true
 
-		if err := up.SetPassword(p, crypto.DefaultKeyDerivationAlgorithm); err != nil {
+		if err := up.SetPassword(p, c.keyDerivationAlgorithm); err != nil {
 			return errors.Wrap(err, "error setting password")
 		}
 	}
@@ -108,7 +111,7 @@ func (c *commandServerUserAddSet) runServerUserAddSet(ctx context.Context, rep r
 
 		changed = true
 
-		if err := up.SetPassword(pwd, crypto.DefaultKeyDerivationAlgorithm); err != nil {
+		if err := up.SetPassword(pwd, c.keyDerivationAlgorithm); err != nil {
 			return errors.Wrap(err, "error setting password")
 		}
 	}

--- a/cli/command_user_add_set.go
+++ b/cli/command_user_add_set.go
@@ -37,7 +37,7 @@ func (c *commandServerUserAddSet) setup(svc appServices, parent commandParent, i
 	}
 
 	cmd.Flag("ask-password", "Ask for user password").BoolVar(&c.userAskPassword)
-	cmd.Flag("key-derivation-algorithm", "Key Derivation Algorithm").Default(crypto.DefaultKeyDerivationAlgorithm).StringVar(&c.keyDerivationAlgorithm)
+	cmd.Flag("key-derivation-algorithm", "Key derivation algorithm").Default(crypto.DefaultKeyDerivationAlgorithm).EnumVar(&c.keyDerivationAlgorithm, crypto.AllowedKeyDerivationAlgorithms()...)
 	cmd.Flag("user-password", "Password").StringVar(&c.userSetPassword)
 	cmd.Flag("user-password-hash", "Password hash").StringVar(&c.userSetPasswordHash)
 	cmd.Flag("user-password-hash-version", "Password hash version").Default("1").IntVar(&c.userSetPasswordHashVersion)

--- a/internal/auth/authn_repo.go
+++ b/internal/auth/authn_repo.go
@@ -22,7 +22,7 @@ type repositoryUserAuthenticator struct {
 	userProfiles map[string]*user.Profile
 	// +checklocks:mu
 	userProfileRefreshFrequency time.Duration
-
+	// +checklocks:mu
 	keyDerivationAlgorithm string
 }
 

--- a/internal/auth/authn_repo_test.go
+++ b/internal/auth/authn_repo_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRepositoryAuthenticator(t *testing.T) {
-	a := auth.AuthenticateRepositoryUsers()
+	a := auth.AuthenticateRepositoryUsers(crypto.DefaultKeyDerivationAlgorithm)
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
 	require.NoError(t, repo.WriteSession(ctx, env.Repository, repo.WriteSessionOptions{},

--- a/internal/crypto/key_derivation_nontest.go
+++ b/internal/crypto/key_derivation_nontest.go
@@ -40,10 +40,12 @@ func DeriveKeyFromPassword(password string, salt []byte, algorithm string) ([]by
 	return kdFunc(password, salt)
 }
 
+// AllowedKeyDerivationAlgorithms returns a slice of the allowed key derivation algorithms.
 func AllowedKeyDerivationAlgorithms() []string {
 	kdAlgorithms := make([]string, 0, len(keyDerivers))
 	for k := range keyDerivers {
 		kdAlgorithms = append(kdAlgorithms, k)
 	}
+
 	return kdAlgorithms
 }

--- a/internal/crypto/key_derivation_nontest.go
+++ b/internal/crypto/key_derivation_nontest.go
@@ -34,8 +34,16 @@ func RegisterKeyDerivationFunc(name string, keyDeriver keyDerivationFunc) {
 func DeriveKeyFromPassword(password string, salt []byte, algorithm string) ([]byte, error) {
 	kdFunc, ok := keyDerivers[algorithm]
 	if !ok {
-		return nil, errors.Errorf("unsupported key algorithm: %v", algorithm)
+		return nil, errors.Errorf("unsupported key algorithm: %v, supported algorithms %v", algorithm, AllowedKeyDerivationAlgorithms())
 	}
 
 	return kdFunc(password, salt)
+}
+
+func AllowedKeyDerivationAlgorithms() []string {
+	kdAlgorithms := make([]string, 0, len(keyDerivers))
+	for k := range keyDerivers {
+		kdAlgorithms = append(kdAlgorithms, k)
+	}
+	return kdAlgorithms
 }

--- a/repo/caching.go
+++ b/repo/caching.go
@@ -77,6 +77,7 @@ func setupCachingOptionsWithDefaults(ctx context.Context, configPath string, lc 
 	lc.Caching.MinMetadataSweepAge = opt.MinMetadataSweepAge
 	lc.Caching.MinIndexSweepAge = opt.MinIndexSweepAge
 
+	lc.Caching.KeyDerivationAlgorithm = opt.KeyDerivationAlgorithm
 	if lc.Caching.KeyDerivationAlgorithm == "" {
 		lc.Caching.KeyDerivationAlgorithm = crypto.DefaultKeyDerivationAlgorithm
 	}

--- a/repo/caching.go
+++ b/repo/caching.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/repo/content"
 )
 
@@ -75,6 +76,10 @@ func setupCachingOptionsWithDefaults(ctx context.Context, configPath string, lc 
 	lc.Caching.MinContentSweepAge = opt.MinContentSweepAge
 	lc.Caching.MinMetadataSweepAge = opt.MinMetadataSweepAge
 	lc.Caching.MinIndexSweepAge = opt.MinIndexSweepAge
+
+	if lc.Caching.KeyDerivationAlgorithm == "" {
+		lc.Caching.KeyDerivationAlgorithm = crypto.DefaultKeyDerivationAlgorithm
+	}
 
 	log(ctx).Debugf("Creating cache directory '%v' with max size %v", lc.Caching.CacheDirectory, lc.Caching.ContentCacheSizeBytes)
 

--- a/repo/content/caching_options.go
+++ b/repo/content/caching_options.go
@@ -29,6 +29,7 @@ type CachingOptions struct {
 	MinContentSweepAge          DurationSeconds `json:"minContentSweepAge,omitempty"`
 	MinIndexSweepAge            DurationSeconds `json:"minIndexSweepAge,omitempty"`
 	HMACSecret                  []byte          `json:"-"`
+	KeyDerivationAlgorithm      string          `json:"keyDerivationAlgorithm"`
 }
 
 // EffectiveMetadataCacheSizeBytes returns the effective metadata cache size.

--- a/repo/format/content_format.go
+++ b/repo/format/content_format.go
@@ -12,12 +12,13 @@ import (
 
 // ContentFormat describes the rules for formatting contents in repository.
 type ContentFormat struct {
-	Hash               string `json:"hash,omitempty"`                        // identifier of the hash algorithm used
-	Encryption         string `json:"encryption,omitempty"`                  // identifier of the encryption algorithm used
-	ECC                string `json:"ecc,omitempty"`                         // identifier of the ecc algorithm used
-	ECCOverheadPercent int    `json:"eccOverheadPercent,omitempty"`          // space overhead for ecc
-	HMACSecret         []byte `json:"secret,omitempty" kopia:"sensitive"`    // HMAC secret used to generate encryption keys
-	MasterKey          []byte `json:"masterKey,omitempty" kopia:"sensitive"` // master encryption key (SIV-mode encryption only)
+	Hash                   string `json:"hash,omitempty"`                        // identifier of the hash algorithm used
+	Encryption             string `json:"encryption,omitempty"`                  // identifier of the encryption algorithm used
+	ECC                    string `json:"ecc,omitempty"`                         // identifier of the ecc algorithm used
+	ECCOverheadPercent     int    `json:"eccOverheadPercent,omitempty"`          // space overhead for ecc
+	HMACSecret             []byte `json:"secret,omitempty" kopia:"sensitive"`    // HMAC secret used to generate encryption keys
+	MasterKey              []byte `json:"masterKey,omitempty" kopia:"sensitive"` // master encryption key (SIV-mode encryption only)
+	KeyDerivationAlgorithm string `json:"keyDerivationAlgorithm,omitempty"`      // key derivation algorith used to generate keys
 	MutableParameters
 
 	EnablePasswordChange bool `json:"enablePasswordChange"` // disables replication of kopia.repository blob in packs

--- a/repo/format/format_blob.go
+++ b/repo/format/format_blob.go
@@ -17,9 +17,6 @@ import (
 // DefaultFormatEncryption is the identifier of the default format blob encryption algorithm.
 const DefaultFormatEncryption = "AES256_GCM"
 
-// DefaultKeyDerivationAlgorithm is the key derivation algorithm for new configurations.
-const DefaultKeyDerivationAlgorithm = crypto.DefaultKeyDerivationAlgorithm
-
 const (
 	aes256GcmEncryption             = "AES256_GCM"
 	lengthOfRecoverBlockLength      = 2 // number of bytes used to store recover block length

--- a/repo/format/format_manager.go
+++ b/repo/format/format_manager.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/internal/feature"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
@@ -456,7 +457,7 @@ func Initialize(ctx context.Context, st blob.Storage, formatBlob *KopiaRepositor
 	}
 
 	if formatBlob.KeyDerivationAlgorithm == "" {
-		formatBlob.KeyDerivationAlgorithm = DefaultKeyDerivationAlgorithm
+		formatBlob.KeyDerivationAlgorithm = crypto.DefaultKeyDerivationAlgorithm
 	}
 
 	if len(formatBlob.UniqueID) == 0 {

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -35,12 +35,13 @@ const (
 // NewRepositoryOptions specifies options that apply to newly created repositories.
 // All fields are optional, when not provided, reasonable defaults will be used.
 type NewRepositoryOptions struct {
-	UniqueID        []byte               `json:"uniqueID"` // force the use of particular unique ID
-	BlockFormat     format.ContentFormat `json:"blockFormat"`
-	DisableHMAC     bool                 `json:"disableHMAC"`
-	ObjectFormat    format.ObjectFormat  `json:"objectFormat"` // object format
-	RetentionMode   blob.RetentionMode   `json:"retentionMode,omitempty"`
-	RetentionPeriod time.Duration        `json:"retentionPeriod,omitempty"`
+	UniqueID               []byte               `json:"uniqueID"` // force the use of particular unique ID
+	BlockFormat            format.ContentFormat `json:"blockFormat"`
+	DisableHMAC            bool                 `json:"disableHMAC"`
+	KeyDerivationAlgorithm string               `json:"keyDerivationAlgorithm"`
+	ObjectFormat           format.ObjectFormat  `json:"objectFormat"` // object format
+	RetentionMode          blob.RetentionMode   `json:"retentionMode,omitempty"`
+	RetentionPeriod        time.Duration        `json:"retentionPeriod,omitempty"`
 }
 
 // Initialize creates initial repository data structures in the specified storage with given credentials.
@@ -66,7 +67,7 @@ func formatBlobFromOptions(opt *NewRepositoryOptions) *format.KopiaRepositoryJSO
 		Tool:                   "https://github.com/kopia/kopia",
 		BuildInfo:              BuildInfo,
 		BuildVersion:           BuildVersion,
-		KeyDerivationAlgorithm: format.DefaultKeyDerivationAlgorithm,
+		KeyDerivationAlgorithm: opt.KeyDerivationAlgorithm,
 		UniqueID:               applyDefaultRandomBytes(opt.UniqueID, format.UniqueIDLengthBytes),
 		EncryptionAlgorithm:    format.DefaultFormatEncryption,
 	}

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -35,13 +35,12 @@ const (
 // NewRepositoryOptions specifies options that apply to newly created repositories.
 // All fields are optional, when not provided, reasonable defaults will be used.
 type NewRepositoryOptions struct {
-	UniqueID               []byte               `json:"uniqueID"` // force the use of particular unique ID
-	BlockFormat            format.ContentFormat `json:"blockFormat"`
-	DisableHMAC            bool                 `json:"disableHMAC"`
-	KeyDerivationAlgorithm string               `json:"keyDerivationAlgorithm"`
-	ObjectFormat           format.ObjectFormat  `json:"objectFormat"` // object format
-	RetentionMode          blob.RetentionMode   `json:"retentionMode,omitempty"`
-	RetentionPeriod        time.Duration        `json:"retentionPeriod,omitempty"`
+	UniqueID        []byte               `json:"uniqueID"` // force the use of particular unique ID
+	BlockFormat     format.ContentFormat `json:"blockFormat"`
+	DisableHMAC     bool                 `json:"disableHMAC"`
+	ObjectFormat    format.ObjectFormat  `json:"objectFormat"` // object format
+	RetentionMode   blob.RetentionMode   `json:"retentionMode,omitempty"`
+	RetentionPeriod time.Duration        `json:"retentionPeriod,omitempty"`
 }
 
 // Initialize creates initial repository data structures in the specified storage with given credentials.
@@ -67,7 +66,7 @@ func formatBlobFromOptions(opt *NewRepositoryOptions) *format.KopiaRepositoryJSO
 		Tool:                   "https://github.com/kopia/kopia",
 		BuildInfo:              BuildInfo,
 		BuildVersion:           BuildVersion,
-		KeyDerivationAlgorithm: opt.KeyDerivationAlgorithm,
+		KeyDerivationAlgorithm: opt.BlockFormat.KeyDerivationAlgorithm,
 		UniqueID:               applyDefaultRandomBytes(opt.UniqueID, format.UniqueIDLengthBytes),
 		EncryptionAlgorithm:    format.DefaultFormatEncryption,
 	}

--- a/repo/open.go
+++ b/repo/open.go
@@ -143,7 +143,7 @@ func getContentCacheOrNil(ctx context.Context, opt *content.CachingOptions, pass
 	// derive content cache key from the password & HMAC secret
 	saltWithPurpose := append([]byte("content-cache-protection"), opt.HMACSecret...)
 
-	cacheEncryptionKey, err := crypto.DeriveKeyFromPassword(password, saltWithPurpose, crypto.DefaultKeyDerivationAlgorithm)
+	cacheEncryptionKey, err := crypto.DeriveKeyFromPassword(password, saltWithPurpose, opt.KeyDerivationAlgorithm)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to derive cache encryption key from password")
 	}

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -68,6 +68,7 @@ type DirectRepository interface {
 	Repository
 
 	ObjectFormat() format.ObjectFormat
+	CachingOptions() content.CachingOptions
 	FormatManager() *format.Manager
 	BlobReader() blob.Reader
 	BlobVolume() blob.Volume
@@ -152,6 +153,10 @@ func (r *directRepository) DeriveKey(purpose []byte, keyLength int) []byte {
 // ClientOptions returns client options.
 func (r *directRepository) ClientOptions() ClientOptions {
 	return r.cliOpts
+}
+
+func (r *directRepository) CachingOptions() content.CachingOptions {
+	return r.cachingOptions
 }
 
 // BlobStorage returns the blob storage.

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -861,7 +861,7 @@ func TestDeriveKey(t *testing.T) {
 
 	j := format.KopiaRepositoryJSON{
 		UniqueID:               uniqueID,
-		KeyDerivationAlgorithm: format.DefaultKeyDerivationAlgorithm,
+		KeyDerivationAlgorithm: crypto.DefaultKeyDerivationAlgorithm,
 	}
 
 	formatEncryptionKeyFromPassword, err := j.DeriveFormatEncryptionKeyFromPassword(repotesting.DefaultPasswordForTesting)


### PR DESCRIPTION
This PR allows kopia users to pick the key derivation algorithm to use.
This is a follow up to https://github.com/kopia/kopia/pull/3725 which added the ability to switch between multiple key derivation algorithms.

![image](https://github.com/kopia/kopia/assets/443193/43ff0418-c91e-443a-83e5-588445c49ac4)
