### PR TITLE
fix(general): Update minimum salt size of key derivers to 16

### DIFF
--- a/internal/crypto/pbkdf.go
+++ b/internal/crypto/pbkdf.go
@@ -14,11 +14,12 @@ import (
 const pbkdf2Sha256Iterations = 1<<20 - 1<<18 // 786,432
 
 // The NIST recommended minimum size for a salt for pbkdf2 is 16 bytes.
-// However, a good rule of thumb is to use a salt that is the same size
+//
+// TBD: However, a good rule of thumb is to use a salt that is the same size
 // as the output of the hash function. For example, the output of SHA256
 // is 256 bits (32 bytes), so the salt should be at least 32 random bytes.
 // See: https://crackstation.net/hashing-security.htm
-const minPbkdfSha256SaltSize = 32 // size in bytes == 256 bits
+const minPbkdfSha256SaltSize = 16 // size in bytes == 128 bits
 
 func init() {
 	RegisterKeyDerivationFunc(Pbkdf2Algorithm, func(password string, salt []byte) ([]byte, error) {

--- a/internal/crypto/scrypt.go
+++ b/internal/crypto/scrypt.go
@@ -8,13 +8,15 @@ import (
 	"golang.org/x/crypto/scrypt"
 )
 
-// The recommended minimum size for a salt to be used for scrypt
-// A good rule of thumb is to use a salt that is the same size
+// The recommended minimum size for a salt to be used for scrypt.
+// Currently set to 16 bytes (128 bits).
+//
+// TBD: A good rule of thumb is to use a salt that is the same size
 // as the output of the hash function. For example, the output of SHA256
 // is 256 bits (32 bytes), so the salt should be at least 32 random bytes.
 // Scrypt uses a SHA256 hash function.
 // https://crackstation.net/hashing-security.htm
-const minScryptSha256SaltSize = 32 // size in bytes == 256 bits
+const minScryptSha256SaltSize = 16 // size in bytes == 128 bits
 
 func init() {
 	RegisterKeyDerivationFunc(ScryptAlgorithm, func(password string, salt []byte) ([]byte, error) {


### PR DESCRIPTION
This PR updates the minimum salt size for the key derivers to 16. 
This may not be the recommended size for a key derivation algorithm however the current cache keys require this.
There will be follow up work for the cache keys to conform to the minimum length equal to the sha (32).