### PR TITLE
refactor(general): closedIntRange

### DIFF
--- a/internal/epoch/epoch_utils.go
+++ b/internal/epoch/epoch_utils.go
@@ -121,10 +121,11 @@ const (
 // A range of the form [v,v) means the range is empty.
 // When the range is not continuous an error is returned.
 func getKeyRange[E any](m map[int]E) (intRange, error) {
-	var count uint
+	if len(m) == 0 {
+		return intRange{}, nil
+	}
 
 	lo, hi := maxInt, minInt
-
 	for k := range m {
 		if k < lo {
 			lo = k
@@ -133,18 +134,12 @@ func getKeyRange[E any](m map[int]E) (intRange, error) {
 		if k > hi {
 			hi = k
 		}
-
-		count++
-	}
-
-	if count == 0 {
-		return intRange{}, nil
 	}
 
 	// hi and lo are from unique map keys, so for the range to be continuous
 	// the difference between hi and lo cannot be larger than count -1.
 	// For example, if lo==2, hi==4, and count == 3, the range must be contiguous => {2, 3, 4}.
-	if uint(hi-lo) > count-1 {
+	if count := uint(len(m)); uint(hi-lo) > count-1 {
 		return intRange{}, errors.Wrapf(errNonContiguousRange, "[lo: %d, hi: %d], length: %d", lo, hi, count)
 	}
 

--- a/internal/epoch/epoch_utils.go
+++ b/internal/epoch/epoch_utils.go
@@ -94,13 +94,13 @@ func deletionWatermarkFromBlobID(blobID blob.ID) (time.Time, bool) {
 	return time.Unix(unixSeconds, 0), true
 }
 
-// intRange represents a discrete closed-closed [lo, hi] range for ints.
+// closedIntRange represents a discrete closed-closed [lo, hi] range for ints.
 // That is, the range includes both lo and hi.
-type intRange struct {
+type closedIntRange struct {
 	lo, hi int
 }
 
-func (r intRange) length() uint {
+func (r closedIntRange) length() uint {
 	// any range where lo > hi is empty. The canonical empty representation
 	// is {lo:0, hi: -1}
 	if r.lo > r.hi {
@@ -110,7 +110,7 @@ func (r intRange) length() uint {
 	return uint(r.hi - r.lo + 1)
 }
 
-func (r intRange) isEmpty() bool {
+func (r closedIntRange) isEmpty() bool {
 	return r.length() == 0
 }
 
@@ -126,9 +126,9 @@ const (
 )
 
 // Returns a range for the keys in m. It returns an empty range when m is empty.
-func getKeyRange[E any](m map[int]E) intRange {
+func getKeyRange[E any](m map[int]E) closedIntRange {
 	if len(m) == 0 {
-		return intRange{lo: 0, hi: -1}
+		return closedIntRange{lo: 0, hi: -1}
 	}
 
 	lo, hi := maxInt, minInt
@@ -142,12 +142,12 @@ func getKeyRange[E any](m map[int]E) intRange {
 		}
 	}
 
-	return intRange{lo: lo, hi: hi}
+	return closedIntRange{lo: lo, hi: hi}
 }
 
 // Returns a contiguous range for the keys in m.
 // When the range is not continuous an error is returned.
-func getContiguousKeyRange[E any](m map[int]E) (intRange, error) {
+func getContiguousKeyRange[E any](m map[int]E) (closedIntRange, error) {
 	r := getKeyRange(m)
 
 	// r.hi and r.lo are from unique map keys, so for the range to be continuous
@@ -155,7 +155,7 @@ func getContiguousKeyRange[E any](m map[int]E) (intRange, error) {
 	// For example, if lo==2, hi==4, and len(m) == 3, the range must be
 	// contiguous => {2, 3, 4}
 	if r.length() != uint(len(m)) {
-		return intRange{-1, -2}, errors.Wrapf(errNonContiguousRange, "[lo: %d, hi: %d], length: %d", r.lo, r.hi, len(m))
+		return closedIntRange{-1, -2}, errors.Wrapf(errNonContiguousRange, "[lo: %d, hi: %d], length: %d", r.lo, r.hi, len(m))
 	}
 
 	return r, nil

--- a/internal/epoch/epoch_utils_test.go
+++ b/internal/epoch/epoch_utils_test.go
@@ -78,57 +78,57 @@ func TestGroupByEpochNumber(t *testing.T) {
 }
 
 func TestGetContiguosKeyRange(t *testing.T) {
-	invalidEmptyRange := intRange{-1, -2}
+	invalidEmptyRange := closedIntRange{-1, -2}
 
 	cases := []struct {
 		input     map[int]bool
-		want      intRange
+		want      closedIntRange
 		shouldErr bool
 		length    uint
 		isEmpty   bool
 	}{
 		{
 			isEmpty: true,
-			want:    intRange{0, -1},
+			want:    closedIntRange{0, -1},
 		},
 		{
 			input:  map[int]bool{0: true},
-			want:   intRange{lo: 0, hi: 0},
+			want:   closedIntRange{lo: 0, hi: 0},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{-5: true},
-			want:   intRange{lo: -5, hi: -5},
+			want:   closedIntRange{lo: -5, hi: -5},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{-5: true, -4: true},
-			want:   intRange{lo: -5, hi: -4},
+			want:   closedIntRange{lo: -5, hi: -4},
 			length: 2,
 		},
 		{
 			input:  map[int]bool{0: true},
-			want:   intRange{lo: 0, hi: 0},
+			want:   closedIntRange{lo: 0, hi: 0},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{5: true},
-			want:   intRange{lo: 5, hi: 5},
+			want:   closedIntRange{lo: 5, hi: 5},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{0: true, 1: true},
-			want:   intRange{lo: 0, hi: 1},
+			want:   closedIntRange{lo: 0, hi: 1},
 			length: 2,
 		},
 		{
 			input:  map[int]bool{8: true, 9: true},
-			want:   intRange{lo: 8, hi: 9},
+			want:   closedIntRange{lo: 8, hi: 9},
 			length: 2,
 		},
 		{
 			input:  map[int]bool{1: true, 2: true, 3: true, 4: true, 5: true},
-			want:   intRange{lo: 1, hi: 5},
+			want:   closedIntRange{lo: 1, hi: 5},
 			length: 5,
 		},
 		{
@@ -169,17 +169,17 @@ func TestGetContiguosKeyRange(t *testing.T) {
 		},
 		{
 			input:  map[int]bool{minInt: true},
-			want:   intRange{lo: minInt, hi: minInt},
+			want:   closedIntRange{lo: minInt, hi: minInt},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{maxInt - 1: true},
-			want:   intRange{lo: maxInt - 1, hi: maxInt - 1},
+			want:   closedIntRange{lo: maxInt - 1, hi: maxInt - 1},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{maxInt: true},
-			want:   intRange{lo: maxInt, hi: maxInt},
+			want:   closedIntRange{lo: maxInt, hi: maxInt},
 			length: 1,
 		},
 	}
@@ -206,98 +206,98 @@ func TestAssertMinMaxIntConstants(t *testing.T) {
 func TestGetKeyRange(t *testing.T) {
 	cases := []struct {
 		input   map[int]bool
-		want    intRange
+		want    closedIntRange
 		length  uint
 		isEmpty bool
 	}{
 		{
 			isEmpty: true,
-			want:    intRange{lo: 0, hi: -1},
+			want:    closedIntRange{lo: 0, hi: -1},
 		},
 		{
 			input:  map[int]bool{0: true},
-			want:   intRange{lo: 0, hi: 0},
+			want:   closedIntRange{lo: 0, hi: 0},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{-5: true},
-			want:   intRange{lo: -5, hi: -5},
+			want:   closedIntRange{lo: -5, hi: -5},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{-5: true, -4: true},
-			want:   intRange{lo: -5, hi: -4},
+			want:   closedIntRange{lo: -5, hi: -4},
 			length: 2,
 		},
 		{
 			input:  map[int]bool{0: true},
-			want:   intRange{lo: 0, hi: 0},
+			want:   closedIntRange{lo: 0, hi: 0},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{5: true},
-			want:   intRange{lo: 5, hi: 5},
+			want:   closedIntRange{lo: 5, hi: 5},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{0: true, 1: true},
-			want:   intRange{lo: 0, hi: 1},
+			want:   closedIntRange{lo: 0, hi: 1},
 			length: 2,
 		},
 		{
 			input:  map[int]bool{8: true, 9: true},
-			want:   intRange{lo: 8, hi: 9},
+			want:   closedIntRange{lo: 8, hi: 9},
 			length: 2,
 		},
 		{
 			input:  map[int]bool{1: true, 2: true, 3: true, 4: true, 5: true},
-			want:   intRange{lo: 1, hi: 5},
+			want:   closedIntRange{lo: 1, hi: 5},
 			length: 5,
 		},
 		{
 			input:  map[int]bool{8: true, 10: true},
-			want:   intRange{lo: 8, hi: 10},
+			want:   closedIntRange{lo: 8, hi: 10},
 			length: 3,
 		},
 		{
 			input:  map[int]bool{1: true, 2: true, 3: true, 5: true},
-			want:   intRange{lo: 1, hi: 5},
+			want:   closedIntRange{lo: 1, hi: 5},
 			length: 5,
 		},
 		{
 			input:  map[int]bool{-5: true, -7: true},
-			want:   intRange{lo: -7, hi: -5},
+			want:   closedIntRange{lo: -7, hi: -5},
 			length: 3,
 		},
 		{
 			input:  map[int]bool{0: true, minInt: true},
-			want:   intRange{lo: minInt, hi: 0},
+			want:   closedIntRange{lo: minInt, hi: 0},
 			length: -minInt + 1,
 		},
 		{
 			input:  map[int]bool{0: true, maxInt: true},
-			want:   intRange{lo: 0, hi: maxInt},
+			want:   closedIntRange{lo: 0, hi: maxInt},
 			length: maxInt + 1,
 		},
 		{
 			input:   map[int]bool{maxInt: true, minInt: true},
-			want:    intRange{lo: minInt, hi: maxInt},
+			want:    closedIntRange{lo: minInt, hi: maxInt},
 			length:  0, // corner case, not representable :(
 			isEmpty: true,
 		},
 		{
 			input:  map[int]bool{minInt: true},
-			want:   intRange{lo: minInt, hi: minInt},
+			want:   closedIntRange{lo: minInt, hi: minInt},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{maxInt - 1: true},
-			want:   intRange{lo: maxInt - 1, hi: maxInt - 1},
+			want:   closedIntRange{lo: maxInt - 1, hi: maxInt - 1},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{maxInt: true},
-			want:   intRange{lo: maxInt, hi: maxInt},
+			want:   closedIntRange{lo: maxInt, hi: maxInt},
 			length: 1,
 		},
 	}

--- a/internal/epoch/epoch_utils_test.go
+++ b/internal/epoch/epoch_utils_test.go
@@ -77,7 +77,7 @@ func TestGroupByEpochNumber(t *testing.T) {
 	}
 }
 
-func TestGetKeyRange(t *testing.T) {
+func TestGetContiguosKeyRange(t *testing.T) {
 	cases := []struct {
 		input     map[int]bool
 		want      intRange
@@ -178,7 +178,7 @@ func TestGetKeyRange(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprint("case: ", i), func(t *testing.T) {
-			got, err := getKeyRange(tc.input)
+			got, err := getContiguousKeyRange(tc.input)
 			if tc.shouldErr {
 				require.Error(t, err, "input: %v", tc.input)
 			}

--- a/internal/epoch/epoch_utils_test.go
+++ b/internal/epoch/epoch_utils_test.go
@@ -78,6 +78,8 @@ func TestGroupByEpochNumber(t *testing.T) {
 }
 
 func TestGetContiguosKeyRange(t *testing.T) {
+	invalidEmptyRange := intRange{-1, -2}
+
 	cases := []struct {
 		input     map[int]bool
 		want      intRange
@@ -87,91 +89,97 @@ func TestGetContiguosKeyRange(t *testing.T) {
 	}{
 		{
 			isEmpty: true,
+			want:    intRange{0, -1},
+		},
+		{
+			input:  map[int]bool{0: true},
+			want:   intRange{lo: 0, hi: 0},
+			length: 1,
 		},
 		{
 			input:  map[int]bool{-5: true},
-			want:   intRange{lo: -5, hi: -4},
+			want:   intRange{lo: -5, hi: -5},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{-5: true, -4: true},
-			want:   intRange{lo: -5, hi: -3},
+			want:   intRange{lo: -5, hi: -4},
 			length: 2,
 		},
 		{
 			input:  map[int]bool{0: true},
-			want:   intRange{lo: 0, hi: 1},
+			want:   intRange{lo: 0, hi: 0},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{5: true},
-			want:   intRange{lo: 5, hi: 6},
+			want:   intRange{lo: 5, hi: 5},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{0: true, 1: true},
-			want:   intRange{lo: 0, hi: 2},
+			want:   intRange{lo: 0, hi: 1},
 			length: 2,
 		},
 		{
 			input:  map[int]bool{8: true, 9: true},
-			want:   intRange{lo: 8, hi: 10},
+			want:   intRange{lo: 8, hi: 9},
 			length: 2,
 		},
 		{
 			input:  map[int]bool{1: true, 2: true, 3: true, 4: true, 5: true},
-			want:   intRange{lo: 1, hi: 6},
+			want:   intRange{lo: 1, hi: 5},
 			length: 5,
 		},
 		{
 			input:     map[int]bool{8: true, 10: true},
-			want:      intRange{},
+			want:      invalidEmptyRange,
 			shouldErr: true,
 			isEmpty:   true,
 		},
 		{
 			input:     map[int]bool{1: true, 2: true, 3: true, 5: true},
-			want:      intRange{},
+			want:      invalidEmptyRange,
 			shouldErr: true,
 			isEmpty:   true,
 		},
 		{
 			input:     map[int]bool{-5: true, -7: true},
-			want:      intRange{},
+			want:      invalidEmptyRange,
 			shouldErr: true,
 			isEmpty:   true,
 		},
 		{
 			input:     map[int]bool{0: true, minInt: true},
-			want:      intRange{},
+			want:      invalidEmptyRange,
 			shouldErr: true,
 			isEmpty:   true,
 		},
 		{
 			input:     map[int]bool{0: true, maxInt: true},
-			want:      intRange{},
+			want:      invalidEmptyRange,
 			shouldErr: true,
 			isEmpty:   true,
 		},
 		{
 			input:     map[int]bool{maxInt: true, minInt: true},
-			want:      intRange{},
+			want:      invalidEmptyRange,
 			shouldErr: true,
 			isEmpty:   true,
 		},
 		{
 			input:  map[int]bool{minInt: true},
-			want:   intRange{lo: minInt, hi: minInt + 1},
+			want:   intRange{lo: minInt, hi: minInt},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{maxInt - 1: true},
-			want:   intRange{lo: maxInt - 1, hi: maxInt},
+			want:   intRange{lo: maxInt - 1, hi: maxInt - 1},
 			length: 1,
 		},
 		{
 			input:  map[int]bool{maxInt: true},
-			want:   intRange{lo: maxInt, hi: minInt}, // not representable corner case :(
+			want:   intRange{lo: maxInt, hi: maxInt},
 			length: 1,
 		},
 	}
@@ -193,4 +201,114 @@ func TestGetContiguosKeyRange(t *testing.T) {
 func TestAssertMinMaxIntConstants(t *testing.T) {
 	require.Equal(t, math.MinInt, minInt)
 	require.Equal(t, math.MaxInt, maxInt)
+}
+
+func TestGetKeyRange(t *testing.T) {
+	cases := []struct {
+		input   map[int]bool
+		want    intRange
+		length  uint
+		isEmpty bool
+	}{
+		{
+			isEmpty: true,
+			want:    intRange{lo: 0, hi: -1},
+		},
+		{
+			input:  map[int]bool{0: true},
+			want:   intRange{lo: 0, hi: 0},
+			length: 1,
+		},
+		{
+			input:  map[int]bool{-5: true},
+			want:   intRange{lo: -5, hi: -5},
+			length: 1,
+		},
+		{
+			input:  map[int]bool{-5: true, -4: true},
+			want:   intRange{lo: -5, hi: -4},
+			length: 2,
+		},
+		{
+			input:  map[int]bool{0: true},
+			want:   intRange{lo: 0, hi: 0},
+			length: 1,
+		},
+		{
+			input:  map[int]bool{5: true},
+			want:   intRange{lo: 5, hi: 5},
+			length: 1,
+		},
+		{
+			input:  map[int]bool{0: true, 1: true},
+			want:   intRange{lo: 0, hi: 1},
+			length: 2,
+		},
+		{
+			input:  map[int]bool{8: true, 9: true},
+			want:   intRange{lo: 8, hi: 9},
+			length: 2,
+		},
+		{
+			input:  map[int]bool{1: true, 2: true, 3: true, 4: true, 5: true},
+			want:   intRange{lo: 1, hi: 5},
+			length: 5,
+		},
+		{
+			input:  map[int]bool{8: true, 10: true},
+			want:   intRange{lo: 8, hi: 10},
+			length: 3,
+		},
+		{
+			input:  map[int]bool{1: true, 2: true, 3: true, 5: true},
+			want:   intRange{lo: 1, hi: 5},
+			length: 5,
+		},
+		{
+			input:  map[int]bool{-5: true, -7: true},
+			want:   intRange{lo: -7, hi: -5},
+			length: 3,
+		},
+		{
+			input:  map[int]bool{0: true, minInt: true},
+			want:   intRange{lo: minInt, hi: 0},
+			length: -minInt + 1,
+		},
+		{
+			input:  map[int]bool{0: true, maxInt: true},
+			want:   intRange{lo: 0, hi: maxInt},
+			length: maxInt + 1,
+		},
+		{
+			input:   map[int]bool{maxInt: true, minInt: true},
+			want:    intRange{lo: minInt, hi: maxInt},
+			length:  0, // corner case, not representable :(
+			isEmpty: true,
+		},
+		{
+			input:  map[int]bool{minInt: true},
+			want:   intRange{lo: minInt, hi: minInt},
+			length: 1,
+		},
+		{
+			input:  map[int]bool{maxInt - 1: true},
+			want:   intRange{lo: maxInt - 1, hi: maxInt - 1},
+			length: 1,
+		},
+		{
+			input:  map[int]bool{maxInt: true},
+			want:   intRange{lo: maxInt, hi: maxInt},
+			length: 1,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprint("case: ", i), func(t *testing.T) {
+			got := getKeyRange(tc.input)
+
+			require.Equal(t, tc.want, got, "input: %#v", tc.input)
+			require.Equal(t, tc.length, got.length())
+			require.Equal(t, tc.isEmpty, got.isEmpty())
+		})
+	}
 }


### PR DESCRIPTION
Refactoring for the original implementation with `intRange` and `getKeyRange` from _closed-open_ ranges `[lo, hi)` to closed ranges: `[lo, hi]`. The primary motivation is for consistency with the implementation of `epoch.RangeMetadata` in the same package, and thus  avoid confusion and reduce cognitive load.

Changes:
- adds a `getContiguousKeyRange` wrapper that checks for contiguity.
- `getKeyRange` simply returns a range with minimum and maximum values for the keys in the map.
- changes the range implementation from _closed-open_ ranges `[lo, hi)` to closed ranges: `[lo, hi]` where both lo and hi are included in the range. Additional unit tests are included.
- renames `intRange` to `closedIntRange` to reflect new functionality.

Ref:
- Follow up #3721
- Needed for #3728
- #3638
