### PR TITLE
fix(repository): Wrap manifest compaction error instead of clobbering it

### DIFF
--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -183,7 +183,7 @@ func (m *committedManifestManager) loadCommittedContentsLocked(ctx context.Conte
 	m.loadManifestContentsLocked(manifests)
 
 	if err := m.maybeCompactLocked(ctx); err != nil {
-		return errors.Errorf("error auto-compacting contents")
+		return errors.Wrap(err, "error auto-compacting contents")
 	}
 
 	return nil


### PR DESCRIPTION
Clobbering the error loses information and makes debugging more difficult