### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/klauspost/compress v1.17.7
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.1
-	github.com/kopia/htmluibuild v0.0.1-0.20231019063300-75c2a788c7d0
+	github.com/kopia/htmluibuild v0.0.1-0.20240324231127-d8300f5781d0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.69

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.1 h1:NhWgum1efX1x58daOBGCFWcxtEhOhXKKl1HAPQUp03Q=
 github.com/klauspost/reedsolomon v1.12.1/go.mod h1:nEi5Kjb6QqtbofI6s+cbG/j1da11c96IBYBSnVGtuBs=
-github.com/kopia/htmluibuild v0.0.1-0.20231019063300-75c2a788c7d0 h1:TvupyyfbUZzsO4DQJpQhKZnUa61xERcJ+ejCbHWG2NY=
-github.com/kopia/htmluibuild v0.0.1-0.20231019063300-75c2a788c7d0/go.mod h1:cSImbrlwvv2phvj5RfScL2v08ghX6xli0PcK6f+t8S0=
+github.com/kopia/htmluibuild v0.0.1-0.20240324231127-d8300f5781d0 h1:3oJD2VtlEBxdmP/YA5bNk2SMyxwH1OU5JVDNoGzki1U=
+github.com/kopia/htmluibuild v0.0.1-0.20240324231127-d8300f5781d0/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/44ad26dabec430b9a1d1cad30aef2b984f55e515...HEAD

* Oct 23 2023 https://github.com/kopia/htmlui/commit/98d4a1b dependabot[bot] build(deps-dev): bump @babel/traverse from 7.18.5 to 7.23.2
* Nov 3 2023 https://github.com/kopia/htmlui/commit/6412ee7 dependabot[bot] build(deps): bump react-select from 5.7.4 to 5.7.7
* Nov 7 2023 https://github.com/kopia/htmlui/commit/9aa9839 dependabot[bot] build(deps-dev): bump @testing-library/jest-dom from 6.1.3 to 6.1.4
* Nov 9 2023 https://github.com/kopia/htmlui/commit/59fdf8e Christoph Anderson Removed obsolet dependencies
* Nov 11 2023 https://github.com/kopia/htmlui/commit/1fd4dd2 dependabot[bot] build(deps-dev): bump axios from 1.4.0 to 1.6.0
* Nov 12 2023 https://github.com/kopia/htmlui/commit/644d9af Christoph Anderson fix(ui): Minor fixes related to css
* Nov 18 2023 https://github.com/kopia/htmlui/commit/f2d98ea Christoph Anderson feat(ui):  Change project structure
* Nov 22 2023 https://github.com/kopia/htmlui/commit/467920f Lolginer Constant navbar width
* Dec 2 2023 https://github.com/kopia/htmlui/commit/e1fd7be dependabot[bot] build(deps): bump @fortawesome/free-solid-svg-icons from 6.1.1 to 6.5.1
* Dec 2 2023 https://github.com/kopia/htmlui/commit/38ec9dd dependabot[bot] build(deps-dev): bump @adobe/css-tools from 4.3.1 to 4.3.2
* Dec 2 2023 https://github.com/kopia/htmlui/commit/f256cf1 dependabot[bot] build(deps): bump @fortawesome/fontawesome-svg-core from 6.4.2 to 6.5.1
* Dec 9 2023 https://github.com/kopia/htmlui/commit/e5c3d3e Christoph Anderson fix(ui): Changed button appearance and fixed tooltip
* Sat Jan 6 08:37 https://github.com/kopia/htmlui/commit/aa79356 dependabot[bot] build(deps): bump moment from 2.29.4 to 2.30.1
* Sat Jan 6 08:38 https://github.com/kopia/htmlui/commit/3872f51 dependabot[bot] build(deps-dev): bump @testing-library/react from 14.0.0 to 14.1.2
* Tue Jan 9 21:07 https://github.com/kopia/htmlui/commit/8a0991e dependabot[bot] build(deps): bump follow-redirects from 1.15.1 to 1.15.4
* Thu Jan 11 06:10 https://github.com/kopia/htmlui/commit/b46bd79 Christoph Anderson feat(ui): Added the ability to change font-sizes
* Sun Jan 14 10:59 https://github.com/kopia/htmlui/commit/239b530 Christoph Anderson Fix bug while setting font sizes
* Thu Jan 25 20:00 https://github.com/kopia/htmlui/commit/d3822cf dependabot[bot] build(deps-dev): bump @types/react from 18.2.24 to 18.2.46
* Thu Jan 25 20:02 https://github.com/kopia/htmlui/commit/ac057d3 Christoph Anderson feat(ui): Added directory selector for snapshots and filesystem repository
* Sat Feb 3 09:38 https://github.com/kopia/htmlui/commit/29eaade dependabot[bot] build(deps-dev): bump @testing-library/jest-dom from 6.1.4 to 6.4.1
* Fri Mar 1 22:40 https://github.com/kopia/htmlui/commit/0a4a3da dependabot[bot] build(deps-dev): bump @testing-library/user-event from 14.5.1 to 14.5.2
* Fri Mar 1 16:14 https://github.com/kopia/htmlui/commit/7558b55 dependabot[bot] build(deps-dev): bump @types/react-dom from 18.2.8 to 18.2.19
* 3 hours ago https://github.com/kopia/htmlui/commit/114a030 dependabot[bot] build(deps): bump follow-redirects from 1.15.4 to 1.15.6
* 3 hours ago https://github.com/kopia/htmlui/commit/313ed31 dependabot[bot] build(deps-dev): bump @types/react from 18.2.46 to 18.2.61
* 52 minutes ago https://github.com/kopia/htmlui/commit/067de13 dependabot[bot] build(deps-dev): bump webpack-dev-middleware from 5.3.3 to 5.3.4

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Sun Mar 24 23:11:48 UTC 2024*
