### PR TITLE
refactor(deps): migrate from `go.uber.org/multierr` to standard `errors`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.24.0
 	go.opentelemetry.io/otel/sdk v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.21.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
@@ -131,6 +130,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.1.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 // indirect

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	std_errors "errors"
+	stderrors "errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -67,7 +67,7 @@ func (st equivalentBlobStorageConnections) closeAdditional(ctx context.Context) 
 	var err error
 
 	for i := 1; i < len(st); i++ {
-		err = std_errors.Join(err, st[i].Close(ctx))
+		err = stderrors.Join(err, st[i].Close(ctx))
 	}
 
 	return errors.Wrap(err, "error closing additional connections")

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	std_errors "errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/kopia/kopia/internal/clock"
@@ -67,7 +67,7 @@ func (st equivalentBlobStorageConnections) closeAdditional(ctx context.Context) 
 	var err error
 
 	for i := 1; i < len(st); i++ {
-		err = multierr.Combine(err, st[i].Close(ctx))
+		err = std_errors.Join(err, st[i].Close(ctx))
 	}
 
 	return errors.Wrap(err, "error closing additional connections")

--- a/repo/content/index/merged.go
+++ b/repo/content/index/merged.go
@@ -2,10 +2,10 @@ package index
 
 import (
 	"container/heap"
+	std_errors "errors"
 	"sync"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 )
 
 // Merged is an implementation of Index that transparently merges returns from underlying Indexes.
@@ -27,7 +27,7 @@ func (m Merged) Close() error {
 	var err error
 
 	for _, ndx := range m {
-		err = multierr.Append(err, ndx.Close())
+		err = std_errors.Join(err, ndx.Close())
 	}
 
 	return errors.Wrap(err, "closing index shards")

--- a/repo/content/index/merged.go
+++ b/repo/content/index/merged.go
@@ -2,7 +2,7 @@ package index
 
 import (
 	"container/heap"
-	std_errors "errors"
+	stderrors "errors"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -27,7 +27,7 @@ func (m Merged) Close() error {
 	var err error
 
 	for _, ndx := range m {
-		err = std_errors.Join(err, ndx.Close())
+		err = stderrors.Join(err, ndx.Close())
 	}
 
 	return errors.Wrap(err, "closing index shards")

--- a/repo/refcount_closer.go
+++ b/repo/refcount_closer.go
@@ -2,7 +2,7 @@ package repo
 
 import (
 	"context"
-	std_errors "errors"
+	stderrors "errors"
 	"sync/atomic"
 )
 
@@ -36,7 +36,7 @@ func (c *refCountedCloser) Close(ctx context.Context) error {
 		errors = append(errors, closer(ctx))
 	}
 
-	return std_errors.Join(errors...)
+	return stderrors.Join(errors...)
 }
 
 func (c *refCountedCloser) addRef() {

--- a/repo/refcount_closer.go
+++ b/repo/refcount_closer.go
@@ -2,9 +2,8 @@ package repo
 
 import (
 	"context"
+	std_errors "errors"
 	"sync/atomic"
-
-	"go.uber.org/multierr"
 )
 
 // closeFunc is a function to invoke when the last repository reference is closed.
@@ -37,8 +36,7 @@ func (c *refCountedCloser) Close(ctx context.Context) error {
 		errors = append(errors, closer(ctx))
 	}
 
-	//nolint:wrapcheck
-	return multierr.Combine(errors...)
+	return std_errors.Join(errors...)
 }
 
 func (c *refCountedCloser) addRef() {

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -3,6 +3,7 @@ package snapshotfs
 import (
 	"bytes"
 	"context"
+	std_errors "errors"
 	"io"
 	"math/rand"
 	"os"
@@ -18,7 +19,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/multierr"
 
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/fs/ignorefs"
@@ -202,7 +202,7 @@ func (u *Uploader) uploadFileInternal(ctx context.Context, parentCheckpointRegis
 	wg.Wait()
 
 	// see if we got any errors
-	if err := multierr.Combine(partErrors...); err != nil {
+	if err := std_errors.Join(partErrors...); err != nil {
 		return nil, errors.Wrap(err, "error uploading parts")
 	}
 

--- a/snapshot/snapshotfs/upload.go
+++ b/snapshot/snapshotfs/upload.go
@@ -3,7 +3,7 @@ package snapshotfs
 import (
 	"bytes"
 	"context"
-	std_errors "errors"
+	stderrors "errors"
 	"io"
 	"math/rand"
 	"os"
@@ -202,7 +202,7 @@ func (u *Uploader) uploadFileInternal(ctx context.Context, parentCheckpointRegis
 	wg.Wait()
 
 	// see if we got any errors
-	if err := std_errors.Join(partErrors...); err != nil {
+	if err := stderrors.Join(partErrors...); err != nil {
 		return nil, errors.Wrap(err, "error uploading parts")
 	}
 


### PR DESCRIPTION
Since go1.20, standard errors package provides [Join function](https://pkg.go.dev/errors#Join) that can replace `go.uber.org/multierr`.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
