### PR TITLE
feat(general): User_profile_add_set cli changes

### DIFF
--- a/internal/auth/authn_repo.go
+++ b/internal/auth/authn_repo.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/clock"
-	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/internal/user"
 	"github.com/kopia/kopia/repo"
 )
@@ -52,7 +51,7 @@ func (ac *repositoryUserAuthenticator) IsValid(ctx context.Context, rep repo.Rep
 
 	// IsValidPassword can be safely called on nil and the call will take as much time as for a valid user
 	// thus not revealing anything about whether the user exists.
-	return ac.userProfiles[username].IsValidPassword(password, crypto.DefaultKeyDerivationAlgorithm)
+	return ac.userProfiles[username].IsValidPassword(password)
 }
 
 func (ac *repositoryUserAuthenticator) Refresh(ctx context.Context) error {

--- a/internal/auth/authn_repo_test.go
+++ b/internal/auth/authn_repo_test.go
@@ -43,6 +43,13 @@ func TestRepositoryAuthenticator(t *testing.T) {
 					},
 					password: "password3",
 				},
+				{
+					profile: &user.Profile{
+						Username:               "user4@host4",
+						KeyDerivationAlgorithm: crypto.Pbkdf2Algorithm,
+					},
+					password: "password4",
+				},
 			} {
 				tc.profile.SetPassword(tc.password)
 				err := user.SetUserProfile(ctx, w, tc.profile)
@@ -64,6 +71,9 @@ func TestRepositoryAuthenticator(t *testing.T) {
 
 	// Test for User with neither key derivation or PasswordHashVersion set
 	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user3@host3", "password3", false)
+
+	// Test for PBKDF2 key derivation
+	verifyRepoAuthenticator(ctx, t, a, env.Repository, "user4@host4", "password4", true)
 }
 
 func verifyRepoAuthenticator(ctx context.Context, t *testing.T, a auth.Authenticator, r repo.Repository, username, password string, want bool) {

--- a/internal/auth/authn_repo_test.go
+++ b/internal/auth/authn_repo_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/auth"
-	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/internal/user"
 	"github.com/kopia/kopia/repo"
@@ -23,7 +22,7 @@ func TestRepositoryAuthenticator(t *testing.T) {
 				Username: "user1@host1",
 			}
 
-			p.SetPassword("password1", crypto.DefaultKeyDerivationAlgorithm)
+			p.SetPassword("password1")
 
 			return user.SetUserProfile(ctx, w, p)
 		}))

--- a/internal/crypto/key_derivation_nontest.go
+++ b/internal/crypto/key_derivation_nontest.go
@@ -34,8 +34,18 @@ func RegisterKeyDerivationFunc(name string, keyDeriver keyDerivationFunc) {
 func DeriveKeyFromPassword(password string, salt []byte, algorithm string) ([]byte, error) {
 	kdFunc, ok := keyDerivers[algorithm]
 	if !ok {
-		return nil, errors.Errorf("unsupported key algorithm: %v", algorithm)
+		return nil, errors.Errorf("unsupported key algorithm: %v, supported algorithms %v", algorithm, AllowedKeyDerivationAlgorithms())
 	}
 
 	return kdFunc(password, salt)
+}
+
+// AllowedKeyDerivationAlgorithms returns a slice of the allowed key derivation algorithms.
+func AllowedKeyDerivationAlgorithms() []string {
+	kdAlgorithms := make([]string, 0, len(keyDerivers))
+	for k := range keyDerivers {
+		kdAlgorithms = append(kdAlgorithms, k)
+	}
+
+	return kdAlgorithms
 }

--- a/internal/crypto/key_derivation_nontest.go
+++ b/internal/crypto/key_derivation_nontest.go
@@ -17,6 +17,7 @@ const (
 // DefaultKeyDerivationAlgorithm is the key derivation algorithm for new configurations.
 const DefaultKeyDerivationAlgorithm = ScryptAlgorithm
 
+// KeyDeriver is an interface that contains methods for deriving a key from a password.
 type KeyDeriver interface {
 	DeriveKeyFromPassword(password string, salt []byte) ([]byte, error)
 	RecommendedSaltLength() int
@@ -30,6 +31,7 @@ func RegisterKeyDerivers(name string, keyDeriver KeyDeriver) {
 	if _, ok := keyDerivers[name]; ok {
 		panic(fmt.Sprintf("key deriver (%s) is already registered", name))
 	}
+
 	keyDerivers[name] = keyDeriver
 }
 
@@ -39,14 +41,18 @@ func DeriveKeyFromPassword(password string, salt []byte, algorithm string) ([]by
 	if !ok {
 		return nil, errors.Errorf("unsupported key algorithm: %v, supported algorithms %v", algorithm, AllowedKeyDerivationAlgorithms())
 	}
+
+	//nolint:wrapcheck
 	return kd.DeriveKeyFromPassword(password, salt)
 }
 
+// RecommendedSaltLength returns the recommended salt length of a given key derivation algorithm.
 func RecommendedSaltLength(algorithm string) (int, error) {
 	kd, ok := keyDerivers[algorithm]
 	if !ok {
 		return 0, errors.Errorf("unsupported key algorithm: %v, supported algorithms %v", algorithm, AllowedKeyDerivationAlgorithms())
 	}
+
 	return kd.RecommendedSaltLength(), nil
 }
 
@@ -56,5 +62,6 @@ func AllowedKeyDerivationAlgorithms() []string {
 	for k := range keyDerivers {
 		kdAlgorithms = append(kdAlgorithms, k)
 	}
+
 	return kdAlgorithms
 }

--- a/internal/crypto/key_derivation_nontest.go
+++ b/internal/crypto/key_derivation_nontest.go
@@ -4,40 +4,52 @@
 package crypto
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 )
 
 const (
 	// MasterKeyLength describes the length of the master key.
 	MasterKeyLength = 32
-
-	// ScryptAlgorithm is the key for the scrypt algorithm.
-	ScryptAlgorithm = "scrypt-65536-8-1"
-	// Pbkdf2Algorithm is the key for the pbkdf algorithm.
-	Pbkdf2Algorithm = "pbkdf2"
 )
 
 // DefaultKeyDerivationAlgorithm is the key derivation algorithm for new configurations.
 const DefaultKeyDerivationAlgorithm = ScryptAlgorithm
 
+type KeyDeriver interface {
+	DeriveKeyFromPassword(password string, salt []byte) ([]byte, error)
+	RecommendedSaltLength() int
+}
+
 type keyDerivationFunc func(password string, salt []byte) ([]byte, error)
 
 //nolint:gochecknoglobals
-var keyDerivers = map[string]keyDerivationFunc{}
+var keyDerivers = map[string]KeyDeriver{}
 
-// RegisterKeyDerivationFunc registers various key derivation functions.
-func RegisterKeyDerivationFunc(name string, keyDeriver keyDerivationFunc) {
+// RegisterKeyDerivers registers various key derivation functions.
+func RegisterKeyDerivers(name string, keyDeriver KeyDeriver) {
+	if _, ok := keyDerivers[name]; ok {
+		panic(fmt.Sprintf("key (%s) deriver already register", name))
+	}
 	keyDerivers[name] = keyDeriver
 }
 
 // DeriveKeyFromPassword derives encryption key using the provided password and per-repository unique ID.
 func DeriveKeyFromPassword(password string, salt []byte, algorithm string) ([]byte, error) {
-	kdFunc, ok := keyDerivers[algorithm]
+	kd, ok := keyDerivers[algorithm]
 	if !ok {
 		return nil, errors.Errorf("unsupported key algorithm: %v, supported algorithms %v", algorithm, AllowedKeyDerivationAlgorithms())
 	}
+	return kd.DeriveKeyFromPassword(password, salt)
+}
 
-	return kdFunc(password, salt)
+func RecommendedSaltLength(algorithm string) (int, error) {
+	kd, ok := keyDerivers[algorithm]
+	if !ok {
+		return 0, errors.Errorf("unsupported key algorithm: %v, supported algorithms %v", algorithm, AllowedKeyDerivationAlgorithms())
+	}
+	return kd.RecommendedSaltLength(), nil
 }
 
 // AllowedKeyDerivationAlgorithms returns a slice of the allowed key derivation algorithms.
@@ -46,6 +58,5 @@ func AllowedKeyDerivationAlgorithms() []string {
 	for k := range keyDerivers {
 		kdAlgorithms = append(kdAlgorithms, k)
 	}
-
 	return kdAlgorithms
 }

--- a/internal/crypto/key_derivation_nontest.go
+++ b/internal/crypto/key_derivation_nontest.go
@@ -22,15 +22,13 @@ type KeyDeriver interface {
 	RecommendedSaltLength() int
 }
 
-type keyDerivationFunc func(password string, salt []byte) ([]byte, error)
-
 //nolint:gochecknoglobals
 var keyDerivers = map[string]KeyDeriver{}
 
 // RegisterKeyDerivers registers various key derivation functions.
 func RegisterKeyDerivers(name string, keyDeriver KeyDeriver) {
 	if _, ok := keyDerivers[name]; ok {
-		panic(fmt.Sprintf("key (%s) deriver already register", name))
+		panic(fmt.Sprintf("key deriver (%s) is already registered", name))
 	}
 	keyDerivers[name] = keyDeriver
 }

--- a/internal/crypto/key_derivation_testing.go
+++ b/internal/crypto/key_derivation_testing.go
@@ -9,20 +9,28 @@ import (
 	"github.com/pkg/errors"
 )
 
-// DefaultKeyDerivationAlgorithm is the key derivation algorithm for new configurations.
-const DefaultKeyDerivationAlgorithm = "testing-only-insecure"
+const (
+	// DefaultKeyDerivationAlgorithm is the key derivation algorithm for new configurations.
+	DefaultKeyDerivationAlgorithm = "testing-only-insecure"
 
-// MasterKeyLength describes the length of the master key.
-const MasterKeyLength = 32
+	// MasterKeyLength describes the length of the master key.
+	MasterKeyLength = 32
+
+	V1SaltLength    = 32
+	HashVersion1    = 1 // this translates to Scrypt KeyDerivationAlgorithm
+	ScryptAlgorithm = "scrypt-65536-8-1"
+	Pbkdf2Algorithm = "pbkdf2"
+)
 
 // DeriveKeyFromPassword derives encryption key using the provided password and per-repository unique ID.
 func DeriveKeyFromPassword(password string, salt []byte, algorithm string) ([]byte, error) {
 	const masterKeySize = 32
 
 	switch algorithm {
-	case DefaultKeyDerivationAlgorithm:
+	case DefaultKeyDerivationAlgorithm, ScryptAlgorithm, Pbkdf2Algorithm:
 		h := sha256.New()
-		if _, err := h.Write([]byte(password)); err != nil {
+		// Adjust password so that we get a different key for each algorithm
+		if _, err := h.Write([]byte(password + algorithm)); err != nil {
 			return nil, err
 		}
 
@@ -31,4 +39,12 @@ func DeriveKeyFromPassword(password string, salt []byte, algorithm string) ([]by
 	default:
 		return nil, errors.Errorf("unsupported key algorithm: %v", algorithm)
 	}
+}
+
+func RecommendedSaltLength(algorithm string) (int, error) {
+	return V1SaltLength, nil
+}
+
+func AllowedKeyDerivationAlgorithms() []string {
+	return []string{DefaultKeyDerivationAlgorithm}
 }

--- a/internal/crypto/pbkdf.go
+++ b/internal/crypto/pbkdf.go
@@ -10,23 +10,43 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 )
 
-// The NIST recommended iterations for PBKDF2 with SHA256 hash is 600,000.
-const pbkdf2Sha256Iterations = 1<<20 - 1<<18 // 786,432
+const (
+	// The NIST recommended minimum size for a salt for pbkdf2 is 16 bytes.
+	//
+	// TBD: However, a good rule of thumb is to use a salt that is the same size
+	// as the output of the hash function. For example, the output of SHA256
+	// is 256 bits (32 bytes), so the salt should be at least 32 random bytes.
+	// See: https://crackstation.net/hashing-security.htm
+	minPbkdfSha256SaltSize = 32 // size in bytes == 128 bits
 
-// The NIST recommended minimum size for a salt for pbkdf2 is 16 bytes.
-//
-// TBD: However, a good rule of thumb is to use a salt that is the same size
-// as the output of the hash function. For example, the output of SHA256
-// is 256 bits (32 bytes), so the salt should be at least 32 random bytes.
-// See: https://crackstation.net/hashing-security.htm
-const minPbkdfSha256SaltSize = 16 // size in bytes == 128 bits
+	// The NIST recommended iterations for PBKDF2 with SHA256 hash is 600,000.
+	pbkdf2Sha256Iterations = 1<<20 - 1<<18 // 786,432
+
+	// Pbkdf2Algorithm is the key for the pbkdf algorithm.
+	Pbkdf2Algorithm = "pbkdf2"
+)
 
 func init() {
-	RegisterKeyDerivationFunc(Pbkdf2Algorithm, func(password string, salt []byte) ([]byte, error) {
-		if len(salt) < minPbkdfSha256SaltSize {
-			return nil, errors.Errorf("required salt size is atleast %d bytes", minPbkdfSha256SaltSize)
-		}
-
-		return pbkdf2.Key([]byte(password), salt, pbkdf2Sha256Iterations, MasterKeyLength, sha256.New), nil
+	RegisterKeyDerivers(Pbkdf2Algorithm, &pbkdf2KeyDeriver{
+		iterations:            pbkdf2Sha256Iterations,
+		recommendedSaltLength: minPbkdfSha256SaltSize,
+		minSaltLength:         minPbkdfSha256SaltSize,
 	})
+}
+
+type pbkdf2KeyDeriver struct {
+	iterations            int
+	recommendedSaltLength int
+	minSaltLength         int
+}
+
+func (s *pbkdf2KeyDeriver) DeriveKeyFromPassword(password string, salt []byte) ([]byte, error) {
+	if len(salt) < s.minSaltLength {
+		return nil, errors.Errorf("required salt size is atleast %d bytes", s.minSaltLength)
+	}
+	return pbkdf2.Key([]byte(password), salt, s.iterations, MasterKeyLength, sha256.New), nil
+}
+
+func (s *pbkdf2KeyDeriver) RecommendedSaltLength() int {
+	return s.recommendedSaltLength
 }

--- a/internal/crypto/pbkdf.go
+++ b/internal/crypto/pbkdf.go
@@ -44,6 +44,7 @@ func (s *pbkdf2KeyDeriver) DeriveKeyFromPassword(password string, salt []byte) (
 	if len(salt) < s.minSaltLength {
 		return nil, errors.Errorf("required salt size is atleast %d bytes", s.minSaltLength)
 	}
+
 	return pbkdf2.Key([]byte(password), salt, s.iterations, MasterKeyLength, sha256.New), nil
 }
 

--- a/internal/crypto/scrypt.go
+++ b/internal/crypto/scrypt.go
@@ -22,18 +22,18 @@ const (
 	// ScryptAlgorithm is the key for the scrypt algorithm.
 	ScryptAlgorithm = "scrypt-65536-8-1"
 
-	// Legacy hash version salt length
+	// Legacy hash version salt length.
 	V1SaltLength = 32
 
-	// Legacy hash version system translates to KeyDerivationAlgorithm
+	// Legacy hash version system translates to KeyDerivationAlgorithm.
 	HashVersion1 = 1 // this translates to Scrypt KeyDerivationAlgorithm
 
 )
 
 func init() {
 	RegisterKeyDerivers(ScryptAlgorithm, &scryptKeyDeriver{
-		n:                     65536,
-		r:                     8,
+		n:                     65536, //nolint:gomnd
+		r:                     8,     //nolint:gomnd
 		p:                     1,
 		recommendedSaltLength: V1SaltLength,
 		minSaltLength:         minScryptSha256SaltSize,
@@ -56,6 +56,7 @@ func (s *scryptKeyDeriver) DeriveKeyFromPassword(password string, salt []byte) (
 	if len(salt) < s.minSaltLength {
 		return nil, errors.Errorf("required salt size is atleast %d bytes", s.minSaltLength)
 	}
+	//nolint:wrapcheck
 	return scrypt.Key([]byte(password), salt, s.n, s.r, s.p, MasterKeyLength)
 }
 

--- a/internal/crypto/scrypt.go
+++ b/internal/crypto/scrypt.go
@@ -16,15 +16,49 @@ import (
 // is 256 bits (32 bytes), so the salt should be at least 32 random bytes.
 // Scrypt uses a SHA256 hash function.
 // https://crackstation.net/hashing-security.htm
-const minScryptSha256SaltSize = 16 // size in bytes == 128 bits
+const (
+	minScryptSha256SaltSize = 16 // size in bytes == 128 bits
+
+	// ScryptAlgorithm is the key for the scrypt algorithm.
+	ScryptAlgorithm = "scrypt-65536-8-1"
+
+	// Legacy hash version salt length
+	V1SaltLength = 32
+
+	// Legacy hash version system translates to KeyDerivationAlgorithm
+	HashVersion1 = 1 // this translates to Scrypt KeyDerivationAlgorithm
+
+)
 
 func init() {
-	RegisterKeyDerivationFunc(ScryptAlgorithm, func(password string, salt []byte) ([]byte, error) {
-		if len(salt) < minScryptSha256SaltSize {
-			return nil, errors.Errorf("required salt size is atleast %d bytes", minPbkdfSha256SaltSize)
-		}
-
-		//nolint:gomnd
-		return scrypt.Key([]byte(password), salt, 65536, 8, 1, MasterKeyLength)
+	RegisterKeyDerivers(ScryptAlgorithm, &scryptKeyDeriver{
+		n:                     65536,
+		r:                     8,
+		p:                     1,
+		recommendedSaltLength: V1SaltLength,
+		minSaltLength:         minScryptSha256SaltSize,
 	})
+}
+
+type scryptKeyDeriver struct {
+	// n scryptCostParameterN is scrypt's CPU/memory cost parameter.
+	n int
+	// r scryptCostParameterR is scrypt's work factor.
+	r int
+	// p scryptCostParameterP is scrypt's parallelization parameter.
+	p int
+
+	recommendedSaltLength int
+	minSaltLength         int
+}
+
+func (s *scryptKeyDeriver) DeriveKeyFromPassword(password string, salt []byte) ([]byte, error) {
+	if len(salt) < s.minSaltLength {
+		return nil, errors.Errorf("required salt size is atleast %d bytes", s.minSaltLength)
+	}
+	return scrypt.Key([]byte(password), salt, s.n, s.r, s.p, MasterKeyLength)
+}
+
+func (s *scryptKeyDeriver) RecommendedSaltLength() int {
+	return s.recommendedSaltLength
 }

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -1,6 +1,8 @@
 package user
 
 import (
+	"math/rand"
+
 	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/repo/manifest"
 )
@@ -23,10 +25,10 @@ func (p *Profile) SetPassword(password string) error {
 // IsValidPassword determines whether the password is valid for a given user.
 func (p *Profile) IsValidPassword(password string) bool {
 	if p == nil {
+		algorithms := crypto.AllowedKeyDerivationAlgorithms()
 		// if the user is invalid, return false but use the same amount of time as when we
 		// compare against valid user to avoid revealing whether the user account exists.
-		isValidPassword(password, dummyV1HashThatNeverMatchesAnyPassword, crypto.DefaultKeyDerivationAlgorithm)
-
+		isValidPassword(password, dummyV1HashThatNeverMatchesAnyPassword, algorithms[rand.Intn(len(algorithms))])
 		return false
 	}
 	// Legacy case where password hash version is set
@@ -37,5 +39,4 @@ func (p *Profile) IsValidPassword(password string) bool {
 		return isValidPassword(password, p.PasswordHash, p.KeyDerivationAlgorithm)
 	}
 	return false
-
 }

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -17,7 +17,7 @@ type Profile struct {
 
 // SetPassword changes the password for a user profile.
 func (p *Profile) SetPassword(password string) error {
-	return p.setPasswordV1(password)
+	return p.setPassword(password)
 }
 
 // IsValidPassword determines whether the password is valid for a given user.
@@ -25,16 +25,16 @@ func (p *Profile) IsValidPassword(password string) bool {
 	if p == nil {
 		// if the user is invalid, return false but use the same amount of time as when we
 		// compare against valid user to avoid revealing whether the user account exists.
-		isValidPasswordV1(password, dummyV1HashThatNeverMatchesAnyPassword, crypto.DefaultKeyDerivationAlgorithm)
+		isValidPassword(password, dummyV1HashThatNeverMatchesAnyPassword, crypto.DefaultKeyDerivationAlgorithm)
 
 		return false
 	}
 	// Legacy case where password hash version is set
-	if p.PasswordHashVersion == hashVersion1 {
-		return isValidPasswordV1(password, p.PasswordHash, crypto.ScryptAlgorithm)
+	if p.PasswordHashVersion == crypto.HashVersion1 {
+		return isValidPassword(password, p.PasswordHash, crypto.ScryptAlgorithm)
 	}
 	if len(p.KeyDerivationAlgorithm) > 0 {
-		return isValidPasswordV1(password, p.PasswordHash, p.KeyDerivationAlgorithm)
+		return isValidPassword(password, p.PasswordHash, p.KeyDerivationAlgorithm)
 	}
 	return false
 

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -28,15 +28,19 @@ func (p *Profile) IsValidPassword(password string) bool {
 		algorithms := crypto.AllowedKeyDerivationAlgorithms()
 		// if the user is invalid, return false but use the same amount of time as when we
 		// compare against valid user to avoid revealing whether the user account exists.
-		isValidPassword(password, dummyV1HashThatNeverMatchesAnyPassword, algorithms[rand.Intn(len(algorithms))])
+		isValidPassword(password, dummyV1HashThatNeverMatchesAnyPassword, algorithms[rand.Intn(len(algorithms))]) //nolint:gosec
+
 		return false
 	}
+
 	// Legacy case where password hash version is set
 	if p.PasswordHashVersion == crypto.HashVersion1 {
 		return isValidPassword(password, p.PasswordHash, crypto.ScryptAlgorithm)
 	}
-	if len(p.KeyDerivationAlgorithm) > 0 {
+
+	if p.KeyDerivationAlgorithm != "" {
 		return isValidPassword(password, p.PasswordHash, p.KeyDerivationAlgorithm)
 	}
+
 	return false
 }

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/repo/manifest"
 )
 
@@ -8,31 +9,33 @@ import (
 type Profile struct {
 	ManifestID manifest.ID `json:"-"`
 
-	Username            string `json:"username"`
-	PasswordHashVersion int    `json:"passwordHashVersion"` // indicates how password is hashed
-	PasswordHash        []byte `json:"passwordHash"`
+	Username               string `json:"username"`
+	PasswordHashVersion    int    `json:"passwordHashVersion,omitempty"` // indicates how password is hashed, deprecated in favor of KeyDerivationAlgorithm
+	KeyDerivationAlgorithm string `json:"keyDerivationAlgorithm,omitempty"`
+	PasswordHash           []byte `json:"passwordHash"`
 }
 
 // SetPassword changes the password for a user profile.
-func (p *Profile) SetPassword(password, keyDerivationAlgorithm string) error {
-	return p.setPasswordV1(password, keyDerivationAlgorithm)
+func (p *Profile) SetPassword(password string) error {
+	return p.setPasswordV1(password)
 }
 
 // IsValidPassword determines whether the password is valid for a given user.
-func (p *Profile) IsValidPassword(password, keyDerivationAlgorithm string) bool {
+func (p *Profile) IsValidPassword(password string) bool {
 	if p == nil {
 		// if the user is invalid, return false but use the same amount of time as when we
 		// compare against valid user to avoid revealing whether the user account exists.
-		isValidPasswordV1(password, dummyV1HashThatNeverMatchesAnyPassword, keyDerivationAlgorithm)
+		isValidPasswordV1(password, dummyV1HashThatNeverMatchesAnyPassword, crypto.DefaultKeyDerivationAlgorithm)
 
 		return false
 	}
-
-	switch p.PasswordHashVersion {
-	case hashVersion1:
-		return isValidPasswordV1(password, p.PasswordHash, keyDerivationAlgorithm)
-
-	default:
-		return false
+	// Legacy case where password hash version is set
+	if p.PasswordHashVersion == hashVersion1 {
+		return isValidPasswordV1(password, p.PasswordHash, crypto.ScryptAlgorithm)
 	}
+	if len(p.KeyDerivationAlgorithm) > 0 {
+		return isValidPasswordV1(password, p.PasswordHash, p.KeyDerivationAlgorithm)
+	}
+	return false
+
 }

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -14,17 +14,18 @@ import (
 var dummyV1HashThatNeverMatchesAnyPassword = make([]byte, crypto.MasterKeyLength+crypto.V1SaltLength)
 
 func (p *Profile) setPassword(password string) error {
-	if len(p.KeyDerivationAlgorithm) == 0 {
+	keyDerivationAlgorithm := p.KeyDerivationAlgorithm
+	if len(keyDerivationAlgorithm) == 0 {
 		if p.PasswordHashVersion == 0 {
 			return errors.New("key derivation algorithm and password hash version not set")
 		}
 		// Setup to handle legacy hashVersion.
 		if p.PasswordHashVersion == crypto.HashVersion1 {
-			p.KeyDerivationAlgorithm = crypto.ScryptAlgorithm
+			keyDerivationAlgorithm = crypto.ScryptAlgorithm
 		}
 	}
 
-	saltLength, err := crypto.RecommendedSaltLength(p.KeyDerivationAlgorithm)
+	saltLength, err := crypto.RecommendedSaltLength(keyDerivationAlgorithm)
 	if err != nil {
 		return err
 	}
@@ -33,7 +34,7 @@ func (p *Profile) setPassword(password string) error {
 		return errors.Wrap(err, "error generating salt")
 	}
 
-	p.PasswordHash, err = computePasswordHash(password, salt, p.KeyDerivationAlgorithm)
+	p.PasswordHash, err = computePasswordHash(password, salt, keyDerivationAlgorithm)
 
 	return err
 }

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -10,35 +10,29 @@ import (
 	"github.com/kopia/kopia/internal/crypto"
 )
 
-// parameters for v1 hashing.
-const (
-	// Legacy hash version system translates to KeyDerivationAlgorithm
-	hashVersion1 = 1 // this translates to Scrypt KeyDerivationAlgorithm
-
-	v1SaltLength = 32
-)
-
 //nolint:gochecknoglobals
-var dummyV1HashThatNeverMatchesAnyPassword = make([]byte, crypto.MasterKeyLength+v1SaltLength)
+var dummyV1HashThatNeverMatchesAnyPassword = make([]byte, crypto.MasterKeyLength+crypto.V1SaltLength)
 
-func (p *Profile) setPasswordV1(password string) error {
-	salt := make([]byte, v1SaltLength)
+func (p *Profile) setPassword(password string) error {
+	// Setup to handle legacy hashVersion.
+	if p.PasswordHashVersion == crypto.HashVersion1 {
+		p.KeyDerivationAlgorithm = crypto.ScryptAlgorithm
+	}
+	saltLength, err := crypto.RecommendedSaltLength(p.KeyDerivationAlgorithm)
+	if err != nil {
+		return err
+	}
+	salt := make([]byte, saltLength)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
 		return errors.Wrap(err, "error generating salt")
 	}
 
-	var err error
-
-	// Setup to handle legacy hashVersion.
-	if p.PasswordHashVersion == hashVersion1 {
-		p.KeyDerivationAlgorithm = crypto.ScryptAlgorithm
-	}
-	p.PasswordHash, err = computePasswordHashV1(password, salt, p.KeyDerivationAlgorithm)
+	p.PasswordHash, err = computePasswordHash(password, salt, p.KeyDerivationAlgorithm)
 
 	return err
 }
 
-func computePasswordHashV1(password string, salt []byte, keyDerivationAlgorithm string) ([]byte, error) {
+func computePasswordHash(password string, salt []byte, keyDerivationAlgorithm string) ([]byte, error) {
 	key, err := crypto.DeriveKeyFromPassword(password, salt, keyDerivationAlgorithm)
 	if err != nil {
 		return nil, errors.Wrap(err, "error deriving key from password")
@@ -49,14 +43,18 @@ func computePasswordHashV1(password string, salt []byte, keyDerivationAlgorithm 
 	return payload, nil
 }
 
-func isValidPasswordV1(password string, hashedPassword []byte, keyDerivationAlgorithm string) bool {
-	if len(hashedPassword) != v1SaltLength+crypto.MasterKeyLength {
+func isValidPassword(password string, hashedPassword []byte, keyDerivationAlgorithm string) bool {
+	saltLength, err := crypto.RecommendedSaltLength(keyDerivationAlgorithm)
+	if err != nil {
+		panic(err)
+	}
+	if len(hashedPassword) != saltLength+crypto.MasterKeyLength {
 		return false
 	}
 
-	salt := hashedPassword[0:v1SaltLength]
+	salt := hashedPassword[0:saltLength]
 
-	h, err := computePasswordHashV1(password, salt, keyDerivationAlgorithm)
+	h, err := computePasswordHash(password, salt, keyDerivationAlgorithm)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -14,10 +14,16 @@ import (
 var dummyV1HashThatNeverMatchesAnyPassword = make([]byte, crypto.MasterKeyLength+crypto.V1SaltLength)
 
 func (p *Profile) setPassword(password string) error {
-	// Setup to handle legacy hashVersion.
-	if p.PasswordHashVersion == crypto.HashVersion1 {
-		p.KeyDerivationAlgorithm = crypto.ScryptAlgorithm
+	if len(p.KeyDerivationAlgorithm) == 0 {
+		if p.PasswordHashVersion == 0 {
+			return errors.New("key derivation algorithm and password hash version not set")
+		}
+		// Setup to handle legacy hashVersion.
+		if p.PasswordHashVersion == crypto.HashVersion1 {
+			p.KeyDerivationAlgorithm = crypto.ScryptAlgorithm
+		}
 	}
+
 	saltLength, err := crypto.RecommendedSaltLength(p.KeyDerivationAlgorithm)
 	if err != nil {
 		return err

--- a/internal/user/user_profile_hash_v1.go
+++ b/internal/user/user_profile_hash_v1.go
@@ -15,7 +15,7 @@ var dummyV1HashThatNeverMatchesAnyPassword = make([]byte, crypto.MasterKeyLength
 
 func (p *Profile) setPassword(password string) error {
 	keyDerivationAlgorithm := p.KeyDerivationAlgorithm
-	if len(keyDerivationAlgorithm) == 0 {
+	if keyDerivationAlgorithm == "" {
 		if p.PasswordHashVersion == 0 {
 			return errors.New("key derivation algorithm and password hash version not set")
 		}
@@ -27,8 +27,9 @@ func (p *Profile) setPassword(password string) error {
 
 	saltLength, err := crypto.RecommendedSaltLength(keyDerivationAlgorithm)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error getting recommended salt length")
 	}
+
 	salt := make([]byte, saltLength)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
 		return errors.Wrap(err, "error generating salt")
@@ -55,6 +56,7 @@ func isValidPassword(password string, hashedPassword []byte, keyDerivationAlgori
 	if err != nil {
 		panic(err)
 	}
+
 	if len(hashedPassword) != saltLength+crypto.MasterKeyLength {
 		return false
 	}

--- a/internal/user/user_profile_test.go
+++ b/internal/user/user_profile_test.go
@@ -25,6 +25,15 @@ func TestLegacyUserProfile(t *testing.T) {
 	if p.IsValidPassword("bar") {
 		t.Fatalf("password unexpectedly valid!")
 	}
+
+	// Setting the key derivation to scrypt and unsetting PasswordHashVersion
+	// Legacy profile should translate to scrypt
+	p.KeyDerivationAlgorithm = crypto.ScryptAlgorithm
+	p.PasswordHashVersion = 0
+	if !p.IsValidPassword("foo") {
+		t.Fatalf("password not valid!")
+	}
+
 }
 
 func TestUserProfile(t *testing.T) {

--- a/internal/user/user_profile_test.go
+++ b/internal/user/user_profile_test.go
@@ -7,30 +7,65 @@ import (
 	"github.com/kopia/kopia/internal/user"
 )
 
-func TestUserProfile(t *testing.T) {
-	p := &user.Profile{}
+func TestLegacyUserProfile(t *testing.T) {
+	p := &user.Profile{
+		PasswordHashVersion: 1, // hashVersion1
+	}
 
-	if p.IsValidPassword("bar", crypto.DefaultKeyDerivationAlgorithm) {
+	if p.IsValidPassword("bar") {
 		t.Fatalf("password unexpectedly valid!")
 	}
 
-	p.SetPassword("foo", crypto.DefaultKeyDerivationAlgorithm)
+	p.SetPassword("foo")
 
-	if !p.IsValidPassword("foo", crypto.DefaultKeyDerivationAlgorithm) {
+	if !p.IsValidPassword("foo") {
 		t.Fatalf("password not valid!")
 	}
 
-	if p.IsValidPassword("bar", crypto.DefaultKeyDerivationAlgorithm) {
+	if p.IsValidPassword("bar") {
 		t.Fatalf("password unexpectedly valid!")
 	}
+}
+
+func TestUserProfile(t *testing.T) {
+	p := &user.Profile{
+		KeyDerivationAlgorithm: crypto.ScryptAlgorithm,
+	}
+
+	if p.IsValidPassword("bar") {
+		t.Fatalf("password unexpectedly valid!")
+	}
+
+	p.SetPassword("foo")
+
+	if !p.IsValidPassword("foo") {
+		t.Fatalf("password not valid!")
+	}
+
+	if p.IsValidPassword("bar") {
+		t.Fatalf("password unexpectedly valid!")
+	}
+
+	// Different key derivation algorithm besides the original should fail
+	p.KeyDerivationAlgorithm = crypto.Pbkdf2Algorithm
+	if p.IsValidPassword("foo") {
+		t.Fatalf("password unexpectedly valid!")
+	}
+
 }
 
 func TestBadKeyDerivationAlgorithmPanic(t *testing.T) {
 	defer func() { _ = recover() }()
 	func() {
-		p := &user.Profile{}
-		p.SetPassword("foo", crypto.DefaultKeyDerivationAlgorithm)
-		p.IsValidPassword("foo", "bad algorithm")
+		// mock a valid password
+		p := &user.Profile{
+			KeyDerivationAlgorithm: crypto.ScryptAlgorithm,
+		}
+		p.SetPassword("foo")
+		// Assume the key derivation algorithm is bad. This will cause
+		// a panic when validating
+		p.KeyDerivationAlgorithm = "some bad algorithm"
+		p.IsValidPassword("foo")
 	}()
 	t.Errorf("should have panicked")
 }
@@ -38,7 +73,7 @@ func TestBadKeyDerivationAlgorithmPanic(t *testing.T) {
 func TestNilUserProfile(t *testing.T) {
 	var p *user.Profile
 
-	if p.IsValidPassword("bar", crypto.DefaultKeyDerivationAlgorithm) {
+	if p.IsValidPassword("bar") {
 		t.Fatalf("password unexpectedly valid!")
 	}
 }
@@ -51,7 +86,7 @@ func TestInvalidPasswordHash(t *testing.T) {
 
 	for _, tc := range cases {
 		p := &user.Profile{PasswordHash: tc}
-		if p.IsValidPassword("some-password", crypto.DefaultKeyDerivationAlgorithm) {
+		if p.IsValidPassword("some-password") {
 			t.Fatalf("password unexpectedly valid for %v", tc)
 		}
 	}

--- a/internal/user/user_profile_test.go
+++ b/internal/user/user_profile_test.go
@@ -33,7 +33,6 @@ func TestLegacyUserProfile(t *testing.T) {
 	if !p.IsValidPassword("foo") {
 		t.Fatalf("password not valid!")
 	}
-
 }
 
 func TestUserProfile(t *testing.T) {
@@ -60,7 +59,6 @@ func TestUserProfile(t *testing.T) {
 	if p.IsValidPassword("foo") {
 		t.Fatalf("password unexpectedly valid!")
 	}
-
 }
 
 func TestBadKeyDerivationAlgorithmPanic(t *testing.T) {


### PR DESCRIPTION
This PR allows users to set the key derivation algorithm in a profile. 
The previous control `user-password-hash-version` was in place to handle any variations, however it has only ever supported 1 version and is not quite accurate. It has been replace with `key-derivation-algorithm`.

There is support to handle older profiles that have the PasswordHashVersion set. It will default to using the `Scrypt` key derivation algorithm as it had in the past.

An example where a profile is created with the old changes and one that is created with these new ones-
```
./kopianew2 server user list --json
[
 {"username":"tes2@test","passwordHashVersion":1,"passwordHash":"CE/3mjeFF6PnFYfXw7H6Lxq6MWG0TKLzKZ1C2cH5YIQSnVtL9gP8KpHmlK88BiA0qhXKUwOvPHgiumCDQUFmTw=="},
 {"username":"test3@test","keyDerivationAlgorithm":"scrypt-65536-8-1","passwordHash":"ksfKeB2hg4XlTzOxqvsU7mog9F/7x1Ca5Huj5KnGN4kzcV/Fj9ws0PJGtYZ254scDerHuoAJR6+IMbymK6p5Gg=="},
 
]            
```
