### PR TITLE
feat(repository): improved zstd decompression memory usage

### DIFF
--- a/repo/compression/compressor_zstd.go
+++ b/repo/compression/compressor_zstd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/freepool"
 	"github.com/kopia/kopia/internal/iocopy"
 )
 
@@ -59,6 +60,15 @@ func (c *zstdCompressor) Compress(output io.Writer, input io.Reader) error {
 	return nil
 }
 
+//nolint:gochecknoglobals
+var decoderPool = freepool.New(func() *zstd.Decoder {
+	r, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
+	mustSucceed(err)
+	return r
+}, func(v *zstd.Decoder) {
+	mustSucceed(v.Reset(nil))
+})
+
 func (c *zstdCompressor) Decompress(output io.Writer, input io.Reader, withHeader bool) error {
 	if withHeader {
 		if err := verifyCompressionHeader(input, c.header); err != nil {
@@ -66,13 +76,14 @@ func (c *zstdCompressor) Decompress(output io.Writer, input io.Reader, withHeade
 		}
 	}
 
-	r, err := zstd.NewReader(input)
-	if err != nil {
-		return errors.Wrap(err, "unable to open zstd stream")
-	}
-	defer r.Close()
+	dec := decoderPool.Take()
+	defer decoderPool.Return(dec)
 
-	if err := iocopy.JustCopy(output, r); err != nil {
+	if err := dec.Reset(input); err != nil {
+		return errors.Wrap(err, "decompression reset error")
+	}
+
+	if err := iocopy.JustCopy(output, dec); err != nil {
 		return errors.Wrap(err, "decompression error")
 	}
 


### PR DESCRIPTION
```
$ kopia benchmark compression --data-file ~/Downloads/kopia-index-inspect-all.log --algorithms zstd,zstd-fastest,zstd-better-compression,zstd-best-compression --parallel 16 --operations=decompress --repeat=10
```

BEFORE:

```
     Compression                Compressed   Throughput   Allocs   Memory Usage
------------------------------------------------------------------------------------------------
  0. zstd-fastest               18.4 MB      6.2 GB/s     22539    5.5 GB
  1. zstd-better-compression    16.4 MB      5.1 GB/s     18252    6.3 GB
  2. zstd                       18.1 MB      4.7 GB/s     17933    6.4 GB
  3. zstd-best-compression      16.2 MB      4 GB/s       18632    6.3 GB (deprecated)
```

AFTER

```
     Compression                Compressed   Throughput   Allocs   Memory Usage
------------------------------------------------------------------------------------------------
  0. zstd-fastest               18.4 MB      7.8 GB/s     1078     4.3 GB
  1. zstd-best-compression      16.2 MB      5.8 GB/s     1265     4.4 GB (deprecated)
  2. zstd-better-compression    16.4 MB      5.7 GB/s     1250     4.4 GB
  3. zstd                       18.1 MB      5.4 GB/s     1570     4.5 GB
```