### PR TITLE
refactor(general): avoid wrapping known-to-be-nil error

### DIFF
--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -93,7 +93,7 @@ func (c *diskCommittedContentIndexCache) mmapOpenWithRetry(path string) (mmap.MM
 		}
 
 		return nil
-	}, errors.Wrap(err, "mmap() error")
+	}, nil
 }
 
 func (c *diskCommittedContentIndexCache) hasIndexBlobID(ctx context.Context, indexBlobID blob.ID) (bool, error) {


### PR DESCRIPTION
Ref:
- #1980