### PR TITLE
refactor(general):  include parameters in pbkdf2 instantiation

### DIFF
--- a/internal/crypto/pbkdf.go
+++ b/internal/crypto/pbkdf.go
@@ -23,7 +23,7 @@ const (
 	pbkdf2Sha256Iterations = 600_000
 
 	// Pbkdf2Algorithm is the key for the pbkdf algorithm.
-	Pbkdf2Algorithm = "pbkdf2"
+	Pbkdf2Algorithm = "pbkdf2-sha256-600000"
 )
 
 func init() {


### PR DESCRIPTION
Use `pbkdf2-sha256-600000` as the name to be consistent with the scrypt instantiation.

The format is `pbkdf2-<hash_type>-<number_of_iterations>`