### PR TITLE
fix(cli): Fix client IPv6 URI generation for gRPC connections

### DIFF
--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/url"
 	"runtime"
 	"sync"
@@ -837,7 +838,7 @@ func openGRPCAPIRepository(ctx context.Context, si *APIServerInfo, password stri
 		return nil, errors.Errorf("invalid server address, must be 'https://host:port' or 'unix+https://<path>")
 	}
 
-	uri := u.Hostname() + ":" + u.Port()
+	uri := net.JoinHostPort(u.Hostname(), u.Port())
 	if u.Scheme == "unix+https" {
 		uri = "unix:" + u.Path
 	}


### PR DESCRIPTION
Connecting to gRPC repository API using an IPv6 address does not correctly configure the URI for the client's dial. Reconstructing the parsed URL into `hostname + ":" + port` will remove the square brackets required for IPv6 addressing, resulting in a `too many colons in address` error.

Fix the issue by instead using the helper `net.JoinHostPort()`, which will add square brackets for IPv6 hostnames.

Tested by running `TestServer` with `httptest.serve` flag set, forcing the test server to listen on the IPv6 loopback:
```
cd internal/server
go test -v -run=TestServer$ --httptest.serve=[::1]:0 ./server
```

Fails without fix:
```
    server_test.go:48: 
                Error Trace:    /workspaces/kopia/internal/server/server_test.go:48
                Error:          Received unexpected error:
                                failed to exit idle mode: invalid target address ::1:45373, error info: address ::1:45373:443: too many colons in address
```

Passes with fix:
```
--- PASS: TestServer (0.81s)
PASS
```