### PR TITLE
refactor(general): avoid using empty master keys

### DIFF
--- a/internal/crypto/key_derivation.go
+++ b/internal/crypto/key_derivation.go
@@ -9,6 +9,10 @@ import (
 
 // DeriveKeyFromMasterKey computes a key for a specific purpose and length using HKDF based on the master key.
 func DeriveKeyFromMasterKey(masterKey, salt, purpose []byte, length int) []byte {
+	if len(masterKey) == 0 {
+		panic("invalid master key")
+	}
+
 	key := make([]byte, length)
 	k := hkdf.New(sha256.New, masterKey, salt, purpose)
 

--- a/internal/crypto/key_derivation_test.go
+++ b/internal/crypto/key_derivation_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kopia/kopia/internal/crypto"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/crypto"
 )
 
 var (

--- a/internal/crypto/key_derivation_test.go
+++ b/internal/crypto/key_derivation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/kopia/kopia/internal/crypto"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -19,28 +20,18 @@ func TestDeriveKeyFromMasterKey(t *testing.T) {
 
 		expected := "828769ee8969bc37f11dbaa32838f8db6c19daa6e3ae5f5eed2da2d94d8faddb"
 		got := fmt.Sprintf("%02x", key)
-		if got != expected {
-			t.Errorf("incorrect key\nexpected: %s\n     got: %s", expected, got)
-		}
+		require.Equal(t, expected, got)
 	})
 
 	t.Run("PanicsOnNilMasterKey", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Error("expected panic")
-			}
-		}()
-
-		crypto.DeriveKeyFromMasterKey(nil, TestSalt, TestPurpose, 32)
+		require.Panics(t, func() {
+			crypto.DeriveKeyFromMasterKey(nil, TestSalt, TestPurpose, 32)
+		})
 	})
 
 	t.Run("PanicsOnEmptyMasterKey", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Error("expected panic")
-			}
-		}()
-
-		crypto.DeriveKeyFromMasterKey([]byte{}, TestSalt, TestPurpose, 32)
+		require.Panics(t, func() {
+			crypto.DeriveKeyFromMasterKey([]byte{}, TestSalt, TestPurpose, 32)
+		})
 	})
 }

--- a/internal/crypto/key_derivation_test.go
+++ b/internal/crypto/key_derivation_test.go
@@ -1,0 +1,46 @@
+package crypto_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kopia/kopia/internal/crypto"
+)
+
+var (
+	TestMasterKey = []byte("ABCDEFGHIJKLMNOP")
+	TestSalt      = []byte("0123456789012345")
+	TestPurpose   = []byte("the-test-purpose")
+)
+
+func TestDeriveKeyFromMasterKey(t *testing.T) {
+	t.Run("ReturnsKey", func(t *testing.T) {
+		key := crypto.DeriveKeyFromMasterKey(TestMasterKey, TestSalt, TestPurpose, 32)
+
+		expected := "828769ee8969bc37f11dbaa32838f8db6c19daa6e3ae5f5eed2da2d94d8faddb"
+		got := fmt.Sprintf("%02x", key)
+		if got != expected {
+			t.Errorf("incorrect key\nexpected: %s\n     got: %s", expected, got)
+		}
+	})
+
+	t.Run("PanicsOnNilMasterKey", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic")
+			}
+		}()
+
+		crypto.DeriveKeyFromMasterKey(nil, TestSalt, TestPurpose, 32)
+	})
+
+	t.Run("PanicsOnEmptyMasterKey", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic")
+			}
+		}()
+
+		crypto.DeriveKeyFromMasterKey([]byte{}, TestSalt, TestPurpose, 32)
+	})
+}

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -68,7 +68,7 @@ func (e *Environment) setup(tb testing.TB, version format.Version, opts ...Optio
 			MutableParameters: format.MutableParameters{
 				Version: version,
 			},
-			HMACSecret:           []byte("test-hmac-secret"),
+			HMACSecret:           []byte("a-repository-testing-hmac-secret"),
 			Hash:                 "HMAC-SHA256",
 			Encryption:           encryption.DefaultAlgorithm,
 			EnablePasswordChange: true,

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -68,7 +68,7 @@ func (e *Environment) setup(tb testing.TB, version format.Version, opts ...Optio
 			MutableParameters: format.MutableParameters{
 				Version: version,
 			},
-			HMACSecret:           []byte{},
+			HMACSecret:           []byte("test-hmac-secret"),
 			Hash:                 "HMAC-SHA256",
 			Encryption:           encryption.DefaultAlgorithm,
 			EnablePasswordChange: true,

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -39,9 +39,9 @@ func (s *formatSpecificTestSuite) TestWriters(t *testing.T) {
 	}{
 		{
 			[]byte("the quick brown fox jumps over the lazy dog"),
-			mustParseObjectID(t, "7f8f3efa67f773c01051a8b727f6426d2762e9556223479dc7d0ba5656924b77"),
+			mustParseObjectID(t, "f65fc4107863281faaeb7087197c05ad59457362607330c665c86c852c5e5906"),
 		},
-		{make([]byte, 100), mustParseObjectID(t, "bba52aa885067beeae9f59b3adea64a654732ab887b8e2af45c302ba2f1390dd")}, // 100 zero bytes
+		{make([]byte, 100), mustParseObjectID(t, "bfa2b4b9421671ab2b5bfa8c90ee33607784a27e452b08556509ef9bd47a37c6")}, // 100 zero bytes
 	}
 
 	for _, c := range cases {
@@ -79,7 +79,7 @@ func (s *formatSpecificTestSuite) TestWriterCompleteChunkInTwoWrites(t *testing.
 	writer.Write(b[0:50])
 	result, err := writer.Result()
 
-	if result != mustParseObjectID(t, "bba52aa885067beeae9f59b3adea64a654732ab887b8e2af45c302ba2f1390dd") {
+	if result != mustParseObjectID(t, "bfa2b4b9421671ab2b5bfa8c90ee33607784a27e452b08556509ef9bd47a37c6") {
 		t.Errorf("unexpected result: %v err: %v", result, err)
 	}
 }
@@ -163,7 +163,7 @@ func (s *formatSpecificTestSuite) TestHMAC(t *testing.T) {
 	w.Write(c)
 	result, err := w.Result()
 
-	if result.String() != "e097a8bd0a397b3c3e3ca2decb26e82dc82b646a2a5a7e8769c205c68a74f591" {
+	if result.String() != "e37e93ba74e074ad1366ee2f032ee9c3a5b81ec82c140b053c1a4e6673d5d9d9" {
 		t.Errorf("unexpected result: %v err: %v", result.String(), err)
 	}
 }
@@ -252,8 +252,8 @@ func TestFormats(t *testing.T) {
 			format: func(n *repo.NewRepositoryOptions) {
 			},
 			oids: map[string]object.ID{
-				"": mustParseObjectID(t, "f2b05c22b9314703b5f1745beec2b17545853003d1438cd961641f2369021e7e"),
-				"The quick brown fox jumps over the lazy dog": mustParseObjectID(t, "87b02856aa241c7501b63850942ee437b8cd0c9dbcedf9d4442d00275777eb52"),
+				"": mustParseObjectID(t, "0c2d44dc80de21b71d4219623082f5dc253fe9bb54e48b0fc90e118f8e6cf419"),
+				"The quick brown fox jumps over the lazy dog": mustParseObjectID(t, "6bbb74fef0699e516fb96252d8280c1c7f3492e12de9ec6d79c3c9c39b7b0063"),
 			},
 		},
 		{

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -39,9 +39,9 @@ func (s *formatSpecificTestSuite) TestWriters(t *testing.T) {
 	}{
 		{
 			[]byte("the quick brown fox jumps over the lazy dog"),
-			mustParseObjectID(t, "345acef0bcf82f1daf8e49fab7b7fac7ec296c518501eabea3645b99345a4e08"),
+			mustParseObjectID(t, "7f8f3efa67f773c01051a8b727f6426d2762e9556223479dc7d0ba5656924b77"),
 		},
-		{make([]byte, 100), mustParseObjectID(t, "1d804f1f69df08f3f59070bf962de69433e3d61ac18522a805a84d8c92741340")}, // 100 zero bytes
+		{make([]byte, 100), mustParseObjectID(t, "bba52aa885067beeae9f59b3adea64a654732ab887b8e2af45c302ba2f1390dd")}, // 100 zero bytes
 	}
 
 	for _, c := range cases {
@@ -79,7 +79,7 @@ func (s *formatSpecificTestSuite) TestWriterCompleteChunkInTwoWrites(t *testing.
 	writer.Write(b[0:50])
 	result, err := writer.Result()
 
-	if result != mustParseObjectID(t, "1d804f1f69df08f3f59070bf962de69433e3d61ac18522a805a84d8c92741340") {
+	if result != mustParseObjectID(t, "bba52aa885067beeae9f59b3adea64a654732ab887b8e2af45c302ba2f1390dd") {
 		t.Errorf("unexpected result: %v err: %v", result, err)
 	}
 }
@@ -163,7 +163,7 @@ func (s *formatSpecificTestSuite) TestHMAC(t *testing.T) {
 	w.Write(c)
 	result, err := w.Result()
 
-	if result.String() != "367352007ee6ca9fa755ce8352347d092c17a24077fd33c62f655574a8cf906d" {
+	if result.String() != "e097a8bd0a397b3c3e3ca2decb26e82dc82b646a2a5a7e8769c205c68a74f591" {
 		t.Errorf("unexpected result: %v err: %v", result.String(), err)
 	}
 }
@@ -252,8 +252,8 @@ func TestFormats(t *testing.T) {
 			format: func(n *repo.NewRepositoryOptions) {
 			},
 			oids: map[string]object.ID{
-				"": mustParseObjectID(t, "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad"),
-				"The quick brown fox jumps over the lazy dog": mustParseObjectID(t, "fb011e6154a19b9a4c767373c305275a5a69e8b68b0b4c9200c383dced19a416"),
+				"": mustParseObjectID(t, "f2b05c22b9314703b5f1745beec2b17545853003d1438cd961641f2369021e7e"),
+				"The quick brown fox jumps over the lazy dog": mustParseObjectID(t, "87b02856aa241c7501b63850942ee437b8cd0c9dbcedf9d4442d00275777eb52"),
 			},
 		},
 		{


### PR DESCRIPTION
Previously, empty master keys were passed to the underlying cryptographic primitives (HKDF, AEAD, etc.).

While this worked because the authentication mechanisms returned an error, it's best to avoid passing empty master keys to these primitives in the first place. This refactor avoids passing empty master keys and enforces this via an assertion in the key derivation function.