### PR TITLE
docs(providers): info about the B2 S3-compatible endpoint

### DIFF
--- a/site/content/docs/Repositories/_index.md
+++ b/site/content/docs/Repositories/_index.md
@@ -114,7 +114,7 @@ After you have created the `repository`, you connect to it using the [`kopia rep
 
 Creating a Backblaze B2 `repository` is done differently depending on if you use Kopia GUI or Kopia CLI.
 
-> NOTE: Currently, object locking is supported for Backblaze B2 but only through Kopia's [S3-compatible storage `repository`](#amazon-s3-and-s3-compatible-cloud-storage) and not through the Backblaze B2 `repository` option. However, Backblaze B2 is fully S3 compatible, so you can setup your Backblaze B2 account via Kopia's [S3 `repository` option](#amazon-s3-and-s3-compatible-cloud-storage).
+> NOTE: Currently, object locking is supported for B2 but only through Kopia's [S3-compatible storage `repository`](#amazon-s3-and-s3-compatible-cloud-storage) and not through the B2 `repository` option. However, B2 is fully S3 compatible, so you can setup your B2 account via Kopia's [S3 `repository` option](#amazon-s3-and-s3-compatible-cloud-storage). To use B2 storage with the S3 `repository` option the `--endpoint` argument must be specified with the appropriate B2 endpoint. This endpoint can be found on the buckets page of the B2 web interface and follows the pattern `s3.<region>.backblazeb2.com`.
 
 ### Kopia GUI
 


### PR DESCRIPTION
This expands the note about using B2 storage as S3-compatible storage by providing some additional context on where to get the endpoint value.

I've also changed the redundant fully qualified "Backblaze B2" to "B2" in the note.