### PR TITLE
docs(server): explain why --insecure cannot be used behind a reverse proxy

### DIFF
--- a/site/content/docs/Repository Server/_index.md
+++ b/site/content/docs/Repository Server/_index.md
@@ -274,7 +274,7 @@ server {
 }
 ```
 
-Make sure you use a recent nginx version (>=1.16) and you start your kopia server with a certificate (`--insecure` does not work), e.g.
+Make sure you use a recent nginx version (>=1.16) and you start your kopia server with a certificate (`--insecure` does not work, as GRPC needs TLS, which is used by Repository Server), e.g.
 
 ```shell
 kopia server start --address 0.0.0.0:51515 --tls-cert-file ~/my.cert --tls-key-file ~/my.key


### PR DESCRIPTION
Add context to why `--insecure` cannot be used behind a reverse proxy.

I am using kopia behind traefik as a reverse proxy. With the current wording, I thought that the lack of --insecure was required by the nginx (config) and not kopia itself. [This thread](https://kopia.discourse.group/t/cant-connect-to-insecure-repository-server/871/4) finally helped me to resolve the connection issues to the repo server.