### PR TITLE
fix(general): change pbkdf2 min salt length to 16 bytes

### DIFF
--- a/internal/crypto/pb_key_deriver_pbkdf2.go
+++ b/internal/crypto/pb_key_deriver_pbkdf2.go
@@ -14,13 +14,13 @@ const (
 	// Pbkdf2Algorithm is the key for the pbkdf algorithm.
 	Pbkdf2Algorithm = "pbkdf2-sha256-600000"
 
-	// The NIST recommended minimum size for a salt for pbkdf2 is 16 bytes.
-	//
-	// However, a good rule of thumb is to use a salt that is the same size
+	// A good rule of thumb is to use a salt that is the same size
 	// as the output of the hash function. For example, the output of SHA256
 	// is 256 bits (32 bytes), so the salt should be at least 32 random bytes.
 	// See: https://crackstation.net/hashing-security.htm
-	pbkdf2Sha256MinSaltLength = 32 // 256 bits
+	//
+	// However, the NIST recommended minimum size for a salt for pbkdf2 is 16 bytes.
+	pbkdf2Sha256MinSaltLength = 16 // 128 bits
 
 	// The NIST recommended iterations for PBKDF2 with SHA256 hash is 600,000.
 	pbkdf2Sha256Iterations = 600_000


### PR DESCRIPTION
Changing the minimum salt length of Pbkdf2 key derivation algorithm to the NIST recommended minimum of 16 bytes.