### PR TITLE
docs(server): add repo password in server start example

### DIFF
--- a/site/content/docs/Repository Server/_index.md
+++ b/site/content/docs/Repository Server/_index.md
@@ -47,14 +47,14 @@ Other commands are also available:
 To start repository server with auto-generated TLS certificate for the first time:
 
 ```shell
-kopia server start \
-  --tls-generate-cert \
-  --tls-cert-file ~/my.cert \
-  --tls-key-file ~/my.key \
-  --address 0.0.0.0:51515 \
-  --server-control-username control \
-  --server-control-password PASSWORD_HERE
-  --password REPO_PASSWORD
+KOPIA_PASSWORD="<password-for-the-repository>" \
+KOPIA_SERVER_CONTROL_PASSWORD="<server-control-password>" \
+  kopia server start \
+    --tls-generate-cert \
+    --tls-cert-file ~/my.cert \
+    --tls-key-file ~/my.key \
+    --address 0.0.0.0:51515 \
+    --server-control-username control
 ```
 
 This will generate TLS certificate and key files and store them in the provided paths (`~/my.cert` and `~/my.key` respectively). It will also print certificate SHA256 fingerprint, which will be used later:

--- a/site/content/docs/Repository Server/_index.md
+++ b/site/content/docs/Repository Server/_index.md
@@ -54,6 +54,7 @@ kopia server start \
   --address 0.0.0.0:51515 \
   --server-control-username control \
   --server-control-password PASSWORD_HERE
+  --password REPO_PASSWORD
 ```
 
 This will generate TLS certificate and key files and store them in the provided paths (`~/my.cert` and `~/my.key` respectively). It will also print certificate SHA256 fingerprint, which will be used later:


### PR DESCRIPTION
When starting the server, the typical use case will not involve responding to interactive prompts. This change better reflects the expectations of a user given that fact.