### PR TITLE
refactor(server): pass hash version to computePasswordHash

### DIFF
--- a/internal/user/password_hashing_version.go
+++ b/internal/user/password_hashing_version.go
@@ -1,0 +1,4 @@
+package user
+
+// defaultPasswordHashVersion is the default scheme used for user password hashing.
+const defaultPasswordHashVersion = ScryptHashVersion

--- a/internal/user/password_hashing_version.go
+++ b/internal/user/password_hashing_version.go
@@ -1,4 +1,18 @@
 package user
 
+import "github.com/pkg/errors"
+
 // defaultPasswordHashVersion is the default scheme used for user password hashing.
 const defaultPasswordHashVersion = ScryptHashVersion
+
+// getPasswordHashAlgorithm returns the password hash algorithm given a version.
+func getPasswordHashAlgorithm(passwordHashVersion int) (string, error) {
+	switch passwordHashVersion {
+	case ScryptHashVersion:
+		return scryptHashAlgorithm, nil
+	case Pbkdf2HashVersion:
+		return pbkdf2HashAlgorithm, nil
+	default:
+		return "", errors.Errorf("unsupported hash version (%d)", passwordHashVersion)
+	}
+}

--- a/internal/user/password_hashings_test.go
+++ b/internal/user/password_hashings_test.go
@@ -33,8 +33,9 @@ func TestSaltLengthIsSupported(t *testing.T) {
 	const badPwd = "password"
 	var salt [passwordHashSaltLength]byte
 
-	for _, h := range PasswordHashingAlgorithms() {
-		_, err := computePasswordHash(badPwd, salt[:], h)
+	for _, v := range []int{ScryptHashVersion, Pbkdf2HashVersion} {
+		h, err := computePasswordHash(badPwd, salt[:], v)
 		require.NoError(t, err)
+		require.NotEmpty(t, h)
 	}
 }

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -1,11 +1,9 @@
 package user
 
 import (
-	"math/rand"
+	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/repo/manifest"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -39,32 +37,16 @@ func (p *Profile) SetPassword(password string) error {
 
 // IsValidPassword determines whether the password is valid for a given user.
 func (p *Profile) IsValidPassword(password string) (bool, error) {
-	var invalidProfile bool
-
-	var passwordHashAlgorithm string
-
-	var err error
-
 	if p == nil {
-		invalidProfile = true
-	} else {
-		passwordHashAlgorithm, err = getPasswordHashAlgorithm(p.PasswordHashVersion)
-		if err != nil {
-			invalidProfile = true
-		}
-	}
-
-	if invalidProfile {
-		algorithms := PasswordHashingAlgorithms()
-		// if the user profile is invalid, either a non-existing user name or password
-		// hash version, then return false but use the same amount of time as when we
+		// if the user profile is invalid, either a non-existing user name, then
+		// return false but use the same amount of time as when we
 		// compare against valid user to avoid revealing whether the user account exists.
-		_, err := isValidPassword(password, dummyHashThatNeverMatchesAnyPassword, algorithms[rand.Intn(len(algorithms))]) //nolint:gosec
+		_, err := isValidPassword(password, dummyHashThatNeverMatchesAnyPassword, defaultPasswordHashVersion)
 
 		return false, err
 	}
 
-	return isValidPassword(password, p.PasswordHash, passwordHashAlgorithm)
+	return isValidPassword(password, p.PasswordHash, p.PasswordHashVersion)
 }
 
 // GetPasswordHashVersion returns the password hash version given an algorithm.

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -67,18 +67,6 @@ func (p *Profile) IsValidPassword(password string) (bool, error) {
 	return isValidPassword(password, p.PasswordHash, passwordHashAlgorithm)
 }
 
-// getPasswordHashAlgorithm returns the password hash algorithm given a version.
-func getPasswordHashAlgorithm(passwordHashVersion int) (string, error) {
-	switch passwordHashVersion {
-	case ScryptHashVersion:
-		return scryptHashAlgorithm, nil
-	case Pbkdf2HashVersion:
-		return pbkdf2HashAlgorithm, nil
-	default:
-		return "", errors.Errorf("unsupported hash version (%d)", passwordHashVersion)
-	}
-}
-
 // GetPasswordHashVersion returns the password hash version given an algorithm.
 func GetPasswordHashVersion(passwordHashAlgorithm string) (int, error) {
 	switch passwordHashAlgorithm {

--- a/internal/user/user_profile_test.go
+++ b/internal/user/user_profile_test.go
@@ -57,7 +57,7 @@ func TestBadPasswordHashVersion(t *testing.T) {
 	isValid, err = p.IsValidPassword("foo")
 
 	require.False(t, isValid, "password unexpectedly valid!")
-	require.NoError(t, err)
+	require.Error(t, err)
 }
 
 func TestNilUserProfile(t *testing.T) {


### PR DESCRIPTION
Motivation: Encapsulate details about the implementation of user profiles, in particular the password hashing scheme.

This is a cleanup, refactoring step in that direction.

No functional change.