### PR TITLE
fix(snapshots): Append path separator to Shadow Copy root directory on Windows

### DIFF
--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -55,7 +55,7 @@ func (e *filesystemEntry) fullPath() string {
 }
 
 func (e *filesystemEntry) isWindowsVSSVolume() bool {
-	return runtime.GOOS == "windows" && //nolint:goconst
+	return runtime.GOOS == "windows" &&
 		e.prefix == `\\?\GLOBALROOT\Device\` &&
 		strings.HasPrefix(e.Name(), "HarddiskVolumeShadowCopy")
 }

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -55,7 +55,7 @@ func (e *filesystemEntry) fullPath() string {
 }
 
 func (e *filesystemEntry) isWindowsVSSVolume() bool {
-	return runtime.GOOS == "windows" &&
+	return runtime.GOOS == "windows" && //nolint:goconst
 		e.prefix == `\\?\GLOBALROOT\Device\` &&
 		strings.HasPrefix(e.Name(), "HarddiskVolumeShadowCopy")
 }

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -50,6 +52,12 @@ func (e *filesystemEntry) Sys() interface{} {
 
 func (e *filesystemEntry) fullPath() string {
 	return e.prefix + e.Name()
+}
+
+func (e *filesystemEntry) isWindowsVSSVolume() bool {
+	return runtime.GOOS == "windows" &&
+		e.prefix == `\\?\GLOBALROOT\Device\` &&
+		strings.HasPrefix(e.Name(), "HarddiskVolumeShadowCopy")
 }
 
 func (e *filesystemEntry) Owner() fs.OwnerInfo {

--- a/fs/localfs/local_fs_os.go
+++ b/fs/localfs/local_fs_os.go
@@ -66,7 +66,13 @@ func (it *filesystemDirectoryIterator) Close() {
 func (fsd *filesystemDirectory) Iterate(_ context.Context) (fs.DirectoryIterator, error) {
 	fullPath := fsd.fullPath()
 
-	f, direrr := os.Open(fullPath) //nolint:gosec
+	// Direct Windows volume paths (e.g. Shadow Copy) require a trailing \ or listing will fail
+	appendPath := ""
+	if fsd.isWindowsVSSVolume() {
+		appendPath = string(os.PathSeparator)
+	}
+
+	f, direrr := os.Open(fullPath + appendPath) //nolint:gosec
 	if direrr != nil {
 		return nil, errors.Wrap(direrr, "unable to read directory")
 	}


### PR DESCRIPTION
This is a fix for #3842.
It's a slightly modified version of the patch in https://github.com/kopia/kopia/issues/3842#issuecomment-2105616219, I separated the code out into a `maybe` function and added some tests. 
The root cause of this issue seems to be a regression in Go 1.22 (see https://github.com/kopia/kopia/issues/3842#issuecomment-2141250166), but as discussed with jkowalski in the issue, it seems better to just fix this up with a special case in Kopia.