### PR TITLE
refactor(server): initialize dummy hash with non-zero value

### DIFF
--- a/internal/user/password_hashings_test.go
+++ b/internal/user/password_hashings_test.go
@@ -17,6 +17,14 @@ func TestPasswordHashingConstantMatchCryptoPackage(t *testing.T) {
 	require.Equal(t, crypto.Pbkdf2Algorithm, pbkdf2HashAlgorithm)
 }
 
+func TestNonZeroDummyHash(t *testing.T) {
+	empty := make([]byte, len(dummyHashThatNeverMatchesAnyPassword))
+
+	require.NotNil(t, dummyHashThatNeverMatchesAnyPassword)
+	require.NotZero(t, dummyHashThatNeverMatchesAnyPassword)
+	require.NotEqual(t, empty, dummyHashThatNeverMatchesAnyPassword)
+}
+
 // The passwordHashSaltLength constant defines the salt length used in this
 // package for password hashing. This trivial test ensures that this hash length
 // meets the minimum requirement for the instantiations of the registered

--- a/internal/user/user_profile_pw_hash.go
+++ b/internal/user/user_profile_pw_hash.go
@@ -11,7 +11,17 @@ import (
 )
 
 //nolint:gochecknoglobals
-var dummyHashThatNeverMatchesAnyPassword = make([]byte, passwordHashSaltLength+passwordHashLength)
+var dummyHashThatNeverMatchesAnyPassword = initDummyHash()
+
+func initDummyHash() []byte {
+	s := make([]byte, passwordHashSaltLength+passwordHashLength)
+
+	for i := range s {
+		s[i] = 0xFF
+	}
+
+	return s
+}
 
 func (p *Profile) setPassword(password string) error {
 	passwordHashAlgorithm, err := getPasswordHashAlgorithm(p.PasswordHashVersion)


### PR DESCRIPTION
Motivation: avoid making accidental decisions based on all-zeros content in the future.

While the dummyHash is a non-zero-value slice, that is it is non-empty (thus not nil), it is still the default value produced by `make([]byte, hashLength)`, and it is possible to accidentally compare and have a positive match against a newly initialized slice.