### PR TITLE
refactor(general): Index compaction enhancement

### DIFF
--- a/internal/epoch/epoch_advance.go
+++ b/internal/epoch/epoch_advance.go
@@ -13,7 +13,8 @@ import (
 //
 // - number of blobs in the epoch exceeds 'countThreshold'
 // - total size of blobs in the epoch exceeds 'totalSizeBytesThreshold'.
-func shouldAdvance(bms []blob.Metadata, minEpochDuration time.Duration, countThreshold int, totalSizeBytesThreshold int64) bool {
+// Or the total index blob size in the current epoch eceeds 'totalSizeBytesThresholdHard'.
+func shouldAdvance(bms []blob.Metadata, minEpochDuration time.Duration, countThreshold int, totalSizeBytesThreshold int64, totalSizeBytesThresholdHard int64) bool {
 	if len(bms) == 0 {
 		return false
 	}
@@ -34,6 +35,10 @@ func shouldAdvance(bms []blob.Metadata, minEpochDuration time.Duration, countThr
 		}
 
 		totalSize += bm.Length
+	}
+
+	if totalSize >= totalSizeBytesThresholdHard {
+		return true
 	}
 
 	// not enough time between first and last write in an epoch.

--- a/internal/epoch/epoch_advance_test.go
+++ b/internal/epoch/epoch_advance_test.go
@@ -52,6 +52,14 @@ func TestShouldAdvanceEpoch(t *testing.T) {
 			want: false,
 		},
 		{
+			desc: "two blobs, not enough time passed, hard size enough to advance",
+			bms: []blob.Metadata{
+				{Timestamp: t0.Add(def.MinEpochDuration - 1), Length: epochAdvanceOnTotalSizeBytesThresholdHard},
+				{Timestamp: t0, Length: 1},
+			},
+			want: true,
+		},
+		{
 			desc: "two blobs, enough time passed, total size enough to advance",
 			bms: []blob.Metadata{
 				{Timestamp: t0, Length: 1},
@@ -84,7 +92,7 @@ func TestShouldAdvanceEpoch(t *testing.T) {
 
 	for _, tc := range cases {
 		require.Equal(t, tc.want,
-			shouldAdvance(tc.bms, def.MinEpochDuration, def.EpochAdvanceOnCountThreshold, def.EpochAdvanceOnTotalSizeBytesThreshold),
+			shouldAdvance(tc.bms, def.MinEpochDuration, def.EpochAdvanceOnCountThreshold, def.EpochAdvanceOnTotalSizeBytesThreshold, epochAdvanceOnTotalSizeBytesThresholdHard),
 			tc.desc)
 	}
 }

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -1297,6 +1297,17 @@ func TestValidateParameters(t *testing.T) {
 				EpochAdvanceOnCountThreshold: 10,
 			}, "epoch advance on size too low",
 		},
+		{
+			Parameters{
+				Enabled:                               true,
+				MinEpochDuration:                      1 * time.Hour,
+				EpochRefreshFrequency:                 10 * time.Minute,
+				FullCheckpointFrequency:               5,
+				CleanupSafetyMargin:                   time.Hour,
+				EpochAdvanceOnCountThreshold:          10,
+				EpochAdvanceOnTotalSizeBytesThreshold: 101 << 20,
+			}, "epoch advance on size too high",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
1. Fix the problem that `runTaskEpochMaintenanceQuick` never gets called in `runQuickMaintenance`
2. Add a hard limit to `epochAdvanceOnTotalSizeBytesThreshold` for `shouldAdvance`. Epoch is advanced when the total index size in the epoch exceeds the hard limit. In this way, we keep indexes in an epoch in a reasonable number/size, so that the index compaction for that epoch won't take extremely high CPU and memory