### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/klauspost/compress v1.17.8
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.1
-	github.com/kopia/htmluibuild v0.0.1-0.20240405040759-90bfbf000696
+	github.com/kopia/htmluibuild v0.0.1-0.20240605215256-b2112bbc1ca5
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.70

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.1 h1:NhWgum1efX1x58daOBGCFWcxtEhOhXKKl1HAPQUp03Q=
 github.com/klauspost/reedsolomon v1.12.1/go.mod h1:nEi5Kjb6QqtbofI6s+cbG/j1da11c96IBYBSnVGtuBs=
-github.com/kopia/htmluibuild v0.0.1-0.20240405040759-90bfbf000696 h1:MaLdTP4HVGUomnowX7k1i4SOXOdtgSi/ekp1gWgubNU=
-github.com/kopia/htmluibuild v0.0.1-0.20240405040759-90bfbf000696/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20240605215256-b2112bbc1ca5 h1:H/gGYl4urkdSdj44Ot92p1edtMquZgYPnXFtBo/XiFY=
+github.com/kopia/htmluibuild v0.0.1-0.20240605215256-b2112bbc1ca5/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/c5ffeee0c77cc4bd850dd5fb3b805315c476089d...7eb8e55c7069209ba8b78a5643a04f7b44709805

* Wed May 1 21:56 https://github.com/kopia/htmlui/commit/bccd89d dependabot[bot] build(deps-dev): bump ejs from 3.1.8 to 3.1.10
* Thu May 2 21:07 https://github.com/kopia/htmlui/commit/979dd1b dependabot[bot] build(deps-dev): bump axios-mock-adapter from 1.21.5 to 1.22.0
* Thu May 2 21:08 https://github.com/kopia/htmlui/commit/83a74bf dependabot[bot] build(deps-dev): bump @testing-library/react from 14.1.2 to 15.0.6
* Sat 22:42 https://github.com/kopia/htmlui/commit/1eea9a8 dependabot[bot] build(deps): bump @fortawesome/react-fontawesome from 0.2.0 to 0.2.2
* 2 minutes ago https://github.com/kopia/htmlui/commit/7eb8e55 dependabot[bot] build(deps): bump bootstrap from 5.3.1 to 5.3.3

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Wed Jun  5 21:53:20 UTC 2024*
