### PR TITLE
refactor(general): better encapsulate user profile implementation

### DIFF
--- a/cli/command_user_add_set.go
+++ b/cli/command_user_add_set.go
@@ -44,25 +44,13 @@ func (c *commandServerUserAddSet) setup(svc appServices, parent commandParent, i
 }
 
 func (c *commandServerUserAddSet) getExistingOrNewUserProfile(ctx context.Context, rep repo.Repository, username string) (*user.Profile, error) {
-	up, err := user.GetUserProfile(ctx, rep, username)
-
 	if c.isNew {
-		switch {
-		case err == nil:
-			return nil, errors.Errorf("user %q already exists", username)
+		up, err := user.GetNewProfile(ctx, rep, username)
 
-		case errors.Is(err, user.ErrUserNotFound):
-			passwordHashVersion, err := user.GetPasswordHashVersion(c.userSetPasswordHashAlgorithm)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to get password hash version")
-			}
-
-			return &user.Profile{
-				Username:            username,
-				PasswordHashVersion: passwordHashVersion,
-			}, nil
-		}
+		return up, errors.Wrap(err, "error getting new user profile")
 	}
+
+	up, err := user.GetUserProfile(ctx, rep, username)
 
 	return up, errors.Wrap(err, "error getting user profile")
 }

--- a/internal/user/password_hashing_version.go
+++ b/internal/user/password_hashing_version.go
@@ -1,0 +1,4 @@
+package user
+
+// defaultPasswordHashVersion is the default scheme used for user password hashing.
+const defaultPasswordHashVersion = ScryptHashVersion

--- a/internal/user/password_hashing_version.go
+++ b/internal/user/password_hashing_version.go
@@ -1,4 +1,18 @@
 package user
 
+import "github.com/pkg/errors"
+
 // defaultPasswordHashVersion is the default scheme used for user password hashing.
 const defaultPasswordHashVersion = ScryptHashVersion
+
+// getPasswordHashAlgorithm returns the password hash algorithm given a version.
+func getPasswordHashAlgorithm(passwordHashVersion int) (string, error) {
+	switch passwordHashVersion {
+	case ScryptHashVersion:
+		return scryptHashAlgorithm, nil
+	case Pbkdf2HashVersion:
+		return pbkdf2HashAlgorithm, nil
+	default:
+		return "", errors.Errorf("unsupported hash version (%d)", passwordHashVersion)
+	}
+}

--- a/internal/user/user_manager.go
+++ b/internal/user/user_manager.go
@@ -21,6 +21,9 @@ const UsernameAtHostnameLabel = "username"
 // ErrUserNotFound is returned to indicate that a user was not found in the system.
 var ErrUserNotFound = errors.New("user not found")
 
+// ErrUserAlreadyExists indicates that a user already exist in the system when attempting to create a new one.
+var ErrUserAlreadyExists = errors.New("user already exists found")
+
 // LoadProfileMap returns the map of all users profiles in the repository by username, using old map as a cache.
 func LoadProfileMap(ctx context.Context, rep repo.Repository, old map[string]*Profile) (map[string]*Profile, error) {
 	if rep == nil {
@@ -97,6 +100,32 @@ func GetUserProfile(ctx context.Context, r repo.Repository, username string) (*P
 	}
 
 	return p, nil
+}
+
+// GetNewProfile returns a profile for a new user with the given username.
+// Returns ErrUserAlreadyExists when the user already exists.
+func GetNewProfile(ctx context.Context, r repo.Repository, username string) (*Profile, error) {
+	if err := ValidateUsername(username); err != nil {
+		return nil, err
+	}
+
+	manifests, err := r.FindManifests(ctx, map[string]string{
+		manifest.TypeLabelKey:   ManifestType,
+		UsernameAtHostnameLabel: username,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error looking for user profile")
+	}
+
+	if len(manifests) != 0 {
+		return nil, errors.Wrap(ErrUserAlreadyExists, username)
+	}
+
+	return &Profile{
+			Username:            username,
+			PasswordHashVersion: defaultPasswordHashVersion,
+		},
+		nil
 }
 
 // validUsernameRegexp matches username@hostname where both username and hostname consist of

--- a/internal/user/user_manager_test.go
+++ b/internal/user/user_manager_test.go
@@ -59,6 +59,29 @@ func TestUserManager(t *testing.T) {
 	}
 }
 
+func TestGetNewProfile(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+
+	p, err := user.GetNewProfile(ctx, env.RepositoryWriter, "alice@somehost")
+
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	err = p.SetPassword("badpassword")
+	require.NoError(t, err)
+
+	err = user.SetUserProfile(ctx, env.RepositoryWriter, p)
+	require.NoError(t, err)
+
+	p, err = user.GetNewProfile(ctx, env.RepositoryWriter, p.Username)
+	require.ErrorIs(t, err, user.ErrUserAlreadyExists)
+	require.Nil(t, p)
+
+	p, err = user.GetNewProfile(ctx, env.RepositoryWriter, "nonexisting@somehost")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+}
+
 func TestValidateUsername_Valid(t *testing.T) {
 	cases := []string{
 		"foo@bar",

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -4,8 +4,6 @@ import (
 	"math/rand"
 
 	"github.com/kopia/kopia/repo/manifest"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -65,16 +63,4 @@ func (p *Profile) IsValidPassword(password string) (bool, error) {
 	}
 
 	return isValidPassword(password, p.PasswordHash, passwordHashAlgorithm)
-}
-
-// GetPasswordHashVersion returns the password hash version given an algorithm.
-func GetPasswordHashVersion(passwordHashAlgorithm string) (int, error) {
-	switch passwordHashAlgorithm {
-	case scryptHashAlgorithm:
-		return ScryptHashVersion, nil
-	case pbkdf2HashAlgorithm:
-		return Pbkdf2HashVersion, nil
-	default:
-		return 0, errors.Errorf("unsupported hash algorithm (%s)", passwordHashAlgorithm)
-	}
 }

--- a/internal/user/user_profile.go
+++ b/internal/user/user_profile.go
@@ -67,18 +67,6 @@ func (p *Profile) IsValidPassword(password string) (bool, error) {
 	return isValidPassword(password, p.PasswordHash, passwordHashAlgorithm)
 }
 
-// getPasswordHashAlgorithm returns the password hash algorithm given a version.
-func getPasswordHashAlgorithm(passwordHashVersion int) (string, error) {
-	switch passwordHashVersion {
-	case ScryptHashVersion:
-		return scryptHashAlgorithm, nil
-	case Pbkdf2HashVersion:
-		return pbkdf2HashAlgorithm, nil
-	default:
-		return "", errors.Errorf("unsupported hash version (%d)", passwordHashVersion)
-	}
-}
-
 // GetPasswordHashVersion returns the password hash version given an algorithm.
 func GetPasswordHashVersion(passwordHashAlgorithm string) (int, error) {
 	switch passwordHashAlgorithm {


### PR DESCRIPTION
Motivation: better encapsulate the implementation details for user profiles, in particular with respect to password hashing schemes.

- Pass hash version to `computePasswordHash` to encapsulate the internal representation of hashing schemes in user profiles.
- Add `user.GetNewProfile` helper to initialize a `user.Profile` in the `user` package. This avoids exposing hashing versions outside of the user package.
