### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/klauspost/compress v1.17.9
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.1
-	github.com/kopia/htmluibuild v0.0.1-0.20240605215256-b2112bbc1ca5
+	github.com/kopia/htmluibuild v0.0.1-0.20240618020100-a11369172a32
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.71

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.1 h1:NhWgum1efX1x58daOBGCFWcxtEhOhXKKl1HAPQUp03Q=
 github.com/klauspost/reedsolomon v1.12.1/go.mod h1:nEi5Kjb6QqtbofI6s+cbG/j1da11c96IBYBSnVGtuBs=
-github.com/kopia/htmluibuild v0.0.1-0.20240605215256-b2112bbc1ca5 h1:H/gGYl4urkdSdj44Ot92p1edtMquZgYPnXFtBo/XiFY=
-github.com/kopia/htmluibuild v0.0.1-0.20240605215256-b2112bbc1ca5/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20240618020100-a11369172a32 h1:q1PGJq7w7Q0Jt5arQ9uDGetIgq1f6B6QKIQjX+UHuTM=
+github.com/kopia/htmluibuild v0.0.1-0.20240618020100-a11369172a32/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/7eb8e55c7069209ba8b78a5643a04f7b44709805...9e0b2bc5f113651c88c0d61df24df71d96f27ced

* Mon 18:59 -0700 https://github.com/kopia/htmlui/commit/9e0b2bc dependabot[bot] build(deps): bump braces from 3.0.2 to 3.0.3

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Tue Jun 18 02:01:17 UTC 2024*
