### PR TITLE
chore(deps): group observability dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
         - "github.com/minio/minio-go/*"
         - "golang.org/x/*"
         - "google.golang.org/*"
+      telemetry-dependencies:
+        patterns:
         - "github.com/prometheus/*"
         - "go.opentelemetry.io/*"
   - package-ecosystem: github-actions


### PR DESCRIPTION
In the past, otel dependencies have introduced non-trivial depencency conflicts.