### PR TITLE
fix(server): ensure repo disconnection on `server start` exit

### DIFF
--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -533,7 +533,7 @@ func TestServerStartInsecure(t *testing.T) {
 	e.RunAndExpectFailure(t, "server", "start", "--ui", "--address=localhost:0", "--tls-generate-cert", "--without-password")
 
 	// server fails to start with TLS but without password.
-	e.RunAndExpectFailure(t, "server", "start", "--ui", "--address=localhost:0", "--password=foo")
+	e.RunAndExpectFailure(t, "server", "start", "--ui", "--address=localhost:0")
 	e.RunAndExpectFailure(t, "server", "start", "--ui", "--address=localhost:0", "--without-password")
 }
 

--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -529,12 +529,12 @@ func TestServerStartInsecure(t *testing.T) {
 
 	waitUntilServerStarted(ctx, t, cli)
 
-	// server fails to start without a password but with TLS.
-	e.RunAndExpectFailure(t, "server", "start", "--ui", "--address=localhost:0", "--tls-generate-cert", "--without-password")
+	// server fails to start with --without-password when `--insecure` is not specified
+	e.RunAndExpectFailure(t, "server", "start", "--ui", "--address=localhost:0", "--without-password")                        // without TLS
+	e.RunAndExpectFailure(t, "server", "start", "--ui", "--address=localhost:0", "--without-password", "--tls-generate-cert") // with TLS
 
-	// server fails to start with TLS but without password.
+	// server fails to start when TLS is not configured and `--insecure` is not specified
 	e.RunAndExpectFailure(t, "server", "start", "--ui", "--address=localhost:0")
-	e.RunAndExpectFailure(t, "server", "start", "--ui", "--address=localhost:0", "--without-password")
 }
 
 func verifyServerConnected(t *testing.T, cli *apiclient.KopiaAPIClient, want bool) *serverapi.StatusResponse {


### PR DESCRIPTION
Ensure repository disconnection at the end of the `server start` CLI command.
This was caught as a result of fixing the test below.

Fix `TestServerStartInsecure`:
Remove `--password=xxx` parameter, which causes a server start failure due to incorrect repo password, and not for the case being checked, which is the lack of the `--insecure` parameter.

Update test comments accordingly.
