### PR TITLE
test(general): allow delete random snapshot action

### DIFF
--- a/tests/robustness/multiclient_test/multiclient_test.go
+++ b/tests/robustness/multiclient_test/multiclient_test.go
@@ -239,13 +239,14 @@ func tryRandomAction(ctx context.Context, t *testing.T, opts engine.ActionOpts) 
 }
 
 // tryDeleteAction runs the given delete action,
-// delete-files or delete-random-subdirectory
+// delete-files or delete-random-subdirectory or delete-random-snapID
 // with options and masks no-op errors, and asserts when called for any other action.
 func tryDeleteAction(ctx context.Context, t *testing.T, action engine.ActionKey, actionOpts map[string]string) {
 	t.Helper()
 	eligibleActionsList := []engine.ActionKey{
 		engine.DeleteDirectoryContentsActionKey,
 		engine.DeleteRandomSubdirectoryActionKey,
+		engine.DeleteRandomSnapshotActionKey,
 	}
 	require.Contains(t, eligibleActionsList, action)
 


### PR DESCRIPTION
This PR fixes a failure introduced in https://github.com/kopia/kopia/pull/3963

The function `tryDeleteAction` should allow the delete-random-snapID action. 

Local run was successful. 