### PR TITLE
chore(ci): re-enable KopiaUI build on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ endif
 endif
 endif
 	$(MAKE) kopia
-ifeq ($(GOARCH),amd64)
+ifneq ($(GOOS)/$(GOARCH),linux/arm64)
 	$(retry) $(MAKE) kopia-ui
 	$(retry) $(MAKE) kopia-ui-test
 endif


### PR DESCRIPTION
Looks like GHA switched to ARM64 runners on macOS.