### PR TITLE
fix(cli): validate safety flag with Action()

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -366,8 +366,6 @@ func (c *App) Attach(app *kingpin.Application) {
 
 // safetyFlagVar defines c --safety=none|full flag that sets the SafetyParameters.
 func safetyFlagVar(cmd *kingpin.CmdClause, result *maintenance.SafetyParameters) {
-	var str string
-
 	*result = maintenance.SafetyFull
 
 	safetyByName := map[string]maintenance.SafetyParameters{
@@ -375,8 +373,13 @@ func safetyFlagVar(cmd *kingpin.CmdClause, result *maintenance.SafetyParameters)
 		"full": maintenance.SafetyFull,
 	}
 
-	cmd.Flag("safety", "Safety level").Default("full").PreAction(func(_ *kingpin.ParseContext) error {
-		r, ok := safetyByName[str]
+	str := cmd.Flag("safety", "Safety level").Default("full").Enum("full", "none")
+
+	// Set an Action callback instead of PreAction so it is only called after parsing and validation succeeds.
+	// Set callback on cmd before the actual "run" callback for the command so
+	// this callback is executed before the command "runs".
+	cmd.Action(func(_ *kingpin.ParseContext) error {
+		r, ok := safetyByName[*str]
 		if !ok {
 			return errors.New("unhandled safety level")
 		}
@@ -384,7 +387,7 @@ func safetyFlagVar(cmd *kingpin.CmdClause, result *maintenance.SafetyParameters)
 		*result = r
 
 		return nil
-	}).EnumVar(&str, "full", "none")
+	})
 }
 
 func (c *App) currentActionName() string {

--- a/cli/command_maintenance_run_test.go
+++ b/cli/command_maintenance_run_test.go
@@ -1,0 +1,22 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/cli"
+	"github.com/kopia/kopia/internal/logfile"
+)
+
+func TestMaintenanceRunReportsInvalidGlobalFlag(t *testing.T) {
+	app := cli.NewApp()
+	parser := kingpin.New("kopia", "")
+	logfile.Attach(app, parser)
+	app.Attach(parser)
+
+	_, err := parser.Parse([]string{"--log-level=warn", "maintenance", "run", "--safety=none"})
+
+	require.ErrorContains(t, err, "enum value must be one of debug,info,warning,error, got 'warn'")
+}


### PR DESCRIPTION
Validate the maintenance safety level flag using `cmd.Action()` instead of `flag.PreAction()`

Ref:
- #4008