### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.17.9
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.3
-	github.com/kopia/htmluibuild v0.0.1-0.20240701232248-2fbad5a561f8
+	github.com/kopia/htmluibuild v0.0.1-0.20240804050249-8f9f37171982
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.74

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.3 h1:tzUznbfc3OFwJaTebv/QdhnFf2Xvb7gZ24XaHLBPmdc=
 github.com/klauspost/reedsolomon v1.12.3/go.mod h1:3K5rXwABAvzGeR01r6pWZieUALXO/Tq7bFKGIb4m4WI=
-github.com/kopia/htmluibuild v0.0.1-0.20240701232248-2fbad5a561f8 h1:fOL97sehrUUUQB3YTVUVYFGY7Z192OEct78tI4aDEvo=
-github.com/kopia/htmluibuild v0.0.1-0.20240701232248-2fbad5a561f8/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20240804050249-8f9f37171982 h1:3Q7nQDgFMq5iR609yDWPORsd3dXiqLzjr8Ka/JIlSYI=
+github.com/kopia/htmluibuild v0.0.1-0.20240804050249-8f9f37171982/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/29ab9112e08e8f4f06b54ef118b0a91fbc91d7dd...fa70e3e6cd7b0cde5d829b34ce5b25a717850673

* Sat 22:01 -0700 https://github.com/kopia/htmlui/commit/fa70e3e dependabot[bot] build(deps): bump react-bootstrap from 2.8.0 to 2.10.4

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Sun Aug  4 05:03:05 UTC 2024*
