### PR TITLE
Revert "chore(ci): silence `TestIndexBlobManagerStress` output on failure"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,13 +275,9 @@ test-with-coverage: $(gotestsum) $(TESTING_ACTION_EXE)
 
 test: GOTESTSUM_FLAGS=--format=$(GOTESTSUM_FORMAT) --no-summary=skipped --jsonfile=.tmp.unit-tests.json
 test: export TESTING_ACTION_EXE ?= $(TESTING_ACTION_EXE)
-test: $(gotestsum) $(TESTING_ACTION_EXE) test-index-blob-v0
-	$(GO_TEST) $(UNIT_TEST_RACE_FLAGS) -tags testing -count=$(REPEAT_TEST) -timeout $(UNIT_TESTS_TIMEOUT) -skip '^TestIndexBlobManagerStress$$' ./...
+test: $(gotestsum) $(TESTING_ACTION_EXE)
+	$(GO_TEST) $(UNIT_TEST_RACE_FLAGS) -tags testing -count=$(REPEAT_TEST) -timeout $(UNIT_TESTS_TIMEOUT) ./...
 	-$(gotestsum) tool slowest --jsonfile .tmp.unit-tests.json  --threshold 1000ms
-
-test-index-blob-v0: GOTESTSUM_FLAGS=--format=testname --no-summary=skipped
-test-index-blob-v0: $(gotestsum) $(TESTING_ACTION_EXE)
-	$(GO_TEST) $(UNIT_TEST_RACE_FLAGS) -tags testing -count=$(REPEAT_TEST) -timeout $(UNIT_TESTS_TIMEOUT)  -run '^TestIndexBlobManagerStress$$' ./repo/content/indexblob/...
 
 provider-tests-deps: $(gotestsum) $(rclone) $(MINIO_MC_PATH)
 


### PR DESCRIPTION
Reverts kopia/kopia#4028

It's causing issues in CI