### PR TITLE
chore(ci): silence `TestIndexBlobManagerStress` output on failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,8 @@ jobs:
       if: ${{ contains(matrix.os, 'macos') }}
     - name: Setup
       run: make -j4 ci-setup
+    - name: Test Blob Index Manager V0
+      run: make test-index-blob-v0
     - name: Tests
       run: make ci-tests
     - name: Integration Tests

--- a/Makefile
+++ b/Makefile
@@ -275,9 +275,13 @@ test-with-coverage: $(gotestsum) $(TESTING_ACTION_EXE)
 
 test: GOTESTSUM_FLAGS=--format=$(GOTESTSUM_FORMAT) --no-summary=skipped --jsonfile=.tmp.unit-tests.json
 test: export TESTING_ACTION_EXE ?= $(TESTING_ACTION_EXE)
-test: $(gotestsum) $(TESTING_ACTION_EXE)
-	$(GO_TEST) $(UNIT_TEST_RACE_FLAGS) -tags testing -count=$(REPEAT_TEST) -timeout $(UNIT_TESTS_TIMEOUT) ./...
+test: $(gotestsum) $(TESTING_ACTION_EXE) test-index-blob-v0
+	$(GO_TEST) $(UNIT_TEST_RACE_FLAGS) -tags testing -count=$(REPEAT_TEST) -timeout $(UNIT_TESTS_TIMEOUT) -skip '^TestIndexBlobManagerStress$$' ./...
 	-$(gotestsum) tool slowest --jsonfile .tmp.unit-tests.json  --threshold 1000ms
+
+test-index-blob-v0: GOTESTSUM_FLAGS=--format=testname --no-summary=skipped
+test-index-blob-v0: $(gotestsum) $(TESTING_ACTION_EXE)
+	$(GO_TEST) $(UNIT_TEST_RACE_FLAGS) -tags testing -count=$(REPEAT_TEST) -timeout $(UNIT_TESTS_TIMEOUT)  -run '^TestIndexBlobManagerStress$$' ./repo/content/indexblob/...
 
 provider-tests-deps: $(gotestsum) $(rclone) $(MINIO_MC_PATH)
 

--- a/Makefile
+++ b/Makefile
@@ -275,11 +275,11 @@ test-with-coverage: $(gotestsum) $(TESTING_ACTION_EXE)
 
 test: GOTESTSUM_FLAGS=--format=$(GOTESTSUM_FORMAT) --no-summary=skipped --jsonfile=.tmp.unit-tests.json
 test: export TESTING_ACTION_EXE ?= $(TESTING_ACTION_EXE)
-test: $(gotestsum) $(TESTING_ACTION_EXE) test-index-blob-v0
+test: $(gotestsum) $(TESTING_ACTION_EXE)
 	$(GO_TEST) $(UNIT_TEST_RACE_FLAGS) -tags testing -count=$(REPEAT_TEST) -timeout $(UNIT_TESTS_TIMEOUT) -skip '^TestIndexBlobManagerStress$$' ./...
 	-$(gotestsum) tool slowest --jsonfile .tmp.unit-tests.json  --threshold 1000ms
 
-test-index-blob-v0: GOTESTSUM_FLAGS=--format=testname --no-summary=skipped
+test-index-blob-v0: GOTESTSUM_FLAGS=--format=pkgname --no-summary=output,skipped
 test-index-blob-v0: $(gotestsum) $(TESTING_ACTION_EXE)
 	$(GO_TEST) $(UNIT_TEST_RACE_FLAGS) -tags testing -count=$(REPEAT_TEST) -timeout $(UNIT_TESTS_TIMEOUT)  -run '^TestIndexBlobManagerStress$$' ./repo/content/indexblob/...
 


### PR DESCRIPTION
Another attempt.

Partially reverts commit commit: 2d2e0314

Changes the approach slightly. Uses `gotestsum`'s `pkgname` output format.
The `testname` format appears to always produce output, at least on GH,
but not locally 🤷🏼 

Ref:
- https://github.com/kopia/kopia/pull/4028
- https://github.com/kopia/kopia/pull/4035
