### PR TITLE
feat(repo): Add `sshfs` to docker container

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV 		DEBIAN_FRONTEND="noninteractive" \
 
 RUN 		apt-get update && \
 		    apt-get upgrade -y --with-new-pkgs && \
-		    apt-get install -y --no-install-recommends fuse3 ca-certificates curl tzdata && \
+		    apt-get install -y --no-install-recommends fuse3 ca-certificates curl tzdata sshfs && \
 		    apt-get clean autoclean -y && \
     		apt-get autoremove -y && \
     		rm -rf /var/lib/apt/* /var/lib/cache/* /var/lib/log/* \


### PR DESCRIPTION
Hey, everyone :wave: 
I'm pretty new to Kopia & kind of have the same problem as described in https://github.com/kopia/kopia/issues/1636
sshfs would work, but it's a bit annoying getting this to work inside the docker container

This PR simply adds sshfs to the docker container, allowing the use of sshfs in before & after backup scripts

If my usecase is too niche, I can attempt building the container myself, but I think that there are some people, that would benefit from this