### PR TITLE
feat(repository): Stream loading of manifests

### DIFF
--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -161,11 +161,13 @@ func (m *committedManifestManager) loadCommittedContentsLocked(ctx context.Conte
 				ci.ContentID,
 				func(e *manifestEntry) bool {
 					mu.Lock()
-					defer mu.Unlock()
-
 					prev := committedEntries[e.ID]
+					mu.Unlock()
+
 					if prev == nil || e.ModTime.After(prev.ModTime) {
+						mu.Lock()
 						committedEntries[e.ID] = e
+						mu.Unlock()
 					}
 
 					// Continue iteration.

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -3,9 +3,11 @@ package manifest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -311,8 +313,8 @@ type contentManagerOpts struct {
 	readOnly bool
 }
 
-func newContentManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.DataMap, opts contentManagerOpts) contentManager {
-	t.Helper()
+func newContentManagerForTesting(ctx context.Context, tb testing.TB, data blobtesting.DataMap, opts contentManagerOpts) contentManager {
+	tb.Helper()
 
 	st := blobtesting.NewMapStorage(data, nil, nil)
 
@@ -329,12 +331,12 @@ func newContentManagerForTesting(ctx context.Context, t *testing.T, data blobtes
 		},
 	}, nil)
 
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	bm, err := content.NewManagerForTesting(ctx, st, fop, nil, nil)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	t.Cleanup(func() { bm.CloseShared(ctx) })
+	tb.Cleanup(func() { bm.CloseShared(ctx) })
 
 	return bm
 }
@@ -441,8 +443,8 @@ func TestManifestConfigureAutoCompaction(t *testing.T) {
 	}
 }
 
-func getManifestContentCount(ctx context.Context, t *testing.T, mgr *Manager) int {
-	t.Helper()
+func getManifestContentCount(ctx context.Context, tb testing.TB, mgr *Manager) int {
+	tb.Helper()
 
 	foundContents := 0
 
@@ -453,7 +455,7 @@ func getManifestContentCount(ctx context.Context, t *testing.T, mgr *Manager) in
 			foundContents++
 			return nil
 		}); err != nil {
-		t.Errorf("unable to list manifest content: %v", err)
+		tb.Errorf("unable to list manifest content: %v", err)
 	}
 
 	return foundContents
@@ -489,4 +491,105 @@ func TestManifestAutoCompactionWithReadOnly(t *testing.T) {
 	entries, err := mgr.Find(ctx, map[string]string{"color": "red"})
 	require.NoError(t, err, "forcing reload of manifest manager")
 	assert.Len(t, entries, 100)
+}
+
+// BenchmarkConcurrentCompactionLoading benchmarks the runtime of loading
+// multiple content pieces containing manifests that are all duplicates of each
+// other. Situations like this can arise when clients concurrently compact
+// manifests.
+func BenchmarkConcurrentCompactionLoading(b *testing.B) {
+	ctx := testlogging.Context(b)
+	data := blobtesting.DataMap{}
+
+	bm := newContentManagerForTesting(ctx, b, data, contentManagerOpts{})
+
+	// Setup a manifest manager with a bunch of manifests of non-trivial size.
+	mgr, err := NewManager(ctx, bm, ManagerOptions{}, nil)
+	require.NoError(b, err, "getting initial manifest manager")
+
+	// Manifest content will be ~1K when serialized.
+	manifestData := map[string]string{}
+	for i := range 64 {
+		str := fmt.Sprintf("%016d", i)
+		manifestData[str] = str
+	}
+
+	labels := map[string]string{"type": "item", "color": "red"}
+
+	for range 100 {
+		_, err = mgr.Put(ctx, labels, manifestData)
+		require.NoError(b, err, "adding item to manifest manager")
+
+		require.NoError(b, mgr.Flush(ctx))
+		require.NoError(b, mgr.b.Flush(ctx))
+	}
+
+	assert.Equal(
+		b,
+		100,
+		getManifestContentCount(ctx, b, mgr),
+		"expected number of content pieces",
+	)
+
+	// Open several other manifest mangers that will concurrently compact the set
+	// of manifests added above.
+	var (
+		wg sync.WaitGroup
+		c  = make(chan struct{})
+	)
+
+	for range 5 {
+		wg.Add(1)
+
+		// Use only asserts below to avoid calling require in goroutines.
+		go func() {
+			defer wg.Done()
+
+			<-c
+
+			mgr, err := NewManager(ctx, bm, ManagerOptions{}, nil)
+			assert.NoError(b, err, "getting compaction instance of manifest manager")
+
+			entries, err := mgr.Find(ctx, map[string]string{"color": "red"})
+			assert.NoError(b, err, "forcing reload of manifest manager")
+			assert.Len(b, entries, 100)
+		}()
+	}
+
+	close(c)
+
+	wg.Wait()
+
+	// If the above compaction attempts failed the benchmark then exit early.
+	if b.Failed() {
+		return
+	}
+
+	// Just log the number of compacted manifests since we can't guarantee they'll
+	// all run compaction due to race conditions.
+	b.Logf(
+		"have %d compacted manifest content pieces",
+		getManifestContentCount(ctx, b, mgr),
+	)
+
+	// Configure things for read-only mode since we don't care about compaction
+	// anymore.
+	bm = newContentManagerForTesting(
+		ctx,
+		b,
+		data,
+		contentManagerOpts{readOnly: true},
+	)
+
+	// Run the actual benchmark with the current setup.
+	b.ResetTimer()
+
+	for range b.N {
+		mgr, err = NewManager(ctx, bm, ManagerOptions{}, nil)
+		require.NoError(b, err, "getting benchmark instance of manifest manager")
+
+		entries, err := mgr.Find(ctx, map[string]string{"color": "red"})
+		require.NoError(b, err, "forcing reload of manifest manager")
+		assert.Len(b, entries, 100)
+	}
 }

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/blobtesting"
@@ -485,6 +486,7 @@ func TestManifestAutoCompactionWithReadOnly(t *testing.T) {
 	mgr, err = NewManager(ctx, bm, ManagerOptions{}, nil)
 	require.NoError(t, err, "getting other instance of manifest manager")
 
-	_, err = mgr.Find(ctx, map[string]string{"color": "red"})
+	entries, err := mgr.Find(ctx, map[string]string{"color": "red"})
 	require.NoError(t, err, "forcing reload of manifest manager")
+	assert.Len(t, entries, 100)
 }

--- a/repo/manifest/serialized.go
+++ b/repo/manifest/serialized.go
@@ -64,39 +64,6 @@ func stringToken(dec *json.Decoder) (string, error) {
 	return l, nil
 }
 
-func decodeManifestArray(r io.Reader) (manifest, error) {
-	var (
-		dec = json.NewDecoder(r)
-		res = manifest{}
-	)
-
-	if err := expectDelimToken(dec, objectOpen); err != nil {
-		return res, err
-	}
-
-	// Need to manually decode fields here since we can't reuse the stdlib
-	// decoder due to memory issues.
-	allProcessed, err := parseFields(
-		dec,
-		func(e *manifestEntry) bool {
-			res.Entries = append(res.Entries, e)
-			return true
-		},
-	)
-	if err != nil {
-		return res, err
-	}
-
-	if !allProcessed {
-		return res, errors.New("didn't see all entries for serialized manifest")
-	}
-
-	// Consumes closing object curly brace after we're done. Don't need to check
-	// for EOF because json.Decode only guarantees decoding the next JSON item in
-	// the stream so this follows that.
-	return res, expectDelimToken(dec, objectClose)
-}
-
 // forEachDeserializedEntry deserializes json data from the provided reader and
 // calls the provided callback for each *manifestEntry. Note that the callback
 // may be called on entries even if an error is later encountered while

--- a/repo/manifest/serialized_test.go
+++ b/repo/manifest/serialized_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,91 @@ func TestManifestDecode_BadInput(t *testing.T) {
 			t.Logf("%v", err)
 
 			require.Error(t, err)
+		})
+	}
+}
+
+func TestManifestDecode_StopEarly(t *testing.T) {
+	table := []struct {
+		name        string
+		input       string
+		expectEntry *manifestEntry
+		expectErr   bool
+	}{
+		{
+			name:  "EntryFoundLast_CompleteObject",
+			input: `{"entries":[{"id":"efg"},{"id":"abcd"}]}`,
+			expectEntry: &manifestEntry{
+				ID: "abcd",
+			},
+		},
+		{
+			name:  "EntryFoundFirst_CompleteObject",
+			input: `{"entries":[{"id":"abcd"},{"id":"efg"}]}`,
+			expectEntry: &manifestEntry{
+				ID: "abcd",
+			},
+		},
+		{
+			name:  "EntryFound_FirstInstanceWins",
+			input: `{"entries":[{"id":"abcd"},{"id":"abcd","deleted":true}]}`,
+			expectEntry: &manifestEntry{
+				ID: "abcd",
+			},
+		},
+		{
+			name:  "EntryNotFound_CompleteObject",
+			input: `{"entries":[{"id":"abcde"},{"id":"efg","deleted":true}]}`,
+		},
+		{
+			name:  "EntryNotFound_CompleteObjectWithOtherFields",
+			input: `{"foo":"bar"}`,
+		},
+		{
+			name:  "EntryNotFound_CompleteObjectNoEntries",
+			input: `{}`,
+		},
+		{
+			name:      "EntryNotFound_IncompleteObject",
+			input:     `{"foo":"bar"`,
+			expectErr: true,
+		},
+		{
+			name:      "EntryNotFound_IncompleteObject",
+			input:     `{"entries":[{"id":"abcde"},{"id":"efg","deleted":true}]`,
+			expectErr: true,
+		},
+		{
+			name:      "EntryFoundLast_IncompleteObject",
+			input:     `{"entries":[{"id":"efg",{"id":"abcd"}]}`,
+			expectErr: true,
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			var found *manifestEntry
+
+			r := strings.NewReader(test.input)
+			err := forEachDeserializedEntry(
+				r,
+				func(e *manifestEntry) bool {
+					if e.ID == "abcd" {
+						found = e
+						return false
+					}
+
+					return true
+				},
+			)
+
+			assert.Equal(t, test.expectEntry, found)
+
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/repo/manifest/serialized_test.go
+++ b/repo/manifest/serialized_test.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -12,6 +13,20 @@ import (
 
 	"github.com/kopia/kopia/repo/manifest/testdata"
 )
+
+func decodeManifestArray(r io.Reader) (manifest, error) {
+	var res manifest
+
+	err := forEachDeserializedEntry(
+		r,
+		func(e *manifestEntry) bool {
+			res.Entries = append(res.Entries, e)
+			return true
+		},
+	)
+
+	return res, err
+}
 
 func TestManifestDecode_GoodInput(t *testing.T) {
 	table := []struct {


### PR DESCRIPTION
Rewrite the logic for loading manifests in the manifest manager to merge individual manifestEntry structs instead of loading all manifestEntry's and then deduping them. This can help reduce memory requirements for repositories that have many duplicate manifests (either due to deletions or concurrent compaction) by discarding entries as soon as possible

It may also require less memory because it can stream unzipped, partially deserialized manifestEntry's instead of needing to hold all manifestEntry's. However, it does still require enough memory to fully pull the content pieces being loaded into memory plus space for any unique manifests already loaded so far

Some benchmark results from the original code and a few variations of this new code. Benchmarks with `-Old-` are the original implementation, benchmarks with `-New-` hold a lock for the entire duration (e.x. lock/defer unlock) of the callback function that merges manifests, benchmarks with `-FGL-` hold a lock to find the previous version of the manifest and again when adding a manifest when executing the callback function. As the benchmark still deals with a relatively small manifest footprint (100 manifests of ~1KB) memory savings may grow as the number of manifests does

```
BenchmarkConcurrentCompactionLoading-New-10     30000     3134501 ns/op     1983854 B/op     7811 allocs/op
BenchmarkConcurrentCompactionLoading-FGL-10     30000     2976051 ns/op     1983797 B/op     7809 allocs/op
BenchmarkConcurrentCompactionLoading-Old-10     30000     3090741 ns/op     1995876 B/op     7863 allocs/op
```