### PR TITLE
feat(repository): Add level of indirection to manifest manager

### DIFF
--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -251,7 +251,7 @@ func (m *committedManifestManager) writeEntriesLockedV1(
 			// based on an easily available metric, the number of contents we have in
 			// this group.
 			//
-			// If every snapshot manifest is ~2KB of data, then 10k of them is ~10MB
+			// If every snapshot manifest is ~1KB of data, then 10k of them is ~10MB
 			// of uncompressed content.
 			if len(staged) >= contentChunkLimit {
 				if err := m.writeContentChunkLocked(ctx, staged, buf); err != nil {

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -51,6 +51,8 @@ type committedManifestManager struct {
 	// Version 0 stored all manifest content inline with metadata. Version 1 adds
 	// a level of indirection to store manifest content as separate content blobs
 	// and has the metadata point to the content blob.
+	//
+	// +checklocks:cmmu
 	formatVersion int
 }
 
@@ -126,7 +128,9 @@ func (m *committedManifestManager) writeEntriesLocked(
 	}
 
 	// If we're just writing out dirty manifests, then allow writing them out in
-	// the v0 format if there's only a few of them.
+	// the v0 format if there's only a few of them. This is a simple check and
+	// won't catch cases like deleting a bunch of manifests and creating only a
+	// few new ones.
 	if m.formatVersion == 0 ||
 		(!isCompaction &&
 			//nolint:mnd

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -211,12 +211,20 @@ func (m *Manager) Find(ctx context.Context, labels map[string]string) ([]*EntryM
 }
 
 func cloneEntryMetadata(e *inMemManifestEntry) *EntryMetadata {
-	return &EntryMetadata{
+	res := &EntryMetadata{
 		ID:      e.ID,
 		Labels:  copyLabels(e.Labels),
 		Length:  len(e.Content),
 		ModTime: e.ModTime,
 	}
+
+	// It's technically possible for manifestEntries to have no content so we
+	// can't just check if the Length field is 0.
+	if e.formatVersion != 0 {
+		res.Length = int(e.Size)
+	}
+
+	return res
 }
 
 // matchesLabels returns true when all entries in 'b' are found in the 'a'.

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kopia/kopia/internal/metrics"
 	"github.com/kopia/kopia/repo/compression"
 	"github.com/kopia/kopia/repo/content"
-	"github.com/kopia/kopia/repo/content/index"
 	"github.com/kopia/kopia/repo/logging"
 )
 

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -683,7 +683,7 @@ func TestManifestAutoCompactionConvertsFormat(t *testing.T) {
 				t,
 				expectIndirect,
 				foundContents,
-				"expected number of  indirect manifest contents",
+				"expected number of indirect manifest contents",
 			)
 		})
 	}

--- a/repo/manifest/serialized.go
+++ b/repo/manifest/serialized.go
@@ -18,7 +18,15 @@ type manifestEntry struct {
 	Labels  map[string]string `json:"labels"`
 	ModTime time.Time         `json:"modified"`
 	Deleted bool              `json:"deleted,omitempty"`
-	Content json.RawMessage   `json:"data"`
+	Content json.RawMessage   `json:"data,omitempty"`
+	// For index versions 1 and above, this is the content ID the manifest data
+	// resides at.
+	ContentID string `json:"contentID,omitempty"`
+	// Version if the serialization format used to store this data. Version 0
+	// stores all manifest content in the Content field. Versions >= 1 store
+	// manifest content as separate content blobs in the content manager and add
+	// the content ID in ContentID.
+	Version int `json:"version,omitempty"`
 }
 
 const (

--- a/repo/manifest/serialized.go
+++ b/repo/manifest/serialized.go
@@ -36,8 +36,8 @@ type inMemManifestEntry struct {
 }
 
 type contentSet struct {
-	Contents []*manifestContent
-	Version  int `json:"version,omitempty"`
+	Contents []*manifestContent `json:"contents"`
+	Version  int                `json:"version,omitempty"`
 }
 
 type manifestContent struct {

--- a/repo/manifest/serialized.go
+++ b/repo/manifest/serialized.go
@@ -21,7 +21,7 @@ type manifestEntry struct {
 	Deleted bool              `json:"deleted,omitempty"`
 	Content json.RawMessage   `json:"data,omitempty"`
 	// For index versions 1 and above, this is the content ID the manifest data
-	// resides at.
+	// resides in.
 	ContentID string `json:"contentID,omitempty"`
 }
 
@@ -33,6 +33,16 @@ type inMemManifestEntry struct {
 	// this out to be for every in-memory struct but not persisted struct allows
 	// us to save some space when serializing content.
 	formatVersion int
+}
+
+type contentSet struct {
+	Contents []*manifestContent
+	Version  int `json:"version,omitempty"`
+}
+
+type manifestContent struct {
+	ID      ID              `json:"id"`
+	Content json.RawMessage `json:"data"`
 }
 
 const (

--- a/repo/manifest/serialized.go
+++ b/repo/manifest/serialized.go
@@ -26,7 +26,7 @@ type manifestEntry struct {
 }
 
 // inMemManifestEntry is the in-memory version of manifests. It adds a few
-// additional fields like a dirty flag and a format version.
+// additional fields like a format version.
 type inMemManifestEntry struct {
 	*manifestEntry
 	// formatVersion is the version this manifest was serialized with. Separating

--- a/repo/manifest/serialized.go
+++ b/repo/manifest/serialized.go
@@ -18,11 +18,13 @@ type manifestEntry struct {
 	ID      ID                `json:"id"`
 	Labels  map[string]string `json:"labels"`
 	ModTime time.Time         `json:"modified"`
+	Size    int32             `json:"size,omitempty"`
 	Deleted bool              `json:"deleted,omitempty"`
-	Content json.RawMessage   `json:"data,omitempty"`
-	// For index versions 1 and above, this is the content ID the manifest data
-	// resides in.
-	ContentID string `json:"contentID,omitempty"`
+	// Content contains either the acutal content of the manifest or the content
+	// ID of the content piece that contains the manifest's content. How to
+	// interpret this field should be determined by the version the manifest was
+	// stored with.
+	Content json.RawMessage `json:"data,omitempty"`
 }
 
 // inMemManifestEntry is the in-memory version of manifests. It adds a few

--- a/repo/manifest/serialized.go
+++ b/repo/manifest/serialized.go
@@ -154,7 +154,7 @@ func parseFields(dec *json.Decoder, res *manifest) error {
 		}
 
 		if _, ok := seenFields[l]; ok {
-			return errors.Errorf("repeated fieldi %q", l)
+			return errors.Errorf("repeated field %q", l)
 		}
 
 		// Only have `entries` field right now. Skip other fields.


### PR DESCRIPTION
This is a rough draft of #3321 meant to gather feedback about the approach in general before going more in-depth and fully writing out a solution

High-level points:
* adds a level of indirection to the manifest manager so that all manifest content is stored in content pieces separate from manifest metadata
* continues to use JSON/gzip for all persisted manifest data since it maintains the same serialization method as the previous implementation and is simple to get running
* groups manifest contents into larger chunks of data that are persisted as content pieces
* updated tests showing the proof-of-concept behaves as expected for simple read/write operations

This doesn't include the following as it's a proof-of-concept:
* optimizations to potentially reduce memory usage when reading large JSON arrays
* optimizations to make loading many manifests at the same time efficient (most things only seem to get manifest metadata instead of bulk-loading manifests)
* manifest content garbage collection and compaction code (i.e. compacting indirect manifest content pieces)
* robust error checking and recovery for things like content not found during lookups in indirect content pieces