### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.17.9
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.3
-	github.com/kopia/htmluibuild v0.0.1-0.20240805213311-7a0a2d1ebd77
+	github.com/kopia/htmluibuild v0.0.1-0.20240821004433-fc47a3948dbf
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.75

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.3 h1:tzUznbfc3OFwJaTebv/QdhnFf2Xvb7gZ24XaHLBPmdc=
 github.com/klauspost/reedsolomon v1.12.3/go.mod h1:3K5rXwABAvzGeR01r6pWZieUALXO/Tq7bFKGIb4m4WI=
-github.com/kopia/htmluibuild v0.0.1-0.20240805213311-7a0a2d1ebd77 h1:NEjDmNPXwiXcHd+b2aWUnRsuIB32VtOK4g0u06ZD3UQ=
-github.com/kopia/htmluibuild v0.0.1-0.20240805213311-7a0a2d1ebd77/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20240821004433-fc47a3948dbf h1:AWRWwCmpK/8HtARlcdMNCbHpg/Cx8KFwGR7984EHqZM=
+github.com/kopia/htmluibuild v0.0.1-0.20240821004433-fc47a3948dbf/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/907ebcc11a023c84e6f6edaef6ffd5b8078b327c...d318e37b877c62c93a226b54226da6d1d4df7752

* Tue 17:42 -0700 https://github.com/kopia/htmlui/commit/d318e37 dependabot[bot] build(deps-dev): bump axios from 1.6.0 to 1.7.4

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Wed Aug 21 00:44:51 UTC 2024*
