### PR TITLE
refactor(general): minor miscellaneous cleanups

### DIFF
--- a/cli/json_output.go
+++ b/cli/json_output.go
@@ -115,8 +115,7 @@ func (l *jsonList) end() {
 }
 
 func (l *jsonList) emit(v interface{}) {
-	fmt.Fprintf(l.o.out, l.separator)            //nolint:errcheck
-	fmt.Fprintf(l.o.out, "%s", l.o.jsonBytes(v)) //nolint:errcheck
+	fmt.Fprintf(l.o.out, "%s%s", l.separator, l.o.jsonBytes(v)) //nolint:errcheck
 
 	if l.o.jsonIndent {
 		l.separator = ","

--- a/cli/json_output.go
+++ b/cli/json_output.go
@@ -96,7 +96,7 @@ func (l *jsonList) begin(o *jsonOutput) {
 	l.o = o
 
 	if o.jsonOutput {
-		fmt.Fprintf(l.o.out, "[") //nolint:errcheck
+		fmt.Fprint(l.o.out, "[") //nolint:errcheck
 
 		if !o.jsonIndent {
 			l.separator = "\n "
@@ -107,10 +107,10 @@ func (l *jsonList) begin(o *jsonOutput) {
 func (l *jsonList) end() {
 	if l.o.jsonOutput {
 		if !l.o.jsonIndent {
-			fmt.Fprintf(l.o.out, "\n") //nolint:errcheck
+			fmt.Fprint(l.o.out, "\n") //nolint:errcheck
 		}
 
-		fmt.Fprintf(l.o.out, "]") //nolint:errcheck
+		fmt.Fprint(l.o.out, "]") //nolint:errcheck
 	}
 }
 

--- a/internal/gather/gather_bytes_test.go
+++ b/internal/gather/gather_bytes_test.go
@@ -314,7 +314,7 @@ func TestGatherBytesReaderAtVariableInputBufferSizes(t *testing.T) {
 
 			// write the generated data
 			n, err := preWrt.Write(buf)
-			require.NoErrorf(t, err, "Write() faiiled, inputBufferSize: %8", tc.inputBufferSize)
+			require.NoErrorf(t, err, "Write() faiiled, inputBufferSize: %v", tc.inputBufferSize)
 			require.Equalf(t, defaultAllocator.chunkSize, preWrt.alloc.chunkSize,
 				"this test expects that the default-allocator will be used, but we are using: %#v", preWrt.alloc)
 

--- a/internal/repodiag/log_manager_test.go
+++ b/internal/repodiag/log_manager_test.go
@@ -53,7 +53,7 @@ func TestLogManager_AutoFlush(t *testing.T) {
 		var b [1024]byte
 
 		rand.Read(b[:])
-		l.Infof(hex.EncodeToString(b[:]))
+		l.Info(hex.EncodeToString(b[:]))
 	}
 
 	w.Wait(ctx)

--- a/repo/blob/s3/s3_versioned_test.go
+++ b/repo/blob/s3/s3_versioned_test.go
@@ -748,7 +748,7 @@ func compareMetadata(tb testing.TB, a, b versionMetadata) {
 	// deletion-marker metadata is not returned by the delete blob operation,
 	// and can only be retrieved later by listing versions.
 	if !a.IsDeleteMarker {
-		require.Equalf(tb, a.Version, b.Version, "blob versions do not match a:%v b:v", a, b)
+		require.Equalf(tb, a.Version, b.Version, "blob versions do not match a:%v b:%v", a, b)
 	}
 }
 

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -833,7 +833,7 @@ func (bm *WriteManager) WriteContent(ctx context.Context, data gather.Bytes, pre
 		logbuf.AppendInt64(previousWriteTime)
 	}
 
-	bm.log.Debugf(logbuf.String())
+	bm.log.Debug(logbuf.String())
 
 	return contentID, bm.addToPackUnlocked(ctx, contentID, data, false, comp, previousWriteTime, mp)
 }

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -144,7 +144,7 @@ func (sm *SharedManager) preparePackDataContent(mp format.MutableParameters, pp 
 		sb.AppendUint32(info.PackedLength)
 		sb.AppendString(" d:")
 		sb.AppendBoolean(info.Deleted)
-		sm.log.Debugf(sb.String())
+		sm.log.Debug(sb.String())
 
 		packFileIndex.Add(info)
 	}

--- a/repo/ecc/ecc_rs_crc.go
+++ b/repo/ecc/ecc_rs_crc.go
@@ -179,7 +179,7 @@ func (r *ReedSolomonCrcECC) Encrypt(input gather.Bytes, _ []byte, output *gather
 
 	// WriteBuffer does not clear the data, so we must clear the padding
 	if lengthSize+len(copied) < len(inputBytes) {
-		clear(inputBytes[lengthSize+len(copied):])
+		fillWithZeros(inputBytes[lengthSize+len(copied):])
 	}
 
 	// Compute and store ECC + checksum
@@ -261,7 +261,7 @@ func (r *ReedSolomonCrcECC) Decrypt(input gather.Bytes, _ []byte, output *gather
 
 	// WriteBuffer does not clear the data, so we must clear the padding
 	if len(copied) < len(inputBytes) {
-		clear(inputBytes[len(copied):])
+		fillWithZeros(inputBytes[len(copied):])
 	}
 
 	eccBytes := inputBytes[:parityPlusCrcSizeInBlock*sizes.Blocks]

--- a/repo/ecc/ecc_utils.go
+++ b/repo/ecc/ecc_utils.go
@@ -34,9 +34,9 @@ func applyPercent(val int, percent float32) int {
 	return int(math.Floor(float64(val) * float64(percent)))
 }
 
-func clear(bytes []byte) {
-	for i := range bytes {
-		bytes[i] = 0
+func fillWithZeros(b []byte) {
+	for i := range b {
+		b[i] = 0
 	}
 }
 

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -740,7 +740,7 @@ func TestParallelUploadUploadsBlobsInParallel(t *testing.T) {
 
 	require.NoError(t, th.repo.Flush(ctx))
 
-	require.Greater(t, maxParallelCalls.Load(), int32(0))
+	require.Positive(t, maxParallelCalls.Load())
 }
 
 func randomBytes(n int64) []byte {

--- a/tests/recovery/recovery_test/recovery_test.go
+++ b/tests/recovery/recovery_test/recovery_test.go
@@ -218,7 +218,7 @@ func TestConsistencyWhenKill9AfterModify(t *testing.T) {
 
 	o, err := cmd.CombinedOutput()
 	require.NoError(t, err)
-	t.Logf(string(o))
+	t.Log(string(o))
 
 	// create snapshot with StderrPipe
 	cmd = exec.Command(kopiaExe, "snap", "create", newDir, "--json", "--parallel=1")
@@ -240,9 +240,8 @@ func TestConsistencyWhenKill9AfterModify(t *testing.T) {
 	stdout, err := bm.RestoreGivenOrRandomSnapshot("", restoreDir)
 	require.NoError(t, err)
 
-	t.Logf(stdout)
-
-	t.Logf("Compare restored data and original data:")
+	t.Log(stdout)
+	t.Log("Compare restored data and original data:")
 	CompareDirs(t, restoreDir, cmpDir)
 }
 
@@ -267,7 +266,7 @@ func killOnCondition(t *testing.T, cmd *exec.Cmd) {
 
 		for scanner.Scan() {
 			output := scanner.Text()
-			t.Logf(output)
+			t.Log(output)
 
 			// Check if the output contains the "hashing" etc.
 			if strings.Contains(output, "hashing") && strings.Contains(output, "hashed") && strings.Contains(output, "uploaded") {

--- a/tests/robustness/multiclient_test/framework/client.go
+++ b/tests/robustness/multiclient_test/framework/client.go
@@ -12,7 +12,9 @@ import (
 
 const nameLen int = 2
 
-var clientKey = struct{}{}
+type clientKeyT struct{}
+
+var clientKey clientKeyT
 
 // Client is a unique client for use in multiclient robustness tests.
 type Client struct {


### PR DESCRIPTION
Cleanups:

- use non-format variants of `Log`/`Print` with no additional args;
- fold in `Fprintf` call with no args into the following one;
- add missing arg placeholder in format strings;
- use `require.Positive` instead of `Greater(..., 0)`;
- rename function to `fillWithZeros` to avoid collision with builtin `clear`;
- define type for context key to avoid collisions;

See individual commits.