### PR TITLE
refactor(repository): Reduce memory allocations during manifest compaction

### DIFF
--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -32,7 +32,7 @@ type committedManifestManager struct {
 	// +checklocks:cmmu
 	committedEntries map[ID]*manifestEntry
 	// +checklocks:cmmu
-	committedContentIDs map[content.ID]bool
+	committedContentIDs map[content.ID]struct{}
 
 	// autoCompactionThreshold controls the threshold after which the manager auto-compacts
 	// manifest contents
@@ -79,7 +79,7 @@ func (m *committedManifestManager) findCommittedEntries(ctx context.Context, lab
 	return findEntriesMatchingLabels(m.committedEntries, labels), nil
 }
 
-func (m *committedManifestManager) commitEntries(ctx context.Context, entries map[ID]*manifestEntry) (map[content.ID]bool, error) {
+func (m *committedManifestManager) commitEntries(ctx context.Context, entries map[ID]*manifestEntry) (map[content.ID]struct{}, error) {
 	if len(entries) == 0 {
 		return nil, nil
 	}
@@ -98,7 +98,7 @@ func (m *committedManifestManager) commitEntries(ctx context.Context, entries ma
 // the lock via commitEntries()) and to compact existing committed entries during compaction
 // where the lock is already being held.
 // +checklocks:m.cmmu
-func (m *committedManifestManager) writeEntriesLocked(ctx context.Context, entries map[ID]*manifestEntry) (map[content.ID]bool, error) {
+func (m *committedManifestManager) writeEntriesLocked(ctx context.Context, entries map[ID]*manifestEntry) (map[content.ID]struct{}, error) {
 	if len(entries) == 0 {
 		return nil, nil
 	}
@@ -127,9 +127,9 @@ func (m *committedManifestManager) writeEntriesLocked(ctx context.Context, entri
 		delete(entries, e.ID)
 	}
 
-	m.committedContentIDs[contentID] = true
+	m.committedContentIDs[contentID] = struct{}{}
 
-	return map[content.ID]bool{contentID: true}, nil
+	return map[content.ID]struct{}{contentID: {}}, nil
 }
 
 // +checklocks:m.cmmu
@@ -192,10 +192,10 @@ func (m *committedManifestManager) loadCommittedContentsLocked(ctx context.Conte
 // +checklocks:m.cmmu
 func (m *committedManifestManager) loadManifestContentsLocked(manifests map[content.ID]manifest) {
 	m.committedEntries = map[ID]*manifestEntry{}
-	m.committedContentIDs = map[content.ID]bool{}
+	m.committedContentIDs = map[content.ID]struct{}{}
 
 	for contentID := range manifests {
-		m.committedContentIDs[contentID] = true
+		m.committedContentIDs[contentID] = struct{}{}
 	}
 
 	for _, man := range manifests {
@@ -269,7 +269,7 @@ func (m *committedManifestManager) compactLocked(ctx context.Context) error {
 
 	// add the newly-created content to the list, could be duplicate
 	for b := range m.committedContentIDs {
-		if written[b] {
+		if _, ok := written[b]; ok {
 			// do not delete content that was just written.
 			continue
 		}
@@ -374,7 +374,7 @@ func newCommittedManager(b contentManager, autoCompactionThreshold int) *committ
 		b:                       b,
 		debugID:                 debugID,
 		committedEntries:        map[ID]*manifestEntry{},
-		committedContentIDs:     map[content.ID]bool{},
+		committedContentIDs:     map[content.ID]struct{}{},
 		autoCompactionThreshold: autoCompactionThreshold,
 	}
 }

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -124,7 +124,6 @@ func (m *committedManifestManager) writeEntriesLocked(ctx context.Context, entri
 
 	for _, e := range entries {
 		m.committedEntries[e.ID] = e
-		delete(entries, e.ID)
 	}
 
 	m.committedContentIDs[contentID] = struct{}{}
@@ -257,12 +256,7 @@ func (m *committedManifestManager) compactLocked(ctx context.Context) error {
 	m.b.DisableIndexFlush(ctx)
 	defer m.b.EnableIndexFlush(ctx)
 
-	tmp := map[ID]*manifestEntry{}
-	for k, v := range m.committedEntries {
-		tmp[k] = v
-	}
-
-	written, err := m.writeEntriesLocked(ctx, tmp)
+	written, err := m.writeEntriesLocked(ctx, m.committedEntries)
 	if err != nil {
 		return err
 	}

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -215,6 +215,9 @@ func (m *Manager) Flush(ctx context.Context) error {
 	defer m.mu.Unlock()
 
 	_, err := m.committed.commitEntries(ctx, m.pendingEntries)
+	if err == nil {
+		m.pendingEntries = map[ID]*manifestEntry{}
+	}
 
 	return err
 }


### PR DESCRIPTION
Mostly aimed at reducing memory allocations during manifest compaction by not modifying the passed in set of items being persisted. Previously this set had persisted entries removed from it, which necessitated cloning the set of committed manifests during compaction. Assuming the number of manifests in the committed set is much larger than the number of dirty entries persisted during calls to `Flush()` this saves copying a map of pointers

Also makes a minor update to how committed contents are tracked since only the value `true` was stored in the map

Consolidated benchmark results with and without these changes where `XItems` represents the total number of manifest entries (benchmark included in PR for reference)
```
go test -v -run X -timeout 120m -bench . -benchmem -benchtime 100x ./repo/manifest/
goos: darwin
goarch: arm64
pkg: github.com/kopia/kopia/repo/manifest
BenchmarkLargeCompaction
BenchmarkLargeCompaction/10000Items
BenchmarkLargeCompaction/10000Items-10       100          20204307 ns/op         5823395 B/op      60463 allocs/op
BenchmarkLargeCompaction-PR/10000Items-10    100          18144909 ns/op         4806542 B/op      60180 allocs/op
BenchmarkLargeCompaction/100000Items
BenchmarkLargeCompaction/100000Items-10      100         241431648 ns/op        50366763 B/op     604206 allocs/op
BenchmarkLargeCompaction-PR/100000Items-10   100         213751905 ns/op        37580470 B/op     600200 allocs/op
BenchmarkLargeCompaction/1000000Items
BenchmarkLargeCompaction/1000000Items-10     100        2932598264 ns/op        613842307 B/op   6038552 allocs/op
BenchmarkLargeCompaction-PR/1000000Items-10  100        2498463415 ns/op        457776432 B/op   6000233 allocs/op

```