### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.17.9
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.3
-	github.com/kopia/htmluibuild v0.0.1-0.20240904044503-877dcdf30ccb
+	github.com/kopia/htmluibuild v0.0.1-0.20240905025602-b5c84c3f1de4
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.76

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.3 h1:tzUznbfc3OFwJaTebv/QdhnFf2Xvb7gZ24XaHLBPmdc=
 github.com/klauspost/reedsolomon v1.12.3/go.mod h1:3K5rXwABAvzGeR01r6pWZieUALXO/Tq7bFKGIb4m4WI=
-github.com/kopia/htmluibuild v0.0.1-0.20240904044503-877dcdf30ccb h1:qkEo7Yl4AI0ZbMuJh6nWUx0wtaD0YlSDXE4nwFdsm54=
-github.com/kopia/htmluibuild v0.0.1-0.20240904044503-877dcdf30ccb/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20240905025602-b5c84c3f1de4 h1:zqfXNghyeZEQs0myP9MwguZJQY39Qvg+yIdeusPUD/I=
+github.com/kopia/htmluibuild v0.0.1-0.20240905025602-b5c84c3f1de4/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/cb8c2e7e581bf222bb2a8145a1a93007eaa1b143...9f0e37f3790c1ea557dd5315aab1239166289913

* Wed 19:54 -0700 https://github.com/kopia/htmlui/commit/9f0e37f dependabot[bot] build(deps-dev): bump @testing-library/react from 15.0.6 to 16.0.1

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Thu Sep  5 02:56:29 UTC 2024*
