### PR TITLE
feat(server): snapshot metrics

### DIFF
--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -28,6 +28,7 @@ type commandPolicySet struct {
 	policySchedulingFlags
 	policyOSSnapshotFlags
 	policyUploadFlags
+	policyMetricsFlags
 }
 
 func (c *commandPolicySet) setup(svc appServices, parent commandParent) {
@@ -46,6 +47,7 @@ func (c *commandPolicySet) setup(svc appServices, parent commandParent) {
 	c.policySchedulingFlags.setup(cmd)
 	c.policyOSSnapshotFlags.setup(cmd)
 	c.policyUploadFlags.setup(cmd)
+	c.policyMetricsFlags.setup(cmd)
 
 	cmd.Action(svc.repositoryWriterAction(c.run))
 }
@@ -136,6 +138,10 @@ func (c *commandPolicySet) setPolicyFromFlags(ctx context.Context, p *policy.Pol
 
 	if err := c.setUploadPolicyFromFlags(ctx, &p.UploadPolicy, changeCount); err != nil {
 		return errors.Wrap(err, "upload policy")
+	}
+
+	if err := c.setMetricsPolicyFromFlags(ctx, &p.MetricsPolicy, changeCount); err != nil {
+		return errors.Wrap(err, "metrics policy")
 	}
 
 	// It's not really a list, just optional boolean, last one wins.

--- a/cli/command_policy_set_metrics.go
+++ b/cli/command_policy_set_metrics.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/snapshot/policy"
+)
+
+type policyMetricsFlags struct {
+	policyExposeMetrics string
+}
+
+func (c *policyMetricsFlags) setup(cmd *kingpin.CmdClause) {
+	cmd.Flag("expose-metrics", "Expose metrics ('true', 'false', 'inherit')").EnumVar(&c.policyExposeMetrics, booleanEnumValues...)
+}
+
+func (c *policyMetricsFlags) setMetricsPolicyFromFlags(ctx context.Context, mp *policy.MetricsPolicy, changeCount *int) error {
+	if err := applyPolicyBoolPtr(ctx, "expose metrics", &mp.ExposeMetrics, c.policyExposeMetrics, changeCount); err != nil {
+		return errors.Wrap(err, "expose metrics")
+	}
+
+	return nil
+}

--- a/cli/observability_flags.go
+++ b/cli/observability_flags.go
@@ -148,8 +148,6 @@ func (c *observabilityFlags) maybeStartListener(ctx context.Context) {
 		m.HandleFunc("/debug/pprof/{cmd}", pprof.Index) // special handling for Gorilla mux, see https://stackoverflow.com/questions/30560859/cant-use-go-tool-pprof-with-an-existing-server/71032595#71032595
 	}
 
-	log(ctx).Infof("starting prometheus metrics on %v", c.metricsListenAddr)
-
 	listener, err := net.Listen("tcp", c.metricsListenAddr)
 	if err != nil {
 		log(ctx).Warnf("unable to start listener: %v", err)

--- a/internal/metrics/metrics_gauge.go
+++ b/internal/metrics/metrics_gauge.go
@@ -53,6 +53,13 @@ func (r *Registry) RemoveGauge(g *Gauge) {
 	}
 }
 
+// RemoveAllGauges remove all gauges from the registry.
+func (r *Registry) RemoveAllGauges() {
+	for _, gauge := range r.allGauges {
+		r.RemoveGauge(gauge)
+	}
+}
+
 // newState initializes gauge state and returns previous state or nil.
 func (g *Gauge) newState() int64 {
 	return g.state.Swap(0)

--- a/internal/metrics/metrics_gauge.go
+++ b/internal/metrics/metrics_gauge.go
@@ -10,7 +10,7 @@ import (
 type Gauge struct {
 	state atomic.Int64
 
-	prom prometheus.Gauge
+	prom *prometheus.GaugeVec
 }
 
 // Set sets the gauge to a specific value.
@@ -19,7 +19,8 @@ func (g *Gauge) Set(v int64) {
 		return
 	}
 
-	g.prom.Set(float64(v))
+	g.prom.With(prometheus.Labels{}).Set(float64(v))
+
 	g.state.Store(v)
 }
 
@@ -29,7 +30,7 @@ func (g *Gauge) Add(v int64) {
 		return
 	}
 
-	g.prom.Add(float64(v))
+	g.prom.With(prometheus.Labels{}).Add(float64(v))
 	g.state.Add(v)
 }
 
@@ -45,7 +46,7 @@ func (r *Registry) RemoveGauge(g *Gauge) {
 	for fullName, gauge := range r.allGauges {
 		if gauge == g {
 			delete(r.allGauges, fullName)
-			prometheus.Unregister(g.prom)
+			g.prom.Delete(prometheus.Labels{})
 
 			return
 		}

--- a/internal/metrics/metrics_gauge.go
+++ b/internal/metrics/metrics_gauge.go
@@ -1,0 +1,79 @@
+package metrics
+
+import (
+	"sync/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Gauge represents a value that can go up and down.
+type Gauge struct {
+	state atomic.Int64
+
+	prom prometheus.Gauge
+}
+
+// Set sets the gauge to a specific value.
+func (g *Gauge) Set(v int64) {
+	if g == nil {
+		return
+	}
+
+	g.prom.Set(float64(v))
+	g.state.Store(v)
+}
+
+// Add adds a value to the gauge.
+func (g *Gauge) Add(v int64) {
+	if g == nil {
+		return
+	}
+
+	g.prom.Add(float64(v))
+	g.state.Add(v)
+}
+
+// newState initializes gauge state and returns previous state or nil.
+func (g *Gauge) newState() int64 {
+	return g.state.Swap(0)
+}
+
+// Snapshot captures the momentary state of a gauge.
+func (g *Gauge) Snapshot(reset bool) int64 {
+	if g == nil {
+		return 0
+	}
+
+	if reset {
+		return g.newState()
+	}
+
+	return g.state.Load()
+}
+
+// GaugeInt64 gets a persistent int64 gauge with the provided name.
+func (r *Registry) GaugeInt64(name, help string, labels map[string]string) *Gauge {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	fullName := name + labelsSuffix(labels)
+
+	g := r.allGauges[fullName]
+	if g == nil {
+		g = &Gauge{
+			prom: getPrometheusGauge(prometheus.GaugeOpts{
+				Name: prometheusPrefix + name,
+				Help: help,
+			}, labels),
+		}
+
+		g.newState()
+		r.allGauges[fullName] = g
+	}
+
+	return g
+}

--- a/internal/metrics/metrics_gauge.go
+++ b/internal/metrics/metrics_gauge.go
@@ -46,6 +46,7 @@ func (r *Registry) RemoveGauge(g *Gauge) {
 		if gauge == g {
 			delete(r.allGauges, fullName)
 			prometheus.Unregister(g.prom)
+
 			return
 		}
 	}
@@ -96,9 +97,10 @@ func (r *Registry) GaugeInt64(name, help string, labels map[string]string) *Gaug
 	return g
 }
 
-// Check if gauge exist in allGauges map
+// HasGauge returns true if gauge exist in allGauges map.
 func (r *Registry) HasGauge(name string, labels map[string]string) bool {
 	fullName := name + labelsSuffix(labels)
 	_, ok := r.allGauges[fullName]
+
 	return ok
 }

--- a/internal/metrics/metrics_gauge_test.go
+++ b/internal/metrics/metrics_gauge_test.go
@@ -68,6 +68,7 @@ func TestGauge_WithLabels(t *testing.T) {
 		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}).
 			GetGauge().GetValue())
 }
+
 func TestGauge_WithMultipleLabels(t *testing.T) {
 	e := metrics.NewRegistry()
 	gauge1 := e.GaugeInt64("last_snapshot_start_time", "Timestamp of the last snapshot start time", map[string]string{"host": "host1", "username": "user1", "path": "path1"})
@@ -94,12 +95,12 @@ func TestGauge_RemoveGauge(t *testing.T) {
 	require.NotNil(t, e.GaugeInt64("test_gauge", "test-help", nil))
 
 	// Verify the gauge exist in proemetheus registry
-	metrics, err := prometheus.DefaultGatherer.Gather()
+	m, err := prometheus.DefaultGatherer.Gather()
 	require.NoError(t, err)
 
 	found := false
-	for _, m := range metrics {
-		if *m.Name == "kopia_test_gauge" {
+	for _, m := range m {
+		if m.GetName() == "kopia_test_gauge" {
 			found = true
 			break
 		}
@@ -113,11 +114,11 @@ func TestGauge_RemoveGauge(t *testing.T) {
 	require.False(t, e.HasGauge("test_gauge", nil))
 
 	// Verify the gauge is removed from Prometheus registry
-	metrics, err = prometheus.DefaultGatherer.Gather()
+	m, err = prometheus.DefaultGatherer.Gather()
 	require.NoError(t, err)
 
-	for _, m := range metrics {
-		if *m.Name == "kopia_test_gauge" {
+	for _, m := range m {
+		if m.GetName() == "kopia_test_gauge" {
 			t.Errorf("gauge was not removed from Prometheus registry")
 		}
 	}

--- a/internal/metrics/metrics_gauge_test.go
+++ b/internal/metrics/metrics_gauge_test.go
@@ -1,0 +1,69 @@
+package metrics_test
+
+import (
+	"testing"
+
+	prommodel "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/metrics"
+)
+
+func TestGauge_Nil(t *testing.T) {
+	var e *metrics.Registry
+	gauge := e.GaugeInt64("aaa", "bbb", nil)
+	require.Nil(t, gauge)
+	gauge.Set(33)
+	require.Equal(t, int64(0), gauge.Snapshot(false))
+}
+
+func TestGauge_NoLabels(t *testing.T) {
+	e := metrics.NewRegistry()
+	gauge := e.GaugeInt64("some_gauge", "some-help", nil)
+
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, nil).
+			GetGauge().GetValue())
+	gauge.Set(33)
+	require.Equal(t, 33.0,
+		mustFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, nil).
+			GetGauge().GetValue())
+	gauge.Add(10)
+	require.Equal(t, 43.0,
+		mustFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, nil).
+			GetGauge().GetValue())
+
+	require.Equal(t, int64(43), gauge.Snapshot(false))
+
+	require.Equal(t, int64(43), gauge.Snapshot(true)) // reset
+	require.Equal(t, int64(0), gauge.Snapshot(false))
+}
+
+func TestGauge_WithLabels(t *testing.T) {
+	e := metrics.NewRegistry()
+	gauge1 := e.GaugeInt64("some_gauge_2", "some-help", map[string]string{"key1": "label1"})
+	gauge2 := e.GaugeInt64("some_gauge_2", "some-help", map[string]string{"key1": "label2"})
+
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"}).
+			GetGauge().GetValue())
+	require.Equal(t, 0.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}).
+			GetGauge().GetValue())
+	gauge1.Set(33)
+	gauge2.Set(44)
+	require.Equal(t, 44.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}).
+			GetGauge().GetValue())
+	require.Equal(t, 33.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"}).
+			GetGauge().GetValue())
+	gauge1.Add(10)
+	gauge2.Add(-10)
+	require.Equal(t, 43.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"}).
+			GetGauge().GetValue())
+	require.Equal(t, 34.0,
+		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}).
+			GetGauge().GetValue())
+}

--- a/internal/metrics/metrics_gauge_test.go
+++ b/internal/metrics/metrics_gauge_test.go
@@ -41,8 +41,8 @@ func TestGauge_NoLabels(t *testing.T) {
 
 func TestGauge_WithLabels(t *testing.T) {
 	e := metrics.NewRegistry()
-	gauge1 := e.GaugeInt64("some_gauge_2", "some-help", map[string]string{"key1": "label1"})
-	gauge2 := e.GaugeInt64("some_gauge_2", "some-help", map[string]string{"key1": "label2"})
+	gauge1 := e.GaugeInt64("some_gauge2", "some-help", map[string]string{"key1": "label1"})
+	gauge2 := e.GaugeInt64("some_gauge2", "some-help", map[string]string{"key1": "label2"})
 
 	require.Equal(t, 0.0,
 		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"}).

--- a/internal/metrics/metrics_gauge_test.go
+++ b/internal/metrics/metrics_gauge_test.go
@@ -21,6 +21,8 @@ func TestGauge_NoLabels(t *testing.T) {
 	e := metrics.NewRegistry()
 	gauge := e.GaugeInt64("some_gauge", "some-help", nil)
 
+	gauge.Set(0)
+
 	require.Equal(t, 0.0,
 		mustFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, nil).
 			GetGauge().GetValue())
@@ -43,6 +45,9 @@ func TestGauge_WithLabels(t *testing.T) {
 	e := metrics.NewRegistry()
 	gauge1 := e.GaugeInt64("some_gauge2", "some-help", map[string]string{"key1": "label1"})
 	gauge2 := e.GaugeInt64("some_gauge2", "some-help", map[string]string{"key1": "label2"})
+
+	gauge1.Set(0)
+	gauge2.Set(0)
 
 	require.Equal(t, 0.0,
 		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"}).
@@ -110,37 +115,37 @@ func TestGauge_RemoveGauge(t *testing.T) {
 
 func TestGauge_RemoveOneOfTwoGaugesWithLabels(t *testing.T) {
 	e := metrics.NewRegistry()
-	gauge1 := e.GaugeInt64("some_gauge", "test-help", map[string]string{"key1": "label1"})
-	gauge2 := e.GaugeInt64("some_gauge", "test-help", map[string]string{"key1": "label2"})
+	gauge1 := e.GaugeInt64("some_gauge_2", "test-help", map[string]string{"key1": "label1"})
+	gauge2 := e.GaugeInt64("some_gauge_2", "test-help", map[string]string{"key1": "label2"})
 
 	// Set values to ensure the gauges are created
 	gauge1.Set(42)
 	gauge2.Set(43)
 
 	// Verify the gauge exists in the registry
-	require.True(t, e.HasGauge("some_gauge", map[string]string{"key1": "label1"}))
-	require.True(t, e.HasGauge("some_gauge", map[string]string{"key1": "label2"}))
+	require.True(t, e.HasGauge("some_gauge_2", map[string]string{"key1": "label1"}))
+	require.True(t, e.HasGauge("some_gauge_2", map[string]string{"key1": "label2"}))
 
 	// Verify both gauges exist in prometheus registry
 	require.Equal(t, 42.0,
-		mustFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"}).
+		mustFindMetric(t, "kopia_some_gauge_2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"}).
 			GetGauge().GetValue())
 	require.Equal(t, 43.0,
-		mustFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}).
+		mustFindMetric(t, "kopia_some_gauge_2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}).
 			GetGauge().GetValue())
 
 	// Remove gauge1
 	e.RemoveGauge(gauge1)
 
 	// Verify gauge1 is removed from the registry
-	require.False(t, e.HasGauge("some_gauge", map[string]string{"key1": "label1"}))
+	require.False(t, e.HasGauge("some_gauge_2", map[string]string{"key1": "label1"}))
 
 	// Verify gauge1 is removed from Prometheus registry
-	mustNotFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"})
+	mustNotFindMetric(t, "kopia_some_gauge_2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label1"})
 
 	// Verify gauge2 still exists in the registry
-	require.True(t, e.HasGauge("some_gauge", map[string]string{"key1": "label2"}))
+	require.True(t, e.HasGauge("some_gauge_2", map[string]string{"key1": "label2"}))
 
 	// Verify gauge2 still exists in Prometheus registry
-	require.NotNil(t, mustFindMetric(t, "kopia_some_gauge", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}))
+	require.NotNil(t, mustFindMetric(t, "kopia_some_gauge_2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}))
 }

--- a/internal/metrics/metrics_gauge_test.go
+++ b/internal/metrics/metrics_gauge_test.go
@@ -67,3 +67,17 @@ func TestGauge_WithLabels(t *testing.T) {
 		mustFindMetric(t, "kopia_some_gauge2", prommodel.MetricType_GAUGE, map[string]string{"key1": "label2"}).
 			GetGauge().GetValue())
 }
+func TestGauge_WithMultipleLabels(t *testing.T) {
+	e := metrics.NewRegistry()
+	gauge1 := e.GaugeInt64("last_snapshot_start_time", "Timestamp of the last snapshot start time", map[string]string{"host": "host1", "username": "user1", "path": "path1"})
+	gauge2 := e.GaugeInt64("last_snapshot_start_time", "Timestamp of the last snapshot start time", map[string]string{"host": "host2", "username": "user2", "path": "path2"})
+
+	gauge1.Set(33)
+	gauge2.Set(44)
+	require.Equal(t, 33.0,
+		mustFindMetric(t, "kopia_last_snapshot_start_time", prommodel.MetricType_GAUGE, map[string]string{"host": "host1", "username": "user1", "path": "path1"}).
+			GetGauge().GetValue())
+	require.Equal(t, 44.0,
+		mustFindMetric(t, "kopia_last_snapshot_start_time", prommodel.MetricType_GAUGE, map[string]string{"host": "host2", "username": "user2", "path": "path2"}).
+			GetGauge().GetValue())
+}

--- a/internal/metrics/metrics_registry.go
+++ b/internal/metrics/metrics_registry.go
@@ -119,6 +119,9 @@ func (r *Registry) Close(ctx context.Context) error {
 		return nil
 	}
 
+	// This helps e2e testing to have a clean prometheus registry
+	r.RemoveAllGauges()
+
 	releasable.Released("metric-registry", r)
 
 	return nil

--- a/internal/metrics/prom_cache.go
+++ b/internal/metrics/prom_cache.go
@@ -20,7 +20,8 @@ var (
 	promCounters = map[string]*prometheus.CounterVec{}
 	// +checklocks:promCacheMutex
 	promHistograms = map[string]*prometheus.HistogramVec{}
-	promGauges     = map[string]*prometheus.GaugeVec{}
+	// +checklocks:promCacheMutex
+	promGauges = map[string]*prometheus.GaugeVec{}
 )
 
 func getPrometheusCounter(opts prometheus.CounterOpts, labels map[string]string) prometheus.Counter {

--- a/internal/metrics/prom_cache.go
+++ b/internal/metrics/prom_cache.go
@@ -37,7 +37,7 @@ func getPrometheusCounter(opts prometheus.CounterOpts, labels map[string]string)
 	return prom.WithLabelValues(maps.Values(labels)...)
 }
 
-func getPrometheusGauge(opts prometheus.GaugeOpts, labels map[string]string) prometheus.Gauge {
+func getPrometheusGauge(opts prometheus.GaugeOpts, labels map[string]string) *prometheus.GaugeVec {
 	promCacheMutex.Lock()
 	defer promCacheMutex.Unlock()
 
@@ -48,7 +48,7 @@ func getPrometheusGauge(opts prometheus.GaugeOpts, labels map[string]string) pro
 		promGauges[opts.Name] = prom
 	}
 
-	return prom.With(labels)
+	return prom.MustCurryWith(prometheus.Labels(labels))
 }
 
 func getPrometheusHistogram(opts prometheus.HistogramOpts, labels map[string]string) prometheus.Observer { //nolint:gocritic

--- a/internal/metrics/prom_cache.go
+++ b/internal/metrics/prom_cache.go
@@ -20,6 +20,7 @@ var (
 	promCounters = map[string]*prometheus.CounterVec{}
 	// +checklocks:promCacheMutex
 	promHistograms = map[string]*prometheus.HistogramVec{}
+	promGauges     = map[string]*prometheus.GaugeVec{}
 )
 
 func getPrometheusCounter(opts prometheus.CounterOpts, labels map[string]string) prometheus.Counter {
@@ -31,6 +32,20 @@ func getPrometheusCounter(opts prometheus.CounterOpts, labels map[string]string)
 		prom = promauto.NewCounterVec(opts, maps.Keys(labels))
 
 		promCounters[opts.Name] = prom
+	}
+
+	return prom.WithLabelValues(maps.Values(labels)...)
+}
+
+func getPrometheusGauge(opts prometheus.GaugeOpts, labels map[string]string) prometheus.Gauge {
+	promCacheMutex.Lock()
+	defer promCacheMutex.Unlock()
+
+	prom := promGauges[opts.Name]
+	if prom == nil {
+		prom = promauto.NewGaugeVec(opts, maps.Keys(labels))
+
+		promGauges[opts.Name] = prom
 	}
 
 	return prom.WithLabelValues(maps.Values(labels)...)

--- a/internal/metrics/prom_cache.go
+++ b/internal/metrics/prom_cache.go
@@ -48,7 +48,7 @@ func getPrometheusGauge(opts prometheus.GaugeOpts, labels map[string]string) pro
 		promGauges[opts.Name] = prom
 	}
 
-	return prom.WithLabelValues(maps.Values(labels)...)
+	return prom.With(labels)
 }
 
 func getPrometheusHistogram(opts prometheus.HistogramOpts, labels map[string]string) prometheus.Observer { //nolint:gocritic

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -672,6 +672,7 @@ func (s *Server) syncSourcesLocked(ctx context.Context) error {
 	// stop source manager for sources no longer in the repo.
 	for _, sm := range oldSourceManagers {
 		sm.stop(ctx)
+		sm.removeMetrics() // Remove metrics for the source manager
 	}
 
 	for src, sm := range oldSourceManagers {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -486,9 +486,6 @@ func handleShutdown(ctx context.Context, rc requestContext) (interface{}, *apiEr
 }
 
 func (s *Server) requestShutdown(ctx context.Context) {
-	// Workaround for passing tests
-	s.rep.Metrics().RemoveAllGauges()
-
 	if f := s.OnShutdown; f != nil {
 		go func() {
 			if err := f(ctx); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1005,13 +1005,6 @@ func (s *Server) getSchedulerItems(ctx context.Context, now time.Time) []schedul
 		NextTime:    nrt,
 	})
 
-	// add a scheduled item to refresh metrics
-	result = append(result, scheduler.Item{
-		Description: "refresh metrics",
-		Trigger:     s.refreshMetrics,
-		NextTime:    now.Add(1 * time.Minute), // Refresh metrics every minute
-	})
-
 	if s.maint != nil {
 		// If we have a direct repository, add an item to run maintenance.
 		// If we're the owner then nextMaintenanceTime will be zero.
@@ -1048,15 +1041,6 @@ func (s *Server) refreshScheduler(reason string) {
 	select {
 	case s.schedulerRefresh <- reason:
 	default:
-	}
-}
-
-func (s *Server) refreshMetrics() {
-	s.serverMutex.RLock()
-	defer s.serverMutex.RUnlock()
-
-	for _, sm := range s.sourceManagers {
-		sm.refreshStatus(s.rootctx)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1005,6 +1005,13 @@ func (s *Server) getSchedulerItems(ctx context.Context, now time.Time) []schedul
 		NextTime:    nrt,
 	})
 
+	// add a scheduled item to refresh metrics
+	result = append(result, scheduler.Item{
+		Description: "refresh metrics",
+		Trigger:     s.refreshMetrics,
+		NextTime:    now.Add(1 * time.Minute), // Refresh metrics every minute
+	})
+
 	if s.maint != nil {
 		// If we have a direct repository, add an item to run maintenance.
 		// If we're the owner then nextMaintenanceTime will be zero.
@@ -1041,6 +1048,15 @@ func (s *Server) refreshScheduler(reason string) {
 	select {
 	case s.schedulerRefresh <- reason:
 	default:
+	}
+}
+
+func (s *Server) refreshMetrics() {
+	s.serverMutex.RLock()
+	defer s.serverMutex.RUnlock()
+
+	for _, sm := range s.sourceManagers {
+		sm.refreshStatus(s.rootctx)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1000,18 +1000,17 @@ func (s *Server) getSchedulerItems(ctx context.Context, now time.Time) []schedul
 	s.nextRefreshTimeLock.Unlock()
 
 	// add a scheduled item to refresh all sources and policies
-	result = append(result, scheduler.Item{
-		Description: "refresh",
-		Trigger:     s.refreshAsync,
-		NextTime:    nrt,
-	})
-
-	// add a scheduled item to refresh metrics
-	result = append(result, scheduler.Item{
-		Description: "refresh metrics",
-		Trigger:     s.refreshMetrics,
-		NextTime:    now.Add(1 * time.Minute), // Refresh metrics every minute
-	})
+	result = append(result,
+		scheduler.Item{
+			Description: "refresh",
+			Trigger:     s.refreshAsync,
+			NextTime:    nrt,
+		},
+		scheduler.Item{
+			Description: "refresh metrics",
+			Trigger:     s.refreshMetrics,
+			NextTime:    now.Add(1 * time.Minute), // Refresh metrics every minute
+		})
 
 	if s.maint != nil {
 		// If we have a direct repository, add an item to run maintenance.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -486,6 +486,9 @@ func handleShutdown(ctx context.Context, rc requestContext) (interface{}, *apiEr
 }
 
 func (s *Server) requestShutdown(ctx context.Context) {
+	// Workaround for passing tests
+	s.rep.Metrics().RemoveAllGauges()
+
 	if f := s.OnShutdown; f != nil {
 		go func() {
 			if err := f(ctx); err != nil {

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -478,7 +478,7 @@ func (s *sourceManager) refreshStatus(ctx context.Context) {
 	if s.lastCompleteSnapshot != nil && s.rep.Metrics() != nil {
 		s.lastSnapshotStartTime.Set(s.lastCompleteSnapshot.StartTime.ToTime().Unix())
 		s.lastSnapshotEndTime.Set(s.lastCompleteSnapshot.EndTime.ToTime().Unix())
-		s.lastSnapshotSize.Set(s.lastCompleteSnapshot.Stats.TotalFileSize)
+		s.lastSnapshotSize.Set(atomic.LoadInt64(&s.lastCompleteSnapshot.Stats.TotalFileSize))
 		s.lastSnapshotFiles.Set(s.lastCompleteSnapshot.RootEntry.DirSummary.TotalFileCount)
 		s.lastSnapshotDirs.Set(s.lastCompleteSnapshot.RootEntry.DirSummary.TotalDirCount)
 	}

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -469,6 +469,11 @@ func (s *sourceManager) refreshStatus(ctx context.Context) {
 		s.nextSnapshotTime = s.findClosestNextSnapshotTimeReadLocked()
 	}
 
+	// Do not expose metrics if the policy does not allow it.
+	if pol.MetricsPolicy.ExposeMetrics == nil || !*pol.MetricsPolicy.ExposeMetrics {
+		return
+	}
+
 	// Update metrics
 	if s.lastCompleteSnapshot != nil && s.rep.Metrics() != nil {
 		s.lastSnapshotStartTime.Set(s.lastCompleteSnapshot.StartTime.ToTime().Unix())

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -298,17 +298,6 @@ func (s *sourceManager) stop(ctx context.Context) {
 	close(s.closed)
 }
 
-func (s *sourceManager) removeMetrics() {
-	if s.rep.Metrics() != nil {
-		registry := s.rep.Metrics()
-		registry.RemoveGauge(s.lastSnapshotStartTime)
-		registry.RemoveGauge(s.lastSnapshotEndTime)
-		registry.RemoveGauge(s.lastSnapshotSize)
-		registry.RemoveGauge(s.lastSnapshotFiles)
-		registry.RemoveGauge(s.lastSnapshotDirs)
-	}
-}
-
 func (s *sourceManager) waitUntilStopped() {
 	s.wg.Wait()
 }
@@ -593,6 +582,7 @@ func (t *uitaskProgress) EstimatedDataSize(fileCount int, totalBytes int64) {
 }
 
 func newSourceManager(src snapshot.SourceInfo, server sourceManagerServerInterface, rep repo.Repository) *sourceManager {
+
 	m := &sourceManager{
 		src:              src,
 		rep:              rep,

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -470,7 +470,7 @@ func (s *sourceManager) refreshStatus(ctx context.Context) {
 	}
 
 	// Do not expose metrics if the policy does not allow it.
-	if pol.MetricsPolicy.ExposeMetrics == nil || !*pol.MetricsPolicy.ExposeMetrics {
+	if !pol.MetricsPolicy.ExposeMetrics.OrDefault(false) {
 		return
 	}
 

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -6,8 +6,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/internal/clock"
@@ -18,6 +16,7 @@ import (
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -200,6 +199,8 @@ func (s *sourceManager) runLocal(ctx context.Context) {
 				s.setStatus("PENDING")
 
 				if err := s.server.runSnapshotTask(ctx, s.src, s.snapshotInternal); err != nil {
+					log(ctx).Errorf("snapshot error: %v", err)
+
 					s.backoffBeforeNextSnapshot()
 				} else {
 					s.refreshStatus(ctx)

--- a/internal/testutil/serverparameters.go
+++ b/internal/testutil/serverparameters.go
@@ -8,6 +8,7 @@ const (
 	serverOutputCertSHA256      = "SERVER CERT SHA256: "
 	serverOutputPassword        = "SERVER PASSWORD: "
 	serverOutputControlPassword = "SERVER CONTROL PASSWORD: "
+	serverOutputMetricsAddress  = "starting prometheus metrics on "
 )
 
 // ServerParameters encapsulates parameters captured by processing stderr of
@@ -17,6 +18,7 @@ type ServerParameters struct {
 	SHA256Fingerprint     string
 	Password              string
 	ServerControlPassword string
+	MetricsAddress        string
 }
 
 // ProcessOutput processes output lines from a server that's starting up.
@@ -36,6 +38,10 @@ func (s *ServerParameters) ProcessOutput(l string) bool {
 
 	if strings.HasPrefix(l, serverOutputControlPassword) {
 		s.ServerControlPassword = strings.TrimPrefix(l, serverOutputControlPassword)
+	}
+
+	if strings.HasPrefix(l, serverOutputMetricsAddress) {
+		s.MetricsAddress = strings.TrimPrefix(l, serverOutputMetricsAddress)
 	}
 
 	return true

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -28,6 +28,7 @@ var tracer = otel.Tracer("kopia/repository")
 //
 //nolint:interfacebloat
 type Repository interface {
+	Metrics() *metrics.Registry
 	OpenObject(ctx context.Context, id object.ID) (object.Reader, error)
 	VerifyObject(ctx context.Context, id object.ID) ([]content.ID, error)
 	GetManifest(ctx context.Context, id manifest.ID, data interface{}) (*manifest.EntryMetadata, error)

--- a/snapshot/policy/metrics_policy.go
+++ b/snapshot/policy/metrics_policy.go
@@ -1,0 +1,19 @@
+package policy
+
+import "github.com/kopia/kopia/snapshot"
+
+// MetricsPolicy controls metrics-related behavior when taking snapshots.
+type MetricsPolicy struct {
+	// ExposeMetrics controls whether metrics should be exposed
+	ExposeMetrics *OptionalBool `json:"exposeMetrics,omitempty"`
+}
+
+// MetricsPolicyDefinition specifies which policy definition provided the value of a particular field.
+type MetricsPolicyDefinition struct {
+	ExposeMetrics snapshot.SourceInfo `json:"exposeMetrics,omitempty"`
+}
+
+// Merge applies default values from the provided policy.
+func (p *MetricsPolicy) Merge(src MetricsPolicy, def *MetricsPolicyDefinition, si snapshot.SourceInfo) {
+	mergeOptionalBool(&p.ExposeMetrics, src.ExposeMetrics, &def.ExposeMetrics, si)
+}

--- a/snapshot/policy/metrics_policy_test.go
+++ b/snapshot/policy/metrics_policy_test.go
@@ -1,0 +1,53 @@
+package policy
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kopia/kopia/snapshot"
+)
+
+func TestMetricsPolicyMerge(t *testing.T) {
+	cases := []struct {
+		name     string
+		policy   MetricsPolicy
+		src      MetricsPolicy
+		expected MetricsPolicy
+	}{
+		{
+			name:     "Both nil",
+			policy:   MetricsPolicy{},
+			src:      MetricsPolicy{},
+			expected: MetricsPolicy{},
+		},
+		{
+			name:     "Source true",
+			policy:   MetricsPolicy{},
+			src:      MetricsPolicy{ExposeMetrics: NewOptionalBool(true)},
+			expected: MetricsPolicy{ExposeMetrics: NewOptionalBool(true)},
+		},
+		{
+			name:     "Source false",
+			policy:   MetricsPolicy{},
+			src:      MetricsPolicy{ExposeMetrics: NewOptionalBool(false)},
+			expected: MetricsPolicy{ExposeMetrics: NewOptionalBool(false)},
+		},
+		{
+			name:     "Policy set, source different",
+			policy:   MetricsPolicy{ExposeMetrics: NewOptionalBool(true)},
+			src:      MetricsPolicy{ExposeMetrics: NewOptionalBool(false)},
+			expected: MetricsPolicy{ExposeMetrics: NewOptionalBool(true)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			def := &MetricsPolicyDefinition{}
+			tc.policy.Merge(tc.src, def, snapshot.SourceInfo{})
+
+			if !reflect.DeepEqual(tc.policy, tc.expected) {
+				t.Errorf("Merge result not as expected.\nGot: %+v\nWant: %+v", tc.policy, tc.expected)
+			}
+		})
+	}
+}

--- a/snapshot/policy/policy.go
+++ b/snapshot/policy/policy.go
@@ -33,6 +33,7 @@ type Policy struct {
 	OSSnapshotPolicy          OSSnapshotPolicy          `json:"osSnapshots,omitempty"`
 	LoggingPolicy             LoggingPolicy             `json:"logging,omitempty"`
 	UploadPolicy              UploadPolicy              `json:"upload,omitempty"`
+	MetricsPolicy             MetricsPolicy             `json:"metrics,omitempty"`
 	NoParent                  bool                      `json:"noParent,omitempty"`
 }
 
@@ -50,6 +51,7 @@ type Definition struct {
 	OSSnapshotPolicy          OSSnapshotPolicyDefinition          `json:"osSnapshots,omitempty"`
 	LoggingPolicy             LoggingPolicyDefinition             `json:"logging,omitempty"`
 	UploadPolicy              UploadPolicyDefinition              `json:"upload,omitempty"`
+	MetricsPolicy             MetricsPolicyDefinition             `json:"metrics,omitempty"`
 }
 
 func (p *Policy) String() string {

--- a/snapshot/policy/policy_merge.go
+++ b/snapshot/policy/policy_merge.go
@@ -29,6 +29,7 @@ func MergePolicies(policies []*Policy, si snapshot.SourceInfo) (*Policy, *Defini
 		merged.Actions.Merge(p.Actions, &def.Actions, p.Target())
 		merged.OSSnapshotPolicy.Merge(p.OSSnapshotPolicy, &def.OSSnapshotPolicy, p.Target())
 		merged.LoggingPolicy.Merge(p.LoggingPolicy, &def.LoggingPolicy, p.Target())
+		merged.MetricsPolicy.Merge(p.MetricsPolicy, &def.MetricsPolicy, p.Target())
 
 		if p.NoParent {
 			return &merged, &def
@@ -47,6 +48,7 @@ func MergePolicies(policies []*Policy, si snapshot.SourceInfo) (*Policy, *Defini
 	merged.Actions.Merge(defaultActionsPolicy, &def.Actions, GlobalPolicySourceInfo)
 	merged.OSSnapshotPolicy.Merge(defaultOSSnapshotPolicy, &def.OSSnapshotPolicy, GlobalPolicySourceInfo)
 	merged.LoggingPolicy.Merge(defaultLoggingPolicy, &def.LoggingPolicy, GlobalPolicySourceInfo)
+	merged.MetricsPolicy.Merge(defaultMetricsPolicy, &def.MetricsPolicy, GlobalPolicySourceInfo)
 
 	if len(policies) > 0 {
 		merged.Actions.MergeNonInheritable(policies[0].Actions)

--- a/snapshot/policy/policy_tree.go
+++ b/snapshot/policy/policy_tree.go
@@ -72,6 +72,11 @@ var (
 		ParallelUploadAboveSize: newOptionalInt64(2 << 30), //nolint:mnd
 	}
 
+	// defaultMetricsPolicy is the default metrics policy.
+	defaultMetricsPolicy = MetricsPolicy{
+		ExposeMetrics: NewOptionalBool(true),
+	}
+
 	// DefaultPolicy is a default policy returned by policy tree in absence of other policies.
 	DefaultPolicy = &Policy{
 		FilesPolicy:               defaultFilesPolicy,
@@ -84,6 +89,7 @@ var (
 		Actions:                   defaultActionsPolicy,
 		OSSnapshotPolicy:          defaultOSSnapshotPolicy,
 		UploadPolicy:              defaultUploadPolicy,
+		MetricsPolicy:             defaultMetricsPolicy,
 	}
 
 	// DefaultDefinition provides the Definition for the default policy.

--- a/tests/end_to_end_test/server_metrics_test.go
+++ b/tests/end_to_end_test/server_metrics_test.go
@@ -38,8 +38,8 @@ func TestServerMetrics(t *testing.T) {
 		"--random-password",
 		"--random-server-control-password",
 		"--tls-generate-cert",
-		"--tls-generate-rsa-key-size=2048",      // use shorter key size to speed up generation
-		"--metrics-listen-addr=localhost:10000", // enable metrics
+		"--tls-generate-rsa-key-size=2048",  // use shorter key size to speed up generation
+		"--metrics-listen-addr=localhost:0", // enable metrics
 	)
 
 	defer wait()
@@ -125,8 +125,8 @@ func TestServerMetricsWithGlobalDisablePolicy(t *testing.T) {
 		"--random-password",
 		"--random-server-control-password",
 		"--tls-generate-cert",
-		"--tls-generate-rsa-key-size=2048",      // use shorter key size to speed up generation
-		"--metrics-listen-addr=localhost:10000", // enable metrics
+		"--tls-generate-rsa-key-size=2048",  // use shorter key size to speed up generation
+		"--metrics-listen-addr=localhost:0", // enable metrics
 	)
 
 	defer wait()
@@ -195,8 +195,8 @@ func TestServerMetricsWithSpecificDisablePolicy(t *testing.T) {
 		"--random-password",
 		"--random-server-control-password",
 		"--tls-generate-cert",
-		"--tls-generate-rsa-key-size=2048",      // use shorter key size to speed up generation
-		"--metrics-listen-addr=localhost:10000", // enable metrics
+		"--tls-generate-rsa-key-size=2048",  // use shorter key size to speed up generation
+		"--metrics-listen-addr=localhost:0", // enable metrics
 	)
 
 	defer wait()

--- a/tests/end_to_end_test/server_metrics_test.go
+++ b/tests/end_to_end_test/server_metrics_test.go
@@ -1,0 +1,92 @@
+package endtoend_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/kopia/kopia/internal/apiclient"
+	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/tests/testenv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerMetrics(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-hostname=fake-hostname", "--override-username=fake-username")
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir2)
+
+	var sp testutil.ServerParameters
+
+	wait, _ := e.RunAndProcessStderr(t, sp.ProcessOutput,
+		"server", "start",
+		"--ui",
+		"--address=localhost:0",
+		"--random-password",
+		"--random-server-control-password",
+		"--tls-generate-cert",
+		"--tls-generate-rsa-key-size=2048",      // use shorter key size to speed up generation
+		"--metrics-listen-addr=localhost:10000", // enable metrics
+	)
+
+	defer wait()
+
+	t.Logf("detected server parameters %#v", sp)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             sp.BaseURL,
+		Username:                            "kopia",
+		Password:                            sp.Password,
+		TrustedServerCertificateFingerprint: sp.SHA256Fingerprint,
+		LogRequests:                         true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	controlClient, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             sp.BaseURL,
+		Username:                            "server-control",
+		Password:                            sp.ServerControlPassword,
+		TrustedServerCertificateFingerprint: sp.SHA256Fingerprint,
+		LogRequests:                         true,
+	})
+	require.NoError(t, err)
+
+	defer serverapi.Shutdown(ctx, controlClient)
+
+	waitUntilServerStarted(ctx, t, controlClient)
+
+	// Check response on the captured metrics address
+	resp, err := http.Get("http://" + sp.MetricsAddress + "/metrics")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	// Response body should not be empty
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, body)
+	metrics := string(body)
+
+	// Define the expected paths
+	expectedPaths := []string{
+		sharedTestDataDir1,
+		sharedTestDataDir2,
+	}
+
+	// Check if the metrics contain the expected paths
+	for _, path := range expectedPaths {
+		require.Contains(t, metrics, fmt.Sprintf(`kopia_last_snapshot_dirs{host="fake-hostname",path="%s",username="fake-username"}`, path))
+	}
+
+}

--- a/tests/end_to_end_test/server_metrics_test.go
+++ b/tests/end_to_end_test/server_metrics_test.go
@@ -121,7 +121,7 @@ func TestServerMetrics(t *testing.T) {
 	require.NotContains(t, metrics, fmt.Sprintf(`kopia_last_snapshot_dirs{host="fake-hostname",path=%q,username="fake-username"}`, sharedTestDataDir2))
 }
 
-func TestServerMetricsWithDisablePolicy(t *testing.T) {
+func TestServerMetricsWithGlobalDisablePolicy(t *testing.T) {
 	ctx := testlogging.Context(t)
 
 	runner := testenv.NewInProcRunner(t)
@@ -201,4 +201,79 @@ func TestServerMetricsWithDisablePolicy(t *testing.T) {
 	for _, path := range expectedPaths {
 		require.NotContains(t, metrics, fmt.Sprintf(`kopia_last_snapshot_dirs{host="fake-hostname",path=%q,username="fake-username"}`, path))
 	}
+}
+
+func TestServerMetricsWithSpecificDisablePolicy(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-hostname=fake-hostname", "--override-username=fake-username")
+
+	e.RunAndExpectSuccess(t, "policy", "set", "--expose-metrics", "false", sharedTestDataDir2)
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir2)
+
+	var sp testutil.ServerParameters
+
+	wait, _ := e.RunAndProcessStderr(t, sp.ProcessOutput,
+		"server", "start",
+		"--ui",
+		"--address=localhost:0",
+		"--random-password",
+		"--random-server-control-password",
+		"--tls-generate-cert",
+		"--tls-generate-rsa-key-size=2048",      // use shorter key size to speed up generation
+		"--metrics-listen-addr=localhost:10000", // enable metrics
+	)
+
+	defer wait()
+
+	t.Logf("detected server parameters %#v", sp)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             sp.BaseURL,
+		Username:                            "kopia",
+		Password:                            sp.Password,
+		TrustedServerCertificateFingerprint: sp.SHA256Fingerprint,
+		LogRequests:                         true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	controlClient, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             sp.BaseURL,
+		Username:                            "server-control",
+		Password:                            sp.ServerControlPassword,
+		TrustedServerCertificateFingerprint: sp.SHA256Fingerprint,
+		LogRequests:                         true,
+	})
+	require.NoError(t, err)
+
+	defer serverapi.Shutdown(ctx, controlClient)
+
+	waitUntilServerStarted(ctx, t, controlClient)
+
+	// Check response on the captured metrics address
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+sp.MetricsAddress+"/metrics", http.NoBody)
+	require.NoError(t, err)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Response body should not be empty
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, body)
+	metrics := string(body)
+
+	// Only sharedTestDataDir should be present
+	require.Contains(t, metrics, fmt.Sprintf(`kopia_last_snapshot_dirs{host="fake-hostname",path=%q,username="fake-username"}`, sharedTestDataDir1))
+	require.NotContains(t, metrics, fmt.Sprintf(`kopia_last_snapshot_dirs{host="fake-hostname",path=%q,username="fake-username"}`, sharedTestDataDir2))
 }

--- a/tests/end_to_end_test/server_metrics_test.go
+++ b/tests/end_to_end_test/server_metrics_test.go
@@ -120,3 +120,85 @@ func TestServerMetrics(t *testing.T) {
 	require.Contains(t, metrics, fmt.Sprintf(`kopia_last_snapshot_dirs{host="fake-hostname",path=%q,username="fake-username"}`, sharedTestDataDir1))
 	require.NotContains(t, metrics, fmt.Sprintf(`kopia_last_snapshot_dirs{host="fake-hostname",path=%q,username="fake-username"}`, sharedTestDataDir2))
 }
+
+func TestServerMetricsWithDisablePolicy(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-hostname=fake-hostname", "--override-username=fake-username")
+
+	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--expose-metrics", "false")
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir1)
+	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir2)
+
+	var sp testutil.ServerParameters
+
+	wait, _ := e.RunAndProcessStderr(t, sp.ProcessOutput,
+		"server", "start",
+		"--ui",
+		"--address=localhost:0",
+		"--random-password",
+		"--random-server-control-password",
+		"--tls-generate-cert",
+		"--tls-generate-rsa-key-size=2048",      // use shorter key size to speed up generation
+		"--metrics-listen-addr=localhost:10000", // enable metrics
+	)
+
+	defer wait()
+
+	t.Logf("detected server parameters %#v", sp)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             sp.BaseURL,
+		Username:                            "kopia",
+		Password:                            sp.Password,
+		TrustedServerCertificateFingerprint: sp.SHA256Fingerprint,
+		LogRequests:                         true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	controlClient, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             sp.BaseURL,
+		Username:                            "server-control",
+		Password:                            sp.ServerControlPassword,
+		TrustedServerCertificateFingerprint: sp.SHA256Fingerprint,
+		LogRequests:                         true,
+	})
+	require.NoError(t, err)
+
+	defer serverapi.Shutdown(ctx, controlClient)
+
+	waitUntilServerStarted(ctx, t, controlClient)
+
+	// Check response on the captured metrics address
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+sp.MetricsAddress+"/metrics", http.NoBody)
+	require.NoError(t, err)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Response body should not be empty
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, body)
+	metrics := string(body)
+
+	// Define the expected paths
+	expectedPaths := []string{
+		sharedTestDataDir1,
+		sharedTestDataDir2,
+	}
+
+	// Check if the metrics contain the expected paths
+	for _, path := range expectedPaths {
+		require.NotContains(t, metrics, fmt.Sprintf(`kopia_last_snapshot_dirs{host="fake-hostname",path=%q,username="fake-username"}`, path))
+	}
+}


### PR DESCRIPTION
 This pull request addresses issue #609 by adding metrics to track information about the last successful snapshots for each source.
 These new metrics provide insights into the recency, size, and content of snapshots across different sources.

 Changes made:
 - Implemented new metrics in the sourceManager to track:
   - Timestamp of the last snapshot start time
   - Timestamp of the last snapshot end time
   - Size of the last snapshot in bytes
   - Number of files in the last snapshot
   - Number of directories in the last snapshot

 These additions will help users and administrators better monitor the details of their most recent backups, enabling quicker  assessment of backup coverage and content.

 Implementation details:
 - Metrics are implemented using the repository's metric registry
 - Each metric is tagged with the source's host, username, and path for precise tracking
 - Metrics are updated only for complete snapshots (those without an IncompleteReason)
 - --refresh-interval will affect the time interval in refreshing snapshot metrics

 Testing:
 - Manually verified the new metrics are correctly reported in the Prometheus output
 - Existing tests should cover the new functionality, as it's integrated into existing methods

 Please review and let me know if any further changes or clarifications are needed.

 Fixes #609