### PR TITLE
refactor(providers): always clone default HTTP transport in S3 provider

### DIFF
--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -301,12 +301,14 @@ func (s *s3Storage) DisplayName() string {
 }
 
 func getCustomTransport(opt *Options) (*http.Transport, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert
+
 	if opt.DoNotVerifyTLS {
 		//nolint:gosec
-		return &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, nil
-	}
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert
+		return transport, nil
+	}
 
 	if len(opt.RootCA) != 0 {
 		rootcas := x509.NewCertPool()


### PR DESCRIPTION
The s3 storage provider had a different http transports for different cases:

- HTTPS without TLS verification: `&http.Transport{}` with default values;
- HTTPS with TLS verification: `http.DefaultTransport.Clone()`

This change uses `http.DefaultTransport` in all cases, instead of creating an empty (zero-value) `http.Transport` for consistency.

Author: @alexvbg