### PR TITLE
fix(providers): GCS tests

### DIFF
--- a/repo/blob/gcs/gcs_immu_test.go
+++ b/repo/blob/gcs/gcs_immu_test.go
@@ -27,7 +27,7 @@ func TestGoogleStorageImmutabilityProtection(t *testing.T) {
 
 	opts := bucketOpts{
 		projectID:       os.Getenv(testBucketProjectID),
-		bucket:          os.Getenv(testImmutableBucketEnv),
+		bucket:          getImmutableBucketNameOrSkip(t),
 		credentialsJSON: getCredJSONFromEnv(t),
 		isLockedBucket:  true,
 	}

--- a/repo/blob/gcs/gcs_immu_test.go
+++ b/repo/blob/gcs/gcs_immu_test.go
@@ -28,7 +28,7 @@ func TestGoogleStorageImmutabilityProtection(t *testing.T) {
 	opts := bucketOpts{
 		projectID:       os.Getenv(testBucketProjectID),
 		bucket:          os.Getenv(testImmutableBucketEnv),
-		credentialsFile: os.Getenv(testBucketCredentialsFile),
+		credentialsJSON: getCredJSONFromEnv(t),
 		isLockedBucket:  true,
 	}
 	createBucket(t, opts)
@@ -43,9 +43,9 @@ func TestGoogleStorageImmutabilityProtection(t *testing.T) {
 	newctx, cancel := context.WithCancel(ctx)
 	prefix := fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data)
 	st, err := gcs.New(newctx, &gcs.Options{
-		BucketName:                    opts.bucket,
-		ServiceAccountCredentialsFile: opts.credentialsFile,
-		Prefix:                        prefix,
+		BucketName:                   opts.bucket,
+		ServiceAccountCredentialJSON: opts.credentialsJSON,
+		Prefix:                       prefix,
 	}, false)
 
 	cancel()
@@ -67,7 +67,7 @@ func TestGoogleStorageImmutabilityProtection(t *testing.T) {
 	}
 	err = st.PutBlob(ctx, dummyBlob, gather.FromSlice([]byte("x")), putOpts)
 	require.NoError(t, err)
-	cli := getGoogleCLI(t, opts.credentialsFile)
+	cli := getGoogleCLI(t, opts.credentialsJSON)
 
 	count := getBlobCount(ctx, t, st, dummyBlob[:1])
 	require.Equal(t, 1, count)
@@ -112,11 +112,11 @@ func TestGoogleStorageImmutabilityProtection(t *testing.T) {
 }
 
 // getGoogleCLI returns a separate client to verify things the Storage interface doesn't support.
-func getGoogleCLI(t *testing.T, credentialsFile string) *gcsclient.Client {
+func getGoogleCLI(t *testing.T, credentialsJSON []byte) *gcsclient.Client {
 	t.Helper()
 
 	ctx := context.Background()
-	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsFile(credentialsFile))
+	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsJSON(credentialsJSON))
 	if err != nil {
 		t.Fatalf("unable to create GCS client: %v", err)
 	}

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -33,7 +33,7 @@ const (
 
 type bucketOpts struct {
 	bucket          string
-	credentialsFile string
+	credentialsJSON []byte
 	projectID       string
 	isLockedBucket  bool
 }
@@ -42,7 +42,7 @@ func createBucket(t *testing.T, opts bucketOpts) {
 	t.Helper()
 	ctx := context.Background()
 
-	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsFile(opts.credentialsFile))
+	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsJSON(opts.credentialsJSON))
 	if err != nil {
 		t.Fatalf("unable to create GCS client: %v", err)
 	}
@@ -75,7 +75,7 @@ func validateBucket(t *testing.T, opts bucketOpts) {
 	t.Helper()
 	ctx := context.Background()
 
-	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsFile(opts.credentialsFile))
+	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsJSON(opts.credentialsJSON))
 	if err != nil {
 		t.Fatalf("unable to create GCS client: %v", err)
 	}

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -151,6 +151,17 @@ func gunzip(d []byte) ([]byte, error) {
 	return io.ReadAll(z)
 }
 
+func getEnvVarOrSkip(t *testing.T, envVarName string) string {
+	t.Helper()
+
+	v := os.Getenv(envVarName)
+	if v == "" {
+		t.Skipf("%q is not set", envVarName)
+	}
+
+	return v
+}
+
 func getCredJSONFromEnv(t *testing.T) []byte {
 	t.Helper()
 

--- a/repo/blob/gcs/gcs_versioned_test.go
+++ b/repo/blob/gcs/gcs_versioned_test.go
@@ -35,9 +35,9 @@ func TestGetBlobVersionsFailsWhenVersioningDisabled(t *testing.T) {
 
 	prefix := fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data)
 	opts := &gcs.Options{
-		BucketName:                    bucket,
-		ServiceAccountCredentialsFile: os.Getenv(testBucketCredentialsFile),
-		Prefix:                        prefix,
+		BucketName:                   bucket,
+		ServiceAccountCredentialJSON: getCredJSONFromEnv(t),
+		Prefix:                       prefix,
 	}
 	st, err := gcs.New(newctx, opts, false)
 	require.NoError(t, err)
@@ -60,7 +60,7 @@ func TestGetBlobVersions(t *testing.T) {
 	bOpts := bucketOpts{
 		projectID:       os.Getenv(testBucketProjectID),
 		bucket:          os.Getenv(testImmutableBucketEnv),
-		credentialsFile: os.Getenv(testBucketCredentialsFile),
+		credentialsJSON: getCredJSONFromEnv(t),
 		isLockedBucket:  true,
 	}
 
@@ -76,9 +76,9 @@ func TestGetBlobVersions(t *testing.T) {
 
 	prefix := fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data)
 	opts := &gcs.Options{
-		BucketName:                    bOpts.bucket,
-		ServiceAccountCredentialsFile: bOpts.credentialsFile,
-		Prefix:                        prefix,
+		BucketName:                   bOpts.bucket,
+		ServiceAccountCredentialJSON: bOpts.credentialsJSON,
+		Prefix:                       prefix,
 	}
 	st, err := gcs.New(newctx, opts, false)
 	require.NoError(t, err)
@@ -167,7 +167,7 @@ func TestGetBlobVersionsWithDeletion(t *testing.T) {
 	bOpts := bucketOpts{
 		projectID:       os.Getenv(testBucketProjectID),
 		bucket:          os.Getenv(testImmutableBucketEnv),
-		credentialsFile: os.Getenv(testBucketCredentialsFile),
+		credentialsJSON: getCredJSONFromEnv(t),
 		isLockedBucket:  true,
 	}
 
@@ -183,9 +183,9 @@ func TestGetBlobVersionsWithDeletion(t *testing.T) {
 
 	prefix := fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data)
 	opts := &gcs.Options{
-		BucketName:                    bOpts.bucket,
-		ServiceAccountCredentialsFile: bOpts.credentialsFile,
-		Prefix:                        prefix,
+		BucketName:                   bOpts.bucket,
+		ServiceAccountCredentialJSON: bOpts.credentialsJSON,
+		Prefix:                       prefix,
 	}
 	st, err := gcs.New(newctx, opts, false)
 	require.NoError(t, err)

--- a/repo/blob/gcs/gcs_versioned_test.go
+++ b/repo/blob/gcs/gcs_versioned_test.go
@@ -59,7 +59,7 @@ func TestGetBlobVersions(t *testing.T) {
 	// must be with Versioning enabled.
 	bOpts := bucketOpts{
 		projectID:       os.Getenv(testBucketProjectID),
-		bucket:          os.Getenv(testImmutableBucketEnv),
+		bucket:          getImmutableBucketNameOrSkip(t),
 		credentialsJSON: getCredJSONFromEnv(t),
 		isLockedBucket:  true,
 	}
@@ -166,7 +166,7 @@ func TestGetBlobVersionsWithDeletion(t *testing.T) {
 	// must be with Versioning enabled.
 	bOpts := bucketOpts{
 		projectID:       os.Getenv(testBucketProjectID),
-		bucket:          os.Getenv(testImmutableBucketEnv),
+		bucket:          getImmutableBucketNameOrSkip(t),
 		credentialsJSON: getCredJSONFromEnv(t),
 		isLockedBucket:  true,
 	}
@@ -255,4 +255,10 @@ func putBlobs(ctx context.Context, cli blob.Storage, blobID blob.ID, blobs []str
 	}
 
 	return putTimes, nil
+}
+
+func getImmutableBucketNameOrSkip(t *testing.T) string {
+	t.Helper()
+
+	return getEnvVarOrSkip(t, testImmutableBucketEnv)
 }


### PR DESCRIPTION
The GCS provider tests broke in #4134

This is an attempt to fix the tests by using the credentials that are available in the providers validation job. Note that a credentials file is not available.

However, the tests still fail because:
- there isn't a versioned / immutable bucket for the tests; and
- the credentials available in the test do not allow creating buckets.

The GCS versioning / immutability tests are skipped in the mean time until the required bucket is created.