### PR TITLE
test(providers): cleanup GCS tests

### DIFF
--- a/repo/blob/gcs/gcs_immu_test.go
+++ b/repo/blob/gcs/gcs_immu_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -26,7 +25,7 @@ func TestGoogleStorageImmutabilityProtection(t *testing.T) {
 	testutil.ProviderTest(t)
 
 	opts := bucketOpts{
-		projectID:       os.Getenv(testBucketProjectID),
+		projectID:       getEnvVarOrSkip(t, testBucketProjectID),
 		bucket:          getImmutableBucketNameOrSkip(t),
 		credentialsJSON: getCredJSONFromEnv(t),
 		isLockedBucket:  true,

--- a/repo/blob/gcs/gcs_immu_test.go
+++ b/repo/blob/gcs/gcs_immu_test.go
@@ -66,10 +66,11 @@ func TestGoogleStorageImmutabilityProtection(t *testing.T) {
 	}
 	err = st.PutBlob(ctx, dummyBlob, gather.FromSlice([]byte("x")), putOpts)
 	require.NoError(t, err)
-	cli := getGoogleCLI(t, opts.credentialsJSON)
 
 	count := getBlobCount(ctx, t, st, dummyBlob[:1])
 	require.Equal(t, 1, count)
+
+	cli := getGoogleCLI(t, opts.credentialsJSON)
 
 	attrs, err := cli.Bucket(opts.bucket).Object(blobNameFullPath).Attrs(ctx)
 	require.NoError(t, err)

--- a/repo/blob/gcs/gcs_immu_test.go
+++ b/repo/blob/gcs/gcs_immu_test.go
@@ -116,9 +116,8 @@ func getGoogleCLI(t *testing.T, credentialsJSON []byte) *gcsclient.Client {
 
 	ctx := context.Background()
 	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsJSON(credentialsJSON))
-	if err != nil {
-		t.Fatalf("unable to create GCS client: %v", err)
-	}
+
+	require.NoError(t, err, "unable to create GCS client")
 
 	return cli
 }

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -26,7 +26,6 @@ import (
 const (
 	testBucketEnv                 = "KOPIA_GCS_TEST_BUCKET"
 	testBucketProjectID           = "KOPIA_GCS_TEST_PROJECT_ID"
-	testBucketCredentialsFile     = "KOPIA_GCS_CREDENTIALS_FILE"
 	testBucketCredentialsJSONGzip = "KOPIA_GCS_CREDENTIALS_JSON_GZIP"
 	testImmutableBucketEnv        = "KOPIA_GCS_TEST_IMMUTABLE_BUCKET"
 )
@@ -133,8 +132,8 @@ func TestGCSStorageInvalid(t *testing.T) {
 	ctx := testlogging.Context(t)
 
 	if _, err := gcs.New(ctx, &gcs.Options{
-		BucketName:                    bucket + "-no-such-bucket",
-		ServiceAccountCredentialsFile: os.Getenv(testBucketCredentialsFile),
+		BucketName:                   bucket + "-no-such-bucket",
+		ServiceAccountCredentialJSON: getCredJSONFromEnv(t),
 	}, false); err == nil {
 		t.Fatalf("unexpected success connecting to GCS, wanted error")
 	}

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -128,7 +128,7 @@ func TestGCSStorageInvalid(t *testing.T) {
 	t.Parallel()
 	testutil.ProviderTest(t)
 
-	bucket := os.Getenv(testBucketEnv)
+	bucket := getEnvVarOrSkip(t, testBucketEnv)
 
 	ctx := testlogging.Context(t)
 
@@ -165,10 +165,7 @@ func getEnvVarOrSkip(t *testing.T, envVarName string) string {
 func getCredJSONFromEnv(t *testing.T) []byte {
 	t.Helper()
 
-	b64Data := os.Getenv(testBucketCredentialsJSONGzip)
-	if b64Data == "" {
-		t.Skip(testBucketCredentialsJSONGzip + "is not set")
-	}
+	b64Data := getEnvVarOrSkip(t, testBucketCredentialsJSONGzip)
 
 	credDataGZ, err := base64.StdEncoding.DecodeString(b64Data)
 	if err != nil {
@@ -186,10 +183,7 @@ func getCredJSONFromEnv(t *testing.T) []byte {
 func mustGetOptionsOrSkip(t *testing.T, prefix string) *gcs.Options {
 	t.Helper()
 
-	bucket := os.Getenv(testBucketEnv)
-	if bucket == "" {
-		t.Skip("KOPIA_GCS_TEST_BUCKET not provided")
-	}
+	bucket := getEnvVarOrSkip(t, testBucketEnv)
 
 	return &gcs.Options{
 		BucketName:                   bucket,

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -105,14 +105,10 @@ func getCredJSONFromEnv(t *testing.T) []byte {
 	b64Data := getEnvVarOrSkip(t, testBucketCredentialsJSONGzip)
 
 	credDataGZ, err := base64.StdEncoding.DecodeString(b64Data)
-	if err != nil {
-		t.Skip("skipping test because GCS credentials file can't be decoded")
-	}
+	require.NoError(t, err, "GCS credentials env value can't be decoded")
 
 	credJSON, err := gunzip(credDataGZ)
-	if err != nil {
-		t.Skip("skipping test because GCS credentials file can't be unzipped")
-	}
+	require.NoError(t, err, "GCS credentials env can't be unzipped")
 
 	return credJSON
 }

--- a/repo/blob/gcs/gcs_storage_test.go
+++ b/repo/blob/gcs/gcs_storage_test.go
@@ -42,9 +42,7 @@ func createBucket(t *testing.T, opts bucketOpts) {
 	ctx := context.Background()
 
 	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsJSON(opts.credentialsJSON))
-	if err != nil {
-		t.Fatalf("unable to create GCS client: %v", err)
-	}
+	require.NoError(t, err, "unable to create GCS client")
 
 	attrs := &gcsclient.BucketAttrs{}
 
@@ -75,9 +73,7 @@ func validateBucket(t *testing.T, opts bucketOpts) {
 	ctx := context.Background()
 
 	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsJSON(opts.credentialsJSON))
-	if err != nil {
-		t.Fatalf("unable to create GCS client: %v", err)
-	}
+	require.NoError(t, err, "unable to create GCS client")
 
 	attrs, err := cli.Bucket(opts.bucket).Attrs(ctx)
 	require.NoError(t, err)
@@ -131,12 +127,11 @@ func TestGCSStorageInvalid(t *testing.T) {
 
 	ctx := testlogging.Context(t)
 
-	if _, err := gcs.New(ctx, &gcs.Options{
+	_, err := gcs.New(ctx, &gcs.Options{
 		BucketName:                   bucket + "-no-such-bucket",
 		ServiceAccountCredentialJSON: getCredJSONFromEnv(t),
-	}, false); err == nil {
-		t.Fatalf("unexpected success connecting to GCS, wanted error")
-	}
+	}, false)
+	require.Error(t, err, "unexpected success connecting to GCS, wanted error")
 }
 
 func gunzip(d []byte) ([]byte, error) {

--- a/repo/blob/gcs/gcs_versioned_test.go
+++ b/repo/blob/gcs/gcs_versioned_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -24,7 +23,7 @@ func TestGetBlobVersionsFailsWhenVersioningDisabled(t *testing.T) {
 	testutil.ProviderTest(t)
 
 	// must be with Versioning disabled.
-	bucket := os.Getenv(testBucketEnv)
+	bucket := getEnvVarOrSkip(t, testBucketEnv)
 
 	ctx := testlogging.Context(t)
 	data := make([]byte, 8)
@@ -58,7 +57,7 @@ func TestGetBlobVersions(t *testing.T) {
 
 	// must be with Versioning enabled.
 	bOpts := bucketOpts{
-		projectID:       os.Getenv(testBucketProjectID),
+		projectID:       getEnvVarOrSkip(t, testBucketProjectID),
 		bucket:          getImmutableBucketNameOrSkip(t),
 		credentialsJSON: getCredJSONFromEnv(t),
 		isLockedBucket:  true,
@@ -165,7 +164,7 @@ func TestGetBlobVersionsWithDeletion(t *testing.T) {
 
 	// must be with Versioning enabled.
 	bOpts := bucketOpts{
-		projectID:       os.Getenv(testBucketProjectID),
+		projectID:       getEnvVarOrSkip(t, testBucketProjectID),
 		bucket:          getImmutableBucketNameOrSkip(t),
 		credentialsJSON: getCredJSONFromEnv(t),
 		isLockedBucket:  true,

--- a/repo/blob/gcs/gcs_versioned_test.go
+++ b/repo/blob/gcs/gcs_versioned_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	gcsclient "cloud.google.com/go/storage"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
 
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/gather"
@@ -17,6 +20,13 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/gcs"
 )
+
+type bucketOpts struct {
+	bucket          string
+	credentialsJSON []byte
+	projectID       string
+	isLockedBucket  bool
+}
 
 func TestGetBlobVersionsFailsWhenVersioningDisabled(t *testing.T) {
 	t.Parallel()
@@ -254,6 +264,53 @@ func putBlobs(ctx context.Context, cli blob.Storage, blobID blob.ID, blobs []str
 	}
 
 	return putTimes, nil
+}
+
+func createBucket(t *testing.T, opts bucketOpts) {
+	t.Helper()
+	ctx := context.Background()
+
+	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsJSON(opts.credentialsJSON))
+	require.NoError(t, err, "unable to create GCS client")
+
+	attrs := &gcsclient.BucketAttrs{}
+
+	bucketHandle := cli.Bucket(opts.bucket)
+	if opts.isLockedBucket {
+		attrs.VersioningEnabled = true
+		bucketHandle = bucketHandle.SetObjectRetention(true)
+	}
+
+	err = bucketHandle.Create(ctx, opts.projectID, attrs)
+	if err == nil {
+		return
+	}
+
+	if strings.Contains(err.Error(), "The requested bucket name is not available") {
+		return
+	}
+
+	if strings.Contains(err.Error(), "Your previous request to create the named bucket succeeded and you already own it") {
+		return
+	}
+
+	t.Fatalf("issue creating bucket: %v", err)
+}
+
+func validateBucket(t *testing.T, opts bucketOpts) {
+	t.Helper()
+	ctx := context.Background()
+
+	cli, err := gcsclient.NewClient(ctx, option.WithCredentialsJSON(opts.credentialsJSON))
+	require.NoError(t, err, "unable to create GCS client")
+
+	attrs, err := cli.Bucket(opts.bucket).Attrs(ctx)
+	require.NoError(t, err)
+
+	if opts.isLockedBucket {
+		require.True(t, attrs.VersioningEnabled)
+		require.Equal(t, "Enabled", attrs.ObjectRetentionMode)
+	}
 }
 
 func getImmutableBucketNameOrSkip(t *testing.T) string {


### PR DESCRIPTION
- Use `getEnvVarOrSkip()` helper
- Use creds from JSON env for test to actually run the test. A file with creds is not available in the testing environment.
- nit: relocate helpers