### PR TITLE
fix(cli): Deadline on s3 requests

### DIFF
--- a/cli/storage_s3.go
+++ b/cli/storage_s3.go
@@ -29,6 +29,7 @@ func (c *storageS3Flags) Setup(svc StorageProviderServices, cmd *kingpin.CmdClau
 	cmd.Flag("prefix", "Prefix to use for objects in the bucket. Put trailing slash (/) if you want to use prefix as directory. e.g my-backup-dir/ would put repository contents inside my-backup-dir directory").StringVar(&c.s3options.Prefix)
 	cmd.Flag("disable-tls", "Disable TLS security (HTTPS)").BoolVar(&c.s3options.DoNotUseTLS)
 	cmd.Flag("disable-tls-verification", "Disable TLS (HTTPS) certificate verification").BoolVar(&c.s3options.DoNotVerifyTLS)
+	cmd.Flag("request-timeout", "Timeout in seconds to use on S3 requests, default is no timeout").Default("0").UintVar(&c.s3options.RequestTimeout)
 
 	commonThrottlingFlags(cmd, &c.s3options.Limits)
 

--- a/cli/storage_s3.go
+++ b/cli/storage_s3.go
@@ -29,7 +29,15 @@ func (c *storageS3Flags) Setup(svc StorageProviderServices, cmd *kingpin.CmdClau
 	cmd.Flag("prefix", "Prefix to use for objects in the bucket. Put trailing slash (/) if you want to use prefix as directory. e.g my-backup-dir/ would put repository contents inside my-backup-dir directory").StringVar(&c.s3options.Prefix)
 	cmd.Flag("disable-tls", "Disable TLS security (HTTPS)").BoolVar(&c.s3options.DoNotUseTLS)
 	cmd.Flag("disable-tls-verification", "Disable TLS (HTTPS) certificate verification").BoolVar(&c.s3options.DoNotVerifyTLS)
-	cmd.Flag("request-timeout", "Timeout in seconds to use on S3 requests, default is no timeout").Default("0").UintVar(&c.s3options.RequestTimeout)
+
+	timeoutPreAction := func(_ *kingpin.ParseContext) error {
+		if c.s3options.RequestTimeout < 0 {
+			return errors.Errorf("invalid request timeout value, needs a positive value")
+		}
+
+		return nil
+	}
+	cmd.Flag("request-timeout", "Timeout in seconds to use on S3 requests, default is no timeout").Default("0").PreAction(timeoutPreAction).Int64Var(&c.s3options.RequestTimeout)
 
 	commonThrottlingFlags(cmd, &c.s3options.Limits)
 

--- a/repo/blob/s3/s3_options.go
+++ b/repo/blob/s3/s3_options.go
@@ -23,6 +23,9 @@ type Options struct {
 	SecretAccessKey string `json:"secretAccessKey" kopia:"sensitive"`
 	SessionToken    string `json:"sessionToken"    kopia:"sensitive"`
 
+	// Timeout is used as a deadline context in Minio API calls.
+	RequestTimeout uint `json:"requestTimeout,omitempty"`
+
 	// Region is an optional region to pass in authorization header.
 	Region string `json:"region,omitempty"`
 

--- a/repo/blob/s3/s3_options.go
+++ b/repo/blob/s3/s3_options.go
@@ -24,7 +24,7 @@ type Options struct {
 	SessionToken    string `json:"sessionToken"    kopia:"sensitive"`
 
 	// Timeout is used as a deadline context in Minio API calls.
-	RequestTimeout uint `json:"requestTimeout,omitempty"`
+	RequestTimeout int64 `json:"requestTimeout,omitempty"`
 
 	// Region is an optional region to pass in authorization header.
 	Region string `json:"region,omitempty"`

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -48,7 +48,7 @@ func (s *s3Storage) getBlobWithVersion(ctx context.Context, b blob.ID, version s
 	if s.RequestTimeout > 0 {
 		var cancel context.CancelFunc
 
-		deadline := time.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
+		deadline := clock.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
 
 		ctx, cancel = context.WithDeadline(ctx, deadline)
 		defer cancel()
@@ -130,7 +130,7 @@ func (s *s3Storage) getVersionMetadata(ctx context.Context, b blob.ID, version s
 	if s.RequestTimeout > 0 {
 		var cancel context.CancelFunc
 
-		deadline := time.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
+		deadline := clock.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
 
 		ctx, cancel = context.WithDeadline(ctx, deadline)
 		defer cancel()
@@ -180,7 +180,7 @@ func (s *s3Storage) putBlob(ctx context.Context, b blob.ID, data blob.Bytes, opt
 	if s.RequestTimeout > 0 {
 		var cancel context.CancelFunc
 
-		deadline := time.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
+		deadline := clock.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
 
 		ctx, cancel = context.WithDeadline(ctx, deadline)
 		defer cancel()
@@ -249,7 +249,7 @@ func (s *s3Storage) DeleteBlob(ctx context.Context, b blob.ID) error {
 	if s.RequestTimeout > 0 {
 		var cancel context.CancelFunc
 
-		deadline := time.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
+		deadline := clock.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
 
 		ctx, cancel = context.WithDeadline(ctx, deadline)
 		defer cancel()
@@ -272,7 +272,7 @@ func (s *s3Storage) ExtendBlobRetention(ctx context.Context, b blob.ID, opts blo
 	if s.RequestTimeout > 0 {
 		var cancel context.CancelFunc
 
-		deadline := time.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
+		deadline := clock.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
 
 		ctx, cancel = context.WithDeadline(ctx, deadline)
 		defer cancel()

--- a/repo/blob/s3/s3_versioned.go
+++ b/repo/blob/s3/s3_versioned.go
@@ -3,10 +3,12 @@ package s3
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/repo/blob"
 )
 
@@ -28,6 +30,15 @@ type versionMetadataCallback func(versionMetadata) error
 // bucket. Notice that when object locking is enabled in a bucket, object
 // versioning is enabled and cannot be suspended.
 func (s *s3Storage) IsVersioned(ctx context.Context) (bool, error) {
+	if s.RequestTimeout > 0 {
+		var cancel context.CancelFunc
+
+		deadline := clock.Now().Add(time.Duration(s.RequestTimeout) * time.Second)
+
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+		defer cancel()
+	}
+
 	vi, err := s.cli.GetBucketVersioning(ctx, s.BucketName)
 	if err != nil {
 		return false, errors.Wrapf(err, "could not get versioning info for %s", s.BucketName)


### PR DESCRIPTION
Hello,

Since last week one of the S3 providers has some issues on their Object Storage infrastructure preventing successful backups.

Specifically, after recent changes in their infrastructure, some requests fails to respond but do not close the connection, causing backups to stall indefinitely.

While this issue is on the provider's side, I took the opportunity to improve the resiliency of Kopia by implementing a "request timeout" using a context deadline, mitigating the issue we had. Requests that are stucks, are now failing in error and are simply retried by Minio.

This PR adds a new flag "--request-timeout" to the commands related to S3 repository (eg. "repository create s3" or "repository connect s3") and accept a value in seconds. By default the value is "0", which is "no timeout", so no breaking change of the actual behavior.

A context deadline is used on every requests but not on ListObjects, which already use a context.WithCancel.

What do you think ?