### PR TITLE
fix(repository): allow extending blob retentions

### DIFF
--- a/repo/blob/gcs/gcs_storage.go
+++ b/repo/blob/gcs/gcs_storage.go
@@ -277,7 +277,7 @@ func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error)
 
 	var err error
 
-	scope := gcsclient.ScopeReadWrite
+	scope := gcsclient.ScopeFullControl
 	if opt.ReadOnly {
 		scope = gcsclient.ScopeReadOnly
 	}


### PR DESCRIPTION
Extending a blob requires full control. On the newer client styles (e.g. `option.WithCredentialsJSON(j)`), this is the default if no scope is specified. 

Before:
```
gcs_immu_test.go:90:
        	Error Trace:	/Users/admin/repo/kopia/repo/blob/gcs/gcs_immu_test.go:90
        	Error:      	Received unexpected error:
        	            	googleapi: Error 403: Access denied., forbidden
        	            	unable to extend retention period to 2024-10-01 20:02:11 +0000 UTC
```

After:
```
PASS
ok  	github.com/kopia/kopia/repo/blob/gcs	3.176s
```