### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/klauspost/compress v1.17.10
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.4
-	github.com/kopia/htmluibuild v0.0.1-0.20241001052939-6d8c75cf019a
+	github.com/kopia/htmluibuild v0.0.1-0.20241006020113-c37037c013ee
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.77

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.4 h1:5aDr3ZGoJbgu/8+j45KtUJxzYm8k08JGtB9Wx1VQ4OA=
 github.com/klauspost/reedsolomon v1.12.4/go.mod h1:d3CzOMOt0JXGIFZm1StgkyF14EYr3xneR2rNWo7NcMU=
-github.com/kopia/htmluibuild v0.0.1-0.20241001052939-6d8c75cf019a h1:sV6nWaRB5smIQtmRyIX6rKtCPKZ6XvK3RJUG/SjZhOw=
-github.com/kopia/htmluibuild v0.0.1-0.20241001052939-6d8c75cf019a/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20241006020113-c37037c013ee h1:TtJGE2mxkn0rmuIdfsp0hYnJI3SgP0JvdcJOcgLZafw=
+github.com/kopia/htmluibuild v0.0.1-0.20241006020113-c37037c013ee/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/2430f2b342d82b6d3ef4caa5f164c5b712b01f24...78af747b91fbbe51930cd7d0280d36c3fe24626f

* Sat 18:59 -0700 https://github.com/kopia/htmlui/commit/44b8403 dependabot[bot] build(deps-dev): bump @testing-library/jest-dom from 6.4.1 to 6.5.0
* Sat 18:59 -0700 https://github.com/kopia/htmlui/commit/1adc8c4 dependabot[bot] build(deps-dev): bump @types/react from 18.2.61 to 18.3.10
* Sat 19:00 -0700 https://github.com/kopia/htmlui/commit/78af747 dependabot[bot] build(deps-dev): bump axios from 1.7.4 to 1.7.7

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Sun Oct  6 02:01:40 UTC 2024*
