### PR TITLE
refactor(server): handle `ErrServerClosed` where it occurs

### DIFF
--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -265,12 +265,7 @@ func (c *commandServerStart) run(ctx context.Context) (reterr error) {
 
 	onExternalConfigReloadRequest(srv.Refresh)
 
-	err = c.startServerWithOptionalTLS(ctx, httpServer)
-	if !errors.Is(err, http.ErrServerClosed) {
-		return err
-	}
-
-	return nil
+	return c.startServerWithOptionalTLS(ctx, httpServer)
 }
 
 func shutdownHTTPServer(ctx context.Context, httpServer *http.Server) {

--- a/cli/command_server_tls.go
+++ b/cli/command_server_tls.go
@@ -122,7 +122,7 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttps://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
 		c.showServerUIPrompt(ctx)
 
-		return checkErrServerClosed(httpServer.ServeTLS(listener, c.serverStartTLSCertFile, c.serverStartTLSKeyFile), "error starting TLS server")
+		return checkErrServerClosed(ctx, httpServer.ServeTLS(listener, c.serverStartTLSCertFile, c.serverStartTLSKeyFile), "error starting TLS server")
 
 	case c.serverStartTLSGenerateCert:
 		// PEM files not provided, generate in-memory TLS cert/key but don't persit.
@@ -158,7 +158,7 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttps://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
 		c.showServerUIPrompt(ctx)
 
-		return checkErrServerClosed(httpServer.ServeTLS(listener, "", ""), "error starting TLS server")
+		return checkErrServerClosed(ctx, httpServer.ServeTLS(listener, "", ""), "error starting TLS server")
 
 	default:
 		if !c.serverStartInsecure {
@@ -168,7 +168,7 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttp://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
 		c.showServerUIPrompt(ctx)
 
-		return checkErrServerClosed(httpServer.Serve(listener), "error starting server")
+		return checkErrServerClosed(ctx, httpServer.Serve(listener), "error starting server")
 	}
 }
 

--- a/cli/command_server_tls.go
+++ b/cli/command_server_tls.go
@@ -178,7 +178,7 @@ func (c *commandServerStart) showServerUIPrompt(ctx context.Context) {
 	}
 }
 
-func checkErrServerClosed(err error, msg string) error {
+func checkErrServerClosed(ctx context.Context, err error, msg string) error {
 	if errors.Is(err, http.ErrServerClosed) {
 		log(ctx).Debug("HTTP server closed:", err)
 


### PR DESCRIPTION
Checks whether any of the `httpServer.Serve*()` calls returns `ErrServerClosed`.

Hhandles `ErrServerClosed` inside the `startServerWithOptionalTLS` function instead of propagating it up.  This means that `startServerWithOptionalTLS` returns a nil error when the HTTP server is closed, so the caller does not need to check for `ErrServerClosed`

No functional changes otherwise.