### PR TITLE
docs(site): Clarify ransomware requirements for Google/Azure

### DIFF
--- a/site/content/docs/Advanced/Ransomware Protection/_index.md
+++ b/site/content/docs/Advanced/Ransomware Protection/_index.md
@@ -19,9 +19,6 @@ For the context of Kopia protection, ransomware refers to viruses, trojans or ot
       Google Cloud Storage (GCS) (see below).
  * Kopia's Backblaze B2 storage engine provides support for using restricted access keys, but not for object locks at the current time.
     * To use storage locks with Backblaze B2, use the S3 storage engine.
- * Kopia's Google Cloud Services (GCS) engine provides neither restricted access key nor object-lock support.
-    * Google's S3 compatibility layer does not provide sufficient access controls to use these features, and thus Kopia cannot use
-      the ransomware mitigation discussed on this page with GCS at this time.
 * Kopia's Azure & Google storage engines support object-locks for ransomware protection.
 
 ### Using application keys to protect your data
@@ -126,7 +123,10 @@ When this is configured, the retention mode can be set to either compliance or g
 
 Follow [these steps](https://learn.microsoft.com/en-us/azure/storage/blobs/versioning-enable) to enable versioning on the storage account and [these steps](https://learn.microsoft.com/en-us/azure/storage/blobs/immutable-policy-configure-version-scope) to enable version-level immutability support on the container or related storage account.
 
-On Kopia side `--retention-mode COMPLIANCE --retention-period <retention time>` should be set like above. 
+On Kopia side `--retention-mode COMPLIANCE --retention-period <retention time>` should be set like above.
+
+To have continuous protection it is also necessary to run: `kopia maintenance set --extend-object-locks true`
+* Note that the `full-interval` must be at least 1 day shorter than the `retention-period` or Kopia will not allow you to enable Object Lock extension
 
 ### Google protection
 
@@ -134,3 +134,9 @@ Kopia supports ransomware protection for Google in a similar manner to S3. The b
 When this is configured, the retention mode can be set to either compliance or governance mode. In both cases the blobs will be in [Locked](https://cloud.google.com/storage/docs/object-lock#overview) mode.
 
 On Kopia side `--retention-mode COMPLIANCE --retention-period <retention time>` should be set like above.
+
+To have continuous protection it is also necessary to run: `kopia maintenance set --extend-object-locks true`
+* Note that the `full-interval` must be at least 1 day shorter than the `retention-period` or Kopia will not allow you to enable Object Lock extension
+
+If using minimal permissions with the credentials,
+`storage.objects.setRetention` permission is also required.


### PR DESCRIPTION
Remove no longer relevant Google section + clarify that `set --extend-object-locks` also needs setting for Azure/Google

<img width="734" alt="image" src="https://github.com/user-attachments/assets/2ed41982-62d9-4744-86d7-c231e624a9c6">

Google section: 

<img width="792" alt="image" src="https://github.com/user-attachments/assets/b1b38f22-3193-4a7e-9973-abff38a3a3e1">



