### PR TITLE
fix(cli): hashing benchmark repeat

### DIFF
--- a/cli/command_benchmark_hashing.go
+++ b/cli/command_benchmark_hashing.go
@@ -25,7 +25,7 @@ type commandBenchmarkHashing struct {
 func (c *commandBenchmarkHashing) setup(svc appServices, parent commandParent) {
 	cmd := parent.Command("hashing", "Run hashing function benchmarks").Alias("hash")
 	cmd.Flag("block-size", "Size of a block to hash").Default("1MB").BytesVar(&c.blockSize)
-	cmd.Flag("repeat", "Number of repetitions").Default("100").IntVar(&c.repeat)
+	cmd.Flag("repeat", "Number of repetitions").Default("10").IntVar(&c.repeat)
 	cmd.Flag("parallel", "Number of parallel goroutines").Default("1").IntVar(&c.parallel)
 	cmd.Flag("print-options", "Print out options usable for repository creation").BoolVar(&c.optionPrint)
 	cmd.Action(svc.noRepositoryAction(c.run))
@@ -81,8 +81,10 @@ func (c *commandBenchmarkHashing) runBenchmark(ctx context.Context) []cryptoBenc
 		runInParallelNoInputNoResult(c.parallel, func() {
 			var hashOutput [hashing.MaxHashSize]byte
 
-			for range hashOutput {
-				hf(hashOutput[:0], input)
+			for range hashCount {
+				for range hashOutput {
+					hf(hashOutput[:0], input)
+				}
 			}
 		})
 


### PR DESCRIPTION
Fixes: #4181

```
kopia benchmark hashing --repeat=20
Benchmarking hash 'BLAKE2B-256' (20 x 1048576 bytes, parallelism 1)
Benchmarking hash 'BLAKE2B-256-128' (20 x 1048576 bytes, parallelism 1)
Benchmarking hash 'BLAKE2S-128' (20 x 1048576 bytes, parallelism 1)
Benchmarking hash 'BLAKE2S-256' (20 x 1048576 bytes, parallelism 1)
Benchmarking hash 'BLAKE3-256' (20 x 1048576 bytes, parallelism 1)
Benchmarking hash 'BLAKE3-256-128' (20 x 1048576 bytes, parallelism 1)
Benchmarking hash 'HMAC-SHA224' (20 x 1048576 bytes, parallelism 1)
Benchmarking hash 'HMAC-SHA256' (20 x 1048576 bytes, parallelism 1)
Benchmarking hash 'HMAC-SHA256-128' (20 x 1048576 bytes, parallelism 1)
Benchmarking hash 'HMAC-SHA3-224' (20 x 1048576 bytes, parallelism 1)
Benchmarking hash 'HMAC-SHA3-256' (20 x 1048576 bytes, parallelism 1)
     Hash                 Throughput
-----------------------------------------------------------------
  0. BLAKE3-256-128       125.1 MB / second
  1. BLAKE3-256           124.1 MB / second
  2. BLAKE2B-256-128      37.7 MB / second
  3. BLAKE2B-256          37.7 MB / second
  4. BLAKE2S-256          27.7 MB / second
  5. BLAKE2S-128          27.6 MB / second
  6. HMAC-SHA256          14.5 MB / second
  7. HMAC-SHA256-128      14.3 MB / second
  8. HMAC-SHA224          14 MB / second
  9. HMAC-SHA3-224        12.9 MB / second
 10. HMAC-SHA3-256        12.2 MB / second
-----------------------------------------------------------------
Fastest option for this machine is: --block-hash=BLAKE3-256-128
```


```
./kopia benchmark hashing --repeat=5
Benchmarking hash 'BLAKE2B-256' (5 x 1048576 bytes, parallelism 1)
Benchmarking hash 'BLAKE2B-256-128' (5 x 1048576 bytes, parallelism 1)
Benchmarking hash 'BLAKE2S-128' (5 x 1048576 bytes, parallelism 1)
Benchmarking hash 'BLAKE2S-256' (5 x 1048576 bytes, parallelism 1)
Benchmarking hash 'BLAKE3-256' (5 x 1048576 bytes, parallelism 1)
Benchmarking hash 'BLAKE3-256-128' (5 x 1048576 bytes, parallelism 1)
Benchmarking hash 'HMAC-SHA224' (5 x 1048576 bytes, parallelism 1)
Benchmarking hash 'HMAC-SHA256' (5 x 1048576 bytes, parallelism 1)
Benchmarking hash 'HMAC-SHA256-128' (5 x 1048576 bytes, parallelism 1)
Benchmarking hash 'HMAC-SHA3-224' (5 x 1048576 bytes, parallelism 1)
Benchmarking hash 'HMAC-SHA3-256' (5 x 1048576 bytes, parallelism 1)
     Hash                 Throughput
-----------------------------------------------------------------
  0. BLAKE3-256-128       121.9 MB / second
  1. BLAKE3-256           120 MB / second
  2. BLAKE2B-256          36.5 MB / second
  3. BLAKE2B-256-128      36.5 MB / second
  4. BLAKE2S-256          27.8 MB / second
  5. BLAKE2S-128          27.2 MB / second
  6. HMAC-SHA224          15.1 MB / second
  7. HMAC-SHA256          14.1 MB / second
  8. HMAC-SHA256-128      13.8 MB / second
  9. HMAC-SHA3-224        12 MB / second
 10. HMAC-SHA3-256        11.3 MB / second
-----------------------------------------------------------------
Fastest option for this machine is: --block-hash=BLAKE3-256-128
```