### PR TITLE
test(cli): prefer require in cli_test_env

### DIFF
--- a/tests/testenv/cli_test_env.go
+++ b/tests/testenv/cli_test_env.go
@@ -117,9 +117,7 @@ func (e *CLITest) RunAndExpectSuccess(t *testing.T, args ...string) []string {
 	t.Helper()
 
 	stdout, _, err := e.Run(t, false, args...)
-	if err != nil {
-		t.Fatalf("'kopia %v' failed with %v", strings.Join(args, " "), err)
-	}
+	require.NoError(t, err, "'kopia %v' failed", strings.Join(args, " "))
 
 	return stdout
 }
@@ -234,9 +232,7 @@ func (e *CLITest) RunAndExpectSuccessWithErrOut(t *testing.T, args ...string) (s
 	t.Helper()
 
 	stdout, stderr, err := e.Run(t, false, args...)
-	if err != nil {
-		t.Fatalf("'kopia %v' failed with %v", strings.Join(args, " "), err)
-	}
+	require.NoError(t, err, "'kopia %v' failed", strings.Join(args, " "))
 
 	return stdout, stderr
 }
@@ -248,9 +244,7 @@ func (e *CLITest) RunAndExpectFailure(t *testing.T, args ...string) (stdout, std
 	var err error
 
 	stdout, stderr, err = e.Run(t, true, args...)
-	if err == nil {
-		t.Fatalf("'kopia %v' succeeded, but expected failure", strings.Join(args, " "))
-	}
+	require.Error(t, err, "'kopia %v' succeeded, but expected failure", strings.Join(args, " "))
 
 	return stdout, stderr
 }
@@ -260,9 +254,7 @@ func (e *CLITest) RunAndVerifyOutputLineCount(t *testing.T, wantLines int, args 
 	t.Helper()
 
 	lines := e.RunAndExpectSuccess(t, args...)
-	if len(lines) != wantLines {
-		t.Fatalf("unexpected list of results of 'kopia %v': %v lines (%v) wanted %v", strings.Join(args, " "), len(lines), lines, wantLines)
-	}
+	require.Len(t, lines, wantLines, "unexpected output lines for 'kopia %v', lines:\n %s", strings.Join(args, " "), strings.Join(lines, "\n "))
 
 	return lines
 }


### PR DESCRIPTION
Facilitates troubleshooting test failures.

Sample output:

```
     	Error Trace:	kopia/tests/testenv/cli_test_env.go:257        	            				  
        	        kopia/cli/command_logs_test.go:100
        	Error:      	"[20241025124935_bb69 2024-10-25 12:49:35 PDT 0s 1.1 KB 1 20241025124935_36e0 2024-10-25 12:49:35 PDT 0s 1 KB 1 20241025124935_0532 2024-10-25 12:49:35 PDT 0s 1.6 KB 1 20241025124935_03b8 2024-10-25 12:49:35 PDT 0s 1.1 KB 1 20241025124935_61e8 2024-10-25 12:49:35 PDT 0s 1.1 KB 1]" should have 1 item(s), but has 5
        	Test:       	TestLogsMaintenance
        	Messages:   	unexpected output lines for 'kopia logs list', lines:
        	            	 20241025124935_bb69 2024-10-25 12:49:35 PDT 0s 1.1 KB 1
        	            	 20241025124935_36e0 2024-10-25 12:49:35 PDT 0s 1 KB 1
        	            	 20241025124935_0532 2024-10-25 12:49:35 PDT 0s 1.6 KB 1
        	            	 20241025124935_03b8 2024-10-25 12:49:35 PDT 0s 1.1 KB 1
        	            	 20241025124935_61e8 2024-10-25 12:49:35 PDT 0s 1.1 KB 1
```