### PR TITLE
fix(cli): avoid memory bloat in `benchmark encryption` command

### DIFF
--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -98,6 +98,8 @@ func (c *commandBenchmarkCrypto) runBenchmark(ctx context.Context) []cryptoBench
 				defer encryptOutput.Close()
 
 				for range hashCount {
+					encryptOutput.Reset()
+
 					contentID := hf(hashOutput[:0], input)
 
 					if encerr := enc.Encrypt(input, contentID, &encryptOutput); encerr != nil {

--- a/cli/command_benchmark_encryption.go
+++ b/cli/command_benchmark_encryption.go
@@ -90,6 +90,8 @@ func (c *commandBenchmarkEncryption) runBenchmark(ctx context.Context) []cryptoB
 			defer encryptOutput.Close()
 
 			for range hashCount {
+				encryptOutput.Reset()
+
 				if encerr := enc.Encrypt(input, hashOutput[:32], &encryptOutput); encerr != nil {
 					log(ctx).Errorf("encryption failed: %v", encerr)
 					break


### PR DESCRIPTION
Reuse the output buffer by resetting it between iterations.

- Fixes: #4210