### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.4
-	github.com/kopia/htmluibuild v0.0.1-0.20241006020113-c37037c013ee
+	github.com/kopia/htmluibuild v0.0.1-0.20241105030613-ff1a0c1deb89
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.80

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.4 h1:5aDr3ZGoJbgu/8+j45KtUJxzYm8k08JGtB9Wx1VQ4OA=
 github.com/klauspost/reedsolomon v1.12.4/go.mod h1:d3CzOMOt0JXGIFZm1StgkyF14EYr3xneR2rNWo7NcMU=
-github.com/kopia/htmluibuild v0.0.1-0.20241006020113-c37037c013ee h1:TtJGE2mxkn0rmuIdfsp0hYnJI3SgP0JvdcJOcgLZafw=
-github.com/kopia/htmluibuild v0.0.1-0.20241006020113-c37037c013ee/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20241105030613-ff1a0c1deb89 h1:xT0FfnpQ0Res3gBXrn5E4tqQeJ34xv7EbtnbPkzF01w=
+github.com/kopia/htmluibuild v0.0.1-0.20241105030613-ff1a0c1deb89/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/78af747b91fbbe51930cd7d0280d36c3fe24626f...7155840f46ce41d6fd25ccb3492ac1e4996ff7e4

* Mon 19:05 -0800 https://github.com/kopia/htmlui/commit/7155840 dependabot[bot] build(deps): bump http-proxy-middleware from 3.0.0 to 3.0.3

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Tue Nov  5 03:06:37 UTC 2024*
