### PR TITLE
test(kopiaui): reduce flaky failures HTML UI E2E test

### DIFF
--- a/tests/htmlui_e2e_test/htmlui_e2e_test.go
+++ b/tests/htmlui_e2e_test/htmlui_e2e_test.go
@@ -67,7 +67,7 @@ func runInBrowser(t *testing.T, run func(ctx context.Context, sp *testutil.Serve
 
 	t.Logf("detected server parameters %#v", sp)
 
-	ctx, cancelTimeout := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancelTimeout := context.WithTimeout(context.Background(), 3*time.Minute)
 	defer cancelTimeout()
 
 	maybeHeadless := chromedp.Headless


### PR DESCRIPTION
Increase test (context) timeout from 2 minutes to 3 minutes.