### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.4
-	github.com/kopia/htmluibuild v0.0.1-0.20241105030613-ff1a0c1deb89
+	github.com/kopia/htmluibuild v0.0.1-0.20241105060252-108f70b353de
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/minio/minio-go/v7 v7.0.80

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.4 h1:5aDr3ZGoJbgu/8+j45KtUJxzYm8k08JGtB9Wx1VQ4OA=
 github.com/klauspost/reedsolomon v1.12.4/go.mod h1:d3CzOMOt0JXGIFZm1StgkyF14EYr3xneR2rNWo7NcMU=
-github.com/kopia/htmluibuild v0.0.1-0.20241105030613-ff1a0c1deb89 h1:xT0FfnpQ0Res3gBXrn5E4tqQeJ34xv7EbtnbPkzF01w=
-github.com/kopia/htmluibuild v0.0.1-0.20241105030613-ff1a0c1deb89/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20241105060252-108f70b353de h1:g+gBeLNkHUNVOQIIqxmJY+5shY2MlgjoPuOR1P5OmiE=
+github.com/kopia/htmluibuild v0.0.1-0.20241105060252-108f70b353de/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/7155840f46ce41d6fd25ccb3492ac1e4996ff7e4...637dd8cf248cd630618fef8182653ed6058a54e7

* Mon 22:01 -0800 https://github.com/kopia/htmlui/commit/978eabc dependabot[bot] build(deps-dev): bump @types/react-dom from 18.3.0 to 18.3.1
* Mon 22:01 -0800 https://github.com/kopia/htmlui/commit/1227736 dependabot[bot] build(deps): bump @fortawesome/free-solid-svg-icons from 6.5.1 to 6.6.0
* Mon 22:01 -0800 https://github.com/kopia/htmlui/commit/637dd8c dependabot[bot] build(deps): bump cookie and express

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Tue Nov  5 06:03:23 UTC 2024*
