### PR TITLE
feat(server): add logging of failed and successful login attempts

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -207,6 +207,9 @@ func isAuthenticated(rc requestContext) bool {
 		rc.w.Header().Set("WWW-Authenticate", `Basic realm="Kopia"`)
 		http.Error(rc.w, "Access denied.\n", http.StatusUnauthorized)
 
+		// Log failed authentication attempt
+		log(rc.req.Context()).Warnf("failed login attempt by client %s for user %s", rc.req.RemoteAddr, username)
+
 		return false
 	}
 
@@ -222,6 +225,9 @@ func isAuthenticated(rc requestContext) bool {
 			Expires: now.Add(kopiaAuthCookieTTL),
 			Path:    "/",
 		})
+
+		// Log successful authentication
+		log(rc.req.Context()).Infof("successful login by client %s for user %s", rc.req.RemoteAddr, username)
 	}
 
 	return true


### PR DESCRIPTION
A minimal commit to add support for monitoring, troubleshooting, and to allow using tools like crowdsec or fail2ban. This to ease the comfort a bit on opening up access to a kopia server over internet.

When/if change is merged or a similar is created I can create instructions and templates for using said tools to protect a kopia server instance running om Linux.