### PR TITLE
fix(notifications): fixed headers for email notifications

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -20,6 +20,7 @@ options:
       - deps-dev
       - infra
       - ci
+      - notifications
       - ui
   commit_groups:
     sort_by: Custom
@@ -37,6 +38,7 @@ options:
       infra: Infrastructure
       general: General Improvements
       providers: Storage Providers
+      notifications: Notifications
       ci: CI/CD
     title_order:
       - cli
@@ -46,6 +48,7 @@ options:
       - server
       - snapshots
       - providers
+      - notifications
       - deps
       - testing
       - lint

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: deepakputhraya/action-pr-title@master
       with:
-        regex: '^(feat|fix|breaking|build|chore|docs|style|refactor|test)\((kopiaui|cli|ui|repository|snapshots|server|providers|deps|deps-dev|site|ci|infra|general)\)!{0,1}: .*$'
+        regex: '^(feat|fix|breaking|build|chore|docs|style|refactor|test)\((kopiaui|cli|ui|repository|snapshots|server|providers|deps|deps-dev|site|ci|infra|notifications|general)\)!{0,1}: .*$'


### PR DESCRIPTION
This fixes sending emails via SendGrid as reported by a user on Slack. The fix has been tested already.