### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.4
-	github.com/kopia/htmluibuild v0.0.1-0.20241119233831-fde0bf2a4817
+	github.com/kopia/htmluibuild v0.0.1-0.20241210014550-892577c722b4
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.4 h1:5aDr3ZGoJbgu/8+j45KtUJxzYm8k08JGtB9Wx1VQ4OA=
 github.com/klauspost/reedsolomon v1.12.4/go.mod h1:d3CzOMOt0JXGIFZm1StgkyF14EYr3xneR2rNWo7NcMU=
-github.com/kopia/htmluibuild v0.0.1-0.20241119233831-fde0bf2a4817 h1:hhGqeQLW6Z5ZS6L+XTTe2FPjb1WhTxMYaByWDPBV9k0=
-github.com/kopia/htmluibuild v0.0.1-0.20241119233831-fde0bf2a4817/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20241210014550-892577c722b4 h1:pyZwS/xlV1XfYSKjVILi1fGg4eEnD/vSgoCWvyehO+M=
+github.com/kopia/htmluibuild v0.0.1-0.20241210014550-892577c722b4/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/e927e3a9bfdc87a52494490c2d381963feb7a1a0...21f642fb517f23d4431b1c3056086ecd086b72db

* Mon 17:44 -0800 https://github.com/kopia/htmlui/commit/83f2cb6 dependabot[bot] build(deps-dev): bump @testing-library/jest-dom from 6.5.0 to 6.6.3
* Mon 17:44 -0800 https://github.com/kopia/htmlui/commit/ec51a13 dependabot[bot] build(deps-dev): bump axios from 1.7.7 to 1.7.8
* Mon 17:44 -0800 https://github.com/kopia/htmlui/commit/21f642f dependabot[bot] build(deps): bump react-bootstrap from 2.10.5 to 2.10.6

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Tue Dec 10 01:46:08 UTC 2024*
