### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.4
-	github.com/kopia/htmluibuild v0.0.1-0.20241210014550-892577c722b4
+	github.com/kopia/htmluibuild v0.0.1-0.20241210040303-6717829a5bde
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.4 h1:5aDr3ZGoJbgu/8+j45KtUJxzYm8k08JGtB9Wx1VQ4OA=
 github.com/klauspost/reedsolomon v1.12.4/go.mod h1:d3CzOMOt0JXGIFZm1StgkyF14EYr3xneR2rNWo7NcMU=
-github.com/kopia/htmluibuild v0.0.1-0.20241210014550-892577c722b4 h1:pyZwS/xlV1XfYSKjVILi1fGg4eEnD/vSgoCWvyehO+M=
-github.com/kopia/htmluibuild v0.0.1-0.20241210014550-892577c722b4/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20241210040303-6717829a5bde h1:ISFS5b9fLdnh5VjXxq9+HRIGSDa2gDUJTDOjefJ02rc=
+github.com/kopia/htmluibuild v0.0.1-0.20241210040303-6717829a5bde/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/21f642fb517f23d4431b1c3056086ecd086b72db...92a95d16e2adab28902635865704ea0d0e75f144

* Mon 20:01 -0800 https://github.com/kopia/htmlui/commit/8ef768c dependabot[bot] build(deps-dev): bump nanoid from 3.3.4 to 3.3.8
* Mon 20:01 -0800 https://github.com/kopia/htmlui/commit/92a95d1 dependabot[bot] build(deps): bump path-to-regexp and express

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Tue Dec 10 04:03:28 UTC 2024*
