### PR TITLE
feat(cli): improve compression benchmark output

### DIFF
--- a/cli/command_benchmark_compression.go
+++ b/cli/command_benchmark_compression.go
@@ -336,7 +336,7 @@ func (c *commandBenchmarkCompression) printResults(results []compressionBechmark
 			maybeDeprecated = " (deprecated)"
 		}
 
-		c.out.printStdout("%3d. %-26v %-12v %-12v/s %-8v %v%v",
+		c.out.printStdout("%3d. %-26v %-12v %8v/s     %-8v %v%v",
 			ndx,
 			r.compression,
 			units.BytesString(r.compressedSize),


### PR DESCRIPTION
make sure MB-or-GB is not separated from /s in table. %-12v will put spaces on the right of the number, then print /s after the spaces.