### PR TITLE
fix(server): ensure server uploads "repodiag" blobs

### DIFF
--- a/internal/blobtesting/map.go
+++ b/internal/blobtesting/map.go
@@ -33,6 +33,10 @@ type mapStorage struct {
 }
 
 func (s *mapStorage) GetCapacity(ctx context.Context) (blob.Capacity, error) {
+	if err := ctx.Err(); err != nil {
+		return blob.Capacity{}, errors.Wrap(err, "get capacity failed")
+	}
+
 	if s.limit < 0 {
 		return blob.Capacity{}, blob.ErrNotAVolume
 	}
@@ -47,6 +51,10 @@ func (s *mapStorage) GetCapacity(ctx context.Context) (blob.Capacity, error) {
 }
 
 func (s *mapStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int64, output blob.OutputBuffer) error {
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "get blob failed")
+	}
+
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -82,6 +90,10 @@ func (s *mapStorage) GetBlob(ctx context.Context, id blob.ID, offset, length int
 }
 
 func (s *mapStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata, error) {
+	if err := ctx.Err(); err != nil {
+		return blob.Metadata{}, errors.Wrap(err, "get metadata failed")
+	}
+
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -98,6 +110,10 @@ func (s *mapStorage) GetMetadata(ctx context.Context, id blob.ID) (blob.Metadata
 }
 
 func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, opts blob.PutOptions) error {
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "pub blob failed")
+	}
+
 	switch {
 	case opts.HasRetentionOptions():
 		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob-retention")
@@ -134,6 +150,10 @@ func (s *mapStorage) PutBlob(ctx context.Context, id blob.ID, data blob.Bytes, o
 }
 
 func (s *mapStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "delete blob failed")
+	}
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -145,6 +165,10 @@ func (s *mapStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
 }
 
 func (s *mapStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback func(blob.Metadata) error) error {
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "list blobs failed")
+	}
+
 	s.mutex.RLock()
 
 	keys := []blob.ID{}
@@ -184,6 +208,10 @@ func (s *mapStorage) ListBlobs(ctx context.Context, prefix blob.ID, callback fun
 }
 
 func (s *mapStorage) TouchBlob(ctx context.Context, blobID blob.ID, threshold time.Duration) (time.Time, error) {
+	if err := ctx.Err(); err != nil {
+		return time.Time{}, errors.Wrap(err, "touch blob failed")
+	}
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/internal/repodiag/log_manager.go
+++ b/internal/repodiag/log_manager.go
@@ -78,7 +78,7 @@ func (m *LogManager) Enable() {
 // NewLogManager creates a new LogManager that will emit logs as repository blobs.
 func NewLogManager(ctx context.Context, w *BlobWriter) *LogManager {
 	return &LogManager{
-		ctx:            ctx,
+		ctx:            context.WithoutCancel(ctx),
 		writer:         w,
 		flushThreshold: blobLoggerFlushThreshold,
 		timeFunc:       clock.Now,

--- a/tests/end_to_end_test/server_repo_logs_test.go
+++ b/tests/end_to_end_test/server_repo_logs_test.go
@@ -1,0 +1,108 @@
+package endtoend_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/apiclient"
+	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/snapshot/policy"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+// Verify that the "diagnostic/log" blobs are uploaded to the  repository when
+// the server exits.
+// Approach / steps:
+// - initialize a repo, note this uploads logs to the repo
+// - start the server
+// - create a "snapshot source" on the server via the server-control API
+// - remove all log blobs from the repo and check that there are 0.
+// - stop the server
+// - check whether or not the server uploaded the logs.
+func TestServerRepoLogsUploadedOnShutdown(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-hostname=fake-hostname", "--override-username=fake-username")
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	logs := e.RunAndExpectSuccess(t, "logs", "list")
+	require.Len(t, logs, 1, "repo create did not upload logs")
+
+	var sp testutil.ServerParameters
+
+	wait, _ := e.RunAndProcessStderr(t, sp.ProcessOutput,
+		"server", "start",
+		"--address=localhost:0",
+		"--insecure",
+		"--without-password",
+		"--tls-generate-rsa-key-size=2048", // use shorter key size to speed up generation,
+	)
+
+	require.NotEmpty(t, sp.BaseURL, "server base URL")
+
+	controlCli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:  sp.BaseURL,
+		Username: defaultServerControlUsername,
+		Password: sp.ServerControlPassword,
+	})
+	require.NoError(t, err)
+
+	checkServerStartedOrFailed := func() bool {
+		var hs apiclient.HTTPStatusError
+
+		_, err := serverapi.Status(ctx, controlCli)
+
+		if errors.As(err, &hs) {
+			switch hs.HTTPStatusCode {
+			case http.StatusBadRequest:
+				return false
+			case http.StatusForbidden:
+				return false
+			}
+		}
+
+		return true
+	}
+
+	require.Eventually(t, checkServerStartedOrFailed, 10*time.Second, 100*time.Millisecond)
+	require.NoError(t, controlCli.FetchCSRFTokenForTesting(ctx))
+
+	keepDaily := policy.OptionalInt(3)
+
+	_, err = serverapi.CreateSnapshotSource(ctx, controlCli, &serverapi.CreateSnapshotSourceRequest{
+		Path: sharedTestDataDir1,
+		Policy: &policy.Policy{
+			RetentionPolicy: policy.RetentionPolicy{
+				KeepDaily: &keepDaily,
+			},
+		},
+		CreateSnapshot: false,
+	})
+
+	require.NoError(t, err)
+
+	lines := e.RunAndExpectSuccess(t, "server", "status", "--address", sp.BaseURL, "--server-control-password", sp.ServerControlPassword)
+	t.Logf("lines: %v", lines)
+
+	e.RunAndExpectSuccess(t, "logs", "cleanup", "--max-age=1ns")
+	logs = e.RunAndExpectSuccess(t, "logs", "list")
+	require.Empty(t, logs, "new logs were uploaded unexpectedly:", logs)
+
+	require.NoError(t, serverapi.Shutdown(ctx, controlCli))
+	require.NoError(t, wait())
+
+	logs = e.RunAndExpectSuccess(t, "logs", "list")
+
+	require.NotEmpty(t, logs, "server logs were not uploaded")
+}


### PR DESCRIPTION
The kopia server was not uploading any logs to the repository, because _"repodiag"_ blob uploads would always fail.

The cause was the following: When the (log) repodiag blob PUT operation was initiated, the `Context` used for this operation was already canceled.

The context used for blob uploads is passed to `repodiag.NewLogManager` when opening the repository. In the case of the kopia server, the repository is asynchronously opened in `server.Server.InitReposotoryAsync`. The context passed to `repo.Open` is canceled after the "open repository" server task completes. This issue was introduced in #1691

Change:
Use `context.WithoutCancel()` instead of the context passed when the repo "diagnoser" is created.

New tests are included to reproduce this failure and verify the fix.

Ref:
- #1691

Thanks to:
- 🎖️ @redgoat650 for reporting this issue;
- 🎖️ @aaron-kasten for the triaging, testing and reproduction of the issue.