### PR TITLE
build(deps): bump codecov/codecov-action from 5.2.0 to 5.3.0

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Run Tests
       run: make test-with-coverage
     - name: Upload Coverage
-      uses: codecov/codecov-action@5a605bd92782ce0810fa3b8acc235c921b497052 # v5.2.0
+      uses: codecov/codecov-action@0da7aa657d958d32c117fc47e1f977e7524753c7 # v5.3.0
       with:
         files: coverage.txt
     - name: Upload Logs


### PR DESCRIPTION
Upgrades [codecov/codecov-action](https://github.com/codecov/codecov-action) from 5.2.0 to 5.3.0.
- [Release notes](https://github.com/codecov/codecov-action/releases)
- [Changelog](https://github.com/codecov/codecov-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/codecov/codecov-action/compare/5a605bd92782ce0810fa3b8acc235c921b497052...0da7aa657d958d32c117fc47e1f977e7524753c7)

---
```
updated-dependencies:
- dependency-name: codecov/codecov-action
  dependency-type: direct:production
  update-type: version-update:semver-minor
```
...