### PR TITLE
feat(snapshot): add an option to skip modifying target dir if it already exists

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -122,6 +122,7 @@ type commandRestore struct {
 	restoreSkipTimes              bool
 	restoreSkipOwners             bool
 	restoreSkipPermissions        bool
+	restoreSkipTargetDir          bool
 	restoreIncremental            bool
 	restoreIgnoreErrors           bool
 	restoreShallowAtDepth         int32
@@ -150,6 +151,7 @@ func (c *commandRestore) setup(svc appServices, parent commandParent) {
 	cmd.Flag("skip-permissions", "Skip permissions during restore").BoolVar(&c.restoreSkipPermissions)
 	cmd.Flag("skip-times", "Skip times during restore").BoolVar(&c.restoreSkipTimes)
 	cmd.Flag("ignore-permission-errors", "Ignore permission errors").Default("true").BoolVar(&c.restoreIgnorePermissionErrors)
+	cmd.Flag("skip-target-dir", "Skip creating or modifying target dir during restore").Default("false").BoolVar(&c.restoreSkipTargetDir)
 	cmd.Flag("write-files-atomically", "Write files atomically to disk, ensuring they are either fully committed, or not written at all, preventing partially written files").Default("false").BoolVar(&c.restoreWriteFilesAtomically)
 	cmd.Flag("ignore-errors", "Ignore all errors").BoolVar(&c.restoreIgnoreErrors)
 	cmd.Flag("skip-existing", "Skip files and symlinks that exist in the output").BoolVar(&c.restoreIncremental)
@@ -266,6 +268,7 @@ func (c *commandRestore) restoreOutput(ctx context.Context, rep repo.Repository)
 			SkipOwners:             c.restoreSkipOwners,
 			SkipPermissions:        c.restoreSkipPermissions,
 			SkipTimes:              c.restoreSkipTimes,
+			SkipTargetDir:          c.restoreSkipTargetDir,
 			WriteSparseFiles:       c.restoreWriteSparseFiles,
 		}
 

--- a/snapshot/restore/local_fs_output.go
+++ b/snapshot/restore/local_fs_output.go
@@ -104,6 +104,9 @@ type FilesystemOutput struct {
 	// SkipTimes when set to true causes restore to skip restoring modification times.
 	SkipTimes bool `json:"skipTimes"`
 
+	// SkipTargetDir when set to true, don't create or modify the target dir.
+	SkipTargetDir bool `json:"skipTargetDir"`
+
 	// WriteSparseFiles when set to true, write contents as sparse files, minimizing allocated disk space.
 	WriteSparseFiles bool `json:"writeSparseFiles"`
 
@@ -132,6 +135,10 @@ func (o *FilesystemOutput) Parallelizable() bool {
 
 // BeginDirectory implements restore.Output interface.
 func (o *FilesystemOutput) BeginDirectory(ctx context.Context, relativePath string, _ fs.Directory) error {
+	if relativePath == "" && o.SkipTargetDir {
+		return nil
+	}
+
 	path := filepath.Join(o.TargetPath, filepath.FromSlash(relativePath))
 
 	if err := o.createDirectory(ctx, path); err != nil {
@@ -144,8 +151,11 @@ func (o *FilesystemOutput) BeginDirectory(ctx context.Context, relativePath stri
 // FinishDirectory implements restore.Output interface.
 func (o *FilesystemOutput) FinishDirectory(ctx context.Context, relativePath string, e fs.Directory) error {
 	path := filepath.Join(o.TargetPath, filepath.FromSlash(relativePath))
-	if err := o.setAttributes(path, e, os.FileMode(0)); err != nil {
-		return errors.Wrap(err, "error setting attributes")
+
+	if relativePath != "" || !o.SkipTargetDir {
+		if err := o.setAttributes(path, e, os.FileMode(0)); err != nil {
+			return errors.Wrap(err, "error setting attributes")
+		}
 	}
 
 	return SafeRemoveAll(path)


### PR DESCRIPTION
Fix issue #4351, add an option to skip modifying target dir if it already exists.

[Test Cases]
kopia snapshot create aaa/bbb

Case 1:

- mkdir aaa/ccc
- kopia restore aaa/bbb aaa/ccc
- aaa/bbb/* is restored to aaa/ccc
- aaa/bbb's attributes ARE restored to aaa/ccc

Case 2:

- mkdir aaa/ccc
- kopia restore aaa/bbb aaa/ccc  --skip-target-dir
- aaa/bbb/* is restored to aaa/ccc
- aaa/ccc's attributes are NOT changed

Case 3:

- kopia restore aaa/bbb aaa/ccc
- aaa/ccc is created
- aaa/bbb/* is restored to aaa/ccc

Case 4:

- kopia restore aaa/bbb aaa/ccc  --skip-target-dir
- restore fails since aaa/ccc doesn't exist

Case 5: 

- mkdir aaa/bbb
- kopia restore aaa/bbb
- aaa/bbb/* data is restored
- aaa/bbb's attributes ARE restored

Case 6: 

- mkdir aaa/bbb
- kopia restore aaa/bbb  --skip-target-dir
- aaa/bbb/* is restored
- aaa/bbb's attributes are NOT changed

Case 7: 

- kopia restore aaa/bbb
- aaa/bbb is creaetd
- aaa/bbb/* is restored

Case 8: 

- kopia restore aaa/bbb --skip-target-dir
- restore fails since aaa/bbb doesn't exist
