### PR TITLE
build(deps): update Go's toolchain to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kopia/kopia
 
 go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require (
 	cloud.google.com/go/storage v1.50.0


### PR DESCRIPTION
This addresses a govuln reported issue present [crypto/internal/nistec](https://pkg.go.dev/crypto/internal/nistec) on `ppc64le`