### PR TITLE
fix(server): prevent maintenance task on read-only repos

### DIFF
--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -38,6 +38,7 @@ type Environment struct {
 
 // Options used during Environment Setup.
 type Options struct {
+	ConnectOptions       func(*repo.ConnectOptions)
 	NewRepositoryOptions func(*repo.NewRepositoryOptions)
 	OpenOptions          func(*repo.Options)
 }
@@ -62,6 +63,7 @@ func (e *Environment) setup(tb testing.TB, version format.Version, opts ...Optio
 	ctx := testlogging.Context(tb)
 	e.configDir = testutil.TempDirectory(tb)
 	openOpt := &repo.Options{}
+	connectOpt := &repo.ConnectOptions{}
 
 	opt := &repo.NewRepositoryOptions{
 		BlockFormat: format.ContentFormat{
@@ -86,6 +88,10 @@ func (e *Environment) setup(tb testing.TB, version format.Version, opts ...Optio
 		if mod.OpenOptions != nil {
 			mod.OpenOptions(openOpt)
 		}
+
+		if mod.ConnectOptions != nil {
+			mod.ConnectOptions(connectOpt)
+		}
 	}
 
 	var st blob.Storage
@@ -106,7 +112,7 @@ func (e *Environment) setup(tb testing.TB, version format.Version, opts ...Optio
 	err := repo.Initialize(ctx, st, opt, e.Password)
 	require.NoError(tb, err)
 
-	err = repo.Connect(ctx, e.ConfigFile(), st, e.Password, nil)
+	err = repo.Connect(ctx, e.ConfigFile(), st, e.Password, connectOpt)
 	require.NoError(tb, err, "can't connect")
 
 	e.connected = true

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -632,11 +632,7 @@ func (s *Server) SetRepository(ctx context.Context, rep repo.Repository) error {
 		return err
 	}
 
-	if dr, ok := s.rep.(repo.DirectRepository); ok {
-		s.maint = startMaintenanceManager(ctx, dr, s, s.options.MinMaintenanceInterval)
-	} else {
-		s.maint = nil
-	}
+	s.maint = startMaintenanceManager(ctx, s.rep, s, s.options.MinMaintenanceInterval)
 
 	s.sched = scheduler.Start(context.WithoutCancel(ctx), s.getSchedulerItems, scheduler.Options{
 		TimeNow:        clock.Now,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -632,7 +632,7 @@ func (s *Server) SetRepository(ctx context.Context, rep repo.Repository) error {
 		return err
 	}
 
-	s.maint = startMaintenanceManager(ctx, s.rep, s, s.options.MinMaintenanceInterval)
+	s.maint = maybeStartMaintenanceManager(ctx, s.rep, s, s.options.MinMaintenanceInterval)
 
 	s.sched = scheduler.Start(context.WithoutCancel(ctx), s.getSchedulerItems, scheduler.Options{
 		TimeNow:        clock.Now,

--- a/internal/server/server_maintenance.go
+++ b/internal/server/server_maintenance.go
@@ -110,7 +110,8 @@ func (s *srvMaintenance) nextMaintenanceTime() time.Time {
 	return s.cachedNextMaintenanceTime
 }
 
-func startMaintenanceManager(
+// Starts a periodic, background srvMaintenance task. Returns nil if no task was created.
+func maybeStartMaintenanceManager(
 	ctx context.Context,
 	rep repo.Repository,
 	srv maintenanceManagerServerInterface,

--- a/internal/server/server_maintenance_test.go
+++ b/internal/server/server_maintenance_test.go
@@ -75,7 +75,7 @@ func TestServerMaintenance(t *testing.T) {
 
 	ts := &testServer{log: t.Logf}
 
-	mm := startMaintenanceManager(ctx, env.RepositoryWriter, ts, time.Minute)
+	mm := maybeStartMaintenanceManager(ctx, env.RepositoryWriter, ts, time.Minute)
 	require.Equal(t, time.Time{}, mm.nextMaintenanceNoEarlierThan)
 
 	defer mm.stop(ctx)
@@ -134,7 +134,7 @@ func TestServerMaintenanceReadOnlyRepoConnection(t *testing.T) {
 	env.MustReopen(t)
 
 	ts := &testServer{log: t.Logf}
-	mm := startMaintenanceManager(ctx, env.RepositoryWriter, ts, time.Minute)
+	mm := maybeStartMaintenanceManager(ctx, env.RepositoryWriter, ts, time.Minute)
 
 	require.Nil(t, mm, "maintenance task should not be created on read-only repo")
 }

--- a/snapshot/snapshotmaintenance/snapshotmaintenance.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance.go
@@ -13,6 +13,10 @@ import (
 
 // Run runs the complete snapshot and repository maintenance.
 func Run(ctx context.Context, dr repo.DirectRepositoryWriter, mode maintenance.Mode, force bool, safety maintenance.SafetyParameters) error {
+	if dr.ClientOptions().ReadOnly {
+		return errors.New("not running maintenance on read-only repository connection")
+	}
+
 	//nolint:wrapcheck
 	return maintenance.RunExclusive(ctx, dr, mode, force,
 		func(ctx context.Context, runParams maintenance.RunParameters) error {

--- a/snapshot/snapshotmaintenance/snapshotmaintenance.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance.go
@@ -11,10 +11,13 @@ import (
 	"github.com/kopia/kopia/snapshot/snapshotgc"
 )
 
+// ErrReadonly indicates a failure when attempting to run maintenance on a read-only repository.
+var ErrReadonly = errors.New("not running maintenance on read-only repository connection")
+
 // Run runs the complete snapshot and repository maintenance.
 func Run(ctx context.Context, dr repo.DirectRepositoryWriter, mode maintenance.Mode, force bool, safety maintenance.SafetyParameters) error {
 	if dr.ClientOptions().ReadOnly {
-		return errors.New("not running maintenance on read-only repository connection")
+		return ErrReadonly
 	}
 
 	//nolint:wrapcheck

--- a/snapshot/snapshotmaintenance/snapshotmaintenance_test.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance_test.go
@@ -322,6 +322,18 @@ func (s *formatSpecificTestSuite) TestMaintenanceAutoLiveness(t *testing.T) {
 	require.NotEmpty(t, sched.Runs[maintenance.TaskSnapshotGarbageCollection], maintenance.TaskSnapshotGarbageCollection)
 }
 
+func TestNoMaintenanceReadOnly(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant, repotesting.Options{
+		ConnectOptions: func(o *repo.ConnectOptions) {
+			o.ReadOnly = true
+		},
+	})
+
+	err := snapshotmaintenance.Run(ctx, env.RepositoryWriter, maintenance.ModeAuto, true, maintenance.SafetyFull)
+
+	require.ErrorIs(t, err, snapshotmaintenance.ErrReadonly)
+}
+
 func (th *testHarness) fakeTimeOpenRepoOption(o *repo.Options) {
 	o.TimeNowFunc = th.fakeTime.NowFunc()
 }


### PR DESCRIPTION
Avoid starting a maintenance task on the server when the repository connection (configuration) is read-only.

- Fixes: #4373