### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.4
-	github.com/kopia/htmluibuild v0.0.1-0.20241228091102-21c41d704c1b
+	github.com/kopia/htmluibuild v0.0.1-0.20250214062624-8902d5ca7c0e
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.4 h1:5aDr3ZGoJbgu/8+j45KtUJxzYm8k08JGtB9Wx1VQ4OA=
 github.com/klauspost/reedsolomon v1.12.4/go.mod h1:d3CzOMOt0JXGIFZm1StgkyF14EYr3xneR2rNWo7NcMU=
-github.com/kopia/htmluibuild v0.0.1-0.20241228091102-21c41d704c1b h1:pg4vjHBCUkPlsNyRQXPnJfeXw4l3AJ+B5RliA95OZNg=
-github.com/kopia/htmluibuild v0.0.1-0.20241228091102-21c41d704c1b/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20250214062624-8902d5ca7c0e h1:5zoBPFP+Y2uzeJh8wPMF9fxObeeatlPKIsdjVePAYGk=
+github.com/kopia/htmluibuild v0.0.1-0.20250214062624-8902d5ca7c0e/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/16dfe3793a020835bc6a98d75e7c2550210954e1...c87a5906602c0c02ad231999ec4fb4e157147351

* Thu 22:24 -0800 https://github.com/kopia/htmlui/commit/ff4c797 dependabot[bot] build(deps): bump @fortawesome/free-regular-svg-icons
* Thu 22:25 -0800 https://github.com/kopia/htmlui/commit/c87a590 dependabot[bot] build(deps-dev): bump @testing-library/react from 16.0.1 to 16.2.0

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Fri Feb 14 06:26:53 UTC 2025*
