### PR TITLE
fix(general): prevent infinite loop while resolving ignore file symlinks

### DIFF
--- a/fs/entry.go
+++ b/fs/entry.go
@@ -78,10 +78,6 @@ func IterateEntries(ctx context.Context, dir Directory, cb func(context.Context,
 	defer iter.Close()
 
 	cur, err := iter.Next(ctx)
-	if err != nil {
-		err = errors.Wrapf(err, "in fs.IterateEntries, on first iteration")
-	}
-
 	for cur != nil {
 		if err2 := cb(ctx, cur); err2 != nil {
 			return errors.Wrapf(err2, "in fs.IterateEntries, while calling callback on file %s", cur.Name())

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -72,7 +72,7 @@ type Directory interface {
 func IterateEntries(ctx context.Context, dir Directory, cb func(context.Context, Entry) error) error {
 	iter, err := dir.Iterate(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "in fs.IterateEntries, creating iterator for directory %s", dir.Name())
+		return errors.Wrapf(err, "cannot iterate directory '%q'", dir.Name())
 	}
 
 	defer iter.Close()
@@ -80,7 +80,7 @@ func IterateEntries(ctx context.Context, dir Directory, cb func(context.Context,
 	cur, err := iter.Next(ctx)
 	for cur != nil {
 		if err2 := cb(ctx, cur); err2 != nil {
-			return errors.Wrapf(err2, "in fs.IterateEntries, while calling callback on file %s", cur.Name())
+			return errors.Wrapf(err2, "callback failed on '%q'", cur.Name())
 		}
 
 		cur, err = iter.Next(ctx)

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -132,7 +132,7 @@ func GetAllEntries(ctx context.Context, d Directory) ([]Entry, error) {
 	defer iter.Close()
 
 	cur, err := iter.Next(ctx)
-	for cur != nil {
+	for err == nil && cur != nil {
 		entries = append(entries, cur)
 		cur, err = iter.Next(ctx)
 	}

--- a/fs/ignorefs/ignorefs.go
+++ b/fs/ignorefs/ignorefs.go
@@ -193,7 +193,7 @@ func (d *ignoreDirectory) Iterate(ctx context.Context) (fs.DirectoryIterator, er
 
 	inner, err := d.Directory.Iterate(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "in ignoreDirectory.Iterate, when creating iterator")
+		return nil, errors.Wrap(err, "cannot create iterator")
 	}
 
 	it := ignoreDirIteratorPool.Get().(*ignoreDirIterator) //nolint:forcetypeassert

--- a/fs/ignorefs/ignorefs.go
+++ b/fs/ignorefs/ignorefs.go
@@ -188,7 +188,7 @@ func (d *ignoreDirectory) Iterate(ctx context.Context) (fs.DirectoryIterator, er
 
 	thisContext, err := d.buildContext(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "in ignoreDirectory.Iterate, when building context")
+		return nil, err
 	}
 
 	inner, err := d.Directory.Iterate(ctx)

--- a/fs/ignorefs/resolve_test.go
+++ b/fs/ignorefs/resolve_test.go
@@ -1,0 +1,31 @@
+package ignorefs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/internal/mockfs"
+	"github.com/kopia/kopia/internal/testlogging"
+)
+
+func TestNoInfiniteResolveLink(t *testing.T) {
+	root := mockfs.NewDirectory()
+
+	root.AddSymlink("a", "./b", 0)
+	root.AddSymlink("b", "./c", 0)
+	root.AddSymlink("c", "./a", 0)
+
+	ctx := testlogging.Context(t)
+	e, err := root.Child(ctx, "b")
+	require.NoError(t, err)
+
+	s, ok := e.(fs.Symlink)
+	require.True(t, ok)
+
+	f, err := resolveSymlink(ctx, s)
+
+	require.ErrorIs(t, err, errTooManySymlinks)
+	require.Nil(t, f)
+}

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -120,7 +120,7 @@ func (fsl *filesystemSymlink) Readlink(ctx context.Context) (string, error) {
 func (fsl *filesystemSymlink) Resolve(ctx context.Context) (fs.Entry, error) {
 	target, err := filepath.EvalSymlinks(fsl.fullPath())
 	if err != nil {
-		return nil, errors.Wrapf(err, "while reading symlink %s", fsl.fullPath())
+		return nil, errors.Wrapf(err, "cannot resolve symlink for '%q'", fsl.fullPath())
 	}
 
 	entry, err := NewEntry(target)

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -123,9 +123,7 @@ func (fsl *filesystemSymlink) Resolve(ctx context.Context) (fs.Entry, error) {
 		return nil, errors.Wrapf(err, "cannot resolve symlink for '%q'", fsl.fullPath())
 	}
 
-	entry, err := NewEntry(target)
-
-	return entry, err
+	return NewEntry(target)
 }
 
 func (e *filesystemErrorEntry) ErrorInfo() error {


### PR DESCRIPTION
Other cleanups:
- simplify error messages
- remove spurious error wrapping

Ref:
- #2037
- #4190