### PR TITLE
Server CLI authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,8 +316,9 @@ $(TESTING_ACTION_EXE): tests/testingaction/main.go
 compat-tests: export KOPIA_CURRENT_EXE=$(CURDIR)/$(kopia_ui_embedded_exe)
 compat-tests: export KOPIA_08_EXE=$(kopia08)
 compat-tests: export KOPIA_017_EXE=$(kopia017)
+compat-tests: export KOPIA_019_EXE=$(kopia019)
 compat-tests: GOTESTSUM_FLAGS=--format=testname --no-summary=skipped --jsonfile=.tmp.compat-tests.json
-compat-tests: $(kopia_ui_embedded_exe) $(kopia08) $(kopia017) $(gotestsum)
+compat-tests: $(kopia_ui_embedded_exe) $(kopia08) $(kopia017) $(kopia019) $(gotestsum)
 	$(GO_TEST) $(TEST_FLAGS) -count=$(REPEAT_TEST) -parallel $(PARALLEL) -timeout 3600s github.com/kopia/kopia/tests/compat_test
 	#  -$(gotestsum) tool slowest --jsonfile .tmp.compat-tests.json  --threshold 1000ms
 

--- a/cli/command_server.go
+++ b/cli/command_server.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"io"
+
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/apiclient"
@@ -39,18 +42,25 @@ type serverClientFlags struct {
 	serverUsername        string
 	serverPassword        string
 	serverCertFingerprint string
+
+	stderrWriter io.Writer
 }
 
 func (c *serverClientFlags) setup(svc appServices, cmd *kingpin.CmdClause) {
 	c.serverUsername = defaultServerControlUsername
+	c.stderrWriter = colorable.NewColorableStderr()
 
 	cmd.Flag("address", "Address of the server to connect to").Envar(svc.EnvName("KOPIA_SERVER_ADDRESS")).Default("http://127.0.0.1:51515").StringVar(&c.serverAddress)
-	cmd.Flag("server-control-username", "Server control username").Envar(svc.EnvName("KOPIA_SERVER_USERNAME")).StringVar(&c.serverUsername)
-	cmd.Flag("server-control-password", "Server control password").PlaceHolder("PASSWORD").Envar(svc.EnvName("KOPIA_SERVER_PASSWORD")).StringVar(&c.serverPassword)
+	cmd.Flag("server-control-username", "Server control username").Envar(svc.EnvName("KOPIA_SERVER_CONTROL_USERNAME")).StringVar(&c.serverUsername)
+	cmd.Flag("server-control-password", "Server control password").PlaceHolder("PASSWORD").Envar(svc.EnvName("KOPIA_SERVER_CONTROL_PASSWORD")).StringVar(&c.serverPassword)
 
 	// aliases for backwards compat
-	cmd.Flag("server-username", "Server control username").Hidden().StringVar(&c.serverUsername)
-	cmd.Flag("server-password", "Server control password").Hidden().StringVar(&c.serverPassword)
+	cmd.Flag("server-username", "Server control username").Envar(svc.EnvName("KOPIA_SERVER_USERNAME")).Hidden().Action(
+		deprecatedFlag(c.stderrWriter, "The '--server-username' flag ($KOPIA_SERVER_USERNAME) is deprecated, use '--server-control-username' ($KOPIA_SERVER_CONTROL_USERNAME) instead."),
+	).StringVar(&c.serverUsername)
+	cmd.Flag("server-password", "Server control password").Envar(svc.EnvName("KOPIA_SERVER_PASSWORD")).Hidden().Action(
+		deprecatedFlag(c.stderrWriter, "The '--server-password' flag ($KOPIA_SERVER_PASSWORD) is deprecated, use '--server-control-password' ($KOPIA_SERVER_CONTROL_PASSWORD) instead."),
+	).StringVar(&c.serverPassword)
 
 	cmd.Flag("server-cert-fingerprint", "Server certificate fingerprint").PlaceHolder("SHA256-FINGERPRINT").Envar(svc.EnvName("KOPIA_SERVER_CERT_FINGERPRINT")).StringVar(&c.serverCertFingerprint)
 }

--- a/tests/compat_test/compat_test.go
+++ b/tests/compat_test/compat_test.go
@@ -16,6 +16,7 @@ var (
 	kopiaCurrentExe = os.Getenv("KOPIA_CURRENT_EXE")
 	kopia08exe      = os.Getenv("KOPIA_08_EXE")
 	kopia017exe     = os.Getenv("KOPIA_017_EXE")
+	kopia019exe     = os.Getenv("KOPIA_019_EXE")
 )
 
 func TestRepoCreatedWith08CanBeOpenedWithCurrent(t *testing.T) {
@@ -200,4 +201,82 @@ func TestClientConnectedUsingV017CanConnectUsingCurrent(t *testing.T) {
 	// everything should still work
 	e2.Runner = runnerCurrent
 	e2.RunAndExpectSuccess(t, "snapshot", "ls")
+}
+
+// Verify `server status` environment variables compatibility for *control* username/password
+func TestServerControlArgs(t *testing.T) {
+	t.Parallel()
+
+	if kopiaCurrentExe == "" {
+		t.Skip()
+	}
+	if kopia019exe == "" {
+		t.Skip()
+	}
+
+	runnerCurrent := testenv.NewExeRunnerWithBinary(t, kopiaCurrentExe)
+	runner019 := testenv.NewExeRunnerWithBinary(t, kopia019exe)
+
+	// create repository using v0.19 and start a server
+	e1 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner019)
+	e1.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e1.RepoDir)
+	e1.RunAndExpectSuccess(t, "server", "users", "add", "foo@bar", "--user-password", "baz")
+
+	var sp testutil.ServerParameters
+
+	tlsCert := filepath.Join(e1.ConfigDir, "tls.cert")
+	tlsKey := filepath.Join(e1.ConfigDir, "tls.key")
+
+	wait, kill := e1.RunAndProcessStderr(t, sp.ProcessOutput,
+		"server", "start",
+		"--address=localhost:0",
+		"--server-control-username=admin-user",
+		"--server-control-password=admin-pwd",
+		"--tls-generate-cert",
+		"--tls-key-file", tlsKey,
+		"--tls-cert-file", tlsCert,
+		"--tls-generate-rsa-key-size=2048", // use shorter key size to speed up generation
+	)
+
+	t.Logf("detected server parameters %#v", sp)
+
+	defer wait()
+	defer kill()
+
+	time.Sleep(3 * time.Second)
+
+	// check server status using v0.19 environment variables for control username/password
+	e2 := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner019)
+
+	// set v0.19 environment variables
+	e2.Environment["KOPIA_SERVER_USERNAME"] = "admin-user"
+	e2.Environment["KOPIA_SERVER_PASSWORD"] = "admin-pwd"
+
+	e2.RunAndExpectSuccess(t,
+		"server", "status",
+		"--address", sp.BaseURL+"/",
+		"--server-cert-fingerprint", sp.SHA256Fingerprint,
+	)
+
+	// now switch to using latest executable with same environment variables,
+	// everything should still work
+	e2.Runner = runnerCurrent
+	e2.RunAndExpectSuccess(t,
+		"server", "status",
+		"--address", sp.BaseURL+"/",
+		"--server-cert-fingerprint", sp.SHA256Fingerprint,
+	)
+
+	// switch to post-0.19 environment variables,
+	// everything should still work
+	delete(e2.Environment, "KOPIA_SERVER_USERNAME")
+	delete(e2.Environment, "KOPIA_SERVER_PASSWORD")
+	e2.Environment["KOPIA_SERVER_CONTROL_USERNAME"] = "admin-user"
+	e2.Environment["KOPIA_SERVER_CONTROL_PASSWORD"] = "admin-pwd"
+
+	e2.RunAndExpectSuccess(t,
+		"server", "status",
+		"--address", sp.BaseURL+"/",
+		"--server-cert-fingerprint", sp.SHA256Fingerprint,
+	)
 }

--- a/tools/gettool/checksums.txt
+++ b/tools/gettool/checksums.txt
@@ -25,6 +25,12 @@ https://github.com/gotestyourself/gotestsum/releases/download/v1.11.0/gotestsum_
 https://github.com/gotestyourself/gotestsum/releases/download/v1.11.0/gotestsum_1.11.0_linux_arm64.tar.gz: 51c7fe29216678edaaa96bb67e38d58437fd54a83468f58a32513995f575dcc3
 https://github.com/gotestyourself/gotestsum/releases/download/v1.11.0/gotestsum_1.11.0_linux_armv6.tar.gz: 79a6a904d73a7b6b010f82205803e0c0a8a202a63f51e93e555e2f9be8aa3ba3
 https://github.com/gotestyourself/gotestsum/releases/download/v1.11.0/gotestsum_1.11.0_windows_amd64.tar.gz: 1518b3dd6a44b5684e9732121933f52b9c3ccab3a6e9efdeac41e7b03f97d019
+https://github.com/kopia/kopia/releases/download/v0.19.0/kopia-0.19.0-linux-arm.tar.gz: fdfeceb195b81a7566c1b494b87eef30b4da1ff90c53450959f5a28efb66767f
+https://github.com/kopia/kopia/releases/download/v0.19.0/kopia-0.19.0-linux-arm64.tar.gz: 632db9d72f2116f1758350bf7c20aa57c22c220480aaccb5f839e75669210ed9
+https://github.com/kopia/kopia/releases/download/v0.19.0/kopia-0.19.0-linux-x64.tar.gz: c07843822c82ec752e5ee749774a18820b858215aabd7da448ce665b9b9107aa
+https://github.com/kopia/kopia/releases/download/v0.19.0/kopia-0.19.0-macOS-arm64.tar.gz: 27c3fbbf4b563beda18c2fea7657fd9bd8f1193e5b918f907c9c639737c747df
+https://github.com/kopia/kopia/releases/download/v0.19.0/kopia-0.19.0-macOS-x64.tar.gz: 6becac56107ab5bd9000e9fa84e8aa1a9876a713293192670bb751dcdadfad9d
+https://github.com/kopia/kopia/releases/download/v0.19.0/kopia-0.19.0-windows-x64.zip: f1e7675715c07574cadf7aa491b8326c7fcb847ed503992394146bd178dcb184
 https://github.com/kopia/kopia/releases/download/v0.17.0/kopia-0.17.0-linux-arm.tar.gz: 25804d7271a0dfe6d0821270c5640caa01da5e05a03a7c4783fd1edafb234d51
 https://github.com/kopia/kopia/releases/download/v0.17.0/kopia-0.17.0-linux-arm64.tar.gz: 9679415cd2717a90cb6a793aa2d4accde4059084245b27fa4807d7e13fbe40a0
 https://github.com/kopia/kopia/releases/download/v0.17.0/kopia-0.17.0-linux-x64.tar.gz: 6851bba9f49c2ca2cabc5bec85a813149a180472d1e338fad42a8285dad047ee

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -213,6 +213,13 @@ kopia017=$(kopia017_dir)$(slash)kopia$(exe_suffix)
 $(kopia017):
 	go run github.com/kopia/kopia/tools/gettool --tool kopia:$(kopia017_version) --output-dir $(kopia017_dir)
 
+kopia019_version=0.19.0
+kopia019_dir=$(TOOLS_DIR)$(slash)kopia-$(kopia019_version)
+kopia019=$(kopia019_dir)$(slash)kopia$(exe_suffix)
+
+$(kopia019):
+	go run github.com/kopia/kopia/tools/gettool --tool kopia:$(kopia019_version) --output-dir $(kopia019_dir)
+
 MINIO_MC_PATH=$(TOOLS_DIR)/bin/mc$(exe_suffix)
 
 $(MINIO_MC_PATH):


### PR DESCRIPTION
Implement server CLI argument/environment name changes discussed in #3783 


Planned tests:
- [x] `TestServerControlArgs` Verification of `kopia server status` CONTROL new/old env vars
	1. SETUP AGAINST: `kopia server start`  with v0.19 env
	2. TEST: `kopia server status` with v0.19 env: `KOPIA_{SERVER_USERNAME,PASSWORD}`
	3. TEST: `kopia server status` with new  env: `KOPIA_SERVER_CONTROL_{USERNAME,PASSWORD}`
- [ ] `TestServerStartControlArgs` Verification of `kopia server start` CONTROL new/old env vars
	1. TEST:  `kopia server start` with  v0.19 env: `KOPIA_SERVER_{USERNAME,PASSWORD}`
	2. CHECK AGAINST:  `kopia server status` with v0.19 env
	3. TEST:  `kopia server start` with  new env: `KOPIA_SERVER_CONTROL_{USERNAME,PASSWORD}`
	4. CHECK AGAINST:  `kopia server status` with v0.19 env
- [ ] `TestServerStartUiArgs` Verification of `kopia server start` UI new/old env/cli vars
	1. TEST: `kopia server start`with:
		1. v0.19 args `--server-{username,password}`
		2. v0.19 env `KOPIA_SERVER_{USERNAME,PASSWORD}`
		3. new args `--server-ui-{username,password}`
		4. new env `KOPIA_SERVER_UI_{USERNAME,PASSWORD}`
	2. for each, CHECK AGAINST: HTTP request to the UI
	    - [ ] need to identify an existing UI authentication test function