### PR TITLE
Compute stats during snapshot comparison using kopia diff

### DIFF
--- a/cli/command_diff.go
+++ b/cli/command_diff.go
@@ -75,7 +75,7 @@ func (c *commandDiff) run(ctx context.Context, rep repo.Repository) error {
 			return errors.Wrap(err, "error marshaling computed snapshot diff stats")
 		}
 
-		fmt.Fprintf(c.out.stdout(), "%v", string(b)) //nolint:errcheck
+		fmt.Fprintf(c.out.stdout(), "%s", string(b)) //nolint:errcheck
 
 		return nil
 	}

--- a/cli/command_diff.go
+++ b/cli/command_diff.go
@@ -75,7 +75,7 @@ func (c *commandDiff) run(ctx context.Context, rep repo.Repository) error {
 			return errors.Wrap(err, "error marshaling computed snapshot diff stats")
 		}
 
-		fmt.Fprintf(c.out.stdout(), "%s", string(b)) //nolint:errcheck
+		fmt.Fprintf(c.out.stdout(), "%s", b) //nolint:errcheck
 
 		return nil
 	}

--- a/cli/command_diff.go
+++ b/cli/command_diff.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -63,8 +65,19 @@ func (c *commandDiff) run(ctx context.Context, rep repo.Repository) error {
 	}
 
 	if isDir1 {
-		_, err := d.Compare(ctx, ent1, ent2)
-		return errors.Wrap(err, "error comparing directories")
+		snapshotDiffStats, err := d.Compare(ctx, ent1, ent2)
+		if err != nil {
+			return errors.Wrap(err, "error comparing directories")
+		}
+
+		b, err := json.Marshal(snapshotDiffStats)
+		if err != nil {
+			return errors.Wrap(err, "error marshaling computed snapshot diff stats")
+		}
+
+		fmt.Fprintf(c.out.stdout(), "%v", string(b))
+
+		return nil
 	}
 
 	return errors.New("comparing files not implemented yet")

--- a/cli/command_diff.go
+++ b/cli/command_diff.go
@@ -63,7 +63,8 @@ func (c *commandDiff) run(ctx context.Context, rep repo.Repository) error {
 	}
 
 	if isDir1 {
-		return errors.Wrap(d.Compare(ctx, ent1, ent2), "error comparing directories")
+		_, err := d.Compare(ctx, ent1, ent2)
+		return errors.Wrap(err, "error comparing directories")
 	}
 
 	return errors.New("comparing files not implemented yet")

--- a/cli/command_diff.go
+++ b/cli/command_diff.go
@@ -75,7 +75,7 @@ func (c *commandDiff) run(ctx context.Context, rep repo.Repository) error {
 			return errors.Wrap(err, "error marshaling computed snapshot diff stats")
 		}
 
-		fmt.Fprintf(c.out.stdout(), "%v", string(b))
+		fmt.Fprintf(c.out.stdout(), "%v", string(b)) //nolint:errcheck
 
 		return nil
 	}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -3,7 +3,6 @@ package diff
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -61,13 +60,6 @@ func (c *Comparer) Compare(ctx context.Context, e1, e2 fs.Entry) (ComparerStats,
 	if err != nil {
 		return c.stats, err
 	}
-
-	b, err := json.Marshal(c.stats)
-	if err != nil {
-		return c.stats, errors.Wrap(err, "error marshaling computed snapshot diff stats")
-	}
-
-	c.output("%v", string(b))
 
 	return c.stats, errors.Wrap(err, "error comparing fs entries")
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -3,6 +3,7 @@ package diff
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -21,18 +22,54 @@ const dirMode = 0o700
 
 var log = logging.Module("diff")
 
+// Stats accumulates specific stats for the snapshots being compared.
+type Stats struct {
+	EntriesAdded    uint32 `json:"entriesAdded"`
+	EntriesRemoved  uint32 `json:"entriesRemoved"`
+	EntriesModified uint32 `json:"entriesModified"`
+
+	// aggregate stats
+	EntriesWithSameOIDButDiffMetadata uint32 `json:"entriesWithSameOIDButDifferentMetadata"`
+
+	// stats categorized based on metadata
+	EntriesWithSameOIDButDiffMode       uint32 `json:"entriesWithSameOIDbutDifferentMode"`
+	EntriesWithSameOIDButDiffModTime    uint32 `json:"entriesWithSameOIDbutDifferentModificationTime"`
+	EntriesWithSameOIDButDiffOwnerUser  uint32 `json:"entriesWithSameOIDbutDifferentUserOwner"`
+	EntriesWithSameOIDButDiffOwnerGroup uint32 `json:"entriesWithSameOIDbutDifferentGroupOwner"`
+}
+
+// ComparerStats accumulates stats between snapshots being compared.
+type ComparerStats struct {
+	FileStats      Stats `json:"fileStats"`
+	DirectoryStats Stats `json:"directoryStats"`
+}
+
 // Comparer outputs diff information between two filesystems.
 type Comparer struct {
-	out    io.Writer
-	tmpDir string
-
+	stats         ComparerStats
+	out           io.Writer
+	tmpDir        string
 	DiffCommand   string
 	DiffArguments []string
 }
 
 // Compare compares two filesystem entries and emits their diff information.
-func (c *Comparer) Compare(ctx context.Context, e1, e2 fs.Entry) error {
-	return c.compareEntry(ctx, e1, e2, ".")
+func (c *Comparer) Compare(ctx context.Context, e1, e2 fs.Entry) (ComparerStats, error) {
+	c.stats = ComparerStats{}
+
+	err := c.compareEntry(ctx, e1, e2, ".")
+	if err != nil {
+		return c.stats, err
+	}
+
+	b, err := json.Marshal(c.stats)
+	if err != nil {
+		return c.stats, errors.Wrap(err, "error marshaling computed snapshot diff stats")
+	}
+
+	c.output("%v", string(b))
+
+	return c.stats, errors.Wrap(err, "error comparing fs entries")
 }
 
 // Close removes all temporary files used by the comparer.
@@ -76,22 +113,33 @@ func (c *Comparer) compareDirectories(ctx context.Context, dir1, dir2 fs.Directo
 //nolint:gocyclo
 func (c *Comparer) compareEntry(ctx context.Context, e1, e2 fs.Entry, path string) error {
 	// see if we have the same object IDs, which implies identical objects, thanks to content-addressable-storage
-	if h1, ok := e1.(object.HasObjectID); ok {
-		if h2, ok := e2.(object.HasObjectID); ok {
-			if h1.ObjectID() == h2.ObjectID() {
-				log(ctx).Debugf("unchanged %v", path)
-				return nil
+	h1, e1HasObjectID := e1.(object.HasObjectID)
+	h2, e2HasObjectID := e2.(object.HasObjectID)
+
+	if e1HasObjectID && e2HasObjectID {
+		if h1.ObjectID() == h2.ObjectID() {
+			if _, isDir := e1.(fs.Directory); isDir {
+				c.compareDirMetadataAndComputeStats(ctx, e1, e2, path)
+			} else {
+				c.compareFileMetadataAndComputeStats(ctx, e1, e2, path)
 			}
+
+			return nil
 		}
 	}
 
 	if e1 == nil {
 		if dir2, isDir2 := e2.(fs.Directory); isDir2 {
 			c.output("added directory %v\n", path)
+
+			c.stats.DirectoryStats.EntriesAdded++
+
 			return c.compareDirectories(ctx, nil, dir2, path)
 		}
 
 		c.output("added file %v (%v bytes)\n", path, e2.Size())
+
+		c.stats.FileStats.EntriesAdded++
 
 		if f, ok := e2.(fs.File); ok {
 			if err := c.compareFiles(ctx, nil, f, path); err != nil {
@@ -105,10 +153,15 @@ func (c *Comparer) compareEntry(ctx context.Context, e1, e2 fs.Entry, path strin
 	if e2 == nil {
 		if dir1, isDir1 := e1.(fs.Directory); isDir1 {
 			c.output("removed directory %v\n", path)
+
+			c.stats.DirectoryStats.EntriesRemoved++
+
 			return c.compareDirectories(ctx, dir1, nil, path)
 		}
 
 		c.output("removed file %v (%v bytes)\n", path, e1.Size())
+
+		c.stats.FileStats.EntriesRemoved++
 
 		if f, ok := e1.(fs.File); ok {
 			if err := c.compareFiles(ctx, f, nil, path); err != nil {
@@ -119,7 +172,7 @@ func (c *Comparer) compareEntry(ctx context.Context, e1, e2 fs.Entry, path strin
 		return nil
 	}
 
-	compareEntry(e1, e2, path, c.out)
+	c.compareEntryMetadata(e1, e2, path)
 
 	dir1, isDir1 := e1.(fs.Directory)
 	dir2, isDir2 := e2.(fs.Directory)
@@ -137,12 +190,16 @@ func (c *Comparer) compareEntry(ctx context.Context, e1, e2 fs.Entry, path strin
 	if isDir2 {
 		// left is non-directory, right is a directory
 		log(ctx).Infof("changed %v from non-directory to a directory", path)
+		c.output("changed %v from non-directory to a directory\n", path)
+
 		return nil
 	}
 
 	if f1, ok := e1.(fs.File); ok {
 		if f2, ok := e2.(fs.File); ok {
 			c.output("changed %v at %v (size %v -> %v)\n", path, e2.ModTime().String(), e1.Size(), e2.Size())
+
+			c.stats.FileStats.EntriesModified++
 
 			if err := c.compareFiles(ctx, f1, f2, path); err != nil {
 				return err
@@ -153,18 +210,81 @@ func (c *Comparer) compareEntry(ctx context.Context, e1, e2 fs.Entry, path strin
 	return nil
 }
 
-func compareEntry(e1, e2 fs.Entry, fullpath string, out io.Writer) bool {
+func (c *Comparer) compareDirMetadataAndComputeStats(ctx context.Context, e1, e2 fs.Entry, path string) {
+	// check for metadata changes pertaining to directories given that content hasn't changed and gather aggregate statistics
+	equal := true
+
+	if m1, m2 := e1.Mode(), e2.Mode(); m1 != m2 {
+		equal = false
+		c.stats.DirectoryStats.EntriesWithSameOIDButDiffMode++
+	}
+
+	if mt1, mt2 := e1.ModTime(), e2.ModTime(); !mt1.Equal(mt2) {
+		equal = false
+		c.stats.DirectoryStats.EntriesWithSameOIDButDiffModTime++
+	}
+
+	o1, o2 := e1.Owner(), e2.Owner()
+	if o1.UserID != o2.UserID {
+		equal = false
+		c.stats.DirectoryStats.EntriesWithSameOIDButDiffOwnerUser++
+	}
+
+	if o1.GroupID != o2.GroupID {
+		equal = false
+		c.stats.DirectoryStats.EntriesWithSameOIDButDiffOwnerGroup++
+	}
+
+	if !equal {
+		c.stats.DirectoryStats.EntriesWithSameOIDButDiffMetadata++
+
+		log(ctx).Debugf("content unchanged but metadata has been modified: %v", path)
+	}
+}
+
+func (c *Comparer) compareFileMetadataAndComputeStats(ctx context.Context, e1, e2 fs.Entry, path string) {
+	// check for metadata changes pertaining to files given that content hasn't changed and gather aggregate statistics
+	equal := true
+	if m1, m2 := e1.Mode(), e2.Mode(); m1 != m2 {
+		equal = false
+		c.stats.FileStats.EntriesWithSameOIDButDiffMode++
+	}
+
+	if mt1, mt2 := e1.ModTime(), e2.ModTime(); !mt1.Equal(mt2) {
+		equal = false
+		c.stats.FileStats.EntriesWithSameOIDButDiffModTime++
+	}
+
+	o1, o2 := e1.Owner(), e2.Owner()
+	if o1.UserID != o2.UserID {
+		equal = false
+		c.stats.FileStats.EntriesWithSameOIDButDiffOwnerUser++
+	}
+
+	if o1.GroupID != o2.GroupID {
+		equal = false
+		c.stats.FileStats.EntriesWithSameOIDButDiffOwnerGroup++
+	}
+
+	if !equal {
+		c.stats.FileStats.EntriesWithSameOIDButDiffMetadata++
+
+		log(ctx).Debugf("content unchanged but metadata has been modified: %v", path)
+	}
+}
+
+func (c *Comparer) compareEntryMetadata(e1, e2 fs.Entry, fullpath string) bool {
 	if e1 == e2 { // in particular e1 == nil && e2 == nil
 		return true
 	}
 
 	if e1 == nil {
-		fmt.Fprintln(out, fullpath, "does not exist in source directory") //nolint:errcheck
+		c.output("%v does not exist in source directory\n", fullpath)
 		return false
 	}
 
 	if e2 == nil {
-		fmt.Fprintln(out, fullpath, "does not exist in destination directory") //nolint:errcheck
+		c.output("%v does not exist in destination directory\n", fullpath)
 		return false
 	}
 
@@ -173,32 +293,43 @@ func compareEntry(e1, e2 fs.Entry, fullpath string, out io.Writer) bool {
 	if m1, m2 := e1.Mode(), e2.Mode(); m1 != m2 {
 		equal = false
 
-		fmt.Fprintln(out, fullpath, "modes differ: ", m1, m2) //nolint:errcheck
+		c.output("%v modes differ: %v %v\n", fullpath, m1, m2)
 	}
 
 	if s1, s2 := e1.Size(), e2.Size(); s1 != s2 {
 		equal = false
 
-		fmt.Fprintln(out, fullpath, "sizes differ: ", s1, s2) //nolint:errcheck
+		c.output("%v sizes differ: %v %v\n", fullpath, s1, s2)
 	}
 
 	if mt1, mt2 := e1.ModTime(), e2.ModTime(); !mt1.Equal(mt2) {
 		equal = false
 
-		fmt.Fprintln(out, fullpath, "modification times differ: ", mt1, mt2) //nolint:errcheck
+		c.output("%v modification times differ: %v %v\n", fullpath, mt1, mt2)
 	}
 
 	o1, o2 := e1.Owner(), e2.Owner()
 	if o1.UserID != o2.UserID {
 		equal = false
 
-		fmt.Fprintln(out, fullpath, "owner users differ: ", o1.UserID, o2.UserID) //nolint:errcheck
+		c.output("%v owner users differ: %v %v\n", fullpath, o1.UserID, o2.UserID)
 	}
 
 	if o1.GroupID != o2.GroupID {
 		equal = false
 
-		fmt.Fprintln(out, fullpath, "owner groups differ: ", o1.GroupID, o2.GroupID) //nolint:errcheck
+		c.output("%v owner groups differ: %v %v\n", fullpath, o1.GroupID, o2.GroupID)
+	}
+
+	_, isDir1 := e1.(fs.Directory)
+	_, isDir2 := e2.(fs.Directory)
+
+	if !equal {
+		if isDir1 && isDir2 {
+			c.stats.DirectoryStats.EntriesModified++
+		} else {
+			c.stats.FileStats.EntriesModified++
+		}
 	}
 
 	// don't compare filesystem boundaries (e1.Device()), it's pretty useless and is not stored in backups
@@ -295,6 +426,12 @@ func downloadFile(ctx context.Context, f fs.File, fname string) error {
 	defer dst.Close() //nolint:errcheck
 
 	return errors.Wrap(iocopy.JustCopy(dst, src), "error downloading file")
+}
+
+// Stats returns aggregated statistics computed during snapshot comparison
+// must be invoked after a call to Compare which populates ComparerStats struct.
+func (c *Comparer) Stats() ComparerStats {
+	return c.stats
 }
 
 func (c *Comparer) output(msg string, args ...interface{}) {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -28,13 +28,13 @@ type EntryTypeStats struct {
 	Modified uint32 `json:"modified"`
 
 	// aggregate stats
-	SameContentButDiffMetadata uint32 `json:"sameContentButDifferentMetadata"`
+	SameContentButDifferentMetadata uint32 `json:"sameContentButDifferentMetadata"`
 
 	// stats categorized based on metadata
-	SameContentButDiffMode       uint32 `json:"sameContentbutDifferentMode"`
-	SameContentButDiffModTime    uint32 `json:"sameContentbutDifferentModificationTime"`
-	SameContentButDiffOwnerUser  uint32 `json:"sameContentbutDifferentUserOwner"`
-	SameContentButDiffOwnerGroup uint32 `json:"sameContentbutDifferentGroupOwner"`
+	SameContentButDifferentMode             uint32 `json:"sameContentButDifferentMode"`
+	SameContentButDifferentModificationTime uint32 `json:"sameContentButDifferentModificationTime"`
+	SameContentButDifferentUserOwner        uint32 `json:"sameContentButDifferentUserOwner"`
+	SameContentButDifferentGroupOwner       uint32 `json:"sameContentButDifferentGroupOwner"`
 }
 
 // Stats accumulates stats between snapshots being compared.
@@ -208,27 +208,27 @@ func (c *Comparer) compareDirMetadataAndComputeStats(ctx context.Context, e1, e2
 
 	if m1, m2 := e1.Mode(), e2.Mode(); m1 != m2 {
 		equal = false
-		c.stats.DirectoryEntries.SameContentButDiffMode++
+		c.stats.DirectoryEntries.SameContentButDifferentMode++
 	}
 
 	if mt1, mt2 := e1.ModTime(), e2.ModTime(); !mt1.Equal(mt2) {
 		equal = false
-		c.stats.DirectoryEntries.SameContentButDiffModTime++
+		c.stats.DirectoryEntries.SameContentButDifferentModificationTime++
 	}
 
 	o1, o2 := e1.Owner(), e2.Owner()
 	if o1.UserID != o2.UserID {
 		equal = false
-		c.stats.DirectoryEntries.SameContentButDiffOwnerUser++
+		c.stats.DirectoryEntries.SameContentButDifferentUserOwner++
 	}
 
 	if o1.GroupID != o2.GroupID {
 		equal = false
-		c.stats.DirectoryEntries.SameContentButDiffOwnerGroup++
+		c.stats.DirectoryEntries.SameContentButDifferentGroupOwner++
 	}
 
 	if !equal {
-		c.stats.DirectoryEntries.SameContentButDiffMetadata++
+		c.stats.DirectoryEntries.SameContentButDifferentMetadata++
 
 		log(ctx).Debugf("content unchanged but metadata has been modified: %v", path)
 	}
@@ -239,27 +239,27 @@ func (c *Comparer) compareFileMetadataAndComputeStats(ctx context.Context, e1, e
 	equal := true
 	if m1, m2 := e1.Mode(), e2.Mode(); m1 != m2 {
 		equal = false
-		c.stats.FileEntries.SameContentButDiffMode++
+		c.stats.FileEntries.SameContentButDifferentMode++
 	}
 
 	if mt1, mt2 := e1.ModTime(), e2.ModTime(); !mt1.Equal(mt2) {
 		equal = false
-		c.stats.FileEntries.SameContentButDiffModTime++
+		c.stats.FileEntries.SameContentButDifferentModificationTime++
 	}
 
 	o1, o2 := e1.Owner(), e2.Owner()
 	if o1.UserID != o2.UserID {
 		equal = false
-		c.stats.FileEntries.SameContentButDiffOwnerUser++
+		c.stats.FileEntries.SameContentButDifferentUserOwner++
 	}
 
 	if o1.GroupID != o2.GroupID {
 		equal = false
-		c.stats.FileEntries.SameContentButDiffOwnerGroup++
+		c.stats.FileEntries.SameContentButDifferentGroupOwner++
 	}
 
 	if !equal {
-		c.stats.FileEntries.SameContentButDiffMetadata++
+		c.stats.FileEntries.SameContentButDifferentMetadata++
 
 		log(ctx).Debugf("content unchanged but metadata has been modified: %v", path)
 	}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -3,6 +3,7 @@ package diff_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"strings"
@@ -13,53 +14,75 @@ import (
 
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/internal/diff"
+	"github.com/kopia/kopia/repo/content/index"
+	"github.com/kopia/kopia/repo/object"
 )
 
-var _ fs.Entry = (*testFile)(nil)
+var (
+	_ fs.Entry     = (*testFile)(nil)
+	_ fs.Directory = (*testDirectory)(nil)
+)
+
+type testBaseEntry struct {
+	modtime time.Time
+	mode    os.FileMode
+	name    string
+	owner   fs.OwnerInfo
+	oid     object.ID
+}
+
+func (f *testBaseEntry) IsDir() bool                 { return false }
+func (f *testBaseEntry) LocalFilesystemPath() string { return f.name }
+func (f *testBaseEntry) Close()                      {}
+func (f *testBaseEntry) Name() string                { return f.name }
+func (f *testBaseEntry) ModTime() time.Time          { return f.modtime }
+func (f *testBaseEntry) Sys() interface{}            { return nil }
+func (f *testBaseEntry) Owner() fs.OwnerInfo         { return f.owner }
+func (f *testBaseEntry) Device() fs.DeviceInfo       { return fs.DeviceInfo{Dev: 1} }
+func (f *testBaseEntry) ObjectID() object.ID         { return f.oid }
+
+func (f *testBaseEntry) Mode() os.FileMode {
+	if f.mode == 0 {
+		return 0o644
+	}
+
+	return f.mode & ^os.ModeDir
+}
 
 type testFile struct {
-	modtime time.Time
-	name    string
+	testBaseEntry
 	content string
 }
 
-func (f *testFile) IsDir() bool                 { return false }
-func (f *testFile) LocalFilesystemPath() string { return f.name }
-func (f *testFile) Close()                      {}
-func (f *testFile) Name() string                { return f.name }
-func (f *testFile) Size() int64                 { return int64(len(f.content)) }
-func (f *testFile) Mode() os.FileMode           { return 0o644 }
-func (f *testFile) ModTime() time.Time          { return f.modtime }
-func (f *testFile) Sys() interface{}            { return nil }
-func (f *testFile) Owner() fs.OwnerInfo         { return fs.OwnerInfo{UserID: 1000, GroupID: 1000} }
-func (f *testFile) Device() fs.DeviceInfo       { return fs.DeviceInfo{Dev: 1} }
 func (f *testFile) Open(ctx context.Context) (io.Reader, error) {
 	return strings.NewReader(f.content), nil
 }
 
-var _ fs.Directory = (*testDirectory)(nil)
+func (f *testFile) Size() int64 { return int64(len(f.content)) }
 
 type testDirectory struct {
-	name    string
-	files   []fs.Entry
-	modtime time.Time
+	testBaseEntry
+	files []fs.Entry
 }
 
 func (d *testDirectory) Iterate(ctx context.Context) (fs.DirectoryIterator, error) {
 	return fs.StaticIterator(d.files, nil), nil
 }
 
-func (d *testDirectory) SupportsMultipleIterations() bool { return false }
-func (d *testDirectory) IsDir() bool                      { return true }
-func (d *testDirectory) LocalFilesystemPath() string      { return d.name }
-func (d *testDirectory) Close()                           {}
-func (d *testDirectory) Name() string                     { return d.name }
-func (d *testDirectory) Size() int64                      { return 0 }
-func (d *testDirectory) Mode() os.FileMode                { return 0o755 }
-func (d *testDirectory) ModTime() time.Time               { return d.modtime }
-func (d *testDirectory) Sys() interface{}                 { return nil }
-func (d *testDirectory) Owner() fs.OwnerInfo              { return fs.OwnerInfo{UserID: 1000, GroupID: 1000} }
-func (d *testDirectory) Device() fs.DeviceInfo            { return fs.DeviceInfo{Dev: 1} }
+func (d *testDirectory) SupportsMultipleIterations() bool                { return false }
+func (d *testDirectory) IsDir() bool                                     { return true }
+func (d *testDirectory) LocalFilesystemPath() string                     { return d.name }
+func (d *testDirectory) Size() int64                                     { return 0 }
+func (d *testDirectory) Readdir(ctx context.Context) ([]fs.Entry, error) { return d.files, nil }
+
+func (d *testDirectory) Mode() os.FileMode {
+	if d.mode == 0 {
+		return os.ModeDir | 0o755
+	}
+
+	return os.ModeDir | d.mode
+}
+
 func (d *testDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {
 	for _, f := range d.files {
 		if f.Name() == name {
@@ -69,16 +92,24 @@ func (d *testDirectory) Child(ctx context.Context, name string) (fs.Entry, error
 
 	return nil, fs.ErrEntryNotFound
 }
-func (d *testDirectory) Readdir(ctx context.Context) ([]fs.Entry, error) { return d.files, nil }
 
 func TestCompareEmptyDirectories(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
 
-	dmodtime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
-	dir1 := createTestDirectory("testDir1", dmodtime)
-	dir2 := createTestDirectory("testDir2", dmodtime)
+	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirOwnerInfo := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
+	dirMode := os.FileMode(0o777)
+
+	cid, _ := index.IDFromHash("p", []byte("sdkjfn"))
+	dirObjectID1 := object.DirectObjectID(cid)
+
+	cid, _ = index.IDFromHash("i", []byte("dfjlgn"))
+	dirObjectID2 := object.DirectObjectID(cid)
+
+	dir1 := createTestDirectory("testDir1", dirModTime, dirOwnerInfo, dirMode, dirObjectID1)
+	dir2 := createTestDirectory("testDir2", dirModTime, dirOwnerInfo, dirMode, dirObjectID2)
 
 	c, err := diff.NewComparer(&buf)
 	require.NoError(t, err)
@@ -87,9 +118,12 @@ func TestCompareEmptyDirectories(t *testing.T) {
 		_ = c.Close()
 	})
 
-	err = c.Compare(ctx, dir1, dir2)
+	snapshotDiffStats := diff.ComparerStats{}
+	expectedOutput := snapshotDiffOutput(snapshotDiffStats)
+
+	_, err = c.Compare(ctx, dir1, dir2)
 	require.NoError(t, err)
-	require.Empty(t, buf.String())
+	require.Equal(t, expectedOutput, buf.String())
 }
 
 func TestCompareIdenticalDirectories(t *testing.T) {
@@ -97,20 +131,41 @@ func TestCompareIdenticalDirectories(t *testing.T) {
 
 	ctx := context.Background()
 
-	dmodtime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
-	fmodtime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirOwnerInfo := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
+	dirMode := os.FileMode(0o777)
+	fileModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+
+	cid, _ := index.IDFromHash("p", []byte("sdkjfn"))
+	dirObjectID1 := object.DirectObjectID(cid)
+
+	cid, _ = index.IDFromHash("i", []byte("dfjlgn"))
+	dirObjectID2 := object.DirectObjectID(cid)
+
+	file1 := &testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file1.txt"}, content: "abcdefghij"}
+	file2 := &testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file2.txt"}, content: "klmnopqrstuvwxyz"}
+
 	dir1 := createTestDirectory(
 		"testDir1",
-		dmodtime,
-		&testFile{name: "file1.txt", content: "abcdefghij", modtime: fmodtime},
-		&testFile{name: "file2.txt", content: "klmnopqrstuvwxyz", modtime: fmodtime},
+		dirModTime,
+		dirOwnerInfo,
+		dirMode,
+		dirObjectID1,
+		file1,
+		file2,
 	)
 	dir2 := createTestDirectory(
 		"testDir2",
-		dmodtime,
-		&testFile{name: "file1.txt", content: "abcdefghij", modtime: fmodtime},
-		&testFile{name: "file2.txt", content: "klmnopqrstuvwxyz", modtime: fmodtime},
+		dirModTime,
+		dirOwnerInfo,
+		dirMode,
+		dirObjectID2,
+		file1,
+		file2,
 	)
+
+	diffSnapshotStats := diff.ComparerStats{}
+	expectedOutput := snapshotDiffOutput(diffSnapshotStats)
 
 	c, err := diff.NewComparer(&buf)
 	require.NoError(t, err)
@@ -119,9 +174,9 @@ func TestCompareIdenticalDirectories(t *testing.T) {
 		_ = c.Close()
 	})
 
-	err = c.Compare(ctx, dir1, dir2)
+	_, err = c.Compare(ctx, dir1, dir2)
 	require.NoError(t, err)
-	require.Empty(t, buf.String())
+	require.Equal(t, expectedOutput, buf.String())
 }
 
 func TestCompareDifferentDirectories(t *testing.T) {
@@ -129,19 +184,34 @@ func TestCompareDifferentDirectories(t *testing.T) {
 
 	ctx := context.Background()
 
-	dmodtime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
-	fmodtime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	fileModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirOwnerInfo := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
+	dirMode := os.FileMode(0o777)
+
+	cid, _ := index.IDFromHash("p", []byte("sdkjfn"))
+	dirObjectID1 := object.DirectObjectID(cid)
+
+	cid, _ = index.IDFromHash("i", []byte("dfjlgn"))
+	dirObjectID2 := object.DirectObjectID(cid)
+
 	dir1 := createTestDirectory(
 		"testDir1",
-		dmodtime,
-		&testFile{name: "file1.txt", content: "abcdefghij", modtime: fmodtime},
-		&testFile{name: "file2.txt", content: "klmnopqrstuvwxyz", modtime: fmodtime},
+		dirModTime,
+		dirOwnerInfo,
+		dirMode,
+		dirObjectID1,
+		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file1.txt"}, content: "abcdefghij"},
+		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file2.txt"}, content: "klmnopqrstuvwxyz"},
 	)
 	dir2 := createTestDirectory(
 		"testDir2",
-		dmodtime,
-		&testFile{name: "file3.txt", content: "abcdefghij1", modtime: fmodtime},
-		&testFile{name: "file4.txt", content: "klmnopqrstuvwxyz2", modtime: fmodtime},
+		dirModTime,
+		dirOwnerInfo,
+		dirMode,
+		dirObjectID2,
+		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file3.txt"}, content: "abcdefghij1"},
+		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file4.txt"}, content: "klmnopqrstuvwxyz2"},
 	)
 
 	c, err := diff.NewComparer(&buf)
@@ -151,11 +221,17 @@ func TestCompareDifferentDirectories(t *testing.T) {
 		_ = c.Close()
 	})
 
+	diffSnapshotStats := diff.ComparerStats{}
+	diffSnapshotStats.FileStats.EntriesAdded = 2
+	diffSnapshotStats.FileStats.EntriesRemoved = 2
+	expectedOutputStats := snapshotDiffOutput(diffSnapshotStats)
+
 	expectedOutput := "added file ./file3.txt (11 bytes)\nadded file ./file4.txt (17 bytes)\n" +
 		"removed file ./file1.txt (10 bytes)\n" +
-		"removed file ./file2.txt (16 bytes)\n"
+		"removed file ./file2.txt (16 bytes)\n" +
+		expectedOutputStats
 
-	err = c.Compare(ctx, dir1, dir2)
+	_, err = c.Compare(ctx, dir1, dir2)
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput, buf.String())
 }
@@ -165,21 +241,40 @@ func TestCompareDifferentDirectories_DirTimeDiff(t *testing.T) {
 
 	ctx := context.Background()
 
-	dmodtime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
-	dmodtime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
-	fmodtime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	fileModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirModTime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirOwnerInfo := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
+	dirMode := os.FileMode(0o777)
+
+	cid, _ := index.IDFromHash("p", []byte("sdkjfn"))
+	dirObjectID1 := object.DirectObjectID(cid)
+
+	cid, _ = index.IDFromHash("i", []byte("dfjlgn"))
+	dirObjectID2 := object.DirectObjectID(cid)
+
 	dir1 := createTestDirectory(
 		"testDir1",
-		dmodtime1,
-		&testFile{name: "file1.txt", content: "abcdefghij", modtime: fmodtime},
-		&testFile{name: "file2.txt", content: "klmnopqrstuvwxyz", modtime: fmodtime},
+		dirModTime1,
+		dirOwnerInfo,
+		dirMode,
+		dirObjectID1,
+		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file1.txt"}, content: "abcdefghij"},
+		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file2.txt"}, content: "klmnopqrstuvwxyz"},
 	)
 	dir2 := createTestDirectory(
 		"testDir2",
-		dmodtime2,
-		&testFile{name: "file1.txt", content: "abcdefghij", modtime: fmodtime},
-		&testFile{name: "file2.txt", content: "klmnopqrstuvwxyz", modtime: fmodtime},
+		dirModTime2,
+		dirOwnerInfo,
+		dirMode,
+		dirObjectID2,
+		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file1.txt"}, content: "abcdefghij"},
+		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file2.txt"}, content: "klmnopqrstuvwxyz"},
 	)
+
+	diffSnapshotStats := diff.ComparerStats{}
+	diffSnapshotStats.DirectoryStats.EntriesModified = 1
+	expectedOutputStats := snapshotDiffOutput(diffSnapshotStats)
 
 	c, err := diff.NewComparer(&buf)
 	require.NoError(t, err)
@@ -188,8 +283,8 @@ func TestCompareDifferentDirectories_DirTimeDiff(t *testing.T) {
 		_ = c.Close()
 	})
 
-	expectedOutput := ". modification times differ:  2023-04-12 10:30:00 +0000 UTC 2022-04-12 10:30:00 +0000 UTC\n"
-	err = c.Compare(ctx, dir1, dir2)
+	expectedOutput := ". modification times differ: 2023-04-12 10:30:00 +0000 UTC 2022-04-12 10:30:00 +0000 UTC\n" + expectedOutputStats
+	_, err = c.Compare(ctx, dir1, dir2)
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput, buf.String())
 }
@@ -199,18 +294,33 @@ func TestCompareDifferentDirectories_FileTimeDiff(t *testing.T) {
 
 	ctx := context.Background()
 
-	fmodtime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
-	fmodtime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
-	dmodtime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	fileModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	fileModTime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirOwnerInfo := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
+	dirMode := os.FileMode(0o700)
+
+	cid, _ := index.IDFromHash("p", []byte("sdkjfn"))
+	OID1 := object.DirectObjectID(cid)
+
+	cid, _ = index.IDFromHash("i", []byte("hvhjb"))
+	OID2 := object.DirectObjectID(cid)
+
 	dir1 := createTestDirectory(
 		"testDir1",
-		dmodtime,
-		&testFile{name: "file1.txt", content: "abcdefghij", modtime: fmodtime1},
+		dirModTime,
+		dirOwnerInfo,
+		dirMode,
+		OID1,
+		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime1, name: "file1.txt", oid: OID1}, content: "abcdefghij"},
 	)
 	dir2 := createTestDirectory(
 		"testDir2",
-		dmodtime,
-		&testFile{name: "file1.txt", content: "abcdefghij", modtime: fmodtime2},
+		dirModTime,
+		dirOwnerInfo,
+		dirMode,
+		OID2,
+		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime2, name: "file1.txt", oid: OID2}, content: "abcdefghij"},
 	)
 
 	c, err := diff.NewComparer(&buf)
@@ -220,13 +330,141 @@ func TestCompareDifferentDirectories_FileTimeDiff(t *testing.T) {
 		_ = c.Close()
 	})
 
-	expectedOutput := "./file1.txt modification times differ:  2023-04-12 10:30:00 +0000 UTC 2022-04-12 10:30:00 +0000 UTC\n"
+	diffSnapshotStats := diff.ComparerStats{}
+	diffSnapshotStats.FileStats.EntriesModified = 1
+	expectedOutputStats := snapshotDiffOutput(diffSnapshotStats)
 
-	err = c.Compare(ctx, dir1, dir2)
+	expectedOutput := "./file1.txt modification times differ: 2023-04-12 10:30:00 +0000 UTC 2022-04-12 10:30:00 +0000 UTC\n" + expectedOutputStats
+
+	_, err = c.Compare(ctx, dir1, dir2)
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput, buf.String())
 }
 
-func createTestDirectory(name string, modtime time.Time, files ...fs.Entry) *testDirectory {
-	return &testDirectory{name: name, files: files, modtime: modtime}
+func TestCompareFileWithIdenticalContentsButDiffFileMetadata(t *testing.T) {
+	var buf bytes.Buffer
+
+	ctx := context.Background()
+
+	fileModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	fileModTime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
+
+	fileOwnerinfo1 := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
+	fileOwnerinfo2 := fs.OwnerInfo{UserID: 1001, GroupID: 1002}
+
+	dirOwnerInfo := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
+	dirMode := os.FileMode(0o777)
+	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+
+	cid, _ := index.IDFromHash("p", []byte("sdkjfn"))
+	dirObjectID1 := object.DirectObjectID(cid)
+
+	cid, _ = index.IDFromHash("i", []byte("dfjlgn"))
+	dirObjectID2 := object.DirectObjectID(cid)
+
+	dir1 := createTestDirectory(
+		"testDir1",
+		dirModTime,
+		dirOwnerInfo,
+		dirMode,
+		dirObjectID1,
+		&testFile{testBaseEntry: testBaseEntry{name: "file1.txt", modtime: fileModTime1, oid: object.ID{}, owner: fileOwnerinfo1, mode: 0o700}, content: "abcdefghij"},
+	)
+
+	dir2 := createTestDirectory(
+		"testDir2",
+		dirModTime,
+		dirOwnerInfo,
+		dirMode,
+		dirObjectID2,
+		&testFile{testBaseEntry: testBaseEntry{name: "file1.txt", modtime: fileModTime2, oid: object.ID{}, owner: fileOwnerinfo2, mode: 0o777}, content: "abcdefghij"},
+	)
+
+	c, err := diff.NewComparer(&buf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = c.Close()
+	})
+
+	diffSnapshotStats := diff.ComparerStats{}
+	diffSnapshotStats.FileStats.EntriesWithSameOIDButDiffMetadata = 1
+	diffSnapshotStats.FileStats.EntriesWithSameOIDButDiffModTime = 1
+	diffSnapshotStats.FileStats.EntriesWithSameOIDButDiffMode = 1
+	diffSnapshotStats.FileStats.EntriesWithSameOIDButDiffOwnerUser = 1
+	diffSnapshotStats.FileStats.EntriesWithSameOIDButDiffOwnerGroup = 1
+	expectedOutputStats := snapshotDiffOutput(diffSnapshotStats)
+
+	expectedOutput := expectedOutputStats
+
+	_, err = c.Compare(ctx, dir1, dir2)
+	require.NoError(t, err)
+	require.Equal(t, expectedOutput, buf.String())
+}
+
+func TestCompareIdenticalDirectoriesWithDiffDirectoryMetadata(t *testing.T) {
+	var buf bytes.Buffer
+
+	ctx := context.Background()
+
+	dirModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+	dirModTime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
+
+	dirOwnerInfo1 := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
+	dirOwnerInfo2 := fs.OwnerInfo{UserID: 1001, GroupID: 1002}
+
+	dirMode1 := os.FileMode(0o644)
+	dirMode2 := os.FileMode(0o777)
+
+	fileModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
+
+	cid, _ := index.IDFromHash("p", []byte("sdkjfn"))
+	dirObjectID := object.DirectObjectID(cid)
+
+	dir1 := createTestDirectory(
+		"testDir1",
+		dirModTime1,
+		dirOwnerInfo1,
+		dirMode1,
+		dirObjectID,
+		&testFile{testBaseEntry: testBaseEntry{name: "file1.txt", modtime: fileModTime}, content: "abcdefghij"},
+	)
+
+	dir2 := createTestDirectory(
+		"testDir2",
+		dirModTime2,
+		dirOwnerInfo2,
+		dirMode2,
+		dirObjectID,
+		&testFile{testBaseEntry: testBaseEntry{name: "file1.txt", modtime: fileModTime}, content: "abcdefghij"},
+	)
+	c, err := diff.NewComparer(&buf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = c.Close()
+	})
+
+	diffSnapshotStats := diff.ComparerStats{}
+	diffSnapshotStats.DirectoryStats.EntriesWithSameOIDButDiffMetadata = 1
+	diffSnapshotStats.DirectoryStats.EntriesWithSameOIDButDiffModTime = 1
+	diffSnapshotStats.DirectoryStats.EntriesWithSameOIDButDiffMode = 1
+	diffSnapshotStats.DirectoryStats.EntriesWithSameOIDButDiffOwnerUser = 1
+	diffSnapshotStats.DirectoryStats.EntriesWithSameOIDButDiffOwnerGroup = 1
+	expectedOutputStats := snapshotDiffOutput(diffSnapshotStats)
+
+	expectedOutput := expectedOutputStats
+
+	_, err = c.Compare(ctx, dir1, dir2)
+	require.NoError(t, err)
+	require.Equal(t, expectedOutput, buf.String())
+}
+
+func createTestDirectory(name string, modtime time.Time, owner fs.OwnerInfo, mode os.FileMode, oid object.ID, files ...fs.Entry) *testDirectory {
+	return &testDirectory{testBaseEntry: testBaseEntry{modtime: modtime, name: name, owner: owner, mode: mode, oid: oid}, files: files}
+}
+
+func snapshotDiffOutput(v interface{}) string {
+	b, _ := json.Marshal(v)
+	return string(b)
 }

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -391,11 +391,11 @@ func TestCompareFileWithIdenticalContentsButDiffFileMetadata(t *testing.T) {
 
 	expectedStats := diff.Stats{
 		FileEntries: diff.EntryTypeStats{
-			SameContentButDiffMetadata:   1,
-			SameContentButDiffModTime:    1,
-			SameContentButDiffMode:       1,
-			SameContentButDiffOwnerUser:  1,
-			SameContentButDiffOwnerGroup: 1,
+			SameContentButDifferentMetadata:         1,
+			SameContentButDifferentModificationTime: 1,
+			SameContentButDifferentMode:             1,
+			SameContentButDifferentUserOwner:        1,
+			SameContentButDifferentGroupOwner:       1,
 		},
 	}
 
@@ -451,11 +451,11 @@ func TestCompareIdenticalDirectoriesWithDiffDirectoryMetadata(t *testing.T) {
 
 	expectedStats := diff.Stats{
 		DirectoryEntries: diff.EntryTypeStats{
-			SameContentButDiffMetadata:   1,
-			SameContentButDiffModTime:    1,
-			SameContentButDiffMode:       1,
-			SameContentButDiffOwnerUser:  1,
-			SameContentButDiffOwnerGroup: 1,
+			SameContentButDifferentMetadata:         1,
+			SameContentButDifferentModificationTime: 1,
+			SameContentButDifferentMode:             1,
+			SameContentButDifferentUserOwner:        1,
+			SameContentButDifferentGroupOwner:       1,
 		},
 	}
 

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -119,11 +119,14 @@ func TestCompareEmptyDirectories(t *testing.T) {
 	})
 
 	snapshotDiffStats := diff.ComparerStats{}
-	expectedOutput := snapshotDiffOutput(snapshotDiffStats)
+	expectedStats := snapshotDiffOutput(snapshotDiffStats)
 
-	_, err = c.Compare(ctx, dir1, dir2)
+	snapshotDiffStats, err = c.Compare(ctx, dir1, dir2)
+	actualStats := snapshotDiffOutput(snapshotDiffStats)
+
 	require.NoError(t, err)
-	require.Equal(t, expectedOutput, buf.String())
+	require.Empty(t, buf.String())
+	require.Equal(t, expectedStats, actualStats)
 }
 
 func TestCompareIdenticalDirectories(t *testing.T) {
@@ -165,7 +168,7 @@ func TestCompareIdenticalDirectories(t *testing.T) {
 	)
 
 	diffSnapshotStats := diff.ComparerStats{}
-	expectedOutput := snapshotDiffOutput(diffSnapshotStats)
+	expectedStats := snapshotDiffOutput(diffSnapshotStats)
 
 	c, err := diff.NewComparer(&buf)
 	require.NoError(t, err)
@@ -174,9 +177,12 @@ func TestCompareIdenticalDirectories(t *testing.T) {
 		_ = c.Close()
 	})
 
-	_, err = c.Compare(ctx, dir1, dir2)
+	snapshotDiffStats, err := c.Compare(ctx, dir1, dir2)
+	actualStats := snapshotDiffOutput(snapshotDiffStats)
+
 	require.NoError(t, err)
-	require.Equal(t, expectedOutput, buf.String())
+	require.Empty(t, buf.String())
+	require.Equal(t, expectedStats, actualStats)
 }
 
 func TestCompareDifferentDirectories(t *testing.T) {
@@ -228,11 +234,13 @@ func TestCompareDifferentDirectories(t *testing.T) {
 
 	expectedOutput := "added file ./file3.txt (11 bytes)\nadded file ./file4.txt (17 bytes)\n" +
 		"removed file ./file1.txt (10 bytes)\n" +
-		"removed file ./file2.txt (16 bytes)\n" +
-		expectedOutputStats
+		"removed file ./file2.txt (16 bytes)\n"
 
-	_, err = c.Compare(ctx, dir1, dir2)
+	snapshotDiffStats, err := c.Compare(ctx, dir1, dir2)
+	actualStats := snapshotDiffOutput(snapshotDiffStats)
+
 	require.NoError(t, err)
+	require.Equal(t, expectedOutputStats, actualStats)
 	require.Equal(t, expectedOutput, buf.String())
 }
 
@@ -283,10 +291,13 @@ func TestCompareDifferentDirectories_DirTimeDiff(t *testing.T) {
 		_ = c.Close()
 	})
 
-	expectedOutput := ". modification times differ: 2023-04-12 10:30:00 +0000 UTC 2022-04-12 10:30:00 +0000 UTC\n" + expectedOutputStats
-	_, err = c.Compare(ctx, dir1, dir2)
+	expectedOutput := ". modification times differ: 2023-04-12 10:30:00 +0000 UTC 2022-04-12 10:30:00 +0000 UTC\n"
+	snapshotDiffStats, err := c.Compare(ctx, dir1, dir2)
+	actualStats := snapshotDiffOutput(snapshotDiffStats)
+
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput, buf.String())
+	require.Equal(t, expectedOutputStats, actualStats)
 }
 
 func TestCompareDifferentDirectories_FileTimeDiff(t *testing.T) {
@@ -334,11 +345,14 @@ func TestCompareDifferentDirectories_FileTimeDiff(t *testing.T) {
 	diffSnapshotStats.FileStats.EntriesModified = 1
 	expectedOutputStats := snapshotDiffOutput(diffSnapshotStats)
 
-	expectedOutput := "./file1.txt modification times differ: 2023-04-12 10:30:00 +0000 UTC 2022-04-12 10:30:00 +0000 UTC\n" + expectedOutputStats
+	expectedOutput := "./file1.txt modification times differ: 2023-04-12 10:30:00 +0000 UTC 2022-04-12 10:30:00 +0000 UTC\n"
 
-	_, err = c.Compare(ctx, dir1, dir2)
+	snapshotDiffStats, err := c.Compare(ctx, dir1, dir2)
+	actualStats := snapshotDiffOutput(snapshotDiffStats)
+
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput, buf.String())
+	require.Equal(t, expectedOutputStats, actualStats)
 }
 
 func TestCompareFileWithIdenticalContentsButDiffFileMetadata(t *testing.T) {
@@ -395,11 +409,12 @@ func TestCompareFileWithIdenticalContentsButDiffFileMetadata(t *testing.T) {
 	diffSnapshotStats.FileStats.EntriesWithSameOIDButDiffOwnerGroup = 1
 	expectedOutputStats := snapshotDiffOutput(diffSnapshotStats)
 
-	expectedOutput := expectedOutputStats
+	snapshotDiffStats, err := c.Compare(ctx, dir1, dir2)
+	actualStats := snapshotDiffOutput(snapshotDiffStats)
 
-	_, err = c.Compare(ctx, dir1, dir2)
 	require.NoError(t, err)
-	require.Equal(t, expectedOutput, buf.String())
+	require.Empty(t, buf.String())
+	require.Equal(t, expectedOutputStats, actualStats)
 }
 
 func TestCompareIdenticalDirectoriesWithDiffDirectoryMetadata(t *testing.T) {
@@ -453,11 +468,12 @@ func TestCompareIdenticalDirectoriesWithDiffDirectoryMetadata(t *testing.T) {
 	diffSnapshotStats.DirectoryStats.EntriesWithSameOIDButDiffOwnerGroup = 1
 	expectedOutputStats := snapshotDiffOutput(diffSnapshotStats)
 
-	expectedOutput := expectedOutputStats
+	snapshotDiffStats, err := c.Compare(ctx, dir1, dir2)
+	actualStats := snapshotDiffOutput(snapshotDiffStats)
 
-	_, err = c.Compare(ctx, dir1, dir2)
 	require.NoError(t, err)
-	require.Equal(t, expectedOutput, buf.String())
+	require.Empty(t, buf.String())
+	require.Equal(t, expectedOutputStats, actualStats)
 }
 
 func createTestDirectory(name string, modtime time.Time, owner fs.OwnerInfo, mode os.FileMode, oid object.ID, files ...fs.Entry) *testDirectory {

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -196,7 +196,7 @@ func compareDirs(t *testing.T, source, restoreDir string) {
 		require.NoError(t, err)
 
 		cmp.DiffCommand = "cmp"
-		_ = cmp.Compare(ctx, s, r)
+		cmp.Compare(ctx, s, r)
 	}
 }
 

--- a/tests/recovery/recovery_test/recovery_test.go
+++ b/tests/recovery/recovery_test/recovery_test.go
@@ -310,7 +310,7 @@ func CompareDirs(t *testing.T, source, destination string) {
 	e2, err := localfs.NewEntry(destination)
 	require.NoError(t, err)
 
-	err = c.Compare(ctx, e1, e2)
+	_, err = c.Compare(ctx, e1, e2)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Added functionality to calculate aggregate statistics when comparing what's changed between snapshots using kopia diff 

Statistics collected during snapshot diff computation includes:
- files added/removed/modified
- dirs added/removed/modified
- files/dirs with metadata changes but same underlying content (OID)

Testing approach:
- Added a test for verifying stats collected when comparing two directories with the same objectID but metadata changes across snapshots (dir mode, dir mod time, dir owner, etc), expectation is all the appropriate dir stats fields are updated.
- Added another test for verifying stats collected when comparing two directories with similar file contents but the metadata for the files have changed between snapshots but content remains unchanged. Expectation is all the relevant file level stats fields are updated.
- Existing tests have been updated due to stats now being printed in addition to previous output.