### PR TITLE
refactor(snapshots): refactored uploader into separate package

### DIFF
--- a/cli/cli_progress.go
+++ b/cli/cli_progress.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/internal/units"
-	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 const (
@@ -30,15 +30,15 @@ type progressFlags struct {
 
 func (p *progressFlags) setup(svc appServices, app *kingpin.Application) {
 	app.Flag("progress", "Enable progress bar").Hidden().Default("true").BoolVar(&p.enableProgress)
-	app.Flag("progress-estimation-type", "Set type of estimation of the data to be snapshotted").Hidden().Default(snapshotfs.EstimationTypeClassic).
-		EnumVar(&p.progressEstimationType, snapshotfs.EstimationTypeClassic, snapshotfs.EstimationTypeRough, snapshotfs.EstimationTypeAdaptive)
+	app.Flag("progress-estimation-type", "Set type of estimation of the data to be snapshotted").Hidden().Default(upload.EstimationTypeClassic).
+		EnumVar(&p.progressEstimationType, upload.EstimationTypeClassic, upload.EstimationTypeRough, upload.EstimationTypeAdaptive)
 	app.Flag("progress-update-interval", "How often to update progress information").Hidden().Default("300ms").DurationVar(&p.progressUpdateInterval)
-	app.Flag("adaptive-estimation-threshold", "Sets the threshold below which the classic estimation method will be used").Hidden().Default(strconv.FormatInt(snapshotfs.AdaptiveEstimationThreshold, 10)).Int64Var(&p.adaptiveEstimationThreshold)
+	app.Flag("adaptive-estimation-threshold", "Sets the threshold below which the classic estimation method will be used").Hidden().Default(strconv.FormatInt(upload.AdaptiveEstimationThreshold, 10)).Int64Var(&p.adaptiveEstimationThreshold)
 	p.out.setup(svc)
 }
 
 type cliProgress struct {
-	snapshotfs.NullUploadProgress
+	upload.NullUploadProgress
 
 	// all int64 must precede all int32 due to alignment requirements on ARM
 	uploadedBytes     atomic.Int64
@@ -270,11 +270,11 @@ func (p *cliProgress) Finish() {
 	}
 }
 
-func (p *cliProgress) EstimationParameters() snapshotfs.EstimationParameters {
-	return snapshotfs.EstimationParameters{
+func (p *cliProgress) EstimationParameters() upload.EstimationParameters {
+	return upload.EstimationParameters{
 		Type:              p.progressEstimationType,
 		AdaptiveThreshold: p.adaptiveEstimationThreshold,
 	}
 }
 
-var _ snapshotfs.UploadProgress = (*cliProgress)(nil)
+var _ upload.Progress = (*cliProgress)(nil)

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
-	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 const (
@@ -215,8 +215,8 @@ func validateStartEndTime(st, et string) error {
 	return nil
 }
 
-func (c *commandSnapshotCreate) setupUploader(rep repo.RepositoryWriter) *snapshotfs.Uploader {
-	u := snapshotfs.NewUploader(rep)
+func (c *commandSnapshotCreate) setupUploader(rep repo.RepositoryWriter) *upload.Uploader {
+	u := upload.NewUploader(rep)
 	u.MaxUploadBytes = c.snapshotCreateCheckpointUploadLimitMB << 20 //nolint:mnd
 
 	if c.snapshotCreateForceEnableActions {
@@ -275,7 +275,7 @@ func (c *commandSnapshotCreate) snapshotSingleSource(
 	fsEntry fs.Entry,
 	setManual bool,
 	rep repo.RepositoryWriter,
-	u *snapshotfs.Uploader,
+	u *upload.Uploader,
 	sourceInfo snapshot.SourceInfo,
 	tags map[string]string,
 	st *notifydata.MultiSnapshotStatus,

--- a/cli/command_snapshot_estimate.go
+++ b/cli/command_snapshot_estimate.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
-	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 type commandSnapshotEstimate struct {
@@ -39,8 +39,8 @@ func (c *commandSnapshotEstimate) setup(svc appServices, parent commandParent) {
 
 type estimateProgress struct {
 	stats        snapshot.Stats
-	included     snapshotfs.SampleBuckets
-	excluded     snapshotfs.SampleBuckets
+	included     upload.SampleBuckets
+	excluded     upload.SampleBuckets
 	excludedDirs []string
 	quiet        bool
 }
@@ -59,7 +59,7 @@ func (ep *estimateProgress) Error(ctx context.Context, filename string, err erro
 	}
 }
 
-func (ep *estimateProgress) Stats(ctx context.Context, st *snapshot.Stats, included, excluded snapshotfs.SampleBuckets, excludedDirs []string, final bool) {
+func (ep *estimateProgress) Stats(ctx context.Context, st *snapshot.Stats, included, excluded upload.SampleBuckets, excludedDirs []string, final bool) {
 	_ = final
 
 	ep.stats = *st
@@ -99,7 +99,7 @@ func (c *commandSnapshotEstimate) run(ctx context.Context, rep repo.Repository) 
 		return errors.Wrapf(err, "error creating policy tree for %v", sourceInfo)
 	}
 
-	if err := snapshotfs.Estimate(ctx, dir, policyTree, &ep, c.maxExamplesPerBucket); err != nil {
+	if err := upload.Estimate(ctx, dir, policyTree, &ep, c.maxExamplesPerBucket); err != nil {
 		return errors.Wrap(err, "error estimating")
 	}
 
@@ -137,7 +137,7 @@ func (c *commandSnapshotEstimate) run(ctx context.Context, rep repo.Repository) 
 	return nil
 }
 
-func (c *commandSnapshotEstimate) showBuckets(buckets snapshotfs.SampleBuckets, showFiles bool) {
+func (c *commandSnapshotEstimate) showBuckets(buckets upload.SampleBuckets, showFiles bool) {
 	for i, bucket := range buckets {
 		if bucket.Count == 0 {
 			continue

--- a/cli/command_snapshot_migrate.go
+++ b/cli/command_snapshot_migrate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 type commandSnapshotMigrate struct {
@@ -63,7 +64,7 @@ func (c *commandSnapshotMigrate) run(ctx context.Context, destRepo repo.Reposito
 		wg              sync.WaitGroup
 		mu              sync.Mutex
 		canceled        bool
-		activeUploaders = map[snapshot.SourceInfo]*snapshotfs.Uploader{}
+		activeUploaders = map[snapshot.SourceInfo]*upload.Uploader{}
 	)
 
 	c.svc.getProgress().StartShared()
@@ -104,7 +105,7 @@ func (c *commandSnapshotMigrate) run(ctx context.Context, destRepo repo.Reposito
 			break
 		}
 
-		uploader := snapshotfs.NewUploader(destRepo)
+		uploader := upload.NewUploader(destRepo)
 		uploader.Progress = c.svc.getProgress()
 		activeUploaders[s] = uploader
 		mu.Unlock()
@@ -220,7 +221,7 @@ func (c *commandSnapshotMigrate) findPreviousSnapshotManifestWithStartTime(ctx c
 	return nil, nil
 }
 
-func (c *commandSnapshotMigrate) migrateSingleSource(ctx context.Context, uploader *snapshotfs.Uploader, sourceRepo repo.Repository, destRepo repo.RepositoryWriter, s snapshot.SourceInfo) error {
+func (c *commandSnapshotMigrate) migrateSingleSource(ctx context.Context, uploader *upload.Uploader, sourceRepo repo.Repository, destRepo repo.RepositoryWriter, s snapshot.SourceInfo) error {
 	manifests, err := snapshot.ListSnapshotManifests(ctx, sourceRepo, &s, nil)
 	if err != nil {
 		return errors.Wrapf(err, "error listing snapshot manifests for %v", s)
@@ -248,7 +249,7 @@ func (c *commandSnapshotMigrate) migrateSingleSource(ctx context.Context, upload
 	return nil
 }
 
-func (c *commandSnapshotMigrate) migrateSingleSourceSnapshot(ctx context.Context, uploader *snapshotfs.Uploader, sourceRepo repo.Repository, destRepo repo.RepositoryWriter, s snapshot.SourceInfo, m *snapshot.Manifest) error {
+func (c *commandSnapshotMigrate) migrateSingleSourceSnapshot(ctx context.Context, uploader *upload.Uploader, sourceRepo repo.Repository, destRepo repo.RepositoryWriter, s snapshot.SourceInfo, m *snapshot.Manifest) error {
 	if m.IncompleteReason != "" {
 		log(ctx).Debugf("ignoring incomplete %v at %v", s, formatTimestamp(m.StartTime.ToTime()))
 		return nil

--- a/internal/repotesting/repotesting_test.go
+++ b/internal/repotesting/repotesting_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
-	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 func TestTimeFuncWiring(t *testing.T) {
@@ -84,7 +84,7 @@ func TestTimeFuncWiring(t *testing.T) {
 	sourceDir.AddFile("f1", []byte{1, 2, 3}, defaultPermissions)
 
 	nt = ft.Advance(1 * time.Hour)
-	u := snapshotfs.NewUploader(env.RepositoryWriter)
+	u := upload.NewUploader(env.RepositoryWriter)
 	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 
 	s1, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{})

--- a/internal/server/api_estimate.go
+++ b/internal/server/api_estimate.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
-	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 type estimateTaskProgress struct {
@@ -36,7 +36,7 @@ func (p estimateTaskProgress) Error(ctx context.Context, dirname string, err err
 	}
 }
 
-func (p estimateTaskProgress) Stats(ctx context.Context, st *snapshot.Stats, included, excluded snapshotfs.SampleBuckets, excludedDirs []string, final bool) {
+func (p estimateTaskProgress) Stats(ctx context.Context, st *snapshot.Stats, included, excluded upload.SampleBuckets, excludedDirs []string, final bool) {
 	_ = excludedDirs
 	_ = final
 
@@ -57,7 +57,7 @@ func (p estimateTaskProgress) Stats(ctx context.Context, st *snapshot.Stats, inc
 	}
 }
 
-func logBucketSamples(ctx context.Context, buckets snapshotfs.SampleBuckets, prefix string, showExamples bool) {
+func logBucketSamples(ctx context.Context, buckets upload.SampleBuckets, prefix string, showExamples bool) {
 	hasAny := false
 
 	for i, bucket := range buckets {
@@ -97,7 +97,7 @@ func logBucketSamples(ctx context.Context, buckets snapshotfs.SampleBuckets, pre
 	}
 }
 
-var _ snapshotfs.EstimateProgress = estimateTaskProgress{}
+var _ upload.EstimateProgress = estimateTaskProgress{}
 
 func handleEstimate(ctx context.Context, rc requestContext) (interface{}, *apiError) {
 	var req serverapi.EstimateRequest
@@ -140,7 +140,7 @@ func handleEstimate(ctx context.Context, rc requestContext) (interface{}, *apiEr
 
 		ctrl.OnCancel(cancel)
 
-		return snapshotfs.Estimate(estimatectx, dir, policyTree, estimateTaskProgress{ctrl}, req.MaxExamplesPerBucket)
+		return upload.Estimate(estimatectx, dir, policyTree, estimateTaskProgress{ctrl}, req.MaxExamplesPerBucket)
 	})
 
 	taskID := <-taskIDChan

--- a/internal/server/api_restore_test.go
+++ b/internal/server/api_restore_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/restore"
-	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 func TestRestoreSnapshots(t *testing.T) {
@@ -32,7 +32,7 @@ func TestRestoreSnapshots(t *testing.T) {
 	var id11 manifest.ID
 
 	require.NoError(t, repo.WriteSession(ctx, env.Repository, repo.WriteSessionOptions{Purpose: "Test"}, func(ctx context.Context, w repo.RepositoryWriter) error {
-		u := snapshotfs.NewUploader(w)
+		u := upload.NewUploader(w)
 
 		dir1 := mockfs.NewDirectory()
 

--- a/internal/server/api_snapshots_test.go
+++ b/internal/server/api_snapshots_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/snapshot"
-	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 func TestListAndDeleteSnapshots(t *testing.T) {
@@ -26,7 +26,7 @@ func TestListAndDeleteSnapshots(t *testing.T) {
 	var id11, id12, id13, id14, id21 manifest.ID
 
 	require.NoError(t, repo.WriteSession(ctx, env.Repository, repo.WriteSessionOptions{Purpose: "Test"}, func(ctx context.Context, w repo.RepositoryWriter) error {
-		u := snapshotfs.NewUploader(w)
+		u := upload.NewUploader(w)
 
 		dir1 := mockfs.NewDirectory()
 
@@ -187,7 +187,7 @@ func TestEditSnapshots(t *testing.T) {
 	var id11 manifest.ID
 
 	require.NoError(t, repo.WriteSession(ctx, env.Repository, repo.WriteSessionOptions{Purpose: "Test"}, func(ctx context.Context, w repo.RepositoryWriter) error {
-		u := snapshotfs.NewUploader(w)
+		u := upload.NewUploader(w)
 
 		dir1 := mockfs.NewDirectory()
 

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
 	"github.com/kopia/kopia/snapshot/restore"
-	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 // StatusResponse is the response of 'status' HTTP API command.
@@ -52,13 +52,13 @@ type SourcesResponse struct {
 
 // SourceStatus describes the status of a single source.
 type SourceStatus struct {
-	Source           snapshot.SourceInfo        `json:"source"`
-	Status           string                     `json:"status"`
-	SchedulingPolicy policy.SchedulingPolicy    `json:"schedule"`
-	LastSnapshot     *snapshot.Manifest         `json:"lastSnapshot,omitempty"`
-	NextSnapshotTime *time.Time                 `json:"nextSnapshotTime,omitempty"`
-	UploadCounters   *snapshotfs.UploadCounters `json:"upload,omitempty"`
-	CurrentTask      string                     `json:"currentTask,omitempty"`
+	Source           snapshot.SourceInfo     `json:"source"`
+	Status           string                  `json:"status"`
+	SchedulingPolicy policy.SchedulingPolicy `json:"schedule"`
+	LastSnapshot     *snapshot.Manifest      `json:"lastSnapshot,omitempty"`
+	NextSnapshotTime *time.Time              `json:"nextSnapshotTime,omitempty"`
+	UploadCounters   *upload.Counters        `json:"upload,omitempty"`
+	CurrentTask      string                  `json:"currentTask,omitempty"`
 }
 
 // PolicyListEntry describes single policy.

--- a/snapshot/snapshotfs/dir_manifest_builder.go
+++ b/snapshot/snapshotfs/dir_manifest_builder.go
@@ -118,6 +118,10 @@ func (b *DirManifestBuilder) Build(dirModTime fs.UTCTimestamp, incompleteReason 
 	}
 }
 
+func isDir(e *snapshot.DirEntry) bool {
+	return e.Type == snapshot.EntryTypeDirectory
+}
+
 func sortedTopFailures(entries []*fs.EntryWithError) []*fs.EntryWithError {
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].EntryPath < entries[j].EntryPath

--- a/snapshot/snapshotfs/dir_rewriter.go
+++ b/snapshot/snapshotfs/dir_rewriter.go
@@ -198,7 +198,7 @@ func (rw *DirRewriter) processDirectoryEntries(ctx context.Context, parentPath s
 
 	dm := builder.Build(entry.ModTime, entry.DirSummary.IncompleteReason)
 
-	oid, err := writeDirManifest(ctx, rw.rep, entry.ObjectID.String(), dm, metadataComp)
+	oid, err := WriteDirManifest(ctx, rw.rep, entry.ObjectID.String(), dm, metadataComp)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to write directory manifest")
 	}

--- a/snapshot/snapshotfs/dir_writer.go
+++ b/snapshot/snapshotfs/dir_writer.go
@@ -12,7 +12,8 @@ import (
 	"github.com/kopia/kopia/snapshot"
 )
 
-func writeDirManifest(ctx context.Context, rep repo.RepositoryWriter, dirRelativePath string, dirManifest *snapshot.DirManifest, metadataComp compression.Name) (object.ID, error) {
+// WriteDirManifest writes a directory manifest to the repository and returns the object ID.
+func WriteDirManifest(ctx context.Context, rep repo.RepositoryWriter, dirRelativePath string, dirManifest *snapshot.DirManifest, metadataComp compression.Name) (object.ID, error) {
 	writer := rep.NewObjectWriter(ctx, object.WriterOptions{
 		Description:        "DIR:" + dirRelativePath,
 		Prefix:             objectIDPrefixDirectory,

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/logging"
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/snapshot"
 )
+
+var repoFSLog = logging.Module("repofs")
 
 // Well-known object ID prefixes.
 const (

--- a/snapshot/snapshotfs/snapshot_storage_stats_test.go
+++ b/snapshot/snapshotfs/snapshot_storage_stats_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 func TestCalculateStorageStats(t *testing.T) {
@@ -29,7 +30,7 @@ func TestCalculateStorageStats(t *testing.T) {
 		Path:     "/dummy",
 	}
 
-	u := snapshotfs.NewUploader(env.RepositoryWriter)
+	u := upload.NewUploader(env.RepositoryWriter)
 	man1, err := u.Upload(ctx, sourceRoot, nil, src)
 	require.NoError(t, err)
 	require.NoError(t, env.RepositoryWriter.Flush(ctx))

--- a/snapshot/snapshotfs/snapshot_tree_walker_test.go
+++ b/snapshot/snapshotfs/snapshot_tree_walker_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 func TestSnapshotTreeWalker(t *testing.T) {
@@ -46,7 +47,7 @@ func TestSnapshotTreeWalker(t *testing.T) {
 	// root directory, 2 subdirectories + 2 unique files (dir1/file11 === dir2/file22)
 	const numUniqueObjects = 5
 
-	u := snapshotfs.NewUploader(env.RepositoryWriter)
+	u := upload.NewUploader(env.RepositoryWriter)
 	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{})
 	require.NoError(t, err)
 
@@ -110,7 +111,7 @@ func TestSnapshotTreeWalker_Errors(t *testing.T) {
 	dir2.AddFile("file21", []byte{1, 2, 3, 4}, 0o644)
 	dir2.AddFile("file22", []byte{1, 2, 3}, 0o644) // same content as dir11/file11
 
-	u := snapshotfs.NewUploader(env.RepositoryWriter)
+	u := upload.NewUploader(env.RepositoryWriter)
 	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{})
 	require.NoError(t, err)
 
@@ -157,7 +158,7 @@ func TestSnapshotTreeWalker_MultipleErrors(t *testing.T) {
 	dir2.AddFile("file21", []byte{1, 2, 3, 4}, 0o644)
 	dir2.AddFile("file22", []byte{1, 2, 3, 4, 5}, 0o644)
 
-	u := snapshotfs.NewUploader(env.RepositoryWriter)
+	u := upload.NewUploader(env.RepositoryWriter)
 	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{})
 	require.NoError(t, err)
 
@@ -207,7 +208,7 @@ func TestSnapshotTreeWalker_MultipleErrorsSameOID(t *testing.T) {
 	dir2.AddFile("file21", []byte{1, 2, 3, 4}, 0o644)
 	dir2.AddFile("file22", []byte{1, 2, 3}, 0o644) // same content as dir11/file11
 
-	u := snapshotfs.NewUploader(env.RepositoryWriter)
+	u := upload.NewUploader(env.RepositoryWriter)
 	man, err := u.Upload(ctx, sourceRoot, nil, snapshot.SourceInfo{})
 	require.NoError(t, err)
 

--- a/snapshot/snapshotfs/snapshot_verifier_test.go
+++ b/snapshot/snapshotfs/snapshot_verifier_test.go
@@ -14,12 +14,13 @@ import (
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 func TestSnapshotVerifier(t *testing.T) {
 	ctx, te := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
-	u := snapshotfs.NewUploader(te.RepositoryWriter)
+	u := upload.NewUploader(te.RepositoryWriter)
 	dir1 := mockfs.NewDirectory()
 
 	si1 := te.LocalPathSourceInfo("/dummy/path")

--- a/snapshot/snapshotfs/source_directories_internal_test.go
+++ b/snapshot/snapshotfs/source_directories_internal_test.go
@@ -1,0 +1,72 @@
+package snapshotfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeNameForMount(t *testing.T) {
+	cases := map[string]string{
+		"/tmp/foo/bar":             "tmp_foo_bar",
+		"/root":                    "root",
+		"/root/":                   "root",
+		"/":                        "__root",
+		"C:":                       "C",
+		"C:\\":                     "C",
+		"C:\\foo":                  "C_foo",
+		"C:\\foo/bar":              "C_foo_bar",
+		"\\\\server\\root":         "__server_root",
+		"\\\\server\\root\\":       "__server_root",
+		"\\\\server\\root\\subdir": "__server_root_subdir",
+		"\\\\server\\root\\subdir/with/forward/slashes":  "__server_root_subdir_with_forward_slashes",
+		"\\\\server\\root\\subdir/with\\mixed/slashes\\": "__server_root_subdir_with_mixed_slashes",
+	}
+
+	for input, want := range cases {
+		assert.Equal(t, want, safeNameForMount(input), input)
+	}
+}
+
+func TestDisambiguateSafeNames(t *testing.T) {
+	cases := []struct {
+		input map[string]string
+		want  map[string]string
+	}{
+		{
+			input: map[string]string{
+				"c:/":  "c",
+				"c:\\": "c",
+				"c:":   "c",
+				"c":    "c",
+			},
+			want: map[string]string{
+				"c":    "c",
+				"c:":   "c (2)",
+				"c:/":  "c (3)",
+				"c:\\": "c (4)",
+			},
+		},
+		{
+			input: map[string]string{
+				"c:/":   "c",
+				"c:\\":  "c",
+				"c:":    "c",
+				"c":     "c",
+				"c (2)": "c (2)",
+			},
+			want: map[string]string{
+				"c":     "c",
+				"c (2)": "c (2)",
+				"c:":    "c (2) (2)",
+				"c:/":   "c (3)",
+				"c:\\":  "c (4)",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, disambiguateSafeNames(tc.input))
+	}
+}

--- a/snapshot/snapshotfs/source_directories_test.go
+++ b/snapshot/snapshotfs/source_directories_test.go
@@ -1,11 +1,10 @@
-package snapshotfs
+package snapshotfs_test
 
 import (
 	"context"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/fs"
@@ -13,12 +12,14 @@ import (
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 func TestAllSources(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 
-	u := NewUploader(env.RepositoryWriter)
+	u := upload.NewUploader(env.RepositoryWriter)
 	man, err := u.Upload(ctx, mockfs.NewDirectory(), nil, snapshot.SourceInfo{Host: "dummy", UserName: "dummy", Path: "dummy"})
 	require.NoError(t, err)
 
@@ -48,7 +49,7 @@ func TestAllSources(t *testing.T) {
 		mustWriteSnapshotManifest(ctx, t, env.RepositoryWriter, snapshot.SourceInfo{UserName: m.user, Host: m.host, Path: m.path}, fs.UTCTimestampFromTime(ts), man)
 	}
 
-	as := AllSourcesEntry(env.RepositoryWriter)
+	as := snapshotfs.AllSourcesEntry(env.RepositoryWriter)
 	gotNames := iterateAllNames(ctx, t, as, "")
 	wantNames := map[string]struct{}{
 		"another-user@some-host/":                              {},
@@ -110,68 +111,4 @@ func mustWriteSnapshotManifest(ctx context.Context, t *testing.T, rep repo.Repos
 
 	_, err := snapshot.SaveSnapshot(ctx, rep, man)
 	require.NoError(t, err)
-}
-
-func TestSafeNameForMount(t *testing.T) {
-	cases := map[string]string{
-		"/tmp/foo/bar":             "tmp_foo_bar",
-		"/root":                    "root",
-		"/root/":                   "root",
-		"/":                        "__root",
-		"C:":                       "C",
-		"C:\\":                     "C",
-		"C:\\foo":                  "C_foo",
-		"C:\\foo/bar":              "C_foo_bar",
-		"\\\\server\\root":         "__server_root",
-		"\\\\server\\root\\":       "__server_root",
-		"\\\\server\\root\\subdir": "__server_root_subdir",
-		"\\\\server\\root\\subdir/with/forward/slashes":  "__server_root_subdir_with_forward_slashes",
-		"\\\\server\\root\\subdir/with\\mixed/slashes\\": "__server_root_subdir_with_mixed_slashes",
-	}
-
-	for input, want := range cases {
-		assert.Equal(t, want, safeNameForMount(input), input)
-	}
-}
-
-func TestDisambiguateSafeNames(t *testing.T) {
-	cases := []struct {
-		input map[string]string
-		want  map[string]string
-	}{
-		{
-			input: map[string]string{
-				"c:/":  "c",
-				"c:\\": "c",
-				"c:":   "c",
-				"c":    "c",
-			},
-			want: map[string]string{
-				"c":    "c",
-				"c:":   "c (2)",
-				"c:/":  "c (3)",
-				"c:\\": "c (4)",
-			},
-		},
-		{
-			input: map[string]string{
-				"c:/":   "c",
-				"c:\\":  "c",
-				"c:":    "c",
-				"c":     "c",
-				"c (2)": "c (2)",
-			},
-			want: map[string]string{
-				"c":     "c",
-				"c (2)": "c (2)",
-				"c:":    "c (2) (2)",
-				"c:/":   "c (3)",
-				"c:\\":  "c (4)",
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		require.Equal(t, tc.want, disambiguateSafeNames(tc.input))
-	}
 }

--- a/snapshot/snapshotmaintenance/helper_test.go
+++ b/snapshot/snapshotmaintenance/helper_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
-	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 // Create snapshots an FS entry.
@@ -28,7 +28,7 @@ func createSnapshot(ctx context.Context, rep repo.RepositoryWriter, e fs.Entry, 
 		return nil, err
 	}
 
-	u := snapshotfs.NewUploader(rep)
+	u := upload.NewUploader(rep)
 
 	manifest, err := u.Upload(ctx, e, policyTree, si, previous...)
 	if err != nil {

--- a/snapshot/upload/checkpoint_registry.go
+++ b/snapshot/upload/checkpoint_registry.go
@@ -1,4 +1,4 @@
-package snapshotfs
+package upload
 
 import (
 	"sync"
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
 
 // checkpointFunc is invoked when checkpoint occurs. The callback must checkpoint current state of
@@ -41,7 +42,7 @@ func (r *checkpointRegistry) removeCheckpointCallback(entryName string) {
 // runCheckpoints invokes all registered checkpointers and adds results to the provided builder, while
 // randomizing file names for non-directory entries. this is to prevent the use of checkpointed objects
 // as authoritative on subsequent runs.
-func (r *checkpointRegistry) runCheckpoints(checkpointBuilder *DirManifestBuilder) error {
+func (r *checkpointRegistry) runCheckpoints(checkpointBuilder *snapshotfs.DirManifestBuilder) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/snapshot/upload/checkpoint_registry_test.go
+++ b/snapshot/upload/checkpoint_registry_test.go
@@ -1,4 +1,4 @@
-package snapshotfs
+package upload
 
 import (
 	"os"
@@ -9,6 +9,7 @@ import (
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/mockfs"
 	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
 
 func TestCheckpointRegistry(t *testing.T) {
@@ -54,7 +55,7 @@ func TestCheckpointRegistry(t *testing.T) {
 	cp.removeCheckpointCallback(f3.Name())
 	cp.removeCheckpointCallback(f3.Name())
 
-	var dmb DirManifestBuilder
+	var dmb snapshotfs.DirManifestBuilder
 
 	dmb.AddEntry(&snapshot.DirEntry{
 		Name: "pre-existing",

--- a/snapshot/upload/estimate.go
+++ b/snapshot/upload/estimate.go
@@ -1,4 +1,4 @@
-package snapshotfs
+package upload
 
 import (
 	"context"

--- a/snapshot/upload/estimate_test.go
+++ b/snapshot/upload/estimate_test.go
@@ -1,4 +1,4 @@
-package snapshotfs_test
+package upload_test
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
-	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 )
 
 type fakeProgress struct {
@@ -31,7 +31,7 @@ func (p *fakeProgress) Error(context.Context, string, error, bool) {}
 func (p *fakeProgress) Stats(
 	ctx context.Context,
 	s *snapshot.Stats,
-	includedFiles, excludedFiles snapshotfs.SampleBuckets,
+	includedFiles, excludedFiles upload.SampleBuckets,
 	excludedDirs []string,
 	final bool,
 ) {
@@ -62,6 +62,6 @@ func TestEstimate_SkipsStreamingDirectory(t *testing.T) {
 		expectedErrors:      0,
 	}
 
-	err := snapshotfs.Estimate(testlogging.Context(t), rootDir, policyTree, p, 1)
+	err := upload.Estimate(testlogging.Context(t), rootDir, policyTree, p, 1)
 	require.NoError(t, err)
 }

--- a/snapshot/upload/upload_actions.go
+++ b/snapshot/upload/upload_actions.go
@@ -1,4 +1,4 @@
-package snapshotfs
+package upload
 
 import (
 	"bufio"

--- a/snapshot/upload/upload_estimator.go
+++ b/snapshot/upload/upload_estimator.go
@@ -1,4 +1,4 @@
-package snapshotfs
+package upload
 
 import (
 	"context"

--- a/snapshot/upload/upload_os_snapshot_nonwindows.go
+++ b/snapshot/upload/upload_os_snapshot_nonwindows.go
@@ -1,7 +1,7 @@
 //go:build !windows
 // +build !windows
 
-package snapshotfs
+package upload
 
 import (
 	"context"

--- a/snapshot/upload/upload_os_snapshot_windows.go
+++ b/snapshot/upload/upload_os_snapshot_windows.go
@@ -1,4 +1,4 @@
-package snapshotfs
+package upload
 
 import (
 	"context"

--- a/snapshot/upload/upload_scan.go
+++ b/snapshot/upload/upload_scan.go
@@ -1,4 +1,4 @@
-package snapshotfs
+package upload
 
 import (
 	"context"

--- a/snapshot/upload/upload_test.go
+++ b/snapshot/upload/upload_test.go
@@ -1,4 +1,4 @@
-package snapshotfs
+package upload
 
 import (
 	"bytes"
@@ -44,6 +44,7 @@ import (
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
 
 const (
@@ -284,7 +285,7 @@ func TestUploadMetadataCompression(t *testing.T) {
 			t.Errorf("Upload error: %v", err)
 		}
 
-		dir := EntryFromDirEntry(th.repo, s1.RootEntry).(fs.Directory)
+		dir := snapshotfs.EntryFromDirEntry(th.repo, s1.RootEntry).(fs.Directory)
 		entries := findAllEntries(t, ctx, dir)
 		verifyMetadataCompressor(t, ctx, th.repo, entries, compression.HeaderZstdFastest)
 	})
@@ -305,7 +306,7 @@ func TestUploadMetadataCompression(t *testing.T) {
 			t.Errorf("Upload error: %v", err)
 		}
 
-		dir := EntryFromDirEntry(th.repo, s1.RootEntry).(fs.Directory)
+		dir := snapshotfs.EntryFromDirEntry(th.repo, s1.RootEntry).(fs.Directory)
 		entries := findAllEntries(t, ctx, dir)
 		verifyMetadataCompressor(t, ctx, th.repo, entries, content.NoCompression)
 	})
@@ -326,7 +327,7 @@ func TestUploadMetadataCompression(t *testing.T) {
 			t.Errorf("Upload error: %v", err)
 		}
 
-		dir := EntryFromDirEntry(th.repo, s1.RootEntry).(fs.Directory)
+		dir := snapshotfs.EntryFromDirEntry(th.repo, s1.RootEntry).(fs.Directory)
 		entries := findAllEntries(t, ctx, dir)
 		verifyMetadataCompressor(t, ctx, th.repo, entries, compression.ByName["gzip"].HeaderID())
 	})
@@ -628,12 +629,12 @@ func TestUpload_SubDirectoryReadFailureSomeIgnoredNoFailFast(t *testing.T) {
 }
 
 type mockProgress struct {
-	UploadProgress
+	Progress
 	finishedFileCheck func(string, error)
 }
 
 func (mp *mockProgress) FinishedFile(relativePath string, err error) {
-	defer mp.UploadProgress.FinishedFile(relativePath, err)
+	defer mp.Progress.FinishedFile(relativePath, err)
 
 	mp.finishedFileCheck(relativePath, err)
 }
@@ -657,7 +658,7 @@ func TestUpload_FinishedFileProgress(t *testing.T) {
 	u := NewUploader(th.repo)
 	u.ForceHashPercentage = 0
 	u.Progress = &mockProgress{
-		UploadProgress: u.Progress,
+		Progress: u.Progress,
 		finishedFileCheck: func(relativePath string, err error) {
 			defer func() {
 				mu.Lock()
@@ -1280,7 +1281,7 @@ func TestParallelUploadOfLargeFiles(t *testing.T) {
 
 	t.Logf("man: %v", man.RootObjectID())
 
-	dir := EntryFromDirEntry(th.repo, man.RootEntry).(fs.Directory)
+	dir := snapshotfs.EntryFromDirEntry(th.repo, man.RootEntry).(fs.Directory)
 
 	successCount := 0
 

--- a/tests/tools/kopiaclient/kopiaclient.go
+++ b/tests/tools/kopiaclient/kopiaclient.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
 	"github.com/kopia/kopia/tests/robustness"
 )
 
@@ -112,7 +113,7 @@ func (kc *KopiaClient) SnapshotCreate(ctx context.Context, key string, val []byt
 	}
 
 	source := kc.getSourceForKeyVal(key, val)
-	u := snapshotfs.NewUploader(rw)
+	u := upload.NewUploader(rw)
 
 	man, err := u.Upload(ctx, source, policyTree, si)
 	if err != nil {


### PR DESCRIPTION
This is completely mechanical, but updated some type names to avoid stuttering.

`upload.UploadCounters` => `upload.Counters`
`upload.UploadProgress` => `upload.Progress`