### PR TITLE
feat(snapshots): add hardlink/inode support

### DIFF
--- a/fs/entry.go
+++ b/fs/entry.go
@@ -20,6 +20,7 @@ type Entry interface {
 	os.FileInfo
 	Owner() OwnerInfo
 	Device() DeviceInfo
+	HardLinkInfo() HardLinkInfo
 	LocalFilesystemPath() string // returns full local filesystem path or "" if not a local filesystem
 	Close()                      // closes or recycles any resources associated with the entry, must be idempotent
 }
@@ -34,6 +35,12 @@ type OwnerInfo struct {
 type DeviceInfo struct {
 	Dev  uint64 `json:"dev"`
 	Rdev uint64 `json:"rdev"`
+}
+
+// HardLinkInfo describes the hardlinks of a filesystem entry.
+type HardLinkInfo struct {
+	UniqId uint64 `json:"uniqid"`
+	NLink  uint64 `json:"nlink"`
 }
 
 // Reader allows reading from a file and retrieving its up-to-date file info.

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -14,12 +14,13 @@ import (
 const numEntriesToRead = 100 // number of directory entries to read in one shot
 
 type filesystemEntry struct {
-	name       string
-	size       int64
-	mtimeNanos int64
-	mode       os.FileMode
-	owner      fs.OwnerInfo
-	device     fs.DeviceInfo
+	name         string
+	size         int64
+	mtimeNanos   int64
+	mode         os.FileMode
+	owner        fs.OwnerInfo
+	device       fs.DeviceInfo
+	hardLinkInfo fs.HardLinkInfo
 
 	prefix string
 }
@@ -58,6 +59,10 @@ func (e *filesystemEntry) Owner() fs.OwnerInfo {
 
 func (e *filesystemEntry) Device() fs.DeviceInfo {
 	return e.device
+}
+
+func (e *filesystemEntry) HardLinkInfo() fs.HardLinkInfo {
+	return e.hardLinkInfo
 }
 
 func (e *filesystemEntry) LocalFilesystemPath() string {

--- a/fs/localfs/local_fs_nonwindows.go
+++ b/fs/localfs/local_fs_nonwindows.go
@@ -5,16 +5,18 @@ package localfs
 
 import (
 	"os"
+	"runtime"
 	"syscall"
 
 	"github.com/kopia/kopia/fs"
+	"golang.org/x/sys/unix"
 )
 
 const isWindows = false
 
 func platformSpecificOwnerInfo(fi os.FileInfo) fs.OwnerInfo {
 	var oi fs.OwnerInfo
-	if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+	if stat, ok := fi.Sys().(*unix.Stat_t); ok {
 		oi.UserID = stat.Uid
 		oi.GroupID = stat.Gid
 	}
@@ -23,14 +25,54 @@ func platformSpecificOwnerInfo(fi os.FileInfo) fs.OwnerInfo {
 }
 
 func platformSpecificDeviceInfo(fi os.FileInfo) fs.DeviceInfo {
-	var oi fs.DeviceInfo
-	if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
-		// not making a separate type for 32-bit platforms here..
-		oi.Dev = platformSpecificWidenDev(stat.Dev)
-		oi.Rdev = platformSpecificWidenDev(stat.Rdev)
+	var di fs.DeviceInfo
+
+	switch runtime.GOOS {
+	case "linux":
+		if stat, ok := fi.Sys().(*unix.Stat_t); ok {
+			di.Dev = platformSpecificWidenDev(stat.Dev)
+			di.Rdev = platformSpecificWidenDev(stat.Rdev)
+		}
+	default:
+		if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+			di.Dev = platformSpecificWidenDev(stat.Dev)
+			di.Rdev = platformSpecificWidenDev(stat.Rdev)
+		}
 	}
 
-	return oi
+	return di
+}
+
+func platformSpecificHardLinkInfo(fi os.FileInfo) fs.HardLinkInfo {
+	var hli fs.HardLinkInfo
+
+	switch runtime.GOOS {
+	case "linux":
+		if stat, ok := fi.Sys().(*unix.Stat_t); ok {
+			hli.UniqId = stat.Ino
+			hli.NLink = uint64(stat.Nlink)
+		}
+	default:
+		if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+			hli.UniqId = stat.Ino
+			hli.NLink = uint64(stat.Nlink)
+		}
+	}
+
+	return hli
+}
+
+func platformSpecificNewEntry(basename string, fi os.FileInfo, prefix string) filesystemEntry {
+	return filesystemEntry{
+		TrimShallowSuffix(basename),
+		fi.Size(),
+		fi.ModTime().UnixNano(),
+		fi.Mode(),
+		platformSpecificOwnerInfo(fi),
+		platformSpecificDeviceInfo(fi),
+		platformSpecificHardLinkInfo(fi),
+		prefix,
+	}
 }
 
 // Direct Windows volume paths (e.g. Shadow Copy) require a trailing separator.

--- a/fs/localfs/local_fs_os.go
+++ b/fs/localfs/local_fs_os.go
@@ -166,13 +166,5 @@ func entryFromDirEntry(basename string, fi os.FileInfo, prefix string) fs.Entry 
 var _ os.FileInfo = (*filesystemEntry)(nil)
 
 func newEntry(basename string, fi os.FileInfo, prefix string) filesystemEntry {
-	return filesystemEntry{
-		TrimShallowSuffix(basename),
-		fi.Size(),
-		fi.ModTime().UnixNano(),
-		fi.Mode(),
-		platformSpecificOwnerInfo(fi),
-		platformSpecificDeviceInfo(fi),
-		prefix,
-	}
+	return platformSpecificNewEntry(basename, fi, prefix)
 }

--- a/fs/localfs/local_fs_windows.go
+++ b/fs/localfs/local_fs_windows.go
@@ -31,3 +31,22 @@ func trailingSeparator(fsd *filesystemDirectory) string {
 
 	return ""
 }
+
+// TODO: if we want to implement it for windows, it will be tricky. On Windows, the value returned by os.FileInfo.Sys() is typically a pointer to a syscall.Win32FileAttributeData structure, which does not include the file's MFT or file ID. In other words, unlike on Unix where you can extract the inode number directly from the stat structure, Windows does not expose the file ID through os.FileInfo.
+func platformSpecificNewEntry(basename string, fi os.FileInfo, prefix string) filesystemEntry {
+	return filesystemEntry{
+		TrimShallowSuffix(basename),
+		fi.Size(),
+		fi.ModTime().UnixNano(),
+		fi.Mode(),
+		platformSpecificOwnerInfo(fi),
+		platformSpecificDeviceInfo(fi),
+		platformSpecificHardLinkInfo(fi),
+		prefix,
+	}
+}
+
+//nolint:revive
+func platformSpecificHardLinkInfo(fi os.FileInfo) fs.HardLinkInfo {
+	return fs.HardLinkInfo{}
+}

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -19,12 +19,13 @@ const (
 
 // virtualEntry is an in-memory implementation of a directory entry.
 type virtualEntry struct {
-	name    string
-	mode    os.FileMode
-	size    int64
-	modTime time.Time
-	owner   fs.OwnerInfo
-	device  fs.DeviceInfo
+	name         string
+	mode         os.FileMode
+	size         int64
+	modTime      time.Time
+	owner        fs.OwnerInfo
+	device       fs.DeviceInfo
+	hardLinkInfo fs.HardLinkInfo
 }
 
 func (e *virtualEntry) Name() string {
@@ -57,6 +58,10 @@ func (e *virtualEntry) Owner() fs.OwnerInfo {
 
 func (e *virtualEntry) Device() fs.DeviceInfo {
 	return e.device
+}
+
+func (e *virtualEntry) HardLinkInfo() fs.HardLinkInfo {
+	return e.hardLinkInfo
 }
 
 func (e *virtualEntry) LocalFilesystemPath() string {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -38,15 +38,16 @@ type testBaseEntry struct {
 	oid     object.ID
 }
 
-func (f *testBaseEntry) IsDir() bool                 { return false }
-func (f *testBaseEntry) LocalFilesystemPath() string { return f.name }
-func (f *testBaseEntry) Close()                      {}
-func (f *testBaseEntry) Name() string                { return f.name }
-func (f *testBaseEntry) ModTime() time.Time          { return f.modtime }
-func (f *testBaseEntry) Sys() any                    { return nil }
-func (f *testBaseEntry) Owner() fs.OwnerInfo         { return f.owner }
-func (f *testBaseEntry) Device() fs.DeviceInfo       { return fs.DeviceInfo{Dev: 1} }
-func (f *testBaseEntry) ObjectID() object.ID         { return f.oid }
+func (f *testBaseEntry) IsDir() bool                   { return false }
+func (f *testBaseEntry) LocalFilesystemPath() string   { return f.name }
+func (f *testBaseEntry) Close()                        {}
+func (f *testBaseEntry) Name() string                  { return f.name }
+func (f *testBaseEntry) ModTime() time.Time            { return f.modtime }
+func (f *testBaseEntry) Sys() any                      { return nil }
+func (f *testBaseEntry) Owner() fs.OwnerInfo           { return f.owner }
+func (f *testBaseEntry) Device() fs.DeviceInfo         { return fs.DeviceInfo{Dev: 1} }
+func (f *testBaseEntry) HardLinkInfo() fs.HardLinkInfo { return fs.HardLinkInfo{UniqId: 1, NLink: 1} }
+func (f *testBaseEntry) ObjectID() object.ID           { return f.oid }
 
 func (f *testBaseEntry) Mode() os.FileMode {
 	if f.mode == 0 {

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -36,12 +36,13 @@ func (c readerSeekerCloser) Close() error {
 }
 
 type entry struct {
-	name    string
-	mode    os.FileMode
-	size    int64
-	modTime time.Time
-	owner   fs.OwnerInfo
-	device  fs.DeviceInfo
+	name         string
+	mode         os.FileMode
+	size         int64
+	modTime      time.Time
+	owner        fs.OwnerInfo
+	device       fs.DeviceInfo
+	hardLinkInfo fs.HardLinkInfo
 }
 
 func (e *entry) Name() string {
@@ -74,6 +75,10 @@ func (e *entry) Owner() fs.OwnerInfo {
 
 func (e *entry) Device() fs.DeviceInfo {
 	return e.device
+}
+
+func (e *entry) HardLinkInfo() fs.HardLinkInfo {
+	return e.hardLinkInfo
 }
 
 func (e *entry) LocalFilesystemPath() string {

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -45,6 +45,10 @@ func (s *repositoryAllSources) Device() fs.DeviceInfo {
 	return fs.DeviceInfo{}
 }
 
+func (s *repositoryAllSources) HardLinkInfo() fs.HardLinkInfo {
+	return fs.HardLinkInfo{}
+}
+
 func (s *repositoryAllSources) Sys() any {
 	return nil
 }

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -79,6 +79,10 @@ func (e *repositoryEntry) Device() fs.DeviceInfo {
 	return fs.DeviceInfo{}
 }
 
+func (e *repositoryEntry) HardLinkInfo() fs.HardLinkInfo {
+	return fs.HardLinkInfo{}
+}
+
 func (e *repositoryEntry) DirEntry() *snapshot.DirEntry {
 	return e.metadata
 }

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -53,6 +53,10 @@ func (s *sourceDirectories) Device() fs.DeviceInfo {
 	return fs.DeviceInfo{}
 }
 
+func (s *sourceDirectories) HardLinkInfo() fs.HardLinkInfo {
+	return fs.HardLinkInfo{}
+}
+
 func (s *sourceDirectories) LocalFilesystemPath() string {
 	return ""
 }

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -51,6 +51,10 @@ func (s *sourceSnapshots) Device() fs.DeviceInfo {
 	return fs.DeviceInfo{}
 }
 
+func (s *sourceSnapshots) HardLinkInfo() fs.HardLinkInfo {
+	return fs.HardLinkInfo{}
+}
+
 func (s *sourceSnapshots) LocalFilesystemPath() string {
 	return ""
 }


### PR DESCRIPTION
I would like to add hardlink support to Kopia (https://github.com/kopia/kopia/issues/544). I believe the first step toward this is making Kopia aware of inodes, similar to what was attempted in this [closed PR](https://github.com/kopia/kopia/pull/1013). I have started by re-implementing that PR here in a (very) WIP, but I have some questions before moving forward with a full featured implementation.

The primary reason is to enable restoring snapshots with many hardlinks. Currently, all hardlinks result in file duplication during restore, requiring significantly more space than was originally used on the snapshotted FS. In the above inode PR, it was stated that storing knowledge of hardlinks in the repository is not needed:

> I don't understand the use of storing inodes in repository, we have a file identifier already oid which is globally unique. If we want to preserve hardlinks on restore, we can do the reverse process there - build a map of oid to inodes of restored files and if we find oid reuse we do a hard-link to a previously-written file.

If I understand the oid correctly, I believe this is in error. The oid for files with the same data would be identical, and thus they would be restored as hardlinks even if they were not originally hardlinks. ~~From reading the discussion on this [PR](https://github.com/kopia/kopia/pull/3643), I see that I will need to do this in a way that supports ""other non-core attributes which are currently unsupported."~~

A secondary reason to make Kopia hardlink-aware is that if it encounters a file that is a hardlink to a previously processed file, it could skip hashing that file—massively increasing snapshot speed on systems with many hardlinks. One caveat is that hardlinks would be detected by matching inodes (on POSIX systems) or File IDs (on Windows), which are not guaranteed to be unique across time. This is not an issue when backing up a static filesystem (e.g., an LVM, ZFS, or VSS snapshot), but we cannot assume that will always be the case. As such, if implemented, I believe this feature should be behind a flag with a warning. The time savings on initial snapshots of large heavily linked systems would still be huge (many days on my dataset).

Looking forward to feedback and if there's anything else for me to consider be for moving forward!