### PR TITLE
fix(site): escape flags with backticks

### DIFF
--- a/tools/cli2md/cli2md.go
+++ b/tools/cli2md/cli2md.go
@@ -32,11 +32,12 @@ const (
 	dirMode = 0o750
 )
 
+// The group at the start is to avoid matching things like "in-place"
+var escapeFlagsRe = regexp.MustCompile(`(^|\s)(--?\w+[-\w]*)`)
+
 // escapeFlags escapes command-line flag references in help text by wrapping them in backticks
 func escapeFlags(text string) string {
-	// The group at the start is to avoid matching things like "in-place"
-	re := regexp.MustCompile(`(^|\s)(-[-\w]+)`)
-	return re.ReplaceAllString(text, "$1`$2`")
+	return escapeFlagsRe.ReplaceAllString(text, "$1`$2`")
 }
 
 //nolint:gochecknoglobals

--- a/tools/cli2md/cli2md.go
+++ b/tools/cli2md/cli2md.go
@@ -32,10 +32,10 @@ const (
 	dirMode = 0o750
 )
 
-// The group at the start is to avoid matching things like "in-place"
+// The group at the start is to avoid matching things like "in-place".
 var escapeFlagsRe = regexp.MustCompile(`(^|\s)(--?\w+[-\w]*)`)
 
-// escapeFlags escapes command-line flag references in help text by wrapping them in backticks
+// escapeFlags escapes command-line flag references in help text by wrapping them in backticks.
 func escapeFlags(text string) string {
 	return escapeFlagsRe.ReplaceAllString(text, "$1`$2`")
 }

--- a/tools/cli2md/cli2md.go
+++ b/tools/cli2md/cli2md.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -30,6 +31,13 @@ const (
 
 	dirMode = 0o750
 )
+
+// escapeFlags escapes command-line flag references in help text by wrapping them in backticks
+func escapeFlags(text string) string {
+	// The group at the start is to avoid matching things like "in-place"
+	re := regexp.MustCompile(`(^|\s)(-[-\w]+)`)
+	return re.ReplaceAllString(text, "$1`$2`")
+}
 
 //nolint:gochecknoglobals
 var overrideDefault = map[string]string{
@@ -75,9 +83,9 @@ func emitFlags(w io.Writer, flags []*kingpin.FlagModel) {
 				defaultValue = "`false`"
 			}
 
-			fmt.Fprintf(w, "| `--[no-]%v` | %v | %v | %v%v |\n", f.Name, shortFlag, defaultValue, maybeAdvanced, f.Help) //nolint:errcheck
+			fmt.Fprintf(w, "| `--[no-]%v` | %v | %v | %v%v |\n", f.Name, shortFlag, defaultValue, maybeAdvanced, escapeFlags(f.Help)) //nolint:errcheck
 		} else {
-			fmt.Fprintf(w, "| `--%v` | %v | %v | %v%v |\n", f.Name, shortFlag, defaultValue, maybeAdvanced, f.Help) //nolint:errcheck
+			fmt.Fprintf(w, "| `--%v` | %v | %v | %v%v |\n", f.Name, shortFlag, defaultValue, maybeAdvanced, escapeFlags(f.Help)) //nolint:errcheck
 		}
 	}
 
@@ -122,7 +130,7 @@ func emitArgs(w io.Writer, args []*kingpin.ArgModel) {
 	})
 
 	for _, f := range args2 {
-		fmt.Fprintf(w, "| `%v` | %v |\n", f.Name, f.Help) //nolint:errcheck
+		fmt.Fprintf(w, "| `%v` | %v |\n", f.Name, escapeFlags(f.Help)) //nolint:errcheck
 	}
 
 	fmt.Fprintf(w, "\n") //nolint:errcheck
@@ -297,7 +305,7 @@ hide_summary: true
 	}
 
 	fmt.Fprintf(f, "```shell\n$ kopia %v%v%v\n```\n\n", cmd.FullCommand, flagSummary, argSummary) //nolint:errcheck
-	fmt.Fprintf(f, "%v\n\n", cmd.Help)                                                            //nolint:errcheck
+	fmt.Fprintf(f, "%v\n\n", escapeFlags(cmd.Help))                                               //nolint:errcheck
 
 	emitFlags(f, cmd.Flags)
 	emitArgs(f, cmd.Args)

--- a/tools/cli2md/cli2md_test.go
+++ b/tools/cli2md/cli2md_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestEscapeFlags(t *testing.T) {
 	cases := []struct {
@@ -58,14 +62,22 @@ func TestEscapeFlags(t *testing.T) {
 			input:    "test in-place and -valid --flags",
 			expected: "test in-place and `-valid` `--flags`",
 		},
+		{
+			name:     "separator line",
+			input:    "---------------",
+			expected: "---------------",
+		},
+		{
+			name:     "too many dashes",
+			input:    "none ---of these --- dashes ----should match",
+			expected: "none ---of these --- dashes ----should match",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := escapeFlags(tc.input)
-			if got != tc.expected {
-				t.Errorf("escapeFlags(%q)\ngot:  %q\nwant: %q", tc.input, got, tc.expected)
-			}
+			require.Equal(t, tc.expected, got)
 		})
 	}
 }

--- a/tools/cli2md/cli2md_test.go
+++ b/tools/cli2md/cli2md_test.go
@@ -1,0 +1,71 @@
+package main
+
+import "testing"
+
+func TestEscapeFlags(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "basic single flag",
+			input:    "use -flag to enable",
+			expected: "use `-flag` to enable",
+		},
+		{
+			name:     "double dash flag",
+			input:    "use --long-flag-name to configure",
+			expected: "use `--long-flag-name` to configure",
+		},
+		{
+			name:     "multiple flags",
+			input:    "use -a or --bee flags",
+			expected: "use `-a` or `--bee` flags",
+		},
+		{
+			name:     "should not match in-place",
+			input:    "performs in-place modification",
+			expected: "performs in-place modification",
+		},
+		{
+			name:     "flags with numbers and hyphens",
+			input:    "use --http2-max-streams or -h2-timeout",
+			expected: "use `--http2-max-streams` or `-h2-timeout`",
+		},
+		{
+			name:     "flag at start of string",
+			input:    "-flag at start",
+			expected: "`-flag` at start",
+		},
+		{
+			name:     "existing backticks",
+			input:    "use `--existing` and -new flags",
+			expected: "use `--existing` and `-new` flags",
+		},
+		{
+			name:     "multiple spaces before flag",
+			input:    "test   -flag with spaces",
+			expected: "test   `-flag` with spaces",
+		},
+		{
+			name:     "mixed valid and invalid patterns",
+			input:    "test in-place and -valid --flags",
+			expected: "test in-place and `-valid` `--flags`",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := escapeFlags(tc.input)
+			if got != tc.expected {
+				t.Errorf("escapeFlags(%q)\ngot:  %q\nwant: %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In the generated markdown docs, flags like `--foo` inside help texts currently get pretty-printed as `–foo` with an em-dash.

This PR applies backticks via a regex replacement (run by `cli2md`), so that they appear as `--foo` in the docs but remain as --foo (without backticks) in the CLI output.

See also #4341 