### PR TITLE
chore(cli): add details to persistent password error message

### DIFF
--- a/cli/password.go
+++ b/cli/password.go
@@ -84,7 +84,7 @@ func (c *App) getPasswordFromFlags(ctx context.Context, isCreate, allowPersisten
 		}
 
 		if !errors.Is(err, passwordpersist.ErrPasswordNotFound) {
-			return "", errors.Wrap(err, "error getting persistent password")
+			return "", errors.Wrap(err, "cannot get persistent password")
 		}
 	}
 

--- a/internal/passwordpersist/passwordpersist_keyring.go
+++ b/internal/passwordpersist/passwordpersist_keyring.go
@@ -33,7 +33,7 @@ func (keyringStrategy) GetPassword(ctx context.Context, configFile string) (stri
 	case errors.Is(err, keyring.ErrUnsupportedPlatform):
 		return "", ErrPasswordNotFound
 	default:
-		return "", errors.Wrap(err, "error retrieving password from OS keyring")
+		return "", errors.Wrap(err, "error retrieving password from OS keyring, the keyring may be locked, attempt unlocking it using the OS-specific method")
 	}
 }
 


### PR DESCRIPTION
Extends error message with a generic, OS-independent hint about what the source of the error may be and a potential solution.

Also, modifies error message to avoid duplicate messages.

- #4449