### PR TITLE
build(deps): use Go 1.23.8 toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kopia/kopia
 
 go 1.23.0
 
-toolchain go1.23.7
+toolchain go1.23.8
 
 require (
 	cloud.google.com/go/storage v1.51.0


### PR DESCRIPTION
- addresses CVE-2025-22871
- https://go.dev/issue/71988
- https://github.com/kopia/kopia/security/advisories/GHSA-63xm-hhjf-fwvg
- https://github.com/golang/vulndb/issues/3563