### PR TITLE
refactor(cli): misc cleanups in internal/diff

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -238,16 +238,13 @@ func compareMetadata(ctx context.Context, e1, e2 fs.Entry, path string, st *Entr
 }
 
 func (c *Comparer) compareEntryMetadata(e1, e2 fs.Entry, fullpath string) {
-	if e1 == e2 { // in particular e1 == nil && e2 == nil
+	switch {
+	case e1 == e2: // in particular e1 == nil && e2 == nil
 		return
-	}
-
-	if e1 == nil {
+	case e1 == nil:
 		c.output("%v does not exist in source directory\n", fullpath)
 		return
-	}
-
-	if e2 == nil {
+	case e2 == nil:
 		c.output("%v does not exist in destination directory\n", fullpath)
 		return
 	}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -198,6 +198,8 @@ func (c *Comparer) compareEntry(ctx context.Context, e1, e2 fs.Entry, path strin
 		}
 	}
 
+	// don't compare filesystem boundaries (e1.Device()), it's pretty useless and is not stored in backups
+
 	return nil
 }
 
@@ -293,8 +295,6 @@ func (c *Comparer) compareEntryMetadata(e1, e2 fs.Entry, fullpath string) bool {
 			c.stats.FileEntries.Modified++
 		}
 	}
-
-	// don't compare filesystem boundaries (e1.Device()), it's pretty useless and is not stored in backups
 
 	return equal
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -21,7 +21,7 @@ const dirMode = 0o700
 
 var log = logging.Module("diff")
 
-// EntryTypeStats accumulates specific stats for the snapshots being compared.
+// EntryTypeStats accumulates stats for an FS entry type.
 type EntryTypeStats struct {
 	Added    uint32 `json:"added"`
 	Removed  uint32 `json:"removed"`

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -237,50 +237,50 @@ func compareMetadata(ctx context.Context, e1, e2 fs.Entry, path string, st *Entr
 	}
 }
 
-func (c *Comparer) compareEntryMetadata(e1, e2 fs.Entry, fullpath string) bool {
+func (c *Comparer) compareEntryMetadata(e1, e2 fs.Entry, fullpath string) {
 	if e1 == e2 { // in particular e1 == nil && e2 == nil
-		return true
+		return
 	}
 
 	if e1 == nil {
 		c.output("%v does not exist in source directory\n", fullpath)
-		return false
+		return
 	}
 
 	if e2 == nil {
 		c.output("%v does not exist in destination directory\n", fullpath)
-		return false
+		return
 	}
 
-	equal := true
+	var changed bool
 
 	if m1, m2 := e1.Mode(), e2.Mode(); m1 != m2 {
-		equal = false
+		changed = true
 
 		c.output("%v modes differ: %v %v\n", fullpath, m1, m2)
 	}
 
 	if s1, s2 := e1.Size(), e2.Size(); s1 != s2 {
-		equal = false
+		changed = true
 
 		c.output("%v sizes differ: %v %v\n", fullpath, s1, s2)
 	}
 
 	if mt1, mt2 := e1.ModTime(), e2.ModTime(); !mt1.Equal(mt2) {
-		equal = false
+		changed = true
 
 		c.output("%v modification times differ: %v %v\n", fullpath, mt1, mt2)
 	}
 
 	o1, o2 := e1.Owner(), e2.Owner()
 	if o1.UserID != o2.UserID {
-		equal = false
+		changed = true
 
 		c.output("%v owner users differ: %v %v\n", fullpath, o1.UserID, o2.UserID)
 	}
 
 	if o1.GroupID != o2.GroupID {
-		equal = false
+		changed = true
 
 		c.output("%v owner groups differ: %v %v\n", fullpath, o1.GroupID, o2.GroupID)
 	}
@@ -288,15 +288,13 @@ func (c *Comparer) compareEntryMetadata(e1, e2 fs.Entry, fullpath string) bool {
 	_, isDir1 := e1.(fs.Directory)
 	_, isDir2 := e2.(fs.Directory)
 
-	if !equal {
+	if changed {
 		if isDir1 && isDir2 {
 			c.stats.DirectoryEntries.Modified++
 		} else {
 			c.stats.FileEntries.Modified++
 		}
 	}
-
-	return equal
 }
 
 func (c *Comparer) compareDirectoryEntries(ctx context.Context, entries1, entries2 []fs.Entry, dirPath string) error {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -181,7 +181,6 @@ func (c *Comparer) compareEntry(ctx context.Context, e1, e2 fs.Entry, path strin
 
 	if isDir2 {
 		// left is non-directory, right is a directory
-		log(ctx).Infof("changed %v from non-directory to a directory", path)
 		c.output("changed %v from non-directory to a directory\n", path)
 
 		return nil


### PR DESCRIPTION
- remove spurious log message, duplicates what is being sent to the output;
- nit: update struct comment;
- consolidate code via a parameterized function;
- rename variable for clarity, it makes it easier to understand by avoiding negative condition check;
- remove unused return value;
- replace if blocks with switch.