### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.4
-	github.com/kopia/htmluibuild v0.0.1-0.20250303064157-676b1b5bc735
+	github.com/kopia/htmluibuild v0.0.1-0.20250404064215-8bfc34d8e3cf
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.4 h1:5aDr3ZGoJbgu/8+j45KtUJxzYm8k08JGtB9Wx1VQ4OA=
 github.com/klauspost/reedsolomon v1.12.4/go.mod h1:d3CzOMOt0JXGIFZm1StgkyF14EYr3xneR2rNWo7NcMU=
-github.com/kopia/htmluibuild v0.0.1-0.20250303064157-676b1b5bc735 h1:jhTarsFN8q9gglhSiFHapzVa2i2Wsg/zbm35MWchDYk=
-github.com/kopia/htmluibuild v0.0.1-0.20250303064157-676b1b5bc735/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20250404064215-8bfc34d8e3cf h1:gQbofNt9EnLDXNdAhhCrLgk6yMfclcUoO17lAyClTcU=
+github.com/kopia/htmluibuild v0.0.1-0.20250404064215-8bfc34d8e3cf/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/7b6496aacff6bdc272f97df4915ab504fcf4cfad...c1e71aa3343db6ebb06c342a6ccb777c144bee44

* Fri Mar 21 14:37 https://github.com/kopia/htmlui/commit/9e66e92 dependabot[bot] build(deps-dev): bump @babel/runtime-corejs3 from 7.18.3 to 7.26.10
* Thu 23:37 -0700 https://github.com/kopia/htmlui/commit/09ed65e Jarek Kowalski chore(ci): migrate htmlui framework to vite, because CRA is deprecated
* Thu 23:41 -0700 https://github.com/kopia/htmlui/commit/c1e71aa dependabot[bot] build(deps-dev): bump typescript from 4.8.4 to 5.8.2

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Fri Apr  4 06:42:45 UTC 2025*
