### PR TITLE
fix(cli): handle missing entries correctly in fusemount

### DIFF
--- a/internal/fusemount/fusefs.go
+++ b/internal/fusemount/fusefs.go
@@ -134,7 +134,7 @@ func (dir *fuseDirectoryNode) directory() fs.Directory {
 func (dir *fuseDirectoryNode) Lookup(ctx context.Context, fileName string, out *fuse.EntryOut) (*gofusefs.Inode, syscall.Errno) {
 	e, err := dir.directory().Child(ctx, fileName)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrEntryNotFound) || errors.Is(err, os.ErrNotExist) {
 			return nil, syscall.ENOENT
 		}
 


### PR DESCRIPTION
I was doing some cursed things, and found a bug in the fusemount implementation.

To replicate, run:

```console
$ kopia mount <snapshot id> /mnt/kopia

$ fuse-overlayfs -o lowerdir=/mnt/kopia /mnt/overlay
```

fuse-overlayfs is from <https://github.com/containers/fuse-overlayfs>, available in debian/arch repos (I'm using version 1.13 but have also replicated with other overlay implementations).

The above example is not very useful, but is fairly minimal.

It errors with:

```
fuse-overlayfs: cannot read upper dir: Input/output error
```

(Which was very confusing; they seem to confuse "upper dir" with "lower dir" in that error message.)

Stracing:

```
-- snip --
openat(AT_FDCWD, "/mnt/kopia", O_RDONLY|O_DIRECTORY) = 3
fgetxattr(3, "security.fuseoverlayfs.override_"..., 0x7fff22e0f880, 64) = -1 ENODATA (No data available)
fgetxattr(3, "user.containers.override_stat", 0x7fff22e0f880, 64) = -1 ENODATA (No data available)
fgetxattr(3, "user.fuseoverlayfs.override_stat", 0x7fff22e0f880, 64) = -1 ENODATA (No data available)
fgetxattr(3, "system.posix_acl_default", 0x7fff22e0f940, 32) = -1 ENODATA (No data available)
faccessat2(3, "/.wh.", F_OK, AT_SYMLINK_NOFOLLOW|AT_EACCESS) = -1 ENOENT (No such file or directory)
openat2(3, ".", {flags=O_RDONLY|O_NONBLOCK|O_NOFOLLOW, resolve=RESOLVE_IN_ROOT}, 24) = 4
statx(4, "", AT_STATX_DONT_SYNC|AT_EMPTY_PATH, STATX_TYPE|STATX_MODE|STATX_INO, {stx_mask=STATX_BASIC_STATS|STATX_MNT_ID, stx_attributes=STATX_ATTR_MOUNT_ROOT, stx_mode=S_IFDIR|000, stx_size=0, ...}) = 0
fgetxattr(4, "trusted.overlay.origin", 0x5e9724434240, 4096) = -1 ENODATA (No data available)
fgetxattr(4, "user.fuseoverlayfs.origin", 0x5e9724434240, 4096) = -1 ENODATA (No data available)
close(4)                                = 0
faccessat2(3, ".wh.", F_OK, AT_SYMLINK_NOFOLLOW|AT_EACCESS) = -1 EIO (Input/output error)
write(2, "fuse-overlayfs: cannot read uppe"..., 37fuse-overlayfs: cannot read upper dir) = 37
write(2, ": Input/output error\n", 21: Input/output error
)  = 21
exit_group(1)                           = ?
+++ exited with 1 +++
```

or, more terse:

```
openat(AT_FDCWD, "/mnt/kopia", O_RDONLY|O_DIRECTORY) = 3
faccessat2(3, ".wh.", F_OK, AT_SYMLINK_NOFOLLOW|AT_EACCESS) = -1 EIO (Input/output error)
```

The error logging didn't seem to work, so I instrumented the code manually and tracked this down to:

```go
// in a Child() implementation
return nil, fs.ErrEntryNotFound

// in fusefs.go
func (dir *fuseDirectoryNode) Lookup(ctx context.Context, fileName string, out *fuse.EntryOut) (*gofusefs.Inode, syscall.Errno) {
	e, err := dir.directory().Child(ctx, fileName)
	if err != nil {
		if os.IsNotExist(err) {
            // this is the branch we're meant to take
			return nil, syscall.ENOENT
		}

        // this is where we end up instead
        // err is: "entry not found"

		log(ctx).Errorf("lookup error %v in %v: %v", fileName, dir.entry.Name(), err)

		return nil, syscall.EIO
	}

	// ...
}
```

Now, why fuse-overlayfs tries to access this, I don't know, but kopia mount should probably not EIO for a missing entry.