### PR TITLE
build(cli): set build info version and info when not set

### DIFF
--- a/repo/buildinfo.go
+++ b/repo/buildinfo.go
@@ -1,0 +1,80 @@
+package repo
+
+import (
+	stdlib "log"
+	"runtime/debug"
+	"strings"
+)
+
+// Kopia's build information.
+//
+//nolint:gochecknoglobals
+var (
+	BuildInfo       = ""
+	BuildVersion    = ""
+	BuildGitHubRepo = ""
+)
+
+func init() {
+	// fill in from executable's build info when these are unset
+	BuildInfo, BuildVersion = getBuildInfoAndVersion(BuildInfo, BuildVersion)
+}
+
+func getBuildInfoAndVersion(linkedInfo, linkedVersion string) (info, version string) {
+	info, version = linkedInfo, linkedVersion
+
+	if info != "" && version != "" {
+		return // use the values specified at link time
+	}
+
+	// a value was not set at link time, set it from the executable's build
+	// info if available.
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		// logging not yet set up, use stdlib's logging
+		stdlib.Println("executable build information is not available")
+		return // executable's build info is not available, use values set at link time, if any
+	}
+
+	if version == "" {
+		version = bi.Main.Version
+	}
+
+	if info == "" {
+		info = getRevisionString(bi.Settings)
+	}
+
+	return
+}
+
+func getRevisionString(s []debug.BuildSetting) string {
+	var (
+		revision, vcsTime string
+		modified          bool
+	)
+
+	for _, v := range s {
+		switch v.Key {
+		case "vcs.revision":
+			revision = v.Value
+		case "vcs.time":
+			vcsTime = v.Value
+		case "vcs.modified":
+			if strings.ToLower(v.Value) == "true" {
+				modified = true
+			}
+		}
+	}
+
+	if revision == "" {
+		revision = "(unknown_revision)"
+	}
+
+	var modStr string
+
+	if modified {
+		modStr = "+dirty"
+	}
+
+	return vcsTime + "-" + revision + modStr
+}

--- a/repo/buildinfo.go
+++ b/repo/buildinfo.go
@@ -37,7 +37,11 @@ func getBuildInfoAndVersion(linkedInfo, linkedVersion string) (info, version str
 	}
 
 	if version == "" {
-		version = bi.Main.Version
+		version = "v0-unofficial"
+
+		if bi.Main.Version != "" { // not set during tests
+			version = bi.Main.Version
+		}
 	}
 
 	if info == "" {

--- a/repo/buildinfo.go
+++ b/repo/buildinfo.go
@@ -39,7 +39,7 @@ func getBuildInfoAndVersion(linkedInfo, linkedVersion string) (info, version str
 	if version == "" {
 		version = "v0-unofficial"
 
-		if bi.Main.Version != "" { // not set during tests
+		if bi.Main.Version != "" && bi.Main.Version != "(devel)" { // set to '(devel)' during tests in Go 1.24
 			version = bi.Main.Version
 		}
 	}

--- a/repo/buildinfo.go
+++ b/repo/buildinfo.go
@@ -60,7 +60,7 @@ func getRevisionString(s []debug.BuildSetting) string {
 		case "vcs.time":
 			vcsTime = v.Value
 		case "vcs.modified":
-			if strings.ToLower(v.Value) == "true" {
+			if strings.EqualFold(v.Value, "true") {
 				modified = true
 			}
 		}

--- a/repo/buildinfo_test.go
+++ b/repo/buildinfo_test.go
@@ -13,7 +13,7 @@ func TestGetRevisionString(t *testing.T) {
 		want  string
 	}{
 		{
-			want: "0.-(unknown_revision)",
+			want: "-(unknown_revision)",
 		},
 		{
 			input: []debug.BuildSetting{
@@ -22,7 +22,7 @@ func TestGetRevisionString(t *testing.T) {
 					Value: "true",
 				},
 			},
-			want: "0.-(unknown_revision)+dirty",
+			want: "-(unknown_revision)+dirty",
 		},
 		{
 			input: []debug.BuildSetting{
@@ -31,7 +31,7 @@ func TestGetRevisionString(t *testing.T) {
 					Value: "2025-04-12T16:01:30Z",
 				},
 			},
-			want: "0.2025-04-12T16:01:30Z-(unknown_revision)",
+			want: "2025-04-12T16:01:30Z-(unknown_revision)",
 		},
 		{
 			input: []debug.BuildSetting{
@@ -44,7 +44,7 @@ func TestGetRevisionString(t *testing.T) {
 					Value: "true",
 				},
 			},
-			want: "0.2025-04-12T16:01:30Z-(unknown_revision)+dirty",
+			want: "2025-04-12T16:01:30Z-(unknown_revision)+dirty",
 		},
 		{
 			input: []debug.BuildSetting{
@@ -57,7 +57,7 @@ func TestGetRevisionString(t *testing.T) {
 					Value: "353676da445938316fa00b2b812a61f4b1dd3ffa",
 				},
 			},
-			want: "0.2025-04-12T16:01:30Z-353676da4459",
+			want: "2025-04-12T16:01:30Z-353676da445938316fa00b2b812a61f4b1dd3ffa",
 		},
 		{
 			input: []debug.BuildSetting{
@@ -70,7 +70,7 @@ func TestGetRevisionString(t *testing.T) {
 					Value: "353676da4459",
 				},
 			},
-			want: "0.2025-04-12T16:01:30Z-353676da4459",
+			want: "2025-04-12T16:01:30Z-353676da4459",
 		},
 		{
 			input: []debug.BuildSetting{
@@ -83,7 +83,7 @@ func TestGetRevisionString(t *testing.T) {
 					Value: "353676da",
 				},
 			},
-			want: "0.2025-04-12T16:01:30Z-353676da",
+			want: "2025-04-12T16:01:30Z-353676da",
 		},
 		{
 			input: []debug.BuildSetting{
@@ -100,12 +100,14 @@ func TestGetRevisionString(t *testing.T) {
 					Value: "true",
 				},
 			},
-			want: "0.2025-04-12T16:01:30Z-353676da4459+dirty",
+			want: "2025-04-12T16:01:30Z-353676da445938316fa00b2b812a61f4b1dd3ffa+dirty",
 		},
 	}
 
 	for _, c := range cases {
-		got := getRevisionString(c.input)
-		require.Equal(t, c.want, got)
+		t.Run("buildinfo", func(t *testing.T) {
+			got := getRevisionString(c.input)
+			require.Equal(t, c.want, got)
+		})
 	}
 }

--- a/repo/buildinfo_test.go
+++ b/repo/buildinfo_test.go
@@ -1,0 +1,111 @@
+package repo
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRevisionString(t *testing.T) {
+	cases := []struct {
+		input []debug.BuildSetting
+		want  string
+	}{
+		{
+			want: "0.-(unknown_revision)",
+		},
+		{
+			input: []debug.BuildSetting{
+				{
+					Key:   "vcs.modified",
+					Value: "true",
+				},
+			},
+			want: "0.-(unknown_revision)+dirty",
+		},
+		{
+			input: []debug.BuildSetting{
+				{
+					Key:   "vcs.time",
+					Value: "2025-04-12T16:01:30Z",
+				},
+			},
+			want: "0.2025-04-12T16:01:30Z-(unknown_revision)",
+		},
+		{
+			input: []debug.BuildSetting{
+				{
+					Key:   "vcs.time",
+					Value: "2025-04-12T16:01:30Z",
+				},
+				{
+					Key:   "vcs.modified",
+					Value: "true",
+				},
+			},
+			want: "0.2025-04-12T16:01:30Z-(unknown_revision)+dirty",
+		},
+		{
+			input: []debug.BuildSetting{
+				{
+					Key:   "vcs.time",
+					Value: "2025-04-12T16:01:30Z",
+				},
+				{
+					Key:   "vcs.revision",
+					Value: "353676da445938316fa00b2b812a61f4b1dd3ffa",
+				},
+			},
+			want: "0.2025-04-12T16:01:30Z-353676da4459",
+		},
+		{
+			input: []debug.BuildSetting{
+				{
+					Key:   "vcs.time",
+					Value: "2025-04-12T16:01:30Z",
+				},
+				{
+					Key:   "vcs.revision",
+					Value: "353676da4459",
+				},
+			},
+			want: "0.2025-04-12T16:01:30Z-353676da4459",
+		},
+		{
+			input: []debug.BuildSetting{
+				{
+					Key:   "vcs.time",
+					Value: "2025-04-12T16:01:30Z",
+				},
+				{
+					Key:   "vcs.revision",
+					Value: "353676da",
+				},
+			},
+			want: "0.2025-04-12T16:01:30Z-353676da",
+		},
+		{
+			input: []debug.BuildSetting{
+				{
+					Key:   "vcs.time",
+					Value: "2025-04-12T16:01:30Z",
+				},
+				{
+					Key:   "vcs.revision",
+					Value: "353676da445938316fa00b2b812a61f4b1dd3ffa",
+				},
+				{
+					Key:   "vcs.modified",
+					Value: "true",
+				},
+			},
+			want: "0.2025-04-12T16:01:30Z-353676da4459+dirty",
+		},
+	}
+
+	for _, c := range cases {
+		got := getRevisionString(c.input)
+		require.Equal(t, c.want, got)
+	}
+}

--- a/repo/initialize.go
+++ b/repo/initialize.go
@@ -18,15 +18,6 @@ import (
 	"github.com/kopia/kopia/repo/splitter"
 )
 
-// BuildInfo is the build information of Kopia.
-//
-//nolint:gochecknoglobals
-var (
-	BuildInfo       = "unknown"
-	BuildVersion    = "v0-unofficial"
-	BuildGitHubRepo = ""
-)
-
 const (
 	hmacSecretLength = 32
 	masterKeyLength  = 32


### PR DESCRIPTION
Sets `repo.BuildInfo` and `repo.BuildVersion` when they are not specified via link flags.

The behavior for binaries built via CI and Make remains the same.