### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.4
-	github.com/kopia/htmluibuild v0.0.1-0.20250404064215-8bfc34d8e3cf
+	github.com/kopia/htmluibuild v0.0.1-0.20250412220712-778c21a64a84
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.4 h1:5aDr3ZGoJbgu/8+j45KtUJxzYm8k08JGtB9Wx1VQ4OA=
 github.com/klauspost/reedsolomon v1.12.4/go.mod h1:d3CzOMOt0JXGIFZm1StgkyF14EYr3xneR2rNWo7NcMU=
-github.com/kopia/htmluibuild v0.0.1-0.20250404064215-8bfc34d8e3cf h1:gQbofNt9EnLDXNdAhhCrLgk6yMfclcUoO17lAyClTcU=
-github.com/kopia/htmluibuild v0.0.1-0.20250404064215-8bfc34d8e3cf/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20250412220712-778c21a64a84 h1:UJCTRN2okJ+ar5L02NguM7cTS3I6wvFxYrH6ihEuLqQ=
+github.com/kopia/htmluibuild v0.0.1-0.20250412220712-778c21a64a84/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/c1e71aa3343db6ebb06c342a6ccb777c144bee44...7044c4437251731ec11ea997e7893fb2495d57a0

* 49 seconds ago https://github.com/kopia/htmlui/commit/7044c44 dependabot[bot] build(deps-dev): bump vite from 6.2.5 to 6.2.6

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Sat Apr 12 22:07:26 UTC 2025*
