### PR TITLE
fix(general): `tempfile.Create` on Linux (x64/arm64)

### DIFF
--- a/internal/tempfile/tempfile_linux.go
+++ b/internal/tempfile/tempfile_linux.go
@@ -10,6 +10,8 @@ import (
 
 // Create creates a temporary file that will be automatically deleted on close.
 func Create(dir string) (*os.File, error) {
+	dir = tempDirOr(dir)
+
 	// on reasonably modern Linux (3.11 and above) O_TMPFILE is supported,
 	// which creates invisible, unlinked file in a given directory.
 	fd, err := unix.Open(dir, unix.O_RDWR|unix.O_TMPFILE|unix.O_CLOEXEC, permissions)

--- a/internal/tempfile/tempfile_test.go
+++ b/internal/tempfile/tempfile_test.go
@@ -36,3 +36,12 @@ func TestTempFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, files)
 }
+
+func TestCreateSucceedsWhenDirIsNotSpecified(t *testing.T) {
+	f, err := tempfile.Create("")
+
+	require.NoError(t, err)
+
+	err = f.Close()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
- Add `TestCreateSucceedsWhenDirIsNotSpecified`
- Use `os.TempDir` when `dir` is not specified (empty string)

Ref:
- Fixes #4331
- Fixes #2415 