### PR TITLE
refactor(general): leverage `os.CreateTemp`

### DIFF
--- a/internal/bigmap/bigmap_internal.go
+++ b/internal/bigmap/bigmap_internal.go
@@ -344,7 +344,7 @@ func (m *internalMap) newMemoryMappedSegment(ctx context.Context) (mmap.MMap, er
 
 // +checklocks:m.mu
 func (m *internalMap) maybeCreateMappedFile(ctx context.Context) (*os.File, error) {
-	f, err := tempfile.Create("")
+	f, err := tempfile.CreateAutoDelete()
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create memory-mapped file")
 	}

--- a/internal/tempfile/tempfile.go
+++ b/internal/tempfile/tempfile.go
@@ -1,13 +1,3 @@
 // Package tempfile provides a cross-platform abstraction for creating private
 // read-write temporary files which are automatically deleted when closed.
 package tempfile
-
-import "os"
-
-func tempDirOr(dir string) string {
-	if dir != "" {
-		return dir
-	}
-
-	return os.TempDir()
-}

--- a/internal/tempfile/tempfile_linux.go
+++ b/internal/tempfile/tempfile_linux.go
@@ -8,6 +8,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const permissions = 0o600
+
 // Create creates a temporary file that will be automatically deleted on close.
 func Create(dir string) (*os.File, error) {
 	dir = tempDirOr(dir)

--- a/internal/tempfile/tempfile_linux.go
+++ b/internal/tempfile/tempfile_linux.go
@@ -10,9 +10,9 @@ import (
 
 const permissions = 0o600
 
-// Create creates a temporary file that will be automatically deleted on close.
-func Create(dir string) (*os.File, error) {
-	dir = tempDirOr(dir)
+// CreateAutoDelete creates a temporary file that will be automatically deleted on close.
+func CreateAutoDelete() (*os.File, error) {
+	dir := os.TempDir()
 
 	// on reasonably modern Linux (3.11 and above) O_TMPFILE is supported,
 	// which creates invisible, unlinked file in a given directory.
@@ -22,7 +22,7 @@ func Create(dir string) (*os.File, error) {
 	}
 
 	if errors.Is(err, syscall.EISDIR) || errors.Is(err, syscall.EOPNOTSUPP) {
-		return createUnixFallback(dir)
+		return createUnixFallback()
 	}
 
 	return nil, &os.PathError{

--- a/internal/tempfile/tempfile_linux_fallback_test.go
+++ b/internal/tempfile/tempfile_linux_fallback_test.go
@@ -1,0 +1,16 @@
+//go:build linux
+// +build linux
+
+package tempfile
+
+import (
+	"testing"
+)
+
+// Explicitly test the create fallback function.
+// This test only applies to Linux to explicitly test the fallback function.
+// In other unix platforms the fallback is the default implementation, so it
+// is already tested in the tests for the Create function.
+func TestCreateFallback(t *testing.T) {
+	VerifyTempfile(t, createUnixFallback)
+}

--- a/internal/tempfile/tempfile_test.go
+++ b/internal/tempfile/tempfile_test.go
@@ -7,23 +7,5 @@ import (
 )
 
 func TestTempFile(t *testing.T) {
-	cases := []struct {
-		name string
-		dir  string
-	}{
-		{
-			name: "empty dir name",
-			dir:  "",
-		},
-		{
-			name: "non-empty dir name",
-			dir:  t.TempDir(),
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			tempfile.VerifyTempfile(t, tc.dir, tempfile.Create)
-		})
-	}
+	tempfile.VerifyTempfile(t, tempfile.Create)
 }

--- a/internal/tempfile/tempfile_test.go
+++ b/internal/tempfile/tempfile_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestTempFile(t *testing.T) {
-	tempfile.VerifyTempfile(t, tempfile.Create)
+	tempfile.VerifyTempfile(t, tempfile.CreateAutoDelete)
 }

--- a/internal/tempfile/tempfile_test.go
+++ b/internal/tempfile/tempfile_test.go
@@ -1,11 +1,7 @@
 package tempfile_test
 
 import (
-	"io"
-	"os"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/tempfile"
 )
@@ -27,32 +23,7 @@ func TestTempFile(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			td := tc.dir
-
-			f, err := tempfile.Create(td)
-			require.NoError(t, err)
-
-			n, err := f.WriteString("hello")
-			require.NoError(t, err)
-			require.Equal(t, 5, n)
-
-			off, err := f.Seek(1, io.SeekStart)
-			require.Equal(t, int64(1), off)
-			require.NoError(t, err)
-
-			buf := make([]byte, 4)
-			n2, err := f.Read(buf)
-			require.NoError(t, err)
-			require.Equal(t, 4, n2)
-			require.Equal(t, []byte("ello"), buf)
-
-			f.Close()
-
-			if td != "" { // $TEMPDIR often has other files, so it does not make sense to check whether it is empty
-				files, err := os.ReadDir(td)
-				require.NoError(t, err)
-				require.Emptyf(t, files, "number of files: %v", len(files))
-			}
+			tempfile.VerifyTempfile(t, tc.dir, tempfile.Create)
 		})
 	}
 }

--- a/internal/tempfile/tempfile_unix_fallback.go
+++ b/internal/tempfile/tempfile_unix_fallback.go
@@ -5,25 +5,19 @@ package tempfile
 
 import (
 	"os"
-	"path/filepath"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
-const permissions = 0o600
-
 // createUnixFallback creates a temporary file that does not need to be removed on close.
 func createUnixFallback(dir string) (*os.File, error) {
-	fullPath := filepath.Join(tempDirOr(dir), uuid.NewString())
-
-	f, err := os.OpenFile(fullPath, os.O_CREATE|os.O_EXCL|os.O_RDWR, permissions) //nolint:gosec
+	f, err := os.CreateTemp(dir, "kt-")
 	if err != nil {
 		return nil, err //nolint:wrapcheck
 	}
 
 	// immediately remove/unlink the file while we keep the handle open.
-	if derr := os.Remove(fullPath); derr != nil {
+	if derr := os.Remove(f.Name()); derr != nil {
 		f.Close() //nolint:errcheck
 		return nil, errors.Wrap(derr, "unable to unlink temporary file")
 	}

--- a/internal/tempfile/tempfile_unix_fallback.go
+++ b/internal/tempfile/tempfile_unix_fallback.go
@@ -10,8 +10,8 @@ import (
 )
 
 // createUnixFallback creates a temporary file that does not need to be removed on close.
-func createUnixFallback(dir string) (*os.File, error) {
-	f, err := os.CreateTemp(dir, "kt-")
+func createUnixFallback() (*os.File, error) {
+	f, err := os.CreateTemp("", "kt-")
 	if err != nil {
 		return nil, err //nolint:wrapcheck
 	}

--- a/internal/tempfile/tempfile_unix_nonlinux.go
+++ b/internal/tempfile/tempfile_unix_nonlinux.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-// Create creates a temporary file that does not need to be removed on close.
-func Create(dir string) (*os.File, error) {
-	return createUnixFallback(dir)
+// CreateAutoDelete creates a temporary file that does not need to be explicitly removed on close.
+func CreateAutoDelete() (*os.File, error) {
+	return createUnixFallback()
 }

--- a/internal/tempfile/tempfile_verify_test.go
+++ b/internal/tempfile/tempfile_verify_test.go
@@ -1,0 +1,38 @@
+package tempfile
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func VerifyTempfile(t *testing.T, testDir string, create func(dir string) (*os.File, error)) {
+	t.Helper()
+
+	f, err := create(testDir)
+	require.NoError(t, err)
+
+	n, err := f.WriteString("hello")
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+
+	off, err := f.Seek(1, io.SeekStart)
+	require.Equal(t, int64(1), off)
+	require.NoError(t, err)
+
+	buf := make([]byte, 4)
+	n2, err := f.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 4, n2)
+	require.Equal(t, []byte("ello"), buf)
+
+	f.Close()
+
+	if testDir != "" { // $TEMPDIR often has other files, so it does not make sense to check whether it is empty
+		files, err := os.ReadDir(testDir)
+		require.NoError(t, err)
+		require.Emptyf(t, files, "number of files: %v", len(files))
+	}
+}

--- a/internal/tempfile/tempfile_windows.go
+++ b/internal/tempfile/tempfile_windows.go
@@ -9,9 +9,9 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// Create creates a temporary file that will be automatically deleted on close.
-func Create(dir string) (*os.File, error) {
-	fullpath := filepath.Join(tempDirOr(dir), uuid.NewString())
+// CreateAutoDelete creates a temporary file that will be automatically deleted on close.
+func CreateAutoDelete() (*os.File, error) {
+	fullpath := filepath.Join(os.TempDir(), uuid.NewString())
 
 	fname, err := syscall.UTF16PtrFromString(fullpath)
 	if err != nil {

--- a/tests/os_snapshot_test/os_snapshot_windows_test.go
+++ b/tests/os_snapshot_test/os_snapshot_windows_test.go
@@ -56,6 +56,7 @@ func TestShadowCopy(t *testing.T) {
 	entries := clitestutil.ListDirectory(t, e, oid)
 
 	if isAdmin {
+		require.NotEmpty(t, entries)
 		lines := e.RunAndExpectSuccess(t, "show", entries[0].ObjectID)
 		require.Equal(t, []string{"locked file"}, lines)
 	} else {

--- a/tests/os_snapshot_test/os_snapshot_windows_test.go
+++ b/tests/os_snapshot_test/os_snapshot_windows_test.go
@@ -2,13 +2,16 @@ package os_snapshot_test
 
 import (
 	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/mxk/go-vss"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
 
-	"github.com/kopia/kopia/internal/tempfile"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/clitestutil"
 	"github.com/kopia/kopia/tests/testenv"
@@ -21,20 +24,18 @@ func TestShadowCopy(t *testing.T) {
 	}
 
 	runner := testenv.NewExeRunnerWithBinary(t, kopiaExe)
-
 	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
-	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--enable-volume-shadow-copy=when-available")
+
+	// create a file that cannot be accessed and then attempt to create a snapshot
 	root := testutil.TempDirectory(t)
-	f, err := tempfile.Create(root)
-	require.NoError(t, err)
-	_, err = f.WriteString("locked file\n")
+	f := createAutoDelete(t, root)
+	_, err := f.WriteString("locked file\n")
+
 	require.NoError(t, err)
 	require.NoError(t, f.Sync())
-
-	defer f.Close()
-
-	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--enable-volume-shadow-copy=when-available")
 
 	_, err = vss.Get("{00000000-0000-0000-0000-000000000000}")
 
@@ -43,7 +44,7 @@ func TestShadowCopy(t *testing.T) {
 		t.Log("Running as admin, expecting snapshot creation to succeed")
 		e.RunAndExpectSuccess(t, "snap", "create", root)
 	} else {
-		t.Log("Not running as admin, expecting snapshot creation to fail")
+		t.Log("Not running as admin, expecting snapshot creation to fail because it cannot access the file that is in use")
 		e.RunAndExpectFailure(t, "snap", "create", root)
 	}
 
@@ -54,6 +55,7 @@ func TestShadowCopy(t *testing.T) {
 
 	oid := sources[0].Snapshots[0].ObjectID
 	entries := clitestutil.ListDirectory(t, e, oid)
+	t.Log("sources[0].Snapshots[0].ObjectID entries:", entries)
 
 	if isAdmin {
 		require.NotEmpty(t, entries)
@@ -62,4 +64,33 @@ func TestShadowCopy(t *testing.T) {
 	} else {
 		require.Empty(t, entries)
 	}
+}
+
+func createAutoDelete(t *testing.T, dir string) *os.File {
+	t.Helper()
+
+	fullpath := filepath.Join(dir, uuid.NewString())
+
+	fname, err := syscall.UTF16PtrFromString(fullpath)
+	require.NoError(t, err, "constructing file name UTF16Ptr")
+
+	// This call creates a file that's automatically deleted on close.
+	h, err := syscall.CreateFile(
+		fname,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		0,
+		nil,
+		syscall.OPEN_ALWAYS,
+		uint32(windows.FILE_FLAG_DELETE_ON_CLOSE),
+		0)
+
+	require.NoError(t, err, "creating file")
+
+	f := os.NewFile(uintptr(h), fullpath)
+
+	t.Cleanup(func() {
+		f.Close()
+	})
+
+	return f
 }


### PR DESCRIPTION
Use `os.CreateTemp` when creating temporary files in `tempfile.createUnixFallback` function
