### PR TITLE
refactor(general): cleanup a few tests

### DIFF
--- a/tests/robustness/snapmeta/index_test.go
+++ b/tests/robustness/snapmeta/index_test.go
@@ -5,6 +5,8 @@ package snapmeta
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestIndex(t *testing.T) {
@@ -18,18 +20,11 @@ func TestIndex(t *testing.T) {
 	idx.AddToIndex(snapIDKey, snapshotIndexName)
 
 	keys := idx.GetKeys(snapshotIndexName)
-	if got, want := len(keys), 1; got != want {
-		t.Fatalf("expected %v keys but got %v", want, got)
-	}
-
-	if got, want := keys[0], snapIDKey; got != want {
-		t.Fatalf("expected %v but got %v", want, got)
-	}
+	require.Len(t, keys, 1, "unexpected number of keys")
+	require.Equal(t, snapIDKey, keys[0])
 
 	idx.RemoveFromIndex(snapIDKey, snapshotIndexName)
 
 	keys = idx.GetKeys(snapshotIndexName)
-	if got, want := len(keys), 0; got != want {
-		t.Fatalf("expected %v keys but got %v", want, got)
-	}
+	require.Empty(t, keys)
 }

--- a/tests/robustness/snapmeta/simple_test.go
+++ b/tests/robustness/snapmeta/simple_test.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kopia/kopia/tests/robustness"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/tests/robustness"
 )
 
 func TestSimpleBasic(t *testing.T) {

--- a/tests/robustness/snapmeta/simple_test.go
+++ b/tests/robustness/snapmeta/simple_test.go
@@ -4,12 +4,11 @@
 package snapmeta
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/kopia/kopia/tests/robustness"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleBasic(t *testing.T) {
@@ -18,35 +17,20 @@ func TestSimpleBasic(t *testing.T) {
 	simple := NewSimple()
 
 	gotData, err := simple.Load(ctx, "non-existent-key")
-	if !errors.Is(err, robustness.ErrKeyNotFound) {
-		t.Fatalf("Did not get expected error: %q", err)
-	}
-
-	if gotData != nil {
-		t.Fatalf("Expecting nil data return from a key that does not exist")
-	}
+	require.ErrorIs(t, err, robustness.ErrKeyNotFound, "Did not get expected error")
+	require.Nil(t, gotData, "Expecting nil data return from a key that does not exist")
 
 	storeKey := "key-to-store"
 	data := []byte("some stored data")
 	simple.Store(ctx, storeKey, data)
 
 	gotData, err = simple.Load(ctx, storeKey)
-	if err != nil {
-		t.Fatalf("Error getting key: %v", err)
-	}
-
-	if !bytes.Equal(gotData, data) {
-		t.Fatalf("Did not get the correct data")
-	}
+	require.NoError(t, err, "Error getting key")
+	require.Equal(t, data, gotData, "Did not get the correct data")
 
 	simple.Delete(ctx, storeKey)
 
 	gotData, err = simple.Load(ctx, storeKey)
-	if !errors.Is(err, robustness.ErrKeyNotFound) {
-		t.Fatalf("Did not get expected error: %q", err)
-	}
-
-	if gotData != nil {
-		t.Fatalf("Expecting nil data return from a deleted key")
-	}
+	require.ErrorIs(t, err, robustness.ErrKeyNotFound, "Did not get expected error")
+	require.Nil(t, gotData, "Expecting nil data return from a deleted key")
 }


### PR DESCRIPTION
Cleanup robustness tests and `local_fs_test.go`

- Use `require` helpers
- Use `testing.T` helpers

"Mechanical" changes.

Note change in functionality: The use of `require` helpers stops tests once a check fails. Before, various checks were using `t.Error`, which fails the test but allows the test to continue its execution.