### PR TITLE
refactor(providers): change rclone's `StartupTimeout` type to Duration

### DIFF
--- a/repo/blob/rclone/rclone_options.go
+++ b/repo/blob/rclone/rclone_options.go
@@ -1,21 +1,22 @@
 package rclone
 
 import (
+	"github.com/kopia/kopia/internal/jsonencoding"
 	"github.com/kopia/kopia/repo/blob/sharded"
 	"github.com/kopia/kopia/repo/blob/throttling"
 )
 
 // Options defines options for RClone storage.
 type Options struct {
-	RemotePath         string   `json:"remotePath"`                   // remote:path supported by RClone
-	RCloneExe          string   `json:"rcloneExe,omitempty"`          // path to rclone executable
-	RCloneArgs         []string `json:"rcloneArgs,omitempty"`         // additional rclone arguments
-	RCloneEnv          []string `json:"rcloneEnv,omitempty"`          // additional rclone environment variables
-	StartupTimeout     int      `json:"startupTimeout,omitempty"`     // time to wait for rclone to start
-	Debug              bool     `json:"debug,omitempty"`              // log rclone output
-	NoWaitForTransfers bool     `json:"noWaitForTransfers,omitempty"` // when set to true, don't wait for transfers to finish when closing
-	EmbeddedConfig     string   `json:"embeddedConfig,omitempty"`
-	AtomicWrites       bool     `json:"atomicWrites"`
+	RemotePath         string                `json:"remotePath"`                   // remote:path supported by RClone
+	RCloneExe          string                `json:"rcloneExe,omitempty"`          // path to rclone executable
+	RCloneArgs         []string              `json:"rcloneArgs,omitempty"`         // additional rclone arguments
+	RCloneEnv          []string              `json:"rcloneEnv,omitempty"`          // additional rclone environment variables
+	StartupTimeout     jsonencoding.Duration `json:"startupTimeout,omitempty"`     // time to wait for rclone to start
+	Debug              bool                  `json:"debug,omitempty"`              // log rclone output
+	NoWaitForTransfers bool                  `json:"noWaitForTransfers,omitempty"` // when set to true, don't wait for transfers to finish when closing
+	EmbeddedConfig     string                `json:"embeddedConfig,omitempty"`
+	AtomicWrites       bool                  `json:"atomicWrites"`
 
 	sharded.Options
 	throttling.Limits

--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -346,8 +346,8 @@ func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error)
 	osexec.DisableInterruptSignal(r.cmd)
 
 	startupTimeout := rcloneStartupTimeout
-	if opt.StartupTimeout != 0 {
-		startupTimeout = time.Duration(opt.StartupTimeout) * time.Second
+	if opt.StartupTimeout.Duration != 0 {
+		startupTimeout = opt.StartupTimeout.Duration
 	}
 
 	rcloneUrls, err := r.runRCloneAndWaitForServerAddress(ctx, r.cmd, startupTimeout)


### PR DESCRIPTION
This allows persistingand reading back the timeout as a duration.

~~The name reflects the unit used for the timeout.~~

There are be no backwards compatibility issues, since the field is
not currently set, so it is not persisted in the configuration file.