### PR TITLE
feat(providers): client certificate authentication for Azure Blob

### DIFF
--- a/cli/storage_azure.go
+++ b/cli/storage_azure.go
@@ -25,6 +25,7 @@ func (c *storageAzureFlags) Setup(svc StorageProviderServices, cmd *kingpin.CmdC
 	cmd.Flag("tenant-id", "Azure service principle tenant ID (overrides AZURE_TENANT_ID environment variable)").Envar(svc.EnvName("AZURE_TENANT_ID")).StringVar(&c.azOptions.TenantID)
 	cmd.Flag("client-id", "Azure service principle client ID (overrides AZURE_CLIENT_ID environment variable)").Envar(svc.EnvName("AZURE_CLIENT_ID")).StringVar(&c.azOptions.ClientID)
 	cmd.Flag("client-secret", "Azure service principle client secret (overrides AZURE_CLIENT_SECRET environment variable)").Envar(svc.EnvName("AZURE_CLIENT_SECRET")).StringVar(&c.azOptions.ClientSecret)
+	cmd.Flag("client-cert", "Azure client certificate (overrides AZURE_CLIENT_CERT environment variable)").Envar(svc.EnvName("AZURE_CLIENT_CERT")).StringVar(&c.azOptions.ClientCert)
 
 	commonThrottlingFlags(cmd, &c.azOptions.Limits)
 

--- a/repo/blob/azure/azure_options.go
+++ b/repo/blob/azure/azure_options.go
@@ -28,6 +28,9 @@ type Options struct {
 	ClientID     string
 	ClientSecret string
 
+	// ClientCert are used for creating ClientCertificateCredentials
+	ClientCert string
+
 	StorageDomain string `json:"storageDomain,omitempty"`
 
 	throttling.Limits

--- a/repo/blob/azure/azure_storage.go
+++ b/repo/blob/azure/azure_storage.go
@@ -365,11 +365,6 @@ func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error)
 		return nil, errors.New("container name must be specified")
 	}
 
-	var (
-		service    *azblob.Client
-		serviceErr error
-	)
-
 	storageDomain := opt.StorageDomain
 	if storageDomain == "" {
 		storageDomain = "blob.core.windows.net"
@@ -377,36 +372,7 @@ func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error)
 
 	storageHostname := fmt.Sprintf("%v.%v", opt.StorageAccount, storageDomain)
 
-	switch {
-	// shared access signature
-	case opt.SASToken != "":
-		service, serviceErr = azblob.NewClientWithNoCredential(
-			fmt.Sprintf("https://%s?%s", storageHostname, opt.SASToken), nil)
-
-	// storage account access key
-	case opt.StorageKey != "":
-		// create a credentials object.
-		cred, err := azblob.NewSharedKeyCredential(opt.StorageAccount, opt.StorageKey)
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to initialize storage access key credentials")
-		}
-
-		service, serviceErr = azblob.NewClientWithSharedKeyCredential(
-			fmt.Sprintf("https://%s/", storageHostname), cred, nil,
-		)
-	// client secret
-	case opt.TenantID != "" && opt.ClientID != "" && opt.ClientSecret != "":
-		cred, err := azidentity.NewClientSecretCredential(opt.TenantID, opt.ClientID, opt.ClientSecret, nil)
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to initialize client secret credential")
-		}
-
-		service, serviceErr = azblob.NewClient(fmt.Sprintf("https://%s/", storageHostname), cred, nil)
-
-	default:
-		return nil, errors.New("one of the storage key, SAS token or client secret must be provided")
-	}
-
+	service, serviceErr := getAZService(opt, storageHostname)
 	if serviceErr != nil {
 		return nil, errors.Wrap(serviceErr, "opening azure service")
 	}
@@ -435,6 +401,56 @@ func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error)
 	}
 
 	return az, nil
+}
+
+func getAZService(opt *Options, storageHostname string) (*azblob.Client, error) {
+	var (
+		service    *azblob.Client
+		serviceErr error
+	)
+
+	switch {
+	// shared access signature
+	case opt.SASToken != "":
+		service, serviceErr = azblob.NewClientWithNoCredential(
+			fmt.Sprintf("https://%s?%s", storageHostname, opt.SASToken), nil)
+	// storage account access key
+	case opt.StorageKey != "":
+		// create a credentials object.
+		cred, err := azblob.NewSharedKeyCredential(opt.StorageAccount, opt.StorageKey)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to initialize storage access key credentials")
+		}
+
+		service, serviceErr = azblob.NewClientWithSharedKeyCredential(
+			fmt.Sprintf("https://%s/", storageHostname), cred, nil,
+		)
+	// client secret
+	case opt.TenantID != "" && opt.ClientID != "" && opt.ClientSecret != "":
+		cred, err := azidentity.NewClientSecretCredential(opt.TenantID, opt.ClientID, opt.ClientSecret, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to initialize client secret credential")
+		}
+
+		service, serviceErr = azblob.NewClient(fmt.Sprintf("https://%s/", storageHostname), cred, nil)
+	// client certificate
+	case opt.TenantID != "" && opt.ClientID != "" && opt.ClientCert != "":
+		certs, key, certErr := azidentity.ParseCertificates([]byte(opt.ClientCert), nil)
+		if certErr != nil {
+			return nil, errors.Wrap(certErr, "failed to read client cert")
+		}
+
+		cred, credErr := azidentity.NewClientCertificateCredential(opt.TenantID, opt.ClientID, certs, key, nil)
+		if credErr != nil {
+			return nil, errors.Wrap(credErr, "unable to initialize client cert credential")
+		}
+
+		service, serviceErr = azblob.NewClient(fmt.Sprintf("https://%s/", storageHostname), cred, nil)
+	default:
+		return nil, errors.New("one of the storage key, SAS token, client secret or client certificate must be provided")
+	}
+
+	return service, errors.Wrap(serviceErr, "unable to create azure client")
 }
 
 func init() {


### PR DESCRIPTION
Allow the use of a client certificate when authenticating to an Azure Blob storage provider.

Tests included.

Credit: @DeepikaDixit