### PR TITLE
style(general): cleanup linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,7 +99,6 @@ linters:
     - tparallel
     - usetesting
     - varnamelen # this one may be interesting, but too much churn
-    - wastedassign
     - whitespace
 
   exclusions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,14 +39,14 @@ linters:
     gomodguard:
       blocked:
         modules:
-          - go.uber.org/multierr:
-              recommendations:
-                - errors
-              reason: "multierr.Append() can be replaced by native errors.Join()"
           - github.com/aws/aws-sdk-go:
               recommendations:
                 - github.com/minio/minio-go
               reason: "github.com/aws/aws-sdk-go is not activily developed any longer"
+          - go.uber.org/multierr:
+              recommendations:
+                - errors
+              reason: "multierr.Append() can be replaced by native errors.Join()"
     goconst:
       min-len: 5
       min-occurrences: 3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,10 @@ linters:
               recommendations:
                 - github.com/minio/minio-go
               reason: "github.com/aws/aws-sdk-go is not activily developed any longer"
+          - github.com/rs/zerolog/log:
+              recommendations:
+                - "use kopia's logging packages"
+              reason: "zerolog not currently use"
           - go.uber.org/multierr:
               recommendations:
                 - errors
@@ -111,6 +115,7 @@ linters:
     - usetesting
     - varnamelen # this one may be interesting, but too much churn
     - whitespace
+    - zerologlint # zerolog not currently used in the codebase
 
   exclusions:
     generated: lax

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -185,7 +185,7 @@ formatters:
       sections:
         - standard
         - default
-        - prefix(github.com/kopia/kopia)
+        - localmodule
 
 output:
   show-stats: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,14 @@ linters:
   settings:
     cyclop:
       max-complexity: 20
+    depguard:
+      rules:
+        main:
+          deny:
+            # v2 of the SDK comprises many modules, which means it cannot be
+            # denied with a single gomodguard entry
+            - pkg: "github.com/aws/aws-sdk-go-v2"
+              desc: "use github.com/minio/minio-go"
     exhaustive:
       # indicates that switch statements are to be considered exhaustive if a
       # 'default' case is present, even if all enum members aren't listed in the
@@ -35,6 +43,10 @@ linters:
               recommendations:
                 - errors
               reason: "multierr.Append() can be replaced by native errors.Join()"
+          - github.com/aws/aws-sdk-go:
+              recommendations:
+                - github.com/minio/minio-go
+              reason: "github.com/aws/aws-sdk-go is not activily developed any longer"
     goconst:
       min-len: 5
       min-occurrences: 3
@@ -75,7 +87,6 @@ linters:
 
   default: all
   disable:
-    - depguard
     - exhaustruct
     - forcetypeassert
     - funcorder

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -441,7 +441,7 @@ func TestNoEpochAdvanceOnIndexRead(t *testing.T) {
 	}
 
 	te.mgr.Invalidate()
-	cs, err = te.mgr.Current(ctx)
+	_, err = te.mgr.Current(ctx)
 	require.NoError(t, err)
 
 	te.mgr.Flush() // wait for background work

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -4,7 +4,7 @@ package testutil
 import (
 	"encoding/json"
 	"fmt"
-	"log" //nolint:depguard
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"


### PR DESCRIPTION
- use 'localmodule' for gci linter config
- enable `wastedassign` linter and fix linter issues
- disable `zerologlint` linter
- block dependencies