### PR TITLE
fix(server): add empty line between headers and body in email payload

### DIFF
--- a/notification/sender/email/email_sender.go
+++ b/notification/sender/email/email_sender.go
@@ -47,7 +47,7 @@ func (p *emailProvider) Send(_ context.Context, msg *sender.Message) error {
 		headers = append(headers, fmt.Sprintf("%v: %v", k, v))
 	}
 
-	msgPayload = []byte(strings.Join(headers, "\r\n") + "\r\n" + msg.Body)
+	msgPayload = []byte(strings.Join(headers, "\r\n") + "\r\n\r\n" + msg.Body)
 
 	//nolint:wrapcheck
 	return smtp.SendMail(

--- a/notification/sender/email/email_sender_test.go
+++ b/notification/sender/email/email_sender_test.go
@@ -97,8 +97,7 @@ func TestEmailProvider_Text(t *testing.T) {
 
 	require.Equal(t, "SMTP server: \"localhost\", Mail from: \"some-user@example.com\" Mail to: \"another-user@example.com\" Format: \"txt\"", p.Summary())
 
-	require.NoError(t, p.Send(ctx, &sender.Message{Subject: "Test", Body: `
-This is a test.
+	require.NoError(t, p.Send(ctx, &sender.Message{Subject: "Test", Body: `This is a test.
 
 * one
 * two

--- a/notification/sender/email/email_sender_test.go
+++ b/notification/sender/email/email_sender_test.go
@@ -34,8 +34,7 @@ func TestEmailProvider(t *testing.T) {
 
 	require.Equal(t, "SMTP server: \"localhost\", Mail from: \"some-user@example.com\" Mail to: \"another-user@example.com\" Format: \"html\"", p.Summary())
 
-	require.NoError(t, p.Send(ctx, &sender.Message{Subject: "Test", Body: `
-This is a test.
+	require.NoError(t, p.Send(ctx, &sender.Message{Subject: "Test", Body: `This is a test.
 
 * one
 * two


### PR DESCRIPTION

- Author: Alexandr Kostiuchenko <a.kastsiuchenka>
- Original change: #4414
- Ref: #4420