### PR TITLE
feat(cli): Added a stats-only flag to the kopia diff command

### DIFF
--- a/cli/command_diff.go
+++ b/cli/command_diff.go
@@ -18,6 +18,7 @@ type commandDiff struct {
 	diffFirstObjectPath  string
 	diffSecondObjectPath string
 	diffCompareFiles     bool
+	diffStatsOnly        bool
 	diffCommandCommand   string
 
 	out textOutput
@@ -28,6 +29,7 @@ func (c *commandDiff) setup(svc appServices, parent commandParent) {
 	cmd.Arg("object-path1", "First object/path").Required().StringVar(&c.diffFirstObjectPath)
 	cmd.Arg("object-path2", "Second object/path").Required().StringVar(&c.diffSecondObjectPath)
 	cmd.Flag("files", "Compare files by launching diff command for all pairs of (old,new)").Short('f').BoolVar(&c.diffCompareFiles)
+	cmd.Flag("stats-only", "Displays only aggregate statistics of the changes between two repository objects").BoolVar(&c.diffStatsOnly)
 	cmd.Flag("diff-command", "Displays differences between two repository objects (files or directories)").Default(defaultDiffCommand()).Envar(svc.EnvName("KOPIA_DIFF")).StringVar(&c.diffCommandCommand)
 	cmd.Action(svc.repositoryReaderAction(c.run))
 
@@ -52,7 +54,7 @@ func (c *commandDiff) run(ctx context.Context, rep repo.Repository) error {
 		return errors.New("arguments to diff must both be directories or both non-directories")
 	}
 
-	d, err := diff.NewComparer(c.out.stdout())
+	d, err := diff.NewComparer(c.out.stdout(), c.diffStatsOnly)
 	if err != nil {
 		return errors.Wrap(err, "error creating comparer")
 	}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -98,6 +98,7 @@ func TestCompareEmptyDirectories(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
+	statsOnly := false
 
 	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	dirOwnerInfo := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
@@ -112,7 +113,7 @@ func TestCompareEmptyDirectories(t *testing.T) {
 	dir1 := createTestDirectory("testDir1", dirModTime, dirOwnerInfo, dirMode, dirObjectID1)
 	dir2 := createTestDirectory("testDir2", dirModTime, dirOwnerInfo, dirMode, dirObjectID2)
 
-	c, err := diff.NewComparer(&buf)
+	c, err := diff.NewComparer(&buf, statsOnly)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -131,6 +132,7 @@ func TestCompareIdenticalDirectories(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
+	statsOnly := false
 
 	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	dirOwnerInfo := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
@@ -167,7 +169,7 @@ func TestCompareIdenticalDirectories(t *testing.T) {
 
 	expectedStats := diff.Stats{}
 
-	c, err := diff.NewComparer(&buf)
+	c, err := diff.NewComparer(&buf, statsOnly)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -185,6 +187,7 @@ func TestCompareDifferentDirectories(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
+	statsOnly := false
 
 	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	fileModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
@@ -216,7 +219,7 @@ func TestCompareDifferentDirectories(t *testing.T) {
 		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime, name: "file4.txt"}, content: "klmnopqrstuvwxyz2"},
 	)
 
-	c, err := diff.NewComparer(&buf)
+	c, err := diff.NewComparer(&buf, statsOnly)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -242,6 +245,7 @@ func TestCompareDifferentDirectories_DirTimeDiff(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
+	statsOnly := false
 
 	fileModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	dirModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
@@ -277,7 +281,7 @@ func TestCompareDifferentDirectories_DirTimeDiff(t *testing.T) {
 	expectedStats := diff.Stats{}
 	expectedStats.DirectoryEntries.Modified = 1
 
-	c, err := diff.NewComparer(&buf)
+	c, err := diff.NewComparer(&buf, statsOnly)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -296,6 +300,7 @@ func TestCompareDifferentDirectories_FileTimeDiff(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
+	statsOnly := false
 
 	fileModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	fileModTime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
@@ -326,7 +331,7 @@ func TestCompareDifferentDirectories_FileTimeDiff(t *testing.T) {
 		&testFile{testBaseEntry: testBaseEntry{modtime: fileModTime2, name: "file1.txt", oid: OID2}, content: "abcdefghij"},
 	)
 
-	c, err := diff.NewComparer(&buf)
+	c, err := diff.NewComparer(&buf, statsOnly)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -349,6 +354,7 @@ func TestCompareFileWithIdenticalContentsButDiffFileMetadata(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
+	statsOnly := false
 
 	fileModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	fileModTime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
@@ -384,7 +390,7 @@ func TestCompareFileWithIdenticalContentsButDiffFileMetadata(t *testing.T) {
 		&testFile{testBaseEntry: testBaseEntry{name: "file1.txt", modtime: fileModTime2, oid: object.ID{}, owner: fileOwnerinfo2, mode: 0o777}, content: "abcdefghij"},
 	)
 
-	c, err := diff.NewComparer(&buf)
+	c, err := diff.NewComparer(&buf, statsOnly)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -412,6 +418,7 @@ func TestCompareIdenticalDirectoriesWithDiffDirectoryMetadata(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
+	statsOnly := false
 
 	dirModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	dirModTime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
@@ -444,7 +451,7 @@ func TestCompareIdenticalDirectoriesWithDiffDirectoryMetadata(t *testing.T) {
 		dirObjectID,
 		&testFile{testBaseEntry: testBaseEntry{name: "file1.txt", modtime: fileModTime}, content: "abcdefghij"},
 	)
-	c, err := diff.NewComparer(&buf)
+	c, err := diff.NewComparer(&buf, statsOnly)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/kopia/kopia/repo/object"
 )
 
+const statsOnly = false
+
 var (
 	_ fs.Entry     = (*testFile)(nil)
 	_ fs.Directory = (*testDirectory)(nil)

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -98,7 +98,6 @@ func TestCompareEmptyDirectories(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
-	statsOnly := false
 
 	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	dirOwnerInfo := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
@@ -132,7 +131,6 @@ func TestCompareIdenticalDirectories(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
-	statsOnly := false
 
 	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	dirOwnerInfo := fs.OwnerInfo{UserID: 1000, GroupID: 1000}
@@ -187,7 +185,6 @@ func TestCompareDifferentDirectories(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
-	statsOnly := false
 
 	dirModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	fileModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
@@ -245,7 +242,6 @@ func TestCompareDifferentDirectories_DirTimeDiff(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
-	statsOnly := false
 
 	fileModTime := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	dirModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
@@ -300,7 +296,6 @@ func TestCompareDifferentDirectories_FileTimeDiff(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
-	statsOnly := false
 
 	fileModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	fileModTime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
@@ -354,7 +349,6 @@ func TestCompareFileWithIdenticalContentsButDiffFileMetadata(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
-	statsOnly := false
 
 	fileModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	fileModTime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)
@@ -418,7 +412,6 @@ func TestCompareIdenticalDirectoriesWithDiffDirectoryMetadata(t *testing.T) {
 	var buf bytes.Buffer
 
 	ctx := context.Background()
-	statsOnly := false
 
 	dirModTime1 := time.Date(2023, time.April, 12, 10, 30, 0, 0, time.UTC)
 	dirModTime2 := time.Date(2022, time.April, 12, 10, 30, 0, 0, time.UTC)

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -194,7 +194,7 @@ func compareDirs(t *testing.T, source, restoreDir string) {
 	require.NoError(t, err)
 
 	if !assert.Equal(t, wantHash, gotHash, "restored directory hash does not match source's hash") {
-		cmp, err := diff.NewComparer(os.Stderr)
+		cmp, err := diff.NewComparer(os.Stderr, statsOnly)
 		require.NoError(t, err)
 
 		cmp.DiffCommand = "cmp"

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -177,6 +177,8 @@ func TestRestoreCommand(t *testing.T) {
 func compareDirs(t *testing.T, source, restoreDir string) {
 	t.Helper()
 
+	const statsOnly = false
+
 	// Restored contents should match source
 	s, err := localfs.Directory(source)
 	require.NoError(t, err)

--- a/tests/recovery/recovery_test/recovery_test.go
+++ b/tests/recovery/recovery_test/recovery_test.go
@@ -297,6 +297,8 @@ func CompareDirs(t *testing.T, source, destination string) {
 
 	ctx := context.Background()
 
+	const statsOnly = false
+
 	c, err := diff.NewComparer(&buf)
 	require.NoError(t, err)
 

--- a/tests/recovery/recovery_test/recovery_test.go
+++ b/tests/recovery/recovery_test/recovery_test.go
@@ -299,7 +299,7 @@ func CompareDirs(t *testing.T, source, destination string) {
 
 	const statsOnly = false
 
-	c, err := diff.NewComparer(&buf)
+	c, err := diff.NewComparer(&buf, statsOnly)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
Added the `--stats-only` flag to the  kopia-diff command to reduce output verbosity. When kopia diff is invoked with the `--stats-only` flag it only outputs the aggregate statistics of changes.