### PR TITLE
feat(cli): helper functions to get preceding snapshots for `diff`

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/logging"
-	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/repo/object"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
@@ -434,7 +433,7 @@ func GetPreceedingSnapshot(ctx context.Context, rep repo.Repository, snapshotID 
 	})
 
 	for i, snap := range snapshotList {
-		if snap.ID == manifest.ID(snapshotID) {
+		if snap.ID == snapshotManifest.ID {
 			if i == 0 {
 				return nil, errors.New("Cannot fetch immediately preceding snapshot")
 			}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -443,7 +443,7 @@ func GetPreceedingSnapshot(ctx context.Context, rep repo.Repository, snapshotID 
 func GetTwoLatestSnapshotsForASource(ctx context.Context, rep repo.Repository, source snapshot.SourceInfo) (secondLast, last *snapshot.Manifest, err error) {
 	snapshots, err := snapshot.ListSnapshots(ctx, rep, source)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to list snapshots")
+		return nil, nil, errors.Wrap(err, "failed to list all snapshots")
 	}
 
 	const minimumReqSnapshots = 2

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -429,7 +429,7 @@ func GetPreceedingSnapshot(ctx context.Context, rep repo.Repository, snapshotID 
 	for i, snap := range snapshotList {
 		if snap.ID == snapshotManifest.ID {
 			if i == 0 {
-				return nil, errors.New("cannot fetch immediately preceding snapshot")
+				return nil, errors.New("there is no immediately preceding snapshot")
 			}
 
 			return snapshotList[i-1], nil

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -409,8 +409,8 @@ func NewComparer(out io.Writer) (*Comparer, error) {
 	return &Comparer{out: out, tmpDir: tmp}, nil
 }
 
-// GetPreceedingSnapshot fetches the snapshot manifest for the snapshot immediately preceding the given snapshotID if it exists.
-func GetPreceedingSnapshot(ctx context.Context, rep repo.Repository, snapshotID string) (*snapshot.Manifest, error) {
+// GetPrecedingSnapshot fetches the snapshot manifest for the snapshot immediately preceding the given snapshotID if it exists.
+func GetPrecedingSnapshot(ctx context.Context, rep repo.Repository, snapshotID string) (*snapshot.Manifest, error) {
 	snapshotManifest, err := snapshotfs.FindSnapshotByRootObjectIDOrManifestID(ctx, rep, snapshotID, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get snapshot manifest for the given snapshotID")

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -557,7 +557,7 @@ func TestGetPrecedingSnapshot(t *testing.T) {
 // First call GetTwoLatestSnapshots with insufficient snapshots in the repo and
 // expect an error;
 // As snapshots are added, GetTwoLatestSnapshots is expected to return the
-// manifests for the the two most recent snapshots for a the given source.
+// manifests for the two most recent snapshots for a the given source.
 func TestGetTwoLatestSnapshots(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -526,16 +526,22 @@ func getManifests() map[string]*snapshot.Manifest {
 	return manifests
 }
 
+// Tests GetPrecedingSnapshot function
+//   - GetPrecedingSnapshot with an invalid snapshot id and expect an error;
+//   - Add a snapshot, expect an error from GetPreceedingSnapshot since there is
+//     only a single snapshot in the repo;
+//   - Subsequently add more snapshots and GetPreceedingSnapshot theimmediately
+//     preceding with no error.
 func TestGetPrecedingSnapshot(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 	manifests := getManifests()
 
 	_, err := diff.GetPrecedingSnapshot(ctx, env.RepositoryWriter, "non_existent_snapshot_ID")
-	require.Error(t, err)
+	require.Error(t, err, "expect error when calling GetPrecedingSnapshot with a wrong snapshotID")
 
 	initialSnapshotManifestID := mustSaveSnapshot(t, env.RepositoryWriter, manifests["initial_snapshot"])
 	_, err = diff.GetPrecedingSnapshot(ctx, env.RepositoryWriter, string(initialSnapshotManifestID))
-	require.Error(t, err)
+	require.Error(t, err, "expect error when there is a single snapshot in the repo")
 
 	intermediateSnapshotManifestID := mustSaveSnapshot(t, env.RepositoryWriter, manifests["intermediate_snapshot"])
 	gotManID, err := diff.GetPrecedingSnapshot(ctx, env.RepositoryWriter, string(intermediateSnapshotManifestID))
@@ -548,6 +554,10 @@ func TestGetPrecedingSnapshot(t *testing.T) {
 	require.Equal(t, intermediateSnapshotManifestID, gotManID2.ID)
 }
 
+// First call GetTwoLatestSnapshots with insufficient snapshots in the repo and
+// expect an error;
+// As snapshots are added, GetTwoLatestSnapshots is expected to return the
+// manifests for the the two most recent snapshots for a the given source.
 func TestGetTwoLatestSnapshots(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -526,24 +526,24 @@ func getManifests() map[string]*snapshot.Manifest {
 	return manifests
 }
 
-func TestGetPreceedingSnapshot(t *testing.T) {
+func TestGetPrecedingSnapshot(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 	manifests := getManifests()
 
-	_, err := diff.GetPreceedingSnapshot(ctx, env.RepositoryWriter, "non_existent_snapshot_ID")
+	_, err := diff.GetPrecedingSnapshot(ctx, env.RepositoryWriter, "non_existent_snapshot_ID")
 	require.Error(t, err)
 
 	initialSnapshotManifestID := mustSaveSnapshot(t, env.RepositoryWriter, manifests["initial_snapshot"])
-	_, err = diff.GetPreceedingSnapshot(ctx, env.RepositoryWriter, string(initialSnapshotManifestID))
+	_, err = diff.GetPrecedingSnapshot(ctx, env.RepositoryWriter, string(initialSnapshotManifestID))
 	require.Error(t, err)
 
 	intermediateSnapshotManifestID := mustSaveSnapshot(t, env.RepositoryWriter, manifests["intermediate_snapshot"])
-	gotManID, err := diff.GetPreceedingSnapshot(ctx, env.RepositoryWriter, string(intermediateSnapshotManifestID))
+	gotManID, err := diff.GetPrecedingSnapshot(ctx, env.RepositoryWriter, string(intermediateSnapshotManifestID))
 	require.NoError(t, err)
 	require.Equal(t, initialSnapshotManifestID, gotManID.ID)
 
 	latestSnapshotManifestID := mustSaveSnapshot(t, env.RepositoryWriter, manifests["latest_snapshot"])
-	gotManID2, err := diff.GetPreceedingSnapshot(ctx, env.RepositoryWriter, string(latestSnapshotManifestID))
+	gotManID2, err := diff.GetPrecedingSnapshot(ctx, env.RepositoryWriter, string(latestSnapshotManifestID))
 	require.NoError(t, err)
 	require.Equal(t, intermediateSnapshotManifestID, gotManID2.ID)
 }

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -480,7 +480,7 @@ func getManifests() map[string]*snapshot.Manifest {
 	manifests := make(map[string]*snapshot.Manifest)
 
 	src := getSnapshotSource()
-	currentTime := time.Now()
+	snapshotTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	contentID1, _ := index.IDFromHash("p", []byte("indexID1"))
 	objectID1 := object.DirectObjectID(contentID1)
@@ -499,7 +499,7 @@ func getManifests() map[string]*snapshot.Manifest {
 	initialSnapshotManifest := &snapshot.Manifest{
 		ID:          "manifest_1_id",
 		Source:      src,
-		StartTime:   fs.UTCTimestamp(currentTime.Add((-24) * time.Hour).UnixNano()),
+		StartTime:   fs.UTCTimestamp(snapshotTime.Add((-24) * time.Hour).UnixNano()),
 		Description: "snapshot captured a day ago",
 		RootEntry:   &rootEntry2,
 	}
@@ -508,7 +508,7 @@ func getManifests() map[string]*snapshot.Manifest {
 	intermediateSnapshotManifest := &snapshot.Manifest{
 		ID:          "manifest_2_id",
 		Source:      src,
-		StartTime:   fs.UTCTimestamp(currentTime.Add(-time.Hour).UnixNano()),
+		StartTime:   fs.UTCTimestamp(snapshotTime.Add(-time.Hour).UnixNano()),
 		Description: "snapshot taken an hour ago",
 		RootEntry:   &rootEntry2,
 	}
@@ -517,7 +517,7 @@ func getManifests() map[string]*snapshot.Manifest {
 	LatestSnapshotManifest := &snapshot.Manifest{
 		ID:          "manifest_3_id",
 		Source:      src,
-		StartTime:   fs.UTCTimestamp(currentTime.UnixNano()),
+		StartTime:   fs.UTCTimestamp(snapshotTime.UnixNano()),
 		Description: "latest snapshot",
 		RootEntry:   &rootEntry1,
 	}
@@ -530,7 +530,7 @@ func TestGetPreceedingSnapshot(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
 	manifests := getManifests()
 
-	_, err := diff.GetPreceedingSnapshot(ctx, env.RepositoryWriter, "non_existant_snapshot_ID")
+	_, err := diff.GetPreceedingSnapshot(ctx, env.RepositoryWriter, "non_existent_snapshot_ID")
 	require.Error(t, err)
 
 	initialSnapshotManifestID := mustSaveSnapshot(t, env.RepositoryWriter, manifests["initial_snapshot"])

--- a/snapshot/snapshotfs/objref.go
+++ b/snapshot/snapshotfs/objref.go
@@ -75,12 +75,12 @@ func parseNestedObjectID(ctx context.Context, startingDir fs.Entry, parts []stri
 	return hoid.ObjectID(), nil
 }
 
-// findSnapshotByRootObjectIDOrManifestID returns the list of matching snapshots for a given rootID.
+// FindSnapshotByRootObjectIDOrManifestID returns the list of matching snapshots for a given rootID.
 // which can be either snapshot manifst ID (which matches 0 or 1 snapshots)
 // or the root object ID (which can match arbitrary number of snapshots).
 // If multiple snapshots match and they don't agree on root object attributes and consistentAttributes==true
 // the function fails, otherwise it returns the latest of the snapshots.
-func findSnapshotByRootObjectIDOrManifestID(ctx context.Context, rep repo.Repository, rootID string, consistentAttributes bool) (*snapshot.Manifest, error) {
+func FindSnapshotByRootObjectIDOrManifestID(ctx context.Context, rep repo.Repository, rootID string, consistentAttributes bool) (*snapshot.Manifest, error) {
 	m, err := snapshot.LoadSnapshot(ctx, rep, manifest.ID(rootID))
 	if err == nil {
 		return m, nil
@@ -154,7 +154,7 @@ func FilesystemEntryFromIDWithPath(ctx context.Context, rep repo.Repository, roo
 
 	var startingEntry fs.Entry
 
-	man, err := findSnapshotByRootObjectIDOrManifestID(ctx, rep, pathElements[0], consistentAttributes)
+	man, err := FindSnapshotByRootObjectIDOrManifestID(ctx, rep, pathElements[0], consistentAttributes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Added helper functions to find preceding snapshots.

Part of the planned enhancements for the `diff` command.

Added the helper methods to fetch preceding snapshots. These helpers will be consumed to enhance the CLI for the existing `diff` command implementation.
- Method to fetch the immediately preceding snapshot manifest given a snapshot ID
- Method to fetch the two latest snapshot manifests for a given source

Also added relevant unit tests for the above methods:

- In order to test `GetPrecedingSnapshot`, first the method is invoked with a wrong `snapshotID` and an error is expected. Next a snapshot is saved and the method is invoked again, since there is only a single snapshot in the repo, an error is expected. Subsequently more snapshots are saved and the method is invoked and the immediately preceding snapshot based on timestamp is expected
- In order to test `GetTwoLatestSnapshotsForASource`, a similar strategy is used. The method is invoked with insufficient snapshots stored in the repo and errors are expected. Eventually more snapshots are saved and when the method is invoked the two most recent manifests for snapshot based on start time are expected