### PR TITLE
chore(ci): upgrade Go toolchain to 1.23.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kopia/kopia
 
 go 1.23.0
 
-toolchain go1.23.8
+toolchain go1.23.9
 
 require (
 	cloud.google.com/go/storage v1.54.0


### PR DESCRIPTION
- https://go.dev/doc/devel/release#go1.23.minor
- https://github.com/golang/go/issues?q=milestone%3AGo1.23.8+label%3ACherryPickApproved