### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.4
-	github.com/kopia/htmluibuild v0.0.1-0.20250512051948-f1295f5318a4
+	github.com/kopia/htmluibuild v0.0.1-0.20250516044211-bc4fb8f5a1a7
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.4 h1:5aDr3ZGoJbgu/8+j45KtUJxzYm8k08JGtB9Wx1VQ4OA=
 github.com/klauspost/reedsolomon v1.12.4/go.mod h1:d3CzOMOt0JXGIFZm1StgkyF14EYr3xneR2rNWo7NcMU=
-github.com/kopia/htmluibuild v0.0.1-0.20250512051948-f1295f5318a4 h1:YatTOPU1vS0RKWggABuoHWG7TfmYX6tUGWmLbJ8PwLg=
-github.com/kopia/htmluibuild v0.0.1-0.20250512051948-f1295f5318a4/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20250516044211-bc4fb8f5a1a7 h1:R84hB/fvz/Ls2V+11kP4oVjyG6UaxnrmBwTj9Atlasg=
+github.com/kopia/htmluibuild v0.0.1-0.20250516044211-bc4fb8f5a1a7/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/af6ad6d475700b70935c711fd69f2a0684fcec52...a97f35429e3f79f0921fa67f6b64875c044f8b85

* 11 minutes ago https://github.com/kopia/htmlui/commit/a4348f2 Kian Kasad fix(kopiaui): Remove misleading asterisk from extension placeholders
* Thu 21:41 -0700 https://github.com/kopia/htmlui/commit/a97f354 Jarek Kowalski fix(htmui): restored retention labels

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Fri May 16 04:42:28 UTC 2025*
