### PR TITLE
test(general): fix `TestSnapshotNoLeftoverCheckpoints` slowness

### DIFF
--- a/tests/end_to_end_test/norace_test.go
+++ b/tests/end_to_end_test/norace_test.go
@@ -1,0 +1,63 @@
+//go:build !race
+// +build !race
+
+package endtoend_test
+
+import (
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/tests/clitestutil"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+// Exclude tests below from the -race detection test, because they are resource
+// intensive and way too slow.
+
+func TestSnapshotNoLeftoverCheckpoints(t *testing.T) {
+	// 1 GiB of data seems to be enough for the snapshot time to exceed one second.
+	const (
+		fileSize                  = int64(1) << 30
+		checkpointInterval        = "1s"
+		checkpointIntervalSeconds = float64(1)
+	)
+
+	t.Parallel()
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	baseDir := testutil.TempDirectory(t)
+	f, err := os.Create(filepath.Join(baseDir, "foo"))
+
+	require.NoError(t, err)
+	require.NotNil(t, f)
+
+	n, err := io.CopyN(f, rand.New(rand.NewSource(0)), fileSize)
+	require.NoError(t, err)
+	require.Equal(t, fileSize, n)
+
+	startTime := clock.Now()
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", baseDir, "--checkpoint-interval", checkpointInterval)
+
+	require.Greater(t, clock.Now().Sub(startTime).Seconds(), checkpointIntervalSeconds)
+
+	// This exploits the implementation detail of `ListSnapshotsAndExpectSuccess`, that it does
+	// not sanitize `targets` to exclude flags.
+	si := clitestutil.ListSnapshotsAndExpectSuccess(t, e, "--incomplete", baseDir)
+	require.Len(t, si, 1)
+	require.Len(t, si[0].Snapshots, 1)
+	require.False(t, si[0].Snapshots[0].Incomplete)
+}

--- a/tests/end_to_end_test/norace_test.go
+++ b/tests/end_to_end_test/norace_test.go
@@ -39,14 +39,7 @@ func TestSnapshotNoLeftoverCheckpoints(t *testing.T) {
 	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
 
 	baseDir := testutil.TempDirectory(t)
-	f, err := os.Create(filepath.Join(baseDir, "foo"))
-
-	require.NoError(t, err)
-	require.NotNil(t, f)
-
-	n, err := io.CopyN(f, rand.New(rand.NewSource(0)), fileSize)
-	require.NoError(t, err)
-	require.Equal(t, fileSize, n)
+	writeRandomFile(t, filepath.Join(baseDir, "foo"), fileSize)
 
 	startTime := clock.Now()
 
@@ -60,4 +53,21 @@ func TestSnapshotNoLeftoverCheckpoints(t *testing.T) {
 	require.Len(t, si, 1)
 	require.Len(t, si[0].Snapshots, 1)
 	require.False(t, si[0].Snapshots[0].Incomplete)
+}
+
+func writeRandomFile(t *testing.T, name string, fileSize int64) {
+	t.Helper()
+
+	f, err := os.Create(name)
+
+	require.NoError(t, err)
+	require.NotNil(t, f)
+
+	defer func() {
+		require.NoError(t, f.Close())
+	}()
+
+	n, err := io.CopyN(f, rand.New(rand.NewSource(0)), fileSize)
+	require.NoError(t, err)
+	require.Equal(t, fileSize, n)
 }

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -808,7 +808,7 @@ func TestSnapshotNoLeftoverCheckpoints(t *testing.T) {
 	const (
 		fileSize                  = int64(1) << 30
 		checkpointInterval        = "1s"
-		checkpointIntervalSeconds = 1
+		checkpointIntervalSeconds = float64(1)
 	)
 
 	t.Parallel()

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -834,10 +834,7 @@ func TestSnapshotNoLeftoverCheckpoints(t *testing.T) {
 
 	e.RunAndExpectSuccess(t, "snapshot", "create", baseDir, "--checkpoint-interval", checkpointInterval)
 
-	endTime := clock.Now()
-
-	snapshotTimeSurpassedCheckpointInterval := endTime.Sub(startTime).Seconds() > checkpointIntervalSeconds
-	require.True(t, snapshotTimeSurpassedCheckpointInterval)
+	require.Greater(t, clock.Now().Sub(startTime).Seconds(), checkpointIntervalSeconds)
 
 	// This exploits the implementation detail of `ListSnapshotsAndExpectSuccess`, that it does
 	// not sanitize `targets` to exclude flags.

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -806,7 +806,7 @@ func TestSnapshotCreateWithAllAndPath(t *testing.T) {
 func TestSnapshotNoLeftoverCheckpoints(t *testing.T) {
 	// 1 GiB of data seems to be enough for the snapshot time to exceed one second.
 	const (
-		fileSize                  = 1 << 30
+		fileSize                  = int64(1) << 30
 		checkpointInterval        = "1s"
 		checkpointIntervalSeconds = 1
 	)


### PR DESCRIPTION
Avoid allocating 1GB of RAM to write a test file.
Exclude test from race detector.

- Fixes #4610
- #4439