### PR TITLE
feat(cli): Add `--max-sources` for `kopia snapshot list`

### DIFF
--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -33,6 +33,7 @@ type commandSnapshotList struct {
 	snapshotListShowIdentical        bool
 	snapshotListShowAll              bool
 	maxResultsPerPath                int
+	maxSnapshots                     int
 	snapshotListTags                 []string
 	storageStats                     bool
 	reverseSort                      bool
@@ -56,6 +57,7 @@ func (c *commandSnapshotList) setup(svc appServices, parent commandParent) {
 	cmd.Flag("reverse", "Reverse sort order").BoolVar(&c.reverseSort)
 	cmd.Flag("all", "Show all snapshots (not just current username/host)").Short('a').BoolVar(&c.snapshotListShowAll)
 	cmd.Flag("max-results", "Maximum number of entries per source.").Short('n').IntVar(&c.maxResultsPerPath)
+	cmd.Flag("max-snapshots", "Maximum number of snapshots.").Short('s').IntVar(&c.maxSnapshots)
 	cmd.Flag("tags", "Tag filters to apply on the list items. Must be provided in the <key>:<value> format.").StringsVar(&c.snapshotListTags)
 	c.jo.setup(svc, cmd)
 	c.out.setup(svc)
@@ -133,6 +135,10 @@ func (c *commandSnapshotList) run(ctx context.Context, rep repo.Repository) erro
 	manifests, err := snapshot.LoadSnapshots(ctx, rep, manifestIDs)
 	if err != nil {
 		return errors.Wrap(err, "unable to load snapshots")
+	}
+
+	if c.maxSnapshots > 0 && len(manifests) > 0 {
+		manifests = manifests[:c.maxSnapshots]
 	}
 
 	if c.jo.jsonOutput {

--- a/tests/end_to_end_test/snapshot_create_test.go
+++ b/tests/end_to_end_test/snapshot_create_test.go
@@ -77,6 +77,11 @@ func TestSnapshotCreate(t *testing.T) {
 	sources := clitestutil.ListSnapshotsAndExpectSuccess(t, e)
 	require.Len(t, sources, 3)
 
+	var manifests3 []cli.SnapshotManifest
+
+	testutil.MustParseJSONLines(t, e.RunAndExpectSuccess(t, "snapshot", "list", "-a", "--json", "--max-snapshots=1"), &manifests3)
+	require.Len(t, manifests3, 1)
+
 	// test ignore-identical-snapshot
 	e.RunAndExpectSuccess(t, "policy", "set", "--global", "--ignore-identical-snapshots", "true")
 	e.RunAndExpectSuccess(t, "snapshot", "create", sharedTestDataDir2)


### PR DESCRIPTION
We have around 70-100k snapshots with around 10k sources and this takes almost 8-10 minutes to list.

We noticed a couple times already that repository status reports everything is perfect, but doing snapshot list returns an error about missing blobs, etc.

With this new CLI knob, we could run it more regularly to catch those errors instead of abusing the system with unnecessary load (loading everything).