### PR TITLE
refactor(general): guard access to objectWriter.contentWriteError

### DIFF
--- a/repo/object/object_manager.go
+++ b/repo/object/object_manager.go
@@ -86,7 +86,9 @@ func (om *Manager) NewWriter(ctx context.Context, opt WriterOptions) Writer {
 	}
 
 	w.buffer.Reset()
+	w.contentWriteErrorMutex.Lock()
 	w.contentWriteError = nil
+	w.contentWriteErrorMutex.Unlock()
 
 	return w
 }

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -92,7 +92,8 @@ type objectWriter struct {
 	asyncWritesWG        sync.WaitGroup
 
 	contentWriteErrorMutex sync.Mutex
-	contentWriteError      error // stores async write error, propagated in Result()
+	// +checklocks:contentWriteErrorMutex
+	contentWriteError error // stores async write error, propagated in Result()
 }
 
 func (w *objectWriter) Close() error {

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -290,8 +290,14 @@ func (w *objectWriter) checkpointLocked() (ID, error) {
 	// wait for any in-flight asynchronous writes to finish
 	w.asyncWritesWG.Wait()
 
-	if w.contentWriteError != nil {
-		return EmptyID, w.contentWriteError
+	var err error
+
+	w.contentWriteErrorMutex.Lock()
+	err = w.contentWriteError
+	w.contentWriteErrorMutex.Unlock()
+
+	if err != nil {
+		return EmptyID, err
 	}
 
 	if len(w.indirectIndex) == 0 {


### PR DESCRIPTION
- add checklocks annotation for `contentWriteErrorMutex`
- guard access to `objectWriter.contentWriteError`