### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.4
-	github.com/kopia/htmluibuild v0.0.1-0.20250601194503-380f4c774955
+	github.com/kopia/htmluibuild v0.0.1-0.20250601230402-959aa8b9b7df
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.4 h1:5aDr3ZGoJbgu/8+j45KtUJxzYm8k08JGtB9Wx1VQ4OA=
 github.com/klauspost/reedsolomon v1.12.4/go.mod h1:d3CzOMOt0JXGIFZm1StgkyF14EYr3xneR2rNWo7NcMU=
-github.com/kopia/htmluibuild v0.0.1-0.20250601194503-380f4c774955 h1:Z6ryPgN1MhcrY/iv/QF9eXBO202fYWbgBzzsvM/f32Q=
-github.com/kopia/htmluibuild v0.0.1-0.20250601194503-380f4c774955/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20250601230402-959aa8b9b7df h1:H9XnBCP1BUSeArWVFriYggowPUo51uTvae13OdnBrg4=
+github.com/kopia/htmluibuild v0.0.1-0.20250601230402-959aa8b9b7df/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/9851e662553f54721570f28e24100319e1b5b646...9799feaac19caf31ae35d223be43016ad84c59ec

* 4 minutes ago https://github.com/kopia/htmlui/commit/511cde4 dependabot[bot] build(deps-dev): bump eslint from 9.27.0 to 9.28.0
* 4 minutes ago https://github.com/kopia/htmlui/commit/61a7251 dependabot[bot] build(deps-dev): bump @vitejs/plugin-react from 4.4.1 to 4.5.0
* 4 minutes ago https://github.com/kopia/htmlui/commit/91b2691 dependabot[bot] build(deps-dev): bump typescript-eslint from 8.32.1 to 8.33.0
* 4 minutes ago https://github.com/kopia/htmlui/commit/9799fea dependabot[bot] build(deps): bump react-router-dom from 7.6.0 to 7.6.1

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Sun Jun  1 23:06:44 UTC 2025*
