### PR TITLE
feat(snapshots): Add periodic JSON progress output to snapshot verify

### DIFF
--- a/cli/command_snapshot_fix_invalid_files.go
+++ b/cli/command_snapshot_fix_invalid_files.go
@@ -34,7 +34,7 @@ func (c *commandSnapshotFixInvalidFiles) setup(svc appServices, parent commandPa
 
 func (c *commandSnapshotFixInvalidFiles) rewriteEntry(ctx context.Context, pathFromRoot string, ent *snapshot.DirEntry) (*snapshot.DirEntry, error) {
 	if ent.Type != snapshot.EntryTypeDirectory {
-		if err := c.verifier.VerifyFile(ctx, ent.ObjectID, pathFromRoot); err != nil {
+		if err := c.verifier.VerifyFile(ctx, ent.ObjectID, pathFromRoot, ent.FileSize); err != nil {
 			log(ctx).Warnf("removing invalid file %v due to: %v", pathFromRoot, err)
 
 			return c.failedFileCallback(ctx, pathFromRoot, ent, err)

--- a/cli/command_snapshot_verify_test.go
+++ b/cli/command_snapshot_verify_test.go
@@ -85,7 +85,7 @@ func TestSnapshotVerify(t *testing.T) {
 	stdout, _ := env.RunAndExpectFailure(t, "snapshot", "verify", "--json")
 	require.Len(t, stdout, 1)
 	result := unmarshalSnapVerify(t, stdout[0])
-	require.NotZero(t, result.ProcessedObjectCount)
+	require.NotZero(t, result.Stats.ProcessedObjectCount)
 	require.NotZero(t, result.ErrorCount)
 	require.Len(t, result.ErrorStrings, 1)
 
@@ -93,7 +93,7 @@ func TestSnapshotVerify(t *testing.T) {
 	stdout = env.RunAndExpectSuccess(t, "snapshot", "verify", "--json", string(intactMan.ID))
 	require.Len(t, stdout, 1)
 	result = unmarshalSnapVerify(t, stdout[0])
-	require.NotZero(t, result.ProcessedObjectCount)
+	require.NotZero(t, result.Stats.ProcessedObjectCount)
 	require.Zero(t, result.ErrorCount)
 	require.Empty(t, result.ErrorStrings)
 
@@ -101,7 +101,7 @@ func TestSnapshotVerify(t *testing.T) {
 	stdout, _ = env.RunAndExpectFailure(t, "snapshot", "verify", "--json", string(corruptMan1.ID))
 	require.Len(t, stdout, 1)
 	result = unmarshalSnapVerify(t, stdout[0])
-	require.NotZero(t, result.ProcessedObjectCount)
+	require.NotZero(t, result.Stats.ProcessedObjectCount)
 	require.NotZero(t, result.ErrorCount)
 	require.Len(t, result.ErrorStrings, 1)
 
@@ -109,7 +109,7 @@ func TestSnapshotVerify(t *testing.T) {
 	stdout, _ = env.RunAndExpectFailure(t, "snapshot", "verify", "--json", string(corruptMan2.ID))
 	require.Len(t, stdout, 1)
 	result = unmarshalSnapVerify(t, stdout[0])
-	require.NotZero(t, result.ProcessedObjectCount)
+	require.NotZero(t, result.Stats.ProcessedObjectCount)
 	require.NotZero(t, result.ErrorCount)
 	require.Len(t, result.ErrorStrings, 1)
 
@@ -118,7 +118,7 @@ func TestSnapshotVerify(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, 1, strings.Count(strings.Join(stderr, "\n"), "error processing"))
 	result = unmarshalSnapVerify(t, stdout[0])
-	require.NotZero(t, result.ProcessedObjectCount)
+	require.NotZero(t, result.Stats.ProcessedObjectCount)
 	require.Equal(t, 1, result.ErrorCount)
 	require.Len(t, result.ErrorStrings, 1)
 
@@ -128,14 +128,14 @@ func TestSnapshotVerify(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, 2, strings.Count(strings.Join(stderr, "\n"), "error processing"))
 	result = unmarshalSnapVerify(t, stdout[0])
-	require.NotZero(t, result.ProcessedObjectCount)
+	require.NotZero(t, result.Stats.ProcessedObjectCount)
 	require.Equal(t, 2, result.ErrorCount)
 	require.Len(t, result.ErrorStrings, 2)
 
 	// Requesting a snapshot verify of a non-existent manifest ID results in error.
 	stdout, _ = env.RunAndExpectFailure(t, "snapshot", "verify", "--json", "not-a-manifest-id")
 	result = unmarshalSnapVerify(t, stdout[0])
-	require.Zero(t, result.ProcessedObjectCount)
+	require.Zero(t, result.Stats.ProcessedObjectCount)
 	require.Equal(t, 1, result.ErrorCount)
 	require.Len(t, result.ErrorStrings, 1)
 }

--- a/snapshot/snapshotfs/snapshot_verifier.go
+++ b/snapshot/snapshotfs/snapshot_verifier.go
@@ -2,11 +2,11 @@ package snapshotfs
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"math/rand"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -14,6 +14,7 @@ import (
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/timetrack"
+	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/logging"
@@ -25,14 +26,31 @@ var verifierLog = logging.Module("verifier")
 type verifyFileWorkItem struct {
 	oid       object.ID
 	entryPath string
+	size      int64
 }
 
 // Verifier allows efficient verification of large amounts of filesystem entries in parallel.
 type Verifier struct {
 	throttle timetrack.Throttle
 
-	queued    atomic.Int32
-	processed atomic.Int32
+	statsMu sync.RWMutex
+
+	// +checklocks:statsMu
+	queued int32
+	// +checklocks:statsMu
+	processed int32
+	// +checklocks:statsMu
+	processedBytes int64
+	// +checklocks:statsMu
+	readFiles int64
+	// +checklocks:statsMu
+	readBytes int64
+	// +checklocks:statsMu
+	expectedTotalObjects int64
+	// +checklocks:statsMu
+	expectedTotalFiles int64
+	// +checklocks:statsMu
+	expectedTotalBytes int64
 
 	fileWorkQueue chan verifyFileWorkItem
 	rep           repo.Repository
@@ -42,26 +60,97 @@ type Verifier struct {
 	blobMap map[blob.ID]blob.Metadata // when != nil, will check that each backing blob exists
 }
 
+// AddToExpectedTotals adds the provided values to the corresponding stat
+// total values. If the caller can precompute the expected number
+// of entries that will be iterated over, they can add them to
+// the progress output.
+func (v *Verifier) AddToExpectedTotals(objs, files, bytes int64) {
+	v.statsMu.Lock()
+	defer v.statsMu.Unlock()
+
+	v.expectedTotalObjects += objs
+	v.expectedTotalFiles += files
+	v.expectedTotalBytes += bytes
+}
+
+func (v *Verifier) getStats() VerifierStats {
+	v.statsMu.RLock()
+	defer v.statsMu.RUnlock()
+
+	return VerifierStats{
+		ProcessedObjectCount: int64(v.processed),
+		ProcessedBytes:       v.processedBytes,
+		ReadFileCount:        v.readFiles,
+		ReadBytes:            v.readBytes,
+		ExpectedTotalObjects: v.expectedTotalObjects,
+		ExpectedTotalFiles:   v.expectedTotalFiles,
+		ExpectedTotalBytes:   v.expectedTotalBytes,
+	}
+}
+
+const (
+	inProgressStatsMsg = "Processed"
+	finishedStatsMsg   = "Finished processing"
+)
+
 // ShowStats logs verification statistics.
 func (v *Verifier) ShowStats(ctx context.Context) {
-	processed := v.processed.Load()
-
-	verifierLog(ctx).Infof("Processed %v objects.", processed)
+	v.showStatsf(ctx, inProgressStatsMsg)
 }
 
 // ShowFinalStats logs final verification statistics.
 func (v *Verifier) ShowFinalStats(ctx context.Context) {
-	processed := v.processed.Load()
+	v.showStatsf(ctx, finishedStatsMsg)
+}
 
-	verifierLog(ctx).Infof("Finished processing %v objects.", processed)
+func (v *Verifier) showStatsf(ctx context.Context, msg string) {
+	st := v.getStats()
+
+	if v.opts.JSONStats {
+		v.showStatsJSON(ctx, st)
+		return
+	}
+
+	processed := st.ProcessedObjectCount
+	processedBytes := st.ProcessedBytes
+	readFiles := st.ReadFileCount
+	readBytes := st.ReadBytes
+
+	// "<message> <x> objects. Read <y> files (<z> MB)"
+	verifierLog(ctx).Infof("%v %v objects (%v). Read %v files (%v).", msg, processed, units.BytesString(processedBytes), readFiles, units.BytesString(readBytes))
+}
+
+// VerifierStats contains stats on the amount of work done and current progress.
+type VerifierStats struct {
+	ProcessedObjectCount int64 `json:"processedObjectCount"`
+	ProcessedBytes       int64 `json:"processedBytes"`
+	ReadFileCount        int64 `json:"readFileCount"`
+	ReadBytes            int64 `json:"readBytes"`
+	ExpectedTotalObjects int64 `json:"expectedTotalObjectCount"`
+	ExpectedTotalFiles   int64 `json:"expectedTotalFileCount"`
+	ExpectedTotalBytes   int64 `json:"expectedTotalBytes"`
+}
+
+func (v *Verifier) showStatsJSON(ctx context.Context, st VerifierStats) {
+	b, err := json.Marshal(st)
+	if err != nil {
+		verifierLog(ctx).Errorw("failed to marshal stats", "err", err, "stats", st)
+		return
+	}
+
+	verifierLog(ctx).Infof("%s", b)
 }
 
 // VerifyFile verifies a single file object (using content check, blob map check or full read).
-func (v *Verifier) VerifyFile(ctx context.Context, oid object.ID, entryPath string) error {
+func (v *Verifier) VerifyFile(ctx context.Context, oid object.ID, entryPath string, size int64) error {
 	verifierLog(ctx).Debugf("verifying object %v", oid)
 
 	defer func() {
-		v.processed.Add(1)
+		v.updateProcessedStats(size)
+
+		if v.throttle.ShouldOutput(time.Second) {
+			v.ShowStats(ctx)
+		}
 	}()
 
 	contentIDs, err := v.rep.VerifyObject(ctx, oid)
@@ -92,6 +181,14 @@ func (v *Verifier) VerifyFile(ctx context.Context, oid object.ID, entryPath stri
 	return nil
 }
 
+func (v *Verifier) updateProcessedStats(size int64) {
+	v.statsMu.Lock()
+	defer v.statsMu.Unlock()
+
+	v.processed++
+	v.processedBytes += size
+}
+
 // verifyObject enqueues a single object for verification.
 func (v *Verifier) verifyObject(ctx context.Context, e fs.Entry, oid object.ID, entryPath string) error {
 	if v.throttle.ShouldOutput(time.Second) {
@@ -99,11 +196,18 @@ func (v *Verifier) verifyObject(ctx context.Context, e fs.Entry, oid object.ID, 
 	}
 
 	if !e.IsDir() {
-		v.fileWorkQueue <- verifyFileWorkItem{oid, entryPath}
-		v.queued.Add(1)
+		v.fileWorkQueue <- verifyFileWorkItem{oid, entryPath, e.Size()}
+
+		v.statsMu.Lock()
+		defer v.statsMu.Unlock()
+
+		v.queued++
 	} else {
-		v.queued.Add(1)
-		v.processed.Add(1)
+		v.statsMu.Lock()
+		defer v.statsMu.Unlock()
+
+		v.queued++
+		v.processed++
 	}
 
 	return nil
@@ -119,7 +223,18 @@ func (v *Verifier) readEntireObject(ctx context.Context, oid object.ID, path str
 	}
 	defer r.Close() //nolint:errcheck
 
-	return errors.Wrap(iocopy.JustCopy(io.Discard, r), "unable to read data")
+	n, err := iocopy.Copy(io.Discard, r)
+	if err != nil {
+		return errors.Wrap(err, "unable to read data")
+	}
+
+	v.statsMu.Lock()
+	defer v.statsMu.Unlock()
+
+	v.readBytes += n
+	v.readFiles++
+
+	return nil
 }
 
 // VerifierOptions provides options for the verifier.
@@ -129,26 +244,31 @@ type VerifierOptions struct {
 	Parallelism        int
 	MaxErrors          int
 	BlobMap            map[blob.ID]blob.Metadata
+	JSONStats          bool
 }
 
 // VerifierResult returns results from the verifier.
 type VerifierResult struct {
-	ProcessedObjectCount int      `json:"processedObjectCount"`
-	ErrorCount           int      `json:"errorCount"`
-	Errors               []error  `json:"-"`
-	ErrorStrings         []string `json:"errorStrings,omitempty"`
+	Stats        VerifierStats `json:"stats"`
+	ErrorCount   int           `json:"errorCount"`
+	Errors       []error       `json:"-"`
+	ErrorStrings []string      `json:"errorStrings,omitempty"`
 }
 
-// InParallel starts parallel verification and invokes the provided function which can
-// call Process() on in the provided TreeWalker.
-func (v *Verifier) InParallel(ctx context.Context, enqueue func(tw *TreeWalker) error) (*VerifierResult, error) {
+// InParallel starts parallel verification and invokes the provided function
+// which can call Process() on in the provided TreeWalker. Errors and stats
+// are accumulated into a VerifierResult and returned, independent of whether
+// the error return is nil, that is, `VerifierResult` will contain useful,
+// partial stats when an error is returned, including a collection of errors
+// found in the verification process.
+func (v *Verifier) InParallel(ctx context.Context, enqueue func(tw *TreeWalker) error) (VerifierResult, error) {
 	tw, twerr := NewTreeWalker(ctx, TreeWalkerOptions{
 		Parallelism:   v.opts.Parallelism,
 		EntryCallback: v.verifyObject,
 		MaxErrors:     v.opts.MaxErrors,
 	})
 	if twerr != nil {
-		return nil, errors.Wrap(twerr, "tree walker")
+		return VerifierResult{}, errors.Wrap(twerr, "tree walker")
 	}
 	defer tw.Close(ctx)
 
@@ -165,7 +285,7 @@ func (v *Verifier) InParallel(ctx context.Context, enqueue func(tw *TreeWalker) 
 					continue
 				}
 
-				if err := v.VerifyFile(ctx, wi.oid, wi.entryPath); err != nil {
+				if err := v.VerifyFile(ctx, wi.oid, wi.entryPath, wi.size); err != nil {
 					tw.ReportError(ctx, wi.entryPath, err)
 				}
 			}
@@ -173,6 +293,10 @@ func (v *Verifier) InParallel(ctx context.Context, enqueue func(tw *TreeWalker) 
 	}
 
 	err := enqueue(tw)
+	if err != nil {
+		// Pass the enqueue error to the tree walker for later accumulation.
+		tw.ReportError(ctx, "tree walker enqueue", err)
+	}
 
 	close(v.fileWorkQueue)
 	v.workersWG.Wait()
@@ -185,26 +309,13 @@ func (v *Verifier) InParallel(ctx context.Context, enqueue func(tw *TreeWalker) 
 		errStrs = append(errStrs, twErr.Error())
 	}
 
-	result := &VerifierResult{
-		ProcessedObjectCount: int(v.processed.Load()),
-		ErrorCount:           numErrors,
-		Errors:               twErrs,
-		ErrorStrings:         errStrs,
-	}
-
-	if err != nil {
-		// In some circumstances, the enqueue function may return an error itself, for instance
-		// if it failed to resolve the snapshot manifest from the ID.
-		// Append that error to the result output and return.
-		result.Errors = append(result.Errors, err)
-		result.ErrorStrings = append(result.ErrorStrings, err.Error())
-		result.ErrorCount++
-
-		return result, err
-	}
-
-	// Otherwise return the tree walker error output along with result details.
-	return result, tw.Err()
+	// Return the tree walker error output along with result details.
+	return VerifierResult{
+		Stats:        v.getStats(),
+		Errors:       twErrs,
+		ErrorStrings: errStrs,
+		ErrorCount:   numErrors,
+	}, tw.Err()
 }
 
 // NewVerifier creates a verifier.


### PR DESCRIPTION
- Add read stats to snapshot verifier output.
- Add periodic JSON progress output.
- Refactor the use of directory summary.
- Use stats mutex for all stats.
- Add processedBytes to the snapshot verify output.
- Output more frequently, when bytes processed changes.

- Change depends on #4644; full diff includes both changes until that PR merges. Please see commit c59be0fe615cda71dab9e0bbb53bcf9f94b47467 for changes introduced by this PR.