### PR TITLE
refactor(general): migrate to `crypto/{hkdf,pbkdf2,sha3}`

### DIFF
--- a/internal/crypto/aesgcm.go
+++ b/internal/crypto/aesgcm.go
@@ -17,8 +17,15 @@ var (
 )
 
 func initCrypto(masterKey, salt []byte) (cipher.AEAD, []byte, error) {
-	aesKey := DeriveKeyFromMasterKey(masterKey, salt, purposeAESKey, 32)     //nolint:mnd
-	authData := DeriveKeyFromMasterKey(masterKey, salt, purposeAuthData, 32) //nolint:mnd
+	aesKey, err := DeriveKeyFromMasterKey(masterKey, salt, purposeAESKey, 32) //nolint:mnd
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "cannot derive AES key")
+	}
+
+	authData, err := DeriveKeyFromMasterKey(masterKey, salt, purposeAuthData, 32) //nolint:mnd
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "cannot derive auth data")
+	}
 
 	blk, err := aes.NewCipher(aesKey)
 	if err != nil {

--- a/internal/crypto/key_derivation_test.go
+++ b/internal/crypto/key_derivation_test.go
@@ -17,22 +17,23 @@ var (
 
 func TestDeriveKeyFromMasterKey(t *testing.T) {
 	t.Run("ReturnsKey", func(t *testing.T) {
-		key := crypto.DeriveKeyFromMasterKey(TestMasterKey, TestSalt, TestPurpose, 32)
+		key, err := crypto.DeriveKeyFromMasterKey(TestMasterKey, TestSalt, TestPurpose, 32)
+		require.NoError(t, err)
 
 		expected := "828769ee8969bc37f11dbaa32838f8db6c19daa6e3ae5f5eed2da2d94d8faddb"
 		got := fmt.Sprintf("%02x", key)
 		require.Equal(t, expected, got)
 	})
 
-	t.Run("PanicsOnNilMasterKey", func(t *testing.T) {
-		require.Panics(t, func() {
-			crypto.DeriveKeyFromMasterKey(nil, TestSalt, TestPurpose, 32)
-		})
+	t.Run("ErrorOnNilMasterKey", func(t *testing.T) {
+		k, err := crypto.DeriveKeyFromMasterKey(nil, TestSalt, TestPurpose, 32)
+		require.Error(t, err)
+		require.Nil(t, k)
 	})
 
-	t.Run("PanicsOnEmptyMasterKey", func(t *testing.T) {
-		require.Panics(t, func() {
-			crypto.DeriveKeyFromMasterKey([]byte{}, TestSalt, TestPurpose, 32)
-		})
+	t.Run("ErrorOnEmptyMasterKey", func(t *testing.T) {
+		k, err := crypto.DeriveKeyFromMasterKey([]byte{}, TestSalt, TestPurpose, 32)
+		require.Error(t, err)
+		require.Nil(t, k)
 	})
 }

--- a/internal/crypto/pb_key_deriver_pbkdf2.go
+++ b/internal/crypto/pb_key_deriver_pbkdf2.go
@@ -40,5 +40,10 @@ func (s *pbkdf2KeyDeriver) deriveKeyFromPassword(password string, salt []byte, k
 		return nil, errors.Errorf("required salt size is atleast %d bytes", s.minSaltLength)
 	}
 
-	return pbkdf2.Key(sha256.New, password, salt, s.iterations, keySize)
+	derivedKey, err := pbkdf2.Key(sha256.New, password, salt, s.iterations, keySize)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to derive key")
+	}
+
+	return derivedKey, nil
 }

--- a/internal/crypto/pb_key_deriver_pbkdf2.go
+++ b/internal/crypto/pb_key_deriver_pbkdf2.go
@@ -1,10 +1,10 @@
 package crypto
 
 import (
+	"crypto/pbkdf2"
 	"crypto/sha256"
 
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/pbkdf2"
 )
 
 const (
@@ -40,5 +40,5 @@ func (s *pbkdf2KeyDeriver) deriveKeyFromPassword(password string, salt []byte, k
 		return nil, errors.Errorf("required salt size is atleast %d bytes", s.minSaltLength)
 	}
 
-	return pbkdf2.Key([]byte(password), salt, s.iterations, keySize, sha256.New), nil
+	return pbkdf2.Key(sha256.New, password, salt, s.iterations, keySize)
 }

--- a/repo/format/upgrade_lock_test.go
+++ b/repo/format/upgrade_lock_test.go
@@ -268,7 +268,7 @@ func TestFormatUpgradeFailureToBackupFormatBlobOnLock(t *testing.T) {
 			MutableParameters: format.MutableParameters{
 				Version: format.FormatVersion1,
 			},
-			HMACSecret:           []byte{},
+			HMACSecret:           []byte("test-hmac-secret"),
 			Hash:                 "HMAC-SHA256",
 			Encryption:           encryption.DefaultAlgorithm,
 			EnablePasswordChange: true,

--- a/repo/hashing/sha_hashes.go
+++ b/repo/hashing/sha_hashes.go
@@ -2,14 +2,14 @@ package hashing
 
 import (
 	"crypto/sha256"
-
-	"golang.org/x/crypto/sha3"
+	"crypto/sha3"
+	"hash"
 )
 
 func init() {
-	Register("HMAC-SHA256", truncatedHMACHashFuncFactory(sha256.New, 32))     //nolint:mnd
-	Register("HMAC-SHA256-128", truncatedHMACHashFuncFactory(sha256.New, 16)) //nolint:mnd
-	Register("HMAC-SHA224", truncatedHMACHashFuncFactory(sha256.New224, 28))  //nolint:mnd
-	Register("HMAC-SHA3-224", truncatedHMACHashFuncFactory(sha3.New224, 28))  //nolint:mnd
-	Register("HMAC-SHA3-256", truncatedHMACHashFuncFactory(sha3.New256, 32))  //nolint:mnd
+	Register("HMAC-SHA256", truncatedHMACHashFuncFactory(sha256.New, 32))                                  //nolint:mnd
+	Register("HMAC-SHA256-128", truncatedHMACHashFuncFactory(sha256.New, 16))                              //nolint:mnd
+	Register("HMAC-SHA224", truncatedHMACHashFuncFactory(sha256.New224, 28))                               //nolint:mnd
+	Register("HMAC-SHA3-224", truncatedHMACHashFuncFactory(func() hash.Hash { return sha3.New224() }, 28)) //nolint:mnd
+	Register("HMAC-SHA3-256", truncatedHMACHashFuncFactory(func() hash.Hash { return sha3.New256() }, 32)) //nolint:mnd
 }

--- a/repo/maintenance/maintenance_schedule.go
+++ b/repo/maintenance/maintenance_schedule.go
@@ -63,7 +63,12 @@ func (s *Schedule) ReportRun(taskType TaskType, info RunInfo) {
 }
 
 func getAES256GCM(rep repo.DirectRepository) (cipher.AEAD, error) {
-	c, err := aes.NewCipher(rep.DeriveKey(maintenanceScheduleKeyPurpose, maintenanceScheduleKeySize))
+	k, err := rep.DeriveKey(maintenanceScheduleKeyPurpose, maintenanceScheduleKeySize)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to derive key for encrypting maintenance schedule blob")
+	}
+
+	c, err := aes.NewCipher(k)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create AES-256 cipher")
 	}

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -867,8 +867,11 @@ func TestDeriveKey(t *testing.T) {
 	formatEncryptionKeyFromPassword, err := j.DeriveFormatEncryptionKeyFromPassword(repotesting.DefaultPasswordForTesting)
 	require.NoError(t, err)
 
-	validV1KeyDerivedFromPassword := crypto.DeriveKeyFromMasterKey(formatEncryptionKeyFromPassword, uniqueID, testPurpose, testKeyLength)
-	validV2KeyDerivedFromMasterKey := crypto.DeriveKeyFromMasterKey(masterKey, uniqueID, testPurpose, testKeyLength)
+	validV1KeyDerivedFromPassword, err := crypto.DeriveKeyFromMasterKey(formatEncryptionKeyFromPassword, uniqueID, testPurpose, testKeyLength)
+	require.NoError(t, err)
+
+	validV2KeyDerivedFromMasterKey, err := crypto.DeriveKeyFromMasterKey(masterKey, uniqueID, testPurpose, testKeyLength)
+	require.NoError(t, err)
 
 	setup := func(v format.Version) repo.DirectRepositoryWriter {
 		_, env := repotesting.NewEnvironment(t, v, repotesting.Options{
@@ -930,9 +933,11 @@ func TestDeriveKey(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			mp, err := tc.dw.FormatManager().GetMutableParameters(testlogging.Context(t))
 			require.NoError(t, err)
-
 			require.Equal(t, tc.wantFormat, mp.Version)
-			require.Equal(t, tc.wantKey, tc.dw.DeriveKey(testPurpose, testKeyLength))
+
+			k, err := tc.dw.DeriveKey(testPurpose, testKeyLength)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantKey, k)
 		})
 	}
 }


### PR DESCRIPTION
Functional changes:
- Key derivation no longer panics, instead it returns an error on failed condition checks.
- Migration to `crypto/hkdf` required changes in various function signatures, adding an error return value for propagating key derivation errors up the calling chain. Tests were refactored to account for the signature change as well.

Non-functional changes:
- Added a key derivation helper to reduce function complexity.


