### PR TITLE
fix(cli): remove direct fmt.Printf calls to have a clean JSON log output

### DIFF
--- a/cli/command_server_tls.go
+++ b/cli/command_server_tls.go
@@ -10,7 +10,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -88,7 +87,7 @@ func (c *commandServerStart) maybeGenerateTLS(ctx context.Context) error {
 	}
 
 	fingerprint := sha256.Sum256(cert.Raw)
-	fmt.Fprintf(c.out.stderr(), "SERVER CERT SHA256: %v\n", hex.EncodeToString(fingerprint[:])) //nolint:errcheck
+	log(ctx).Infof("SERVER CERT SHA256: %v", hex.EncodeToString(fingerprint[:]))
 
 	log(ctx).Infof("writing TLS certificate to %v", c.serverStartTLSCertFile)
 
@@ -118,7 +117,7 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 	switch {
 	case c.serverStartTLSCertFile != "" && c.serverStartTLSKeyFile != "":
 		// PEM files provided
-		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttps://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
+		log(ctx).Infof("SERVER ADDRESS: %shttps://%v", udsPfx, httpServer.Addr)
 		c.showServerUIPrompt(ctx)
 
 		return checkErrServerClosed(ctx, httpServer.ServeTLS(listener, c.serverStartTLSCertFile, c.serverStartTLSKeyFile), "error starting TLS server")
@@ -141,7 +140,7 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 		}
 
 		fingerprint := sha256.Sum256(cert.Raw)
-		fmt.Fprintf(c.out.stderr(), "SERVER CERT SHA256: %v\n", hex.EncodeToString(fingerprint[:])) //nolint:errcheck
+		log(ctx).Infof("SERVER CERT SHA256: %v", hex.EncodeToString(fingerprint[:]))
 
 		if c.serverStartTLSPrintFullServerCert {
 			// dump PEM-encoded server cert, only used by KopiaUI to securely connect.
@@ -151,10 +150,10 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 				return errors.Wrap(err, "Failed to write data")
 			}
 
-			fmt.Fprintf(c.out.stderr(), "SERVER CERTIFICATE: %v\n", base64.StdEncoding.EncodeToString(b.Bytes())) //nolint:errcheck
+			log(ctx).Infof("SERVER CERTIFICATE: %v", base64.StdEncoding.EncodeToString(b.Bytes()))
 		}
 
-		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttps://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
+		log(ctx).Infof("SERVER ADDRESS: %shttps://%v", udsPfx, httpServer.Addr)
 		c.showServerUIPrompt(ctx)
 
 		return checkErrServerClosed(ctx, httpServer.ServeTLS(listener, "", ""), "error starting TLS server")
@@ -164,7 +163,7 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 			return errors.New("TLS not configured. To start server without encryption pass --insecure")
 		}
 
-		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttp://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
+		log(ctx).Infof("SERVER ADDRESS: %shttp://%v", udsPfx, httpServer.Addr)
 		c.showServerUIPrompt(ctx)
 
 		return checkErrServerClosed(ctx, httpServer.Serve(listener), "error starting server")

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -72,7 +72,7 @@ func (c *loggingFlags) setup(cliApp *cli.App, app *kingpin.Application) {
 	app.Flag("content-log-dir-max-age", "Maximum age of content log files to retain").Envar(cliApp.EnvName("KOPIA_CONTENT_LOG_DIR_MAX_AGE")).Default("720h").Hidden().DurationVar(&c.contentLogDirMaxAge)
 	app.Flag("content-log-dir-max-total-size-mb", "Maximum total size of log files to retain").Envar(cliApp.EnvName("KOPIA_CONTENT_LOG_DIR_MAX_SIZE_MB")).Hidden().Default("1000").Float64Var(&c.contentLogDirMaxTotalSizeMB)
 	app.Flag("log-level", "Console log level").Default("info").EnumVar(&c.logLevel, logLevels...)
-	app.Flag("json-log-console", "JSON log file").Hidden().BoolVar(&c.jsonLogConsole)
+	app.Flag("json-log-console", "Use JSON format for console log").Hidden().BoolVar(&c.jsonLogConsole)
 	app.Flag("json-log-file", "JSON log file").Hidden().BoolVar(&c.jsonLogFile)
 	app.Flag("file-log-level", "File log level").Default("debug").EnumVar(&c.fileLogLevel, logLevels...)
 	app.Flag("file-log-local-tz", "When logging to a file, use local timezone").Hidden().Envar(cliApp.EnvName("KOPIA_FILE_LOG_LOCAL_TZ")).BoolVar(&c.fileLogLocalTimezone)


### PR DESCRIPTION
This change replaces direct fmt.Printf calls with use of the logging infrastructure. These printf caused non-JSON lines to appear in the console output when using the --json-log-console option.