### PR TITLE
fix(general): use snapshot end time as tie breaker for equal start time

### DIFF
--- a/snapshot/manifest.go
+++ b/snapshot/manifest.go
@@ -237,11 +237,14 @@ func GroupBySource(manifests []*Manifest) [][]*Manifest {
 	return result
 }
 
-// SortByTime returns a slice of manifests sorted by start time.
+// SortByTime returns a slice of manifests sorted by start time, and end time as
+// the tie breaker when start time is the same.
 func SortByTime(manifests []*Manifest, reverse bool) []*Manifest {
 	result := slices.Clone(manifests)
 	sort.Slice(result, func(i, j int) bool {
-		return result[i].StartTime > result[j].StartTime == reverse
+		return (result[i].StartTime > result[j].StartTime ||
+			(result[i].StartTime == result[j].StartTime &&
+				result[i].EndTime > result[j].EndTime)) == reverse
 	})
 
 	return result

--- a/snapshot/upload/upload.go
+++ b/snapshot/upload/upload.go
@@ -1286,10 +1286,6 @@ func (u *Uploader) Upload(
 	// remain immutable.
 	prototypeMan := s
 
-	// Make checkpoints one nanosecond older than the current snapshot, so that
-	// they are cleaned up by retention policies upon creation of the snapshot.
-	prototypeMan.StartTime -= 1
-
 	u.stats = &snapshot.Stats{}
 	u.totalWrittenBytes.Store(0)
 

--- a/snapshot/upload/upload.go
+++ b/snapshot/upload/upload.go
@@ -488,12 +488,10 @@ func newCachedDirEntry(md, cached fs.Entry, fname string) (*snapshot.DirEntry, e
 }
 
 // uploadFileWithCheckpointing uploads the specified File to the repository.
-func (u *Uploader) uploadFileWithCheckpointing(ctx context.Context, relativePath string, file fs.File, pol *policy.Policy, sourceInfo snapshot.SourceInfo, startTime fs.UTCTimestamp) (*snapshot.DirEntry, error) {
+func (u *Uploader) uploadFileWithCheckpointing(ctx context.Context, relativePath string, file fs.File, pol *policy.Policy, prototypeManifest *snapshot.Manifest) (*snapshot.DirEntry, error) {
 	var cp checkpointRegistry
 
-	// Make checkpoints one nanosecond older than the current snapshot, so that they are cleaned
-	// up by retention policies upon creation of the snapshot.
-	cancelCheckpointer := u.periodicallyCheckpoint(ctx, &cp, &snapshot.Manifest{Source: sourceInfo, StartTime: startTime - 1})
+	cancelCheckpointer := u.periodicallyCheckpoint(ctx, &cp, prototypeManifest)
 	defer cancelCheckpointer()
 
 	res, err := u.uploadFileInternal(ctx, &cp, relativePath, file, pol)
@@ -585,15 +583,13 @@ func (u *Uploader) periodicallyCheckpoint(ctx context.Context, cp *checkpointReg
 }
 
 // uploadDirWithCheckpointing uploads the specified Directory to the repository.
-func (u *Uploader) uploadDirWithCheckpointing(ctx context.Context, rootDir fs.Directory, policyTree *policy.Tree, previousDirs []fs.Directory, sourceInfo snapshot.SourceInfo, startTime fs.UTCTimestamp) (*snapshot.DirEntry, error) {
+func (u *Uploader) uploadDirWithCheckpointing(ctx context.Context, rootDir fs.Directory, policyTree *policy.Tree, previousDirs []fs.Directory, prototypeManifest *snapshot.Manifest) (*snapshot.DirEntry, error) {
 	var (
 		dmb snapshotfs.DirManifestBuilder
 		cp  checkpointRegistry
 	)
 
-	// Make checkpoints one nanosecond older than the current snapshot, so that they are cleaned
-	// up by retention policies upon creation of the snapshot.
-	cancelCheckpointer := u.periodicallyCheckpoint(ctx, &cp, &snapshot.Manifest{Source: sourceInfo, StartTime: startTime - 1})
+	cancelCheckpointer := u.periodicallyCheckpoint(ctx, &cp, prototypeManifest)
 	defer cancelCheckpointer()
 
 	var hc actionContext
@@ -1277,27 +1273,35 @@ func (u *Uploader) Upload(
 
 	uploadLog(ctx).Debugw("uploading", "source", sourceInfo, "previousManifests", len(previousManifests), "parallel", parallel)
 
-	s := &snapshot.Manifest{
-		Source: sourceInfo,
-	}
-
 	u.workerPool = workshare.NewPool[*uploadWorkItem](parallel - 1)
 	defer u.workerPool.Close()
+
+	s := snapshot.Manifest{
+		Source:    sourceInfo,
+		StartTime: fs.UTCTimestampFromTime(u.repo.Time()),
+	}
+
+	// prototypeMan is used to construct the manifests for the checkpoints
+	// and the final snapshot; it is passed using a pointer, however it should
+	// remain immutable.
+	prototypeMan := s
+
+	// Make checkpoints one nanosecond older than the current snapshot, so that
+	// they are cleaned up by retention policies upon creation of the snapshot.
+	prototypeMan.StartTime -= 1
 
 	u.stats = &snapshot.Stats{}
 	u.totalWrittenBytes.Store(0)
 
 	var err error
 
-	s.StartTime = fs.UTCTimestampFromTime(u.repo.Time())
-
 	switch entry := source.(type) {
 	case fs.Directory:
-		s.RootEntry, err = u.uploadDir(ctx, previousManifests, entry, policyTree, sourceInfo, s.StartTime)
+		s.RootEntry, err = u.uploadDir(ctx, previousManifests, entry, policyTree, &prototypeMan)
 
 	case fs.File:
 		u.Progress.EstimatedDataSize(1, entry.Size())
-		s.RootEntry, err = u.uploadFileWithCheckpointing(ctx, entry.Name(), entry, policyTree.EffectivePolicy(), sourceInfo, s.StartTime)
+		s.RootEntry, err = u.uploadFileWithCheckpointing(ctx, entry.Name(), entry, policyTree.EffectivePolicy(), &prototypeMan)
 
 	default:
 		return nil, errors.Errorf("unsupported source: %v", s.Source)
@@ -1311,7 +1315,7 @@ func (u *Uploader) Upload(
 	s.EndTime = fs.UTCTimestampFromTime(u.repo.Time())
 	s.Stats = *u.stats
 
-	return s, nil
+	return &s, nil
 }
 
 func (u *Uploader) uploadDir(
@@ -1319,8 +1323,7 @@ func (u *Uploader) uploadDir(
 	previousManifests []*snapshot.Manifest,
 	entry fs.Directory,
 	policyTree *policy.Tree,
-	sourceInfo snapshot.SourceInfo,
-	startTime fs.UTCTimestamp,
+	prototypeManifest *snapshot.Manifest,
 ) (*snapshot.DirEntry, error) {
 	var previousDirs []fs.Directory
 
@@ -1338,7 +1341,7 @@ func (u *Uploader) uploadDir(
 
 	wrapped := u.wrapIgnorefs(uploadLog(ctx), entry, policyTree, true /* reportIgnoreStats */)
 
-	return u.uploadDirWithCheckpointing(ctx, wrapped, policyTree, previousDirs, sourceInfo, startTime)
+	return u.uploadDirWithCheckpointing(ctx, wrapped, policyTree, previousDirs, prototypeManifest)
 }
 
 func (u *Uploader) startDataSizeEstimation(

--- a/snapshot/upload/upload_test.go
+++ b/snapshot/upload/upload_test.go
@@ -793,7 +793,8 @@ func TestUploadWithCheckpointing(t *testing.T) {
 
 	for _, cp := range checkpoints {
 		assert.Equal(t, IncompleteReasonCheckpoint, cp.IncompleteReason, "unexpected incompleteReason")
-		assert.Equal(t, time.Duration(1), s.StartTime.Sub(cp.StartTime), "snapshot start time is expected to be after checkpoint time")
+		assert.Equal(t, s.StartTime, cp.StartTime, "checkpoint start time is expected to match snapshot time")
+		assert.Falsef(t, s.EndTime.Before(cp.EndTime), "snapshot end time (%s) is before checkpoint end time (%s), snapshot end time should be equal or after checkpoint time ", s.EndTime.Format(time.RFC3339Nano), cp.EndTime.Format(time.RFC3339Nano))
 		assert.Equal(t, labels, cp.Tags)
 	}
 }


### PR DESCRIPTION
Refactor uploader to pass a prototype manifest used for creating the checkpoint manifests. This also removes the hack where the checkpoint start time is artificially 1 ns before the snapshot start time.
