### PR TITLE
feat(general): check for clock skew on write session creation

### DIFF
--- a/repo/content/sessions_test.go
+++ b/repo/content/sessions_test.go
@@ -2,11 +2,18 @@ package content
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/epoch"
+	"github.com/kopia/kopia/internal/faketime"
+	"github.com/kopia/kopia/internal/testlogging"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/content/index"
+	"github.com/kopia/kopia/repo/format"
 )
 
 func TestGenerateSessionID(t *testing.T) {
@@ -50,4 +57,84 @@ func TestSessionIDFromBlobID(t *testing.T) {
 			t.Errorf("invalid result for %v: %v, want %v", tc.blobID, got, want)
 		}
 	}
+}
+
+func TestCheckClockSkewBounds_Positive(t *testing.T) {
+	now := clock.Now()
+	modTime := now.Add(maxClockSkew) // within maxClockSkew
+
+	err := checkClockSkewBounds(now, modTime)
+	require.NoError(t, err)
+}
+
+func TestCheckClockSkewBounds_Negative(t *testing.T) {
+	now := clock.Now()
+	modTime := now.Add(maxClockSkew + time.Nanosecond) // exceeds maxClockSkew
+
+	err := checkClockSkewBounds(now, modTime)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "clock skew detected")
+}
+
+func TestWriteSessionMarkerLockedWithoutClockSkew(t *testing.T) {
+	t.Setenv("KOPIA_ENABLE_CLOCK_SKEW_CHECK", "1")
+
+	ctx := testlogging.Context(t)
+	data := blobtesting.DataMap{}
+	keyTime := map[blob.ID]time.Time{}
+
+	// Use TimeAdvance to control the timeNow() in the map storage.
+	ta := faketime.NewTimeAdvance(time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC))
+	st := blobtesting.NewMapStorage(data, keyTime, ta.NowFunc())
+
+	bm, err := NewManagerForTesting(testlogging.Context(t), st, mustCreateFormatProvider(t, &format.ContentFormat{
+		Hash:       "HMAC-SHA256-128",
+		Encryption: "AES256-GCM-HMAC-SHA256",
+		HMACSecret: []byte("foo"),
+		MasterKey:  []byte("0123456789abcdef0123456789abcdef"),
+		MutableParameters: format.MutableParameters{
+			Version:         2,
+			MaxPackSize:     maxPackSize,
+			IndexVersion:    index.Version2,
+			EpochParameters: epoch.DefaultParameters(),
+		},
+	}), nil, &ManagerOptions{TimeNow: ta.NowFunc()}) // Use the same time advance for the manager's timeNow().
+	require.NoError(t, err, "can't create bm")
+
+	t.Cleanup(func() { bm.CloseShared(ctx) })
+
+	err = bm.writeSessionMarkerLocked(ctx)
+	require.NoError(t, err)
+}
+
+func TestWriteSessionMarkerLockedWithClockSkew(t *testing.T) {
+	t.Setenv("KOPIA_ENABLE_CLOCK_SKEW_CHECK", "1")
+
+	ctx := testlogging.Context(t)
+	data := blobtesting.DataMap{}
+	keyTime := map[blob.ID]time.Time{}
+
+	bmTime := faketime.NewTimeAdvance(time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC))
+	stTime := faketime.NewTimeAdvance(time.Date(2018, time.January, 1, 0, int(maxClockSkew), 0, 0, time.UTC))
+	st := blobtesting.NewMapStorage(data, keyTime, stTime.NowFunc())
+
+	bm, err := NewManagerForTesting(testlogging.Context(t), st, mustCreateFormatProvider(t, &format.ContentFormat{
+		Hash:       "HMAC-SHA256-128",
+		Encryption: "AES256-GCM-HMAC-SHA256",
+		HMACSecret: []byte("foo"),
+		MasterKey:  []byte("0123456789abcdef0123456789abcdef"),
+		MutableParameters: format.MutableParameters{
+			Version:         2,
+			MaxPackSize:     maxPackSize,
+			IndexVersion:    index.Version2,
+			EpochParameters: epoch.DefaultParameters(),
+		},
+	}), nil, &ManagerOptions{TimeNow: bmTime.NowFunc()})
+	require.NoError(t, err, "can't create bm")
+
+	t.Cleanup(func() { bm.CloseShared(ctx) })
+
+	err = bm.writeSessionMarkerLocked(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "clock skew detected")
 }


### PR DESCRIPTION
Check for clock skew between the local clock and the storage clock when the session blob is written (on session creation). Tests included.

The check is currently disabled by default.