### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.5
-	github.com/kopia/htmluibuild v0.0.1-0.20250607181534-77e0f3f9f557
+	github.com/kopia/htmluibuild v0.0.1-0.20250812002152-664615f2b214
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.5 h1:4cJuyH926If33BeDgiZpI5OU0pE+wUHZvMSyNGqN73Y=
 github.com/klauspost/reedsolomon v1.12.5/go.mod h1:LkXRjLYGM8K/iQfujYnaPeDmhZLqkrGUyG9p7zs5L68=
-github.com/kopia/htmluibuild v0.0.1-0.20250607181534-77e0f3f9f557 h1:je1C/xnmKxnaJsIgj45me5qA51TgtK9uMwTxgDw+9H0=
-github.com/kopia/htmluibuild v0.0.1-0.20250607181534-77e0f3f9f557/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20250812002152-664615f2b214 h1:11LvVhuNQTPdnJIe+XePZmI1hQp2pQIgPZ9D2ONJH7k=
+github.com/kopia/htmluibuild v0.0.1-0.20250812002152-664615f2b214/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/f951773b9eeb5015c79bedacf49dee15f758bbcb...b23da5d1ca851242e7027e01e7c0b8231f381cca

* Mon 16:56 -0700 https://github.com/kopia/htmlui/commit/a90329c Jarek Kowalski fix(ui): fix failing test
* Mon 17:09 -0700 https://github.com/kopia/htmlui/commit/1926008 dependabot[bot] build(deps-dev): bump axios from 1.9.0 to 1.11.0
* Mon 17:11 -0700 https://github.com/kopia/htmlui/commit/f473c08 dependabot[bot] build(deps): bump react-router-dom from 7.6.1 to 7.7.1
* Mon 17:14 -0700 https://github.com/kopia/htmlui/commit/918f11b dependabot[bot] build(deps-dev): bump @eslint/plugin-kit from 0.3.1 to 0.3.4
* Mon 17:15 -0700 https://github.com/kopia/htmlui/commit/2beeb97 dependabot[bot] build(deps-dev): bump @vitejs/plugin-react from 4.5.0 to 4.7.0
* Mon 17:15 -0700 https://github.com/kopia/htmlui/commit/1963551 dependabot[bot] build(deps-dev): bump globals from 16.1.0 to 16.3.0
* Mon 17:20 -0700 https://github.com/kopia/htmlui/commit/b23da5d dependabot[bot] build(deps-dev): bump vite from 6.3.5 to 7.0.6

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Tue Aug 12 00:22:11 UTC 2025*
