### PR TITLE
refactor(cli): remove deprecated no-op flags

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -295,14 +295,6 @@ func (c *App) setup(app *kingpin.Application) {
 
 	c.setupOSSpecificKeychainFlags(c, app)
 
-	_ = app.Flag("caching", "Enables caching of objects (disable with --no-caching)").Default("true").Hidden().Action(
-		deprecatedFlag(c.stderrWriter, "The '--caching' flag is deprecated and has no effect, use 'kopia cache set' instead."),
-	).Bool()
-
-	_ = app.Flag("list-caching", "Enables caching of list results (disable with --no-list-caching)").Default("true").Hidden().Action(
-		deprecatedFlag(c.stderrWriter, "The '--list-caching' flag is deprecated and has no effect, use 'kopia cache set' instead."),
-	).Bool()
-
 	c.pf.setup(app)
 	c.progress.setup(c, app)
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -2,15 +2,12 @@ package cli
 
 import (
 	"context"
-	"fmt"
-	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
 	"syscall"
 
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/fs"
@@ -18,13 +15,6 @@ import (
 	"github.com/kopia/kopia/internal/ospath"
 	"github.com/kopia/kopia/repo"
 )
-
-func deprecatedFlag(w io.Writer, help string) func(_ *kingpin.ParseContext) error {
-	return func(_ *kingpin.ParseContext) error {
-		fmt.Fprintf(w, "DEPRECATED: %v\n", help) //nolint:errcheck
-		return nil
-	}
-}
 
 func (c *App) onRepositoryFatalError(f func(err error)) {
 	c.onFatalErrorCallbacks = append(c.onFatalErrorCallbacks, f)

--- a/cli/observability_flags.go
+++ b/cli/observability_flags.go
@@ -53,8 +53,7 @@ type observabilityFlags struct {
 	metricsOutputDir    string
 	outputFilePrefix    string
 
-	enableJaeger bool
-	otlpTrace    bool
+	otlpTrace bool
 
 	stopPusher chan struct{}
 	pusherWG   sync.WaitGroup
@@ -75,7 +74,6 @@ func (c *observabilityFlags) setup(svc appServices, app *kingpin.Application) {
 	app.Flag("metrics-push-password", "Password for push gateway").Envar(svc.EnvName("KOPIA_METRICS_PUSH_PASSWORD")).Hidden().StringVar(&c.metricsPushPassword)
 
 	// tracing (OTLP) parameters
-	app.Flag("enable-jaeger-collector", "(DEPRECATED) Emit OpenTelemetry traces to Jaeger collector").Hidden().Envar(svc.EnvName("KOPIA_ENABLE_JAEGER_COLLECTOR")).BoolVar(&c.enableJaeger)
 	app.Flag("otlp-trace", "Send OpenTelemetry traces to OTLP collector using gRPC").Hidden().Envar(svc.EnvName("KOPIA_ENABLE_OTLP_TRACE")).BoolVar(&c.otlpTrace)
 
 	var formats []string
@@ -195,10 +193,6 @@ func (c *observabilityFlags) maybeStartMetricsPusher(ctx context.Context) error 
 }
 
 func (c *observabilityFlags) maybeStartTraceExporter(ctx context.Context) error {
-	if c.enableJaeger {
-		return errors.New("Flag '--enable-jaeger-collector' is no longer supported, use '--otlp' instead. See https://github.com/kopia/kopia/pull/3264 for more information")
-	}
-
 	if !c.otlpTrace {
 		return nil
 	}

--- a/tests/end_to_end_test/index_recover_test.go
+++ b/tests/end_to_end_test/index_recover_test.go
@@ -44,7 +44,7 @@ func (s *formatSpecificTestSuite) TestIndexRecover(t *testing.T) {
 	e.RunAndVerifyOutputLineCount(t, 0, "cache", "clear")
 
 	// there should be no index files at this point
-	e.RunAndVerifyOutputLineCount(t, 0, "index", "ls", "--no-list-caching")
+	e.RunAndVerifyOutputLineCount(t, 0, "index", "ls")
 
 	// there should be no contents, since there are no indexes to find them
 	e.RunAndVerifyOutputLineCount(t, 0, "content", "ls")


### PR DESCRIPTION
Removes:

- `--caching`: no-op
- `--list-caching`: no-op
- `--enable-jaeger-collector`: errors out when specified.