### PR TITLE
refactor(cli): rename flag to `--dangerous-commands`

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -88,7 +88,7 @@ type appServices interface {
 	maybeRepositoryAction(act func(ctx context.Context, rep repo.Repository) error, mode repositoryAccessMode) func(ctx *kingpin.ParseContext) error
 	baseActionWithContext(act func(ctx context.Context) error) func(ctx *kingpin.ParseContext) error
 	openRepository(ctx context.Context, mustBeConnected bool) (repo.Repository, error)
-	advancedCommand()
+	dangerousCommand()
 	repositoryConfigFileName() string
 	getProgress() *cliProgress
 	getRestoreProgress() RestoreProgress
@@ -137,7 +137,7 @@ type App struct {
 	persistCredentials            bool
 	disableInternalLog            bool
 	dumpAllocatorStats            bool
-	AdvancedCommands              string
+	DangerousCommands             string
 	cliStorageProviders           []StorageProvider
 	trackReleasable               []string
 
@@ -277,7 +277,7 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("password", "Repository password.").Envar(c.EnvName("KOPIA_PASSWORD")).Short('p').StringVar(&c.password)
 	app.Flag("persist-credentials", "Persist credentials").Default("true").Envar(c.EnvName("KOPIA_PERSIST_CREDENTIALS_ON_CONNECT")).BoolVar(&c.persistCredentials)
 	app.Flag("disable-internal-log", "Disable internal log").Hidden().Envar(c.EnvName("KOPIA_DISABLE_INTERNAL_LOG")).BoolVar(&c.disableInternalLog)
-	app.Flag("advanced-commands", "Enable dangerous commands that could result in data loss and repository corruption.").Hidden().Envar(c.EnvName("KOPIA_ADVANCED_COMMANDS")).StringVar(&c.AdvancedCommands)
+	app.Flag("dangerous-commands", "Enable dangerous commands that could result in data loss and repository corruption.").Hidden().Envar(c.EnvName("KOPIA_DANGEROUS_COMMANDS")).StringVar(&c.DangerousCommands)
 	app.Flag("track-releasable", "Enable tracking of releasable resources.").Hidden().Envar(c.EnvName("KOPIA_TRACK_RELEASABLE")).StringsVar(&c.trackReleasable)
 	app.Flag("dump-allocator-stats", "Dump allocator stats at the end of execution.").Hidden().Envar(c.EnvName("KOPIA_DUMP_ALLOCATOR_STATS")).BoolVar(&c.dumpAllocatorStats)
 	app.Flag("upgrade-owner-id", "Repository format upgrade owner-id.").Hidden().Envar(c.EnvName("KOPIA_REPO_UPGRADE_OWNER_ID")).StringVar(&c.upgradeOwnerID)
@@ -642,13 +642,13 @@ func (c *App) maybeRunMaintenance(ctx context.Context, rep repo.Repository) erro
 	return errors.Wrap(err, "error running maintenance")
 }
 
-func (c *App) advancedCommand() {
-	if c.AdvancedCommands != "enabled" {
+func (c *App) dangerousCommand() {
+	if c.DangerousCommands != "enabled" {
 		_, _ = errorColor.Fprintf(c.stderrWriter, `
 This command is dangerous, it can corrupt the repository and result in data loss.
 
 Running this command is not needed for using Kopia. Instead, rely on periodic repository maintenance. See https://kopia.io/docs/advanced/maintenance/ for more information.
-To run this command despite the warning, set --advanced-commands=enabled
+To run this command despite the warning, set --dangerous-commands=enabled
 
 `)
 

--- a/cli/command_blob_delete.go
+++ b/cli/command_blob_delete.go
@@ -24,7 +24,7 @@ func (c *commandBlobDelete) setup(svc appServices, parent commandParent) {
 }
 
 func (c *commandBlobDelete) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	c.svc.advancedCommand()
+	c.svc.dangerousCommand()
 
 	for _, b := range c.blobIDs {
 		err := rep.BlobStorage().DeleteBlob(ctx, blob.ID(b))

--- a/cli/command_blob_gc.go
+++ b/cli/command_blob_gc.go
@@ -31,7 +31,7 @@ func (c *commandBlobGC) setup(svc appServices, parent commandParent) {
 }
 
 func (c *commandBlobGC) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	c.svc.advancedCommand()
+	c.svc.dangerousCommand()
 
 	opts := maintenance.DeleteUnreferencedBlobsOptions{
 		DryRun:   c.delete != "yes",

--- a/cli/command_content_delete.go
+++ b/cli/command_content_delete.go
@@ -23,7 +23,7 @@ func (c *commandContentDelete) setup(svc appServices, parent commandParent) {
 }
 
 func (c *commandContentDelete) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	c.svc.advancedCommand()
+	c.svc.dangerousCommand()
 
 	contentIDs, err := toContentIDs(c.ids)
 	if err != nil {

--- a/cli/command_content_rewrite.go
+++ b/cli/command_content_rewrite.go
@@ -41,7 +41,7 @@ func (c *commandContentRewrite) setup(svc appServices, parent commandParent) {
 }
 
 func (c *commandContentRewrite) runContentRewriteCommand(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	c.svc.advancedCommand()
+	c.svc.dangerousCommand()
 
 	contentIDs, err := toContentIDs(c.contentRewriteIDs)
 	if err != nil {

--- a/cli/command_index_optimize.go
+++ b/cli/command_index_optimize.go
@@ -29,7 +29,7 @@ func (c *commandIndexOptimize) setup(svc appServices, parent commandParent) {
 }
 
 func (c *commandIndexOptimize) runOptimizeCommand(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	c.svc.advancedCommand()
+	c.svc.dangerousCommand()
 
 	contentIDs, err := toContentIDs(c.optimizeDropContents)
 	if err != nil {

--- a/cli/command_index_recover.go
+++ b/cli/command_index_recover.go
@@ -40,7 +40,7 @@ func (c *commandIndexRecover) setup(svc appServices, parent commandParent) {
 }
 
 func (c *commandIndexRecover) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	c.svc.advancedCommand()
+	c.svc.dangerousCommand()
 
 	var (
 		processedBlobCount    atomic.Int32

--- a/cli/command_manifest_delete.go
+++ b/cli/command_manifest_delete.go
@@ -23,7 +23,7 @@ func (c *commandManifestDelete) setup(svc appServices, parent commandParent) {
 }
 
 func (c *commandManifestDelete) run(ctx context.Context, rep repo.RepositoryWriter) error {
-	c.svc.advancedCommand()
+	c.svc.dangerousCommand()
 
 	for _, it := range toManifestIDs(c.manifestRemoveItems) {
 		if err := rep.DeleteManifest(ctx, it); err != nil {

--- a/cli/command_repository_repair.go
+++ b/cli/command_repository_repair.go
@@ -30,7 +30,7 @@ func (c *commandRepositoryRepair) setup(svc advancedAppServices, parent commandP
 		cc := cmd.Command(prov.Name, "Repair repository in "+prov.Description).Hidden()
 		f.Setup(svc, cc)
 		cc.Action(func(kpc *kingpin.ParseContext) error {
-			svc.advancedCommand()
+			svc.dangerousCommand()
 
 			return svc.runAppWithContext(kpc.SelectedCommand, func(ctx context.Context) error {
 				st, err := f.Connect(ctx, false, 0)

--- a/tests/recovery/blobmanipulator/blobmanipulator.go
+++ b/tests/recovery/blobmanipulator/blobmanipulator.go
@@ -100,7 +100,7 @@ func (bm *BlobManipulator) DeleteBlob(blobID string) error {
 
 	log.Printf("Deleting BLOB %s", blobID)
 
-	_, _, err := bm.KopiaCommandRunner.Run("blob", "delete", blobID, "--advanced-commands=enabled")
+	_, _, err := bm.KopiaCommandRunner.Run("blob", "delete", blobID, "--dangerous-commands=enabled")
 	if err != nil {
 		return err
 	}

--- a/tests/testenv/cli_inproc_runner.go
+++ b/tests/testenv/cli_inproc_runner.go
@@ -31,7 +31,7 @@ func (e *CLIInProcRunner) Start(t *testing.T, ctx context.Context, args []string
 	t.Helper()
 
 	a := cli.NewApp()
-	a.AdvancedCommands = "enabled"
+	a.DangerousCommands = "enabled"
 
 	envPrefix := fmt.Sprintf("T%v_", atomic.AddInt32(envPrefixCounter, 1))
 	a.SetEnvNamePrefixForTesting(envPrefix)


### PR DESCRIPTION
The new flag name clearly conveys the danger of loosing data or corrupting the repository when using the commands that require this flag.