### PR TITLE
feat(providers): add user-agent string in Azure storage provider

### DIFF
--- a/repo/blob/azure/azure_options.go
+++ b/repo/blob/azure/azure_options.go
@@ -36,6 +36,9 @@ type Options struct {
 
 	StorageDomain string `json:"storageDomain,omitempty"`
 
+	// DoNotUseTLS connects to Azure storage over HTTP instead of HTTPS
+	DoNotUseTLS bool `json:"doNotUseTLS,omitempty"`
+
 	throttling.Limits
 
 	// PointInTime specifies a view of the (versioned) store at that time

--- a/repo/blob/azure/azure_storage_test.go
+++ b/repo/blob/azure/azure_storage_test.go
@@ -3,7 +3,10 @@ package azure_test
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -358,4 +361,42 @@ func getBlobCount(ctx context.Context, t *testing.T, st blob.Storage, prefix blo
 	require.NoError(t, err)
 
 	return count
+}
+
+func TestUserAgent(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	container := "testContainer"
+	storageAccount := "testAccount"
+	storageKey := base64.StdEncoding.EncodeToString([]byte("testKey"))
+
+	uaChannel := make(chan string, 1)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test"))
+
+		uaChannel <- r.Header.Get("User-Agent")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	t.Setenv("HTTP_PROXY", server.URL)
+
+	// azure.New creates a client and uses it to make a request to the Azure service.
+	// We intercept this request to check the User-Agent header.
+	// The User-Agent should contain the application ID of the blob storage client.
+	// If it does not, we fail the test.
+	client, err := azure.New(ctx, &azure.Options{
+		Container:      container,
+		StorageAccount: storageAccount,
+		StorageKey:     storageKey,
+		DoNotUseTLS:    true,
+	}, false)
+	require.Error(t, err)
+	require.Nil(t, client)
+
+	ua := <-uaChannel
+	require.Contains(t, ua, blob.ApplicationID)
 }

--- a/repo/blob/storage.go
+++ b/repo/blob/storage.go
@@ -45,6 +45,10 @@ var ErrNotAVolume = errors.New("unsupported method, storage is not a volume")
 // function on a storage implementation that does not have the intended functionality.
 var ErrUnsupportedObjectLock = errors.New("object locking unsupported")
 
+// ApplicationID is sent to storage providers as metadata in the User-Agent of requests.
+// It is used to identify the application making the request.
+var ApplicationID = "kopia"
+
 // Bytes encapsulates a sequence of bytes, possibly stored in a non-contiguous buffers,
 // which can be written sequentially or treated as a io.Reader.
 type Bytes interface {


### PR DESCRIPTION
- Adds `kopia` as the application ID.
- Adds a unit test verifying that the header sent to Azure contains the application ID in the user agent string.
- Adds an option to use an insecure connection to Azure, primarily for testing.

Authored by: @andrason