### PR TITLE
Corrected environment variable name mismatches in docker compose example

### DIFF
--- a/site/content/docs/Installation/_index.md
+++ b/site/content/docs/Installation/_index.md
@@ -307,12 +307,12 @@ services:
             - --disable-csrf-token-checks
             - --insecure
             - --address=0.0.0.0:51515
-            - --server-username=USERNAME
-            - --server-password=SECRET_PASSWORD
+            - --server-username=KOPIA_USER
+            - --server-password=KOPIA_PASSWORD
         environment:
             # Set repository password
             KOPIA_PASSWORD: "SECRET"
-            USER: "User"
+            KOPIA_USER: "User"
         volumes:
             # Mount local folders needed by kopia
             - /path/to/config/dir:/app/config


### PR DESCRIPTION
Corrected a mismatch between the environment variable names between the `command` and `environment` sections of the docker compose example file on the docs website