### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.5
-	github.com/kopia/htmluibuild v0.0.1-0.20250909213428-6e31bc771aef
+	github.com/kopia/htmluibuild v0.0.1-0.20250916054243-fc9411799322
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.5 h1:4cJuyH926If33BeDgiZpI5OU0pE+wUHZvMSyNGqN73Y=
 github.com/klauspost/reedsolomon v1.12.5/go.mod h1:LkXRjLYGM8K/iQfujYnaPeDmhZLqkrGUyG9p7zs5L68=
-github.com/kopia/htmluibuild v0.0.1-0.20250909213428-6e31bc771aef h1:hK9breG4pfvfvmSlFaD5YKv9KQ/I3xtYnGB9Mrbsfg4=
-github.com/kopia/htmluibuild v0.0.1-0.20250909213428-6e31bc771aef/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20250916054243-fc9411799322 h1:spz0L1ixqBXAkGQaWEZlVJUHbalJkgiuzG8JdzdNCC0=
+github.com/kopia/htmluibuild v0.0.1-0.20250916054243-fc9411799322/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/d0f0d638b44a4974ef6be713b52bd4d5e9fba759...ce2bf7415b2de0a7657f552115a159b3f41838e9

* Mon 22:32 -0700 https://github.com/kopia/htmlui/commit/d5a3314 dependabot[bot] build(deps-dev): bump axios from 1.11.0 to 1.12.1
* Mon 22:41 -0700 https://github.com/kopia/htmlui/commit/ce2bf74 dependabot[bot] build(deps): bump brace-expansion

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Tue Sep 16 05:43:05 UTC 2025*
