### PR TITLE
feat(snapshots): Flush after restoring each file

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -125,6 +125,7 @@ type commandRestore struct {
 	restoreIncremental            bool
 	restoreDeleteExtra            bool
 	restoreIgnoreErrors           bool
+	flushFiles                    bool
 	restoreShallowAtDepth         int32
 	minSizeForPlaceholder         int32
 	snapshotTime                  string
@@ -158,6 +159,7 @@ func (c *commandRestore) setup(svc appServices, parent commandParent) {
 	cmd.Flag("shallow", "Shallow restore the directory hierarchy starting at this level (default is to deep restore the entire hierarchy.)").Int32Var(&c.restoreShallowAtDepth)
 	cmd.Flag("shallow-minsize", "When doing a shallow restore, write actual files instead of placeholders smaller than this size.").Int32Var(&c.minSizeForPlaceholder)
 	cmd.Flag("snapshot-time", "When using a path as the source, use the latest snapshot available before this date. Default is latest").Default("latest").StringVar(&c.snapshotTime)
+	cmd.Flag("flush-files", "Specifies whether or not to flush files after restore completes").Default("false").BoolVar(&c.flushFiles)
 	cmd.Action(svc.repositoryReaderAction(c.run))
 }
 
@@ -269,6 +271,7 @@ func (c *commandRestore) restoreOutput(ctx context.Context, rep repo.Repository)
 			SkipPermissions:        c.restoreSkipPermissions,
 			SkipTimes:              c.restoreSkipTimes,
 			WriteSparseFiles:       c.restoreWriteSparseFiles,
+			FlushFiles:             c.flushFiles,
 		}
 
 		if err := o.Init(ctx); err != nil {


### PR DESCRIPTION
The file restore is using buffered IO, so after the restore completes, file data are actually written to the system cache, there is no guarantee all data have been flushed to disk. The flush may happen some time later according to the system cache's own data management policy.
On the other hand, users may restore data to a "removable disk", e.g., a virtual disk or a USB disk.

As a result, if users remove the disk immediately after the restore (e.g., detach the virtual disk from the hypervisor), the restore data may be lost.

This PR adds a flush call (`f.Sync`) for each file after the restore.

The flush may take some time because it waits for the kernel to completes the flush IO. So for large amount of files, the throughput may get affected.
However, I think for a restore tool, it is always correct to make sure the data is unconditionally restored to the disk. So the overhead is something ought to spend.
So I don't make this as a conditional call (e.g., adding a user option for it). Let me know if this affects other modules or scenarios.
