### PR TITLE
fix(cli): enable quick maintenance by default for new repositories

### DIFF
--- a/cli/auto_upgrade.go
+++ b/cli/auto_upgrade.go
@@ -39,18 +39,6 @@ func setDefaultMaintenanceParameters(ctx context.Context, rep repo.RepositoryWri
 	p := maintenance.DefaultParams()
 	p.Owner = rep.ClientOptions().UsernameAtHost()
 
-	if dw, ok := rep.(repo.DirectRepositoryWriter); ok {
-		_, ok, err := dw.ContentReader().EpochManager(ctx)
-		if err != nil {
-			return errors.Wrap(err, "epoch manager")
-		}
-
-		if ok {
-			// disable quick maintenance cycle
-			p.QuickCycle.Enabled = false
-		}
-	}
-
 	if err := maintenance.SetParams(ctx, rep, &p); err != nil {
 		return errors.Wrap(err, "unable to set maintenance params")
 	}


### PR DESCRIPTION
Avoid disabling quick maintenance on repo creation when the epoch manager is used.