### PR TITLE
refactor(cli): ensure auto-maintenance errors are propagated

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"os"
@@ -568,7 +569,7 @@ func (c *App) maybeRepositoryAction(act func(ctx context.Context, rep repo.Repos
 
 		if rep != nil && err == nil && mode.allowMaintenance {
 			if merr := c.maybeRunMaintenance(ctx, rep); merr != nil {
-				log(ctx).Errorf("error running maintenance: %v", merr)
+				err = stderrors.Join(err, errors.Wrap(merr, "running auto-maintenance")) // surface auto-maitenance error
 			}
 		}
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -586,7 +586,7 @@ func (c *App) maybeRepositoryAction(act func(ctx context.Context, rep repo.Repos
 
 		if rep != nil {
 			if cerr := rep.Close(ctx); cerr != nil {
-				return errors.Wrap(cerr, "unable to close repository")
+				return stderrors.Join(err, errors.Wrap(cerr, "unable to close repository"))
 			}
 		}
 


### PR DESCRIPTION
Ensure auto-maintenance errors are propagated.
Preserve action error when closing the repository fails.