### PR TITLE
test(general): fix endurance test failures

### DIFF
--- a/tests/endurance_test/endurance_test.go
+++ b/tests/endurance_test/endurance_test.go
@@ -145,7 +145,7 @@ func actionSnapshotExisting(t *testing.T, e *testenv.CLITest, s *runnerState) {
 	t.Helper()
 
 	randomPath := s.dirs[rand.Intn(len(s.dirs))]
-	e.RunAndExpectSuccess(t, "snapshot", "create", randomPath)
+	e.RunAndExpectSuccess(t, "--no-auto-maintenance", "snapshot", "create", randomPath)
 
 	s.snapshottedAnything = true
 }
@@ -157,7 +157,7 @@ func actionSnapshotAll(t *testing.T, e *testenv.CLITest, s *runnerState) {
 		return
 	}
 
-	e.RunAndExpectSuccess(t, "snapshot", "create", "--all")
+	e.RunAndExpectSuccess(t, "--no-auto-maintenance", "snapshot", "create", "--all")
 }
 
 func actionSnapshotVerify(t *testing.T, e *testenv.CLITest, s *runnerState) {


### PR DESCRIPTION
Prevent running "auto-maintenance" on snapshot create.

Ref:
- #4851

Context: the test fails because there are concurrent "endurance" runners and each of these advances the clock, some of them significantly (`action{Small,Medium,Large}ClockJump`), which causes the clock skewness check to fail when (auto-)maintenance runs. The test maintenance action does not run into this issue because it runs exclusively on its own, that is, other actions have to wait until maintenance completes.