### PR TITLE
test(general): expand triggers for endurance tests

### DIFF
--- a/.github/workflows/endurance-test.yml
+++ b/.github/workflows/endurance-test.yml
@@ -7,6 +7,13 @@ on:
   schedule:
     # run every 2 hours
     - cron:  '12 */2 * * *'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'branch or git ref to use for the build'
+        required: true
+        default: 'test/endurance'
+
 concurrency: 
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/endurance-test.yml
+++ b/.github/workflows/endurance-test.yml
@@ -1,7 +1,7 @@
 name: Endurance Test
 on:
   push:
-    branches: [ master ]
+    branches: [ master, test/endurance ]
     tags:
       - v*
   schedule:


### PR DESCRIPTION
Run endurance tests:
- on push to the `test/endurance` branch
- on workflow dispatch, it allows choosing the target branch for the run.