### PR TITLE
feat(server): "--kopiaui-info" option

### DIFF
--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -70,8 +70,10 @@ type commandServerStart struct {
 	debugScheduler                      bool
 	minMaintenanceInterval              time.Duration
 
-	shutdownGracePeriod  time.Duration
+	shutdownGracePeriod time.Duration
+
 	kopiauiNotifications bool
+	kopiauiInfo          bool
 
 	logServerRequests bool
 
@@ -127,6 +129,8 @@ func (c *commandServerStart) setup(svc advancedAppServices, parent commandParent
 	cmd.Flag("shutdown-grace-period", "Grace period for shutting down the server").Default("5s").DurationVar(&c.shutdownGracePeriod)
 
 	cmd.Flag("kopiaui-notifications", "Enable notifications to be printed to stdout for KopiaUI").BoolVar(&c.kopiauiNotifications)
+
+	cmd.Flag("kopiaui-info", "Outputs connection info for KopiaUI integration").Default("true").Hidden().BoolVar(&c.kopiauiInfo)
 
 	c.sf.setup(svc, cmd)
 	c.co.setup(svc, cmd)

--- a/cli/command_server_tls.go
+++ b/cli/command_server_tls.go
@@ -88,7 +88,9 @@ func (c *commandServerStart) maybeGenerateTLS(ctx context.Context) error {
 	}
 
 	fingerprint := sha256.Sum256(cert.Raw)
-	fmt.Fprintf(c.out.stderr(), "SERVER CERT SHA256: %v\n", hex.EncodeToString(fingerprint[:])) //nolint:errcheck
+	if c.kopiauiInfo {
+		fmt.Fprintf(c.out.stderr(), "SERVER CERT SHA256: %v\n", hex.EncodeToString(fingerprint[:])) //nolint:errcheck
+	}
 
 	log(ctx).Infof("writing TLS certificate to %v", c.serverStartTLSCertFile)
 
@@ -118,7 +120,10 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 	switch {
 	case c.serverStartTLSCertFile != "" && c.serverStartTLSKeyFile != "":
 		// PEM files provided
-		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttps://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
+		if c.kopiauiInfo {
+			fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttps://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
+		}
+
 		c.showServerUIPrompt(ctx)
 
 		return checkErrServerClosed(ctx, httpServer.ServeTLS(listener, c.serverStartTLSCertFile, c.serverStartTLSKeyFile), "error starting TLS server")
@@ -141,7 +146,9 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 		}
 
 		fingerprint := sha256.Sum256(cert.Raw)
-		fmt.Fprintf(c.out.stderr(), "SERVER CERT SHA256: %v\n", hex.EncodeToString(fingerprint[:])) //nolint:errcheck
+		if c.kopiauiInfo {
+			fmt.Fprintf(c.out.stderr(), "SERVER CERT SHA256: %v\n", hex.EncodeToString(fingerprint[:])) //nolint:errcheck
+		}
 
 		if c.serverStartTLSPrintFullServerCert {
 			// dump PEM-encoded server cert, only used by KopiaUI to securely connect.
@@ -151,10 +158,15 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 				return errors.Wrap(err, "Failed to write data")
 			}
 
-			fmt.Fprintf(c.out.stderr(), "SERVER CERTIFICATE: %v\n", base64.StdEncoding.EncodeToString(b.Bytes())) //nolint:errcheck
+			if c.kopiauiInfo {
+				fmt.Fprintf(c.out.stderr(), "SERVER CERTIFICATE: %v\n", base64.StdEncoding.EncodeToString(b.Bytes())) //nolint:errcheck
+			}
 		}
 
-		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttps://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
+		if c.kopiauiInfo {
+			fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttps://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
+		}
+
 		c.showServerUIPrompt(ctx)
 
 		return checkErrServerClosed(ctx, httpServer.ServeTLS(listener, "", ""), "error starting TLS server")
@@ -164,7 +176,10 @@ func (c *commandServerStart) startServerWithOptionalTLSAndListener(ctx context.C
 			return errors.New("TLS not configured. To start server without encryption pass --insecure")
 		}
 
-		fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttp://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
+		if c.kopiauiInfo {
+			fmt.Fprintf(c.out.stderr(), "SERVER ADDRESS: %shttp://%v\n", udsPfx, httpServer.Addr) //nolint:errcheck
+		}
+
 		c.showServerUIPrompt(ctx)
 
 		return checkErrServerClosed(ctx, httpServer.Serve(listener), "error starting server")


### PR DESCRIPTION
This patch introduces an option to suppress the printing of KopiaUI interface options to stderr by using
"--kopiaui-info=false", with "--kopiaui-info" defaulting to "true" to preserve the original behavior.

This feature is especially beneficial when used alongside the "--json-log-console" option, as it enables a clean, parsable JSON logging stream.