### PR TITLE
feat(server): mTLS authentication

### DIFF
--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -59,6 +59,7 @@ type commandServerStart struct {
 	serverStartTLSGenerateCert          bool
 	serverStartTLSCertFile              string
 	serverStartTLSKeyFile               string
+	serverStartCAFile                   string
 	serverStartTLSGenerateRSAKeySize    int
 	serverStartTLSGenerateCertValidDays int
 	serverStartTLSGenerateCertNames     []string
@@ -111,6 +112,7 @@ func (c *commandServerStart) setup(svc advancedAppServices, parent commandParent
 	cmd.Flag("tls-generate-cert", "Generate TLS certificate").Hidden().BoolVar(&c.serverStartTLSGenerateCert)
 	cmd.Flag("tls-cert-file", "TLS certificate PEM").StringVar(&c.serverStartTLSCertFile)
 	cmd.Flag("tls-key-file", "TLS key PEM file").StringVar(&c.serverStartTLSKeyFile)
+	cmd.Flag("tls-ca-file", "TLS CA PEM file, used for client authentication").StringVar(&c.serverStartCAFile)
 	cmd.Flag("tls-generate-rsa-key-size", "TLS RSA Key size (bits)").Hidden().Default("4096").IntVar(&c.serverStartTLSGenerateRSAKeySize)
 	cmd.Flag("tls-generate-cert-valid-days", "How long should the TLS certificate be valid").Default("3650").Hidden().IntVar(&c.serverStartTLSGenerateCertValidDays)
 	cmd.Flag("tls-generate-cert-name", "Host names/IP addresses to generate TLS certificate for").Default("127.0.0.1").Hidden().StringsVar(&c.serverStartTLSGenerateCertNames)
@@ -388,6 +390,11 @@ User accounts can be added using 'kopia server user add'.
 
 	// handle user accounts stored in the repository
 	authenticators = append(authenticators, auth.AuthenticateRepositoryUsers())
+
+	// handle client certificate authentication
+	if c.serverStartCAFile != "" {
+		authenticators = append(authenticators, auth.AuthenticateClientCertificateUsers())
+	}
 
 	return auth.CombineAuthenticators(authenticators...), nil
 }

--- a/cli/command_server_tls_test.go
+++ b/cli/command_server_tls_test.go
@@ -1,0 +1,234 @@
+package cli_test
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+func TestServerTLS(t *testing.T) {
+	const (
+		userName = "user78"
+		userHost = "client-host"
+		userFull = userName + "@" + userHost
+	)
+
+	randomN, _ := rand.Int(rand.Reader, big.NewInt(1000))
+	userPassword := fmt.Sprintf("password-%v", randomN.Int64())
+
+	serverActiveCA, err := testutil.CreateRootCA("kopia-active", "server-tls-test")
+	require.NoError(t, err, "creating server (active) TLS CA certificate")
+
+	serverInactiveCA, err := testutil.CreateRootCA("kopia-inactive", "server-tls-test")
+	require.NoError(t, err, "creating server (inactive) TLS CA certificate")
+
+	clientActive, err := serverActiveCA.CreateAndSignClientCertificate(userFull)
+	require.NoError(t, err, "creating client (active) TLS certificate")
+
+	clientExpired, err := serverActiveCA.CreateAndSignExpiredClientCertificate(userFull)
+	require.NoError(t, err, "creating client (active) TLS certificate")
+
+	clientInactive, err := serverInactiveCA.CreateAndSignClientCertificate(userFull)
+	require.NoError(t, err, "creating client (inactive) TLS certificate")
+
+	certDir := testutil.TempDirectory(t)
+
+	err = serverActiveCA.WriteTo(
+		path.Join(certDir, "kopia-active-ca.crt"),
+		path.Join(certDir, "kopia-active-ca.key"),
+	)
+	require.NoError(t, err, "writing server (active) TLS certificate")
+
+	err = serverInactiveCA.WriteTo(
+		path.Join(certDir, "kopia-inactive-ca.crt"),
+		path.Join(certDir, "kopia-inactive-ca.key"),
+	)
+	require.NoError(t, err, "writing server (inactive) TLS certificate")
+
+	err = clientActive.WriteTo(
+		path.Join(certDir, "client-active.crt"),
+		path.Join(certDir, "client-active.key"),
+	)
+	require.NoError(t, err, "writing client (active) TLS certificate")
+
+	err = clientExpired.WriteTo(
+		path.Join(certDir, "client-expired.crt"),
+		path.Join(certDir, "client-expired.key"),
+	)
+	require.NoError(t, err, "writing client (expired) TLS certificate")
+
+	err = clientInactive.WriteTo(
+		path.Join(certDir, "client-inactive.crt"),
+		path.Join(certDir, "client-inactive.key"),
+	)
+	require.NoError(t, err, "writing client (inactive) TLS certificate")
+
+	t.Run("no tls-ca-file", func(t *testing.T) {
+		clientEnv := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+		delete(clientEnv.Environment, "KOPIA_PASSWORD")
+
+		serverEnv := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+		defer serverEnv.RunAndExpectSuccess(t, "repo", "disconnect")
+
+		serverEnv.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", serverEnv.RepoDir)
+		serverEnv.RunAndExpectSuccess(t, "server", "users", "add", userFull, "--user-password", userPassword)
+
+		var sp testutil.ServerParameters
+
+		wait, kill := serverEnv.RunAndProcessStderr(t, sp.ProcessOutput,
+			"server", "start",
+			"--address=localhost:0",
+			"--tls-generate-cert",
+			"--random-server-control-password",
+			"--shutdown-grace-period", "100ms",
+		)
+		t.Cleanup(func() {
+			kill()
+			wait()
+			t.Log("server stopped")
+		})
+
+		t.Logf("detected server parameters %#v", sp)
+
+		t.Run("no client cert, good password", func(t *testing.T) {
+			clientEnv.RunAndExpectSuccess(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--override-username", userName,
+				"--override-hostname", userHost,
+				"--password", userPassword)
+		})
+		t.Run("no client cert, bad password", func(t *testing.T) {
+			clientEnv.RunAndExpectFailure(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--override-username", userName,
+				"--override-hostname", userHost,
+				"--password", "bad-"+userPassword)
+		})
+		t.Run("valid client cert, ignored", func(t *testing.T) {
+			clientEnv.RunAndExpectFailure(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--client-certificate", path.Join(certDir, "client-active.crt"),
+				"--client-key", path.Join(certDir, "client-active.key"),
+				"--override-username", userName,
+				"--override-hostname", userHost)
+		})
+	})
+
+	t.Run("with-tls-ca-file", func(t *testing.T) {
+		clientEnv := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+		delete(clientEnv.Environment, "KOPIA_PASSWORD")
+
+		serverEnv := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+		defer serverEnv.RunAndExpectSuccess(t, "repo", "disconnect")
+
+		serverEnv.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", serverEnv.RepoDir)
+		serverEnv.RunAndExpectSuccess(t, "server", "users", "add", userFull, "--user-password", userPassword)
+
+		var sp testutil.ServerParameters
+
+		wait, kill := serverEnv.RunAndProcessStderr(t, sp.ProcessOutput,
+			"server", "start",
+			"--address=localhost:0",
+			"--tls-generate-cert",
+			"--random-server-control-password",
+			"--shutdown-grace-period", "100ms",
+			"--tls-ca-file="+path.Join(certDir, "kopia-active-ca.crt"),
+		)
+		t.Cleanup(func() {
+			kill()
+			wait()
+			t.Log("server stopped")
+		})
+
+		t.Logf("detected server parameters %#v", sp)
+
+		t.Run("no client cert, good password", func(t *testing.T) {
+			clientEnv.RunAndExpectFailure(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--override-username", userName,
+				"--override-hostname", userHost,
+				"--password", userPassword)
+		})
+		t.Run("no client cert, bad password", func(t *testing.T) {
+			clientEnv.RunAndExpectFailure(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--override-username", userName,
+				"--override-hostname", userHost,
+				"--password", "bad-"+userPassword)
+		})
+		t.Run("valid client cert", func(t *testing.T) {
+			clientEnv.RunAndExpectSuccess(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--client-certificate", path.Join(certDir, "client-active.crt"),
+				"--client-key", path.Join(certDir, "client-active.key"),
+				"--override-username", userName,
+				"--override-hostname", userHost)
+		})
+		t.Run("valid client cert, but no private key has been specified", func(t *testing.T) {
+			clientEnv.RunAndExpectFailure(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--client-certificate", path.Join(certDir, "client-active.crt"),
+				"--override-username", userName,
+				"--override-hostname", userHost)
+		})
+		t.Run("valid client cert, but no public key has been specified", func(t *testing.T) {
+			clientEnv.RunAndExpectSuccess(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--client-certificate", path.Join(certDir, "client-active.crt"),
+				"--client-key", path.Join(certDir, "client-active.key"),
+				"--override-username", userName,
+				"--override-hostname", userHost)
+		})
+		t.Run("valid client cert, username not coherent", func(t *testing.T) {
+			clientEnv.RunAndExpectFailure(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--client-certificate", path.Join(certDir, "client-active.crt"),
+				"--client-key", path.Join(certDir, "client-active.key"),
+				"--override-username", "bad-"+userName,
+				"--override-hostname", userHost)
+		})
+		t.Run("valid client cert, hostname not coherent", func(t *testing.T) {
+			clientEnv.RunAndExpectFailure(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--client-certificate", path.Join(certDir, "client-active.crt"),
+				"--client-key", path.Join(certDir, "client-active.key"),
+				"--override-username", userName,
+				"--override-hostname", "bad-"+userHost)
+		})
+		t.Run("invalid client cert (wrong CA)", func(t *testing.T) {
+			clientEnv.RunAndExpectFailure(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--client-certificate", path.Join(certDir, "client-inactive.crt"),
+				"--client-key", path.Join(certDir, "client-inactive.key"),
+				"--override-username", userName,
+				"--override-hostname", userHost)
+		})
+		t.Run("invalid client cert (expired)", func(t *testing.T) {
+			clientEnv.RunAndExpectFailure(t, "repo", "connect", "server",
+				"--url", sp.BaseURL,
+				"--server-cert-fingerprint", sp.SHA256Fingerprint,
+				"--client-certificate", path.Join(certDir, "client-expired.crt"),
+				"--client-key", path.Join(certDir, "client-expired.key"),
+				"--override-username", userName,
+				"--override-hostname", userHost)
+		})
+	})
+}

--- a/internal/auth/authn_certificate.go
+++ b/internal/auth/authn_certificate.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"context"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+
+	"github.com/kopia/kopia/repo"
+)
+
+type clientCertificateAuthenticator struct{}
+
+func (c *clientCertificateAuthenticator) IsValid(
+	ctx context.Context,
+	_ repo.Repository,
+	username string,
+	_ string,
+) bool {
+	peerInfo, ok := peer.FromContext(ctx)
+	if !ok {
+		// Missing peer information
+		log(ctx).Debug("Missing peer information for GRPC request")
+		return false
+	}
+
+	if peerInfo == nil {
+		// Missing peer information
+		log(ctx).Debug("Nil peer information for GRPC request")
+		return false
+	}
+
+	tlsInfo, ok := peerInfo.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		// This was not a TLS connection
+		log(ctx).Debug("Peer authentication was not a TLS info")
+		return false
+	}
+
+	for _, cert := range tlsInfo.State.PeerCertificates {
+		// TODO(leonardoce): it would be nice to allow the user to map CNs to usernames.
+		// This is the same thing PostgreSQL would do with pg_ident.
+		if username == cert.Subject.CommonName {
+			log(ctx).Debugf(
+				"Found matching client certificate with serial %q for user %q",
+				cert.SerialNumber.String(),
+				username,
+			)
+
+			return true
+		}
+
+		log(ctx).Debugf("Client certificate common name %q does not correspond to the requested username %q",
+			cert.Subject.CommonName,
+			username)
+	}
+
+	return false
+}
+
+func (c *clientCertificateAuthenticator) Refresh(_ context.Context) error {
+	return nil
+}
+
+// AuthenticateClientCertificateUsers returns authenticator that uses the client
+// certificates to authenticate users.
+func AuthenticateClientCertificateUsers() Authenticator {
+	a := &clientCertificateAuthenticator{}
+
+	return a
+}

--- a/internal/auth/authn_certificate_test.go
+++ b/internal/auth/authn_certificate_test.go
@@ -1,0 +1,140 @@
+package auth_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+
+	"github.com/kopia/kopia/internal/auth"
+)
+
+type fakeAuthInfo struct{}
+
+func (fakeAuthInfo) AuthType() string {
+	return "fake auth info"
+}
+
+func fakeCertificateForUser(user string) *x509.Certificate {
+	return &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: user,
+		},
+	}
+}
+
+func TestCertificateAuthenticator(t *testing.T) {
+	tests := []struct {
+		name     string
+		peerInfo *peer.Peer
+		isValid  bool
+		username string
+	}{
+		{
+			name: "No peer info",
+		},
+		{
+			name: "No TLS info",
+			peerInfo: &peer.Peer{
+				AuthInfo: fakeAuthInfo{},
+			},
+		},
+		{
+			name: "No certificates",
+			peerInfo: &peer.Peer{
+				AuthInfo: credentials.TLSInfo{
+					State: tls.ConnectionState{
+						PeerCertificates: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "Single certificate, mismatching user name",
+			peerInfo: &peer.Peer{
+				AuthInfo: credentials.TLSInfo{
+					State: tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{
+							fakeCertificateForUser("test@host"),
+						},
+					},
+				},
+			},
+			username: "toast@host",
+		},
+		{
+			name: "Single certificate, matching user name",
+			peerInfo: &peer.Peer{
+				AuthInfo: credentials.TLSInfo{
+					State: tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{
+							fakeCertificateForUser("test@host"),
+						},
+					},
+				},
+			},
+			username: "test@host",
+			isValid:  true,
+		},
+		{
+			name: "Multiple non-matching certificates",
+			peerInfo: &peer.Peer{
+				AuthInfo: credentials.TLSInfo{
+					State: tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{
+							fakeCertificateForUser("test@host"),
+							fakeCertificateForUser("toast@host"),
+						},
+					},
+				},
+			},
+			username: "teeth@host",
+		},
+		{
+			name: "Multiple certificates, the first in the list matches",
+			peerInfo: &peer.Peer{
+				AuthInfo: credentials.TLSInfo{
+					State: tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{
+							fakeCertificateForUser("test@host"),
+							fakeCertificateForUser("taste@host"),
+							fakeCertificateForUser("toast@host"),
+						},
+					},
+				},
+			},
+			username: "test@host",
+			isValid:  true,
+		},
+		{
+			name: "Multiple certificates, the last in the list matches",
+			peerInfo: &peer.Peer{
+				AuthInfo: credentials.TLSInfo{
+					State: tls.ConnectionState{
+						PeerCertificates: []*x509.Certificate{
+							fakeCertificateForUser("test@host"),
+							fakeCertificateForUser("taste@host"),
+							fakeCertificateForUser("toast@host"),
+						},
+					},
+				},
+			},
+			username: "toast@host",
+			isValid:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := peer.NewContext(context.Background(), test.peerInfo)
+
+			isValid := auth.AuthenticateClientCertificateUsers().IsValid(ctx, nil, test.username, "")
+			require.Equal(t, test.isValid, isValid)
+		})
+	}
+}

--- a/internal/testutil/certs.go
+++ b/internal/testutil/certs.go
@@ -1,0 +1,263 @@
+package testutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/clock"
+)
+
+const (
+	// This is the PEM block type of elliptic curves private key.
+	ecPrivateKeyPEMBlockType = "EC PRIVATE KEY"
+
+	// This is the PEM block type for certificates.
+	certificatePEMBlockType = "CERTIFICATE"
+
+	// How many hours are in a day?
+	hoursInDay = 24
+)
+
+var (
+	// ErrInvalidPrivateKeyPEMBlockType is raised when parsing a private key generated
+	// by this package and a wrong PEM block type is detected.
+	ErrInvalidPrivateKeyPEMBlockType = errors.New("invalid private key PEM block type")
+
+	// ErrInvalidPublicKeyPEMBlockType is raised when parsing a public key generated
+	// by this package and a wrong PEM block type is detected.
+	ErrInvalidPublicKeyPEMBlockType = errors.New("invalid public key PEM block type")
+
+	// serialNumberLimit is the upper limit of the certificate serial number.
+	serialNumberLimit int64 = 1000
+)
+
+// KeyPair represent a pair of keys to be used for asymmetric encryption and a
+// certificate declaring the intended usage of those keys.
+type KeyPair struct {
+	// The private key PEM block
+	Private []byte
+
+	// The certificate PEM block
+	Certificate []byte
+}
+
+// WriteTo writes the public and private key to two separate files.
+func (pair *KeyPair) WriteTo(crt, key string) error {
+	crtFile, err := os.Create(crt) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("while creating %v: %w", crt, err)
+	}
+
+	defer func() {
+		_ = crtFile.Close()
+	}()
+
+	keyFile, err := os.Create(key) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("while creating %v: %w", key, err)
+	}
+
+	defer func() {
+		_ = keyFile.Close()
+	}()
+
+	if _, err := crtFile.Write(pair.Certificate); err != nil {
+		return fmt.Errorf("while writing to %v: %w", crt, err)
+	}
+
+	if _, err := keyFile.Write(pair.Private); err != nil {
+		return fmt.Errorf("while writing to %v: %w", key, err)
+	}
+
+	return nil
+}
+
+// CreateAndSignClientCertificate given a CA keypair, generate and sign a leaf keypair.
+func (pair *KeyPair) CreateAndSignClientCertificate(username string) (*KeyPair, error) {
+	certificateDuration := hoursInDay * time.Hour
+	notBefore := clock.Now().Add(time.Minute * -5)
+	notAfter := notBefore.Add(certificateDuration)
+
+	return pair.createAndSignPairWithValidity(username, notBefore, notAfter)
+}
+
+// CreateAndSignExpiredClientCertificate given a CA keypair, generate and sign a leaf keypair.
+func (pair *KeyPair) CreateAndSignExpiredClientCertificate(username string) (*KeyPair, error) {
+	notBefore := clock.Now().Add(-60 * time.Minute)
+	notAfter := notBefore.Add(-40 * time.Minute)
+
+	return pair.createAndSignPairWithValidity(username, notBefore, notAfter)
+}
+
+// ParseECPrivateKey parse the ECDSA private key stored in the pair.
+func (pair *KeyPair) ParseECPrivateKey() (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode(pair.Private)
+	if block == nil || block.Type != ecPrivateKeyPEMBlockType {
+		return nil, ErrInvalidPrivateKeyPEMBlockType
+	}
+
+	result, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("while parsing private key: %w", err)
+	}
+
+	return result, nil
+}
+
+// ParseCertificate parse certificate stored in the pair.
+func (pair *KeyPair) ParseCertificate() (*x509.Certificate, error) {
+	block, _ := pem.Decode(pair.Certificate)
+	if block == nil || block.Type != certificatePEMBlockType {
+		return nil, ErrInvalidPublicKeyPEMBlockType
+	}
+
+	result, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("while parsing public key: %w", err)
+	}
+
+	return result, nil
+}
+
+func (pair *KeyPair) createAndSignPairWithValidity(
+	host string,
+	notBefore,
+	notAfter time.Time,
+) (*KeyPair, error) {
+	caCertificate, err := pair.ParseCertificate()
+	if err != nil {
+		return nil, err
+	}
+
+	caPrivateKey, err := pair.ParseECPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate a new private key
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("while generating ECDSA private key: %w", err)
+	}
+
+	// Sign the public part of this key with the CA
+	serialNumber, err := rand.Int(rand.Reader, big.NewInt(serialNumberLimit))
+	if err != nil {
+		return nil, fmt.Errorf("can't generate serial number: %w", err)
+	}
+
+	leafTemplate := x509.Certificate{
+		SerialNumber:          serialNumber,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+		Subject: pkix.Name{
+			CommonName: host,
+		},
+	}
+
+	leafTemplate.KeyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement
+	leafTemplate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+
+	certificateBytes, err := x509.CreateCertificate(
+		rand.Reader, &leafTemplate, caCertificate, &leafKey.PublicKey, caPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("while formatting X509 certificate: %w", err)
+	}
+
+	privateKey, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		return nil, fmt.Errorf("while formatting EC private key: %w", err)
+	}
+
+	return &KeyPair{
+		Private:     encodePrivateKey(privateKey),
+		Certificate: encodeCertificate(certificateBytes),
+	}, nil
+}
+
+// CreateRootCA generates a CA returning its keys.
+func CreateRootCA(commonName, organizationalUnit string) (*KeyPair, error) {
+	certificateDuration := hoursInDay * time.Hour
+	notBefore := clock.Now().Add(time.Minute * -5)
+	notAfter := notBefore.Add(certificateDuration)
+
+	return createCAWithValidity(notBefore, notAfter, commonName, organizationalUnit)
+}
+
+// createCAWithValidity create a CA with a certain validity, with a parent certificate and signed by a certain
+// private key. If the latest two parameters are nil, the CA will be a root one (self-signed).
+func createCAWithValidity(
+	notBefore,
+	notAfter time.Time,
+	commonName string,
+	organizationalUnit string,
+) (*KeyPair, error) {
+	serialNumber, err := rand.Int(rand.Reader, big.NewInt(serialNumberLimit))
+	if err != nil {
+		return nil, fmt.Errorf("while generating pseudorandom serial number: %w", err)
+	}
+
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("while generating ECDSA private key: %w", err)
+	}
+
+	rootTemplate := x509.Certificate{
+		SerialNumber:          serialNumber,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		Subject: pkix.Name{
+			CommonName: commonName,
+			OrganizationalUnit: []string{
+				organizationalUnit,
+			},
+		},
+	}
+
+	// self-signed certificate
+	parentCertificate := &rootTemplate
+	parentPrivateKey := rootKey
+
+	certificateBytes, err := x509.CreateCertificate(
+		rand.Reader,
+		&rootTemplate,
+		parentCertificate,
+		&rootKey.PublicKey,
+		parentPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("while formatting X509 certificate: %w", err)
+	}
+
+	privateKey, err := x509.MarshalECPrivateKey(rootKey)
+	if err != nil {
+		return nil, fmt.Errorf("while formatting ECDSA private key: %w", err)
+	}
+
+	return &KeyPair{
+		Private:     encodePrivateKey(privateKey),
+		Certificate: encodeCertificate(certificateBytes),
+	}, nil
+}
+
+func encodeCertificate(derBytes []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: certificatePEMBlockType, Bytes: derBytes})
+}
+
+func encodePrivateKey(derBytes []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: ecPrivateKeyPEMBlockType, Bytes: derBytes})
+}

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -133,6 +133,7 @@ func TLSConfigTrustingSingleCertificate(sha256Fingerprint string) *tls.Config {
 	return &tls.Config{
 		InsecureSkipVerify:    true, //nolint:gosec
 		VerifyPeerCertificate: verifyPeerCertificate(sha256Fingerprint),
+		MinVersion:            tls.VersionTLS13,
 	}
 }
 

--- a/repo/api_server_repository.go
+++ b/repo/api_server_repository.go
@@ -16,6 +16,8 @@ type APIServerInfo struct {
 	BaseURL                             string `json:"url"`
 	TrustedServerCertificateFingerprint string `json:"serverCertFingerprint"`
 	LocalCacheKeyDerivationAlgorithm    string `json:"localCacheKeyDerivationAlgorithm,omitempty"`
+	ClientCertificateFile               string `json:"clientCertificateFile,omitempty"`
+	ClientPrivateKeyFile                string `json:"clientPrivateKeyFile,omitempty"`
 }
 
 // ConnectAPIServer sets up repository connection to a particular API server.

--- a/repo/open.go
+++ b/repo/open.go
@@ -207,7 +207,13 @@ func openAPIServer(ctx context.Context, si *APIServerInfo, cliOpts ClientOptions
 		beforeFlush:      options.BeforeFlush,
 	}
 
-	return openGRPCAPIRepository(ctx, si, password, par)
+	r, err := openGRPCAPIRepository(ctx, si, password, par)
+	if err != nil {
+		closer.Close(ctx) //nolint:errcheck
+		return nil, err
+	}
+
+	return r, nil
 }
 
 // openDirect opens the repository that directly manipulates blob storage..


### PR DESCRIPTION
This update introduces a `--tls-ca-file` command line option for `kopia server start`, enabling users to specify a CA certificate.

With this option specified:

* A client-side certificate is requested during the TLS handshake and
  it will be validated using the CA certificate specified.

* A new authenticator is added, allowing clients to authenticate by
  supplying a valid certificate with its CN field matching the requested
  username.

Additionally, two new options have been added to `kopia repository connect server`: `--client-certificate` and `--client-key`. These options enable users to present a client certificate during the TLS handshake, allowing
authentication with it.