### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.1
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.5
-	github.com/kopia/htmluibuild v0.0.1-0.20250916054243-fc9411799322
+	github.com/kopia/htmluibuild v0.0.1-0.20251023045745-2dce6ef2bd3e
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.5 h1:4cJuyH926If33BeDgiZpI5OU0pE+wUHZvMSyNGqN73Y=
 github.com/klauspost/reedsolomon v1.12.5/go.mod h1:LkXRjLYGM8K/iQfujYnaPeDmhZLqkrGUyG9p7zs5L68=
-github.com/kopia/htmluibuild v0.0.1-0.20250916054243-fc9411799322 h1:spz0L1ixqBXAkGQaWEZlVJUHbalJkgiuzG8JdzdNCC0=
-github.com/kopia/htmluibuild v0.0.1-0.20250916054243-fc9411799322/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20251023045745-2dce6ef2bd3e h1:kJ7T/hnmTbgSF6lznr7BfHNiA1Q8MFcvFDHRosNnEpo=
+github.com/kopia/htmluibuild v0.0.1-0.20251023045745-2dce6ef2bd3e/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/ce2bf7415b2de0a7657f552115a159b3f41838e9...82dd063104957efda149104b740a98c61e80f2d9

* Wed 21:55 -0700 https://github.com/kopia/htmlui/commit/0e23459 dependabot[bot] build(deps-dev): bump prettier from 3.5.3 to 3.6.2
* Wed 21:56 -0700 https://github.com/kopia/htmlui/commit/82ab9d7 dependabot[bot] build(deps-dev): bump vite from 7.1.5 to 7.1.7
* Wed 21:56 -0700 https://github.com/kopia/htmlui/commit/82dd063 dependabot[bot] build(deps): bump @fortawesome/free-solid-svg-icons from 6.7.2 to 7.1.0

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Thu Oct 23 04:58:26 UTC 2025*
