### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.1
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.5
-	github.com/kopia/htmluibuild v0.0.1-0.20251023045745-2dce6ef2bd3e
+	github.com/kopia/htmluibuild v0.0.1-0.20251023173116-207007d16d68
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.5 h1:4cJuyH926If33BeDgiZpI5OU0pE+wUHZvMSyNGqN73Y=
 github.com/klauspost/reedsolomon v1.12.5/go.mod h1:LkXRjLYGM8K/iQfujYnaPeDmhZLqkrGUyG9p7zs5L68=
-github.com/kopia/htmluibuild v0.0.1-0.20251023045745-2dce6ef2bd3e h1:kJ7T/hnmTbgSF6lznr7BfHNiA1Q8MFcvFDHRosNnEpo=
-github.com/kopia/htmluibuild v0.0.1-0.20251023045745-2dce6ef2bd3e/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20251023173116-207007d16d68 h1:K+MpGBXAg/3VidXmoYLl1UxUyXCx3xwcBfPcFuaiF8Y=
+github.com/kopia/htmluibuild v0.0.1-0.20251023173116-207007d16d68/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/82dd063104957efda149104b740a98c61e80f2d9...2dd5d80653c9f69f483623a735c6aabf07fd2101

* 2 minutes ago https://github.com/kopia/htmlui/commit/d35c028 dependabot[bot] build(deps): bump vite
* 2 minutes ago https://github.com/kopia/htmlui/commit/2dd5d80 dependabot[bot] build(deps-dev): bump jsdom from 26.1.0 to 27.0.0

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Thu Oct 23 17:31:56 UTC 2025*
