### PR TITLE
fix(general): field and variable names

### DIFF
--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -321,18 +321,18 @@ func (e *Manager) cleanupInternal(ctx context.Context, cs CurrentSnapshot, p *Pa
 	// may have not observed them yet.
 	maxReplacementTime := maxTime.Add(-p.CleanupSafetyMargin)
 
-	var deletedEpochMarkers, deletedDeletionWaterMarks atomic.Int64
+	var deletedEpochMarkersCount, deletedWatermarksCount atomic.Int64
 
 	eg.Go(func() error {
 		deleted, err := e.cleanupEpochMarkers(ctx, cs)
-		deletedEpochMarkers.Store(int64(deleted))
+		deletedEpochMarkersCount.Store(int64(deleted))
 
 		return err
 	})
 
 	eg.Go(func() error {
 		deleted, err := e.cleanupWatermarks(ctx, cs, p, maxReplacementTime)
-		deletedDeletionWaterMarks.Store(int64(deleted))
+		deletedWatermarksCount.Store(int64(deleted))
 
 		return err
 	})
@@ -342,8 +342,8 @@ func (e *Manager) cleanupInternal(ctx context.Context, cs CurrentSnapshot, p *Pa
 	}
 
 	result := &maintenancestats.CleanupMarkersStats{
-		DeletedEpochMarkerBlobCount:       int(deletedEpochMarkers.Load()),
-		DeletedDeletionWaterMarkBlobCount: int(deletedDeletionWaterMarks.Load()),
+		DeletedEpochMarkerBlobCount: int(deletedEpochMarkersCount.Load()),
+		DeletedWatermarkBlobCount:   int(deletedWatermarksCount.Load()),
 	}
 
 	return result, nil

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -1417,8 +1417,8 @@ func TestCleanupMarkers_CleanUpManyMarkers(t *testing.T) {
 	stats, err := te.mgr.CleanupMarkers(ctx)
 	require.NoError(t, err)
 	require.Equal(t, &maintenancestats.CleanupMarkersStats{
-		DeletedEpochMarkerBlobCount:       3,
-		DeletedDeletionWaterMarkBlobCount: 0,
+		DeletedEpochMarkerBlobCount: 3,
+		DeletedWatermarkBlobCount:   0,
 	}, stats)
 
 	// is the epoch marker preserved?

--- a/repo/maintenancestats/builder_test.go
+++ b/repo/maintenancestats/builder_test.go
@@ -24,12 +24,12 @@ func TestBuildExtraSuccess(t *testing.T) {
 		{
 			name: "succeed",
 			stats: &CleanupMarkersStats{
-				DeletedEpochMarkerBlobCount:       10,
-				DeletedDeletionWaterMarkBlobCount: 20,
+				DeletedEpochMarkerBlobCount: 10,
+				DeletedWatermarkBlobCount:   20,
 			},
 			expected: Extra{
 				Kind: "cleanupMarkersStats",
-				Data: []byte(`{"deletedEpochMarkerBlobCount":10,"deletedDeletionWaterMarkBlobCount":20}`),
+				Data: []byte(`{"deletedEpochMarkerBlobCount":10,"deletedWatermarkBlobCount":20}`),
 			},
 		},
 	}
@@ -81,11 +81,11 @@ func TestBuildFromExtraSuccess(t *testing.T) {
 			name: "cleanupMarkersStats",
 			stats: Extra{
 				Kind: cleanupMarkersStatsKind,
-				Data: []byte(`{"deletedEpochMarkerBlobCount":10,"deletedDeletionWaterMarkBlobCount":20}`),
+				Data: []byte(`{"deletedEpochMarkerBlobCount":10,"deletedWatermarkBlobCount":20}`),
 			},
 			expected: &CleanupMarkersStats{
-				DeletedEpochMarkerBlobCount:       10,
-				DeletedDeletionWaterMarkBlobCount: 20,
+				DeletedEpochMarkerBlobCount: 10,
+				DeletedWatermarkBlobCount:   20,
 			},
 		},
 	}

--- a/repo/maintenancestats/stats_cleanup_markers.go
+++ b/repo/maintenancestats/stats_cleanup_markers.go
@@ -10,21 +10,21 @@ const cleanupMarkersStatsKind = "cleanupMarkersStats"
 
 // CleanupMarkersStats are the stats for cleaning up markers.
 type CleanupMarkersStats struct {
-	DeletedEpochMarkerBlobCount       int `json:"deletedEpochMarkerBlobCount"`
-	DeletedDeletionWaterMarkBlobCount int `json:"deletedDeletionWaterMarkBlobCount"`
+	DeletedEpochMarkerBlobCount int `json:"deletedEpochMarkerBlobCount"`
+	DeletedWatermarkBlobCount   int `json:"deletedWatermarkBlobCount"`
 }
 
 // WriteValueTo writes the stats to JSONWriter.
 func (cs *CleanupMarkersStats) WriteValueTo(jw *contentlog.JSONWriter) {
 	jw.BeginObjectField(cs.Kind())
 	jw.IntField("deletedEpochMarkerBlobCount", cs.DeletedEpochMarkerBlobCount)
-	jw.IntField("deletedDeletionWaterMarkBlobCount", cs.DeletedDeletionWaterMarkBlobCount)
+	jw.IntField("deletedWatermarkBlobCount", cs.DeletedWatermarkBlobCount)
 	jw.EndObject()
 }
 
 // Summary generates a human readable summary for the stats.
 func (cs *CleanupMarkersStats) Summary() string {
-	return fmt.Sprintf("Cleaned up %v epoch markers and %v deletion watermarks", cs.DeletedEpochMarkerBlobCount, cs.DeletedDeletionWaterMarkBlobCount)
+	return fmt.Sprintf("Cleaned up %v epoch markers and %v deletion watermarks", cs.DeletedEpochMarkerBlobCount, cs.DeletedWatermarkBlobCount)
 }
 
 // Kind returns the kind name for the stats.


### PR DESCRIPTION
Fixes field names in `CleanupMarkersStats` persistent struct.
Also renames variables for consistency.

- Followup fix for #4900
- #4848