### PR TITLE
feat(general): add stats to maintenance run - CleanupSupersededIndexes

### DIFF
--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -807,8 +807,9 @@ func TestInvalid_Cleanup(t *testing.T) {
 	ctx, cancel := context.WithCancel(testlogging.Context(t))
 	cancel()
 
-	err := te.mgr.CleanupSupersededIndexes(ctx)
+	stats, err := te.mgr.CleanupSupersededIndexes(ctx)
 	require.ErrorIs(t, err, ctx.Err())
+	require.Nil(t, stats)
 }
 
 //nolint:thelper

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -406,7 +406,10 @@ func runTaskEpochMaintenanceFull(ctx context.Context, runParams RunParameters, s
 
 	return reportRunAndMaybeCheckContentIndex(ctx, runParams.rep, TaskEpochDeleteSupersededIndexes, s, func() (maintenancestats.Kind, error) {
 		userLog(ctx).Info("Cleaning up old index blobs which have already been compacted...")
-		return nil, errors.Wrap(em.CleanupSupersededIndexes(ctx), "error removing superseded epoch index blobs")
+
+		stats, err := em.CleanupSupersededIndexes(ctx)
+
+		return stats, errors.Wrap(err, "error removing superseded epoch index blobs")
 	})
 }
 

--- a/repo/maintenancestats/builder.go
+++ b/repo/maintenancestats/builder.go
@@ -50,6 +50,8 @@ func BuildFromExtra(stats Extra) (Summarizer, error) {
 	switch stats.Kind {
 	case cleanupMarkersStatsKind:
 		result = &CleanupMarkersStats{}
+	case cleanupSupersededIndexesStatsKind:
+		result = &CleanupSupersededIndexesStats{}
 	default:
 		return nil, errors.Wrapf(ErrUnSupportedStatKindError, "invalid kind for stats %v", stats)
 	}

--- a/repo/maintenancestats/builder_test.go
+++ b/repo/maintenancestats/builder_test.go
@@ -2,6 +2,7 @@ package maintenancestats
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -86,6 +87,18 @@ func TestBuildFromExtraSuccess(t *testing.T) {
 			expected: &CleanupMarkersStats{
 				DeletedEpochMarkerBlobCount: 10,
 				DeletedWatermarkBlobCount:   20,
+			},
+		},
+		{
+			name: "cleanupSupersededIndexesStats",
+			stats: Extra{
+				Kind: cleanupSupersededIndexesStatsKind,
+				Data: []byte(`{"maxReplacementTime":"2025-01-01T00:00:00Z","deletedBlobCount":10,"deletedTotalSize":1024}`),
+			},
+			expected: &CleanupSupersededIndexesStats{
+				MaxReplacementTime: time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
+				DeletedBlobCount:   10,
+				DeletedTotalSize:   1024,
 			},
 		},
 	}

--- a/repo/maintenancestats/stats_cleanup_superseded_indexes.go
+++ b/repo/maintenancestats/stats_cleanup_superseded_indexes.go
@@ -1,0 +1,36 @@
+package maintenancestats
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kopia/kopia/internal/contentlog"
+)
+
+const cleanupSupersededIndexesStatsKind = "cleanupSupersededIndexesStats"
+
+// CleanupSupersededIndexesStats are the stats for cleaning up superseded indexes.
+type CleanupSupersededIndexesStats struct {
+	MaxReplacementTime time.Time `json:"maxReplacementTime"`
+	DeletedBlobCount   int       `json:"deletedBlobCount"`
+	DeletedTotalSize   int64     `json:"deletedTotalSize"`
+}
+
+// WriteValueTo writes the stats to JSONWriter.
+func (cs *CleanupSupersededIndexesStats) WriteValueTo(jw *contentlog.JSONWriter) {
+	jw.BeginObjectField(cs.Kind())
+	jw.TimeField("maxReplacementTime", cs.MaxReplacementTime)
+	jw.IntField("deletedBlobCount", cs.DeletedBlobCount)
+	jw.Int64Field("deletedTotalSize", cs.DeletedTotalSize)
+	jw.EndObject()
+}
+
+// Summary generates a human readable summary for the stats.
+func (cs *CleanupSupersededIndexesStats) Summary() string {
+	return fmt.Sprintf("Cleaned up %v(%v) superseded index blobs, max replacement time %v", cs.DeletedBlobCount, cs.DeletedTotalSize, cs.MaxReplacementTime)
+}
+
+// Kind returns the kind name for the stats.
+func (cs *CleanupSupersededIndexesStats) Kind() string {
+	return cleanupSupersededIndexesStatsKind
+}


### PR DESCRIPTION
Maintenance is critical for healthy of the repository.
On the other hand, Maintenance is complex, because it runs multiple sub tasks each may generate different results according to the maintenance policy. The results may include deleting/combining/adding data/metadata to the repository.

It is worthy to add more observability for these tasks for below reasons:

- It is helpful for troubleshooting. Any data change to the repository is critical, the observability info helps to understand what happened during the maintenance and why that happened
- It is helpful for users to understand/predict the repo's behavior. The repo data may be stored in a public cloud for which costs are sensitive to scale/duration of data stored. On the other hand, repository has its own policy to manage the data, so the data is not deleted until it is safe enough according to the policy. The observability info helps users to understand how much data is in-use, how much data is out of use and when it is deleted

There will be a serial of PRs to add observability info for each sub task.
The current PR add the stats info for CleanupSupersededIndexes sub task.