### PR TITLE
feat(general): add stats to maintenance run - GenerateRangeCheckpoint

### DIFF
--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -387,7 +387,9 @@ func runTaskEpochMaintenanceFull(ctx context.Context, runParams RunParameters, s
 	if err := reportRunAndMaybeCheckContentIndex(ctx, runParams.rep, TaskEpochGenerateRange, s, func() (maintenancestats.Kind, error) {
 		userLog(ctx).Info("Attempting to compact a range of epoch indexes ...")
 
-		return nil, errors.Wrap(em.MaybeGenerateRangeCheckpoint(ctx), "error creating epoch range indexes")
+		stats, err := em.MaybeGenerateRangeCheckpoint(ctx)
+
+		return stats, errors.Wrap(err, "error creating epoch range indexes")
 	}); err != nil {
 		return err
 	}

--- a/repo/maintenancestats/builder.go
+++ b/repo/maintenancestats/builder.go
@@ -52,6 +52,8 @@ func BuildFromExtra(stats Extra) (Summarizer, error) {
 		result = &CleanupMarkersStats{}
 	case cleanupSupersededIndexesStatsKind:
 		result = &CleanupSupersededIndexesStats{}
+	case generateRangeCheckpointStatsKind:
+		result = &GenerateRangeCheckpointStats{}
 	default:
 		return nil, errors.Wrapf(ErrUnSupportedStatKindError, "invalid kind for stats %v", stats)
 	}

--- a/repo/maintenancestats/builder_test.go
+++ b/repo/maintenancestats/builder_test.go
@@ -101,6 +101,17 @@ func TestBuildFromExtraSuccess(t *testing.T) {
 				DeletedTotalSize:   1024,
 			},
 		},
+		{
+			name: "generateRangeCheckpointStats",
+			stats: Extra{
+				Kind: generateRangeCheckpointStatsKind,
+				Data: []byte(`{"firstEpoch":3,"lastEpoch":5}`),
+			},
+			expected: &GenerateRangeCheckpointStats{
+				FirstEpoch: 3,
+				LastEpoch:  5,
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/repo/maintenancestats/stats_generate_range_checkpoint.go
+++ b/repo/maintenancestats/stats_generate_range_checkpoint.go
@@ -1,0 +1,33 @@
+package maintenancestats
+
+import (
+	"fmt"
+
+	"github.com/kopia/kopia/internal/contentlog"
+)
+
+const generateRangeCheckpointStatsKind = "generateRangeCheckpointStats"
+
+// GenerateRangeCheckpointStats are the stats for generating range checkpoints.
+type GenerateRangeCheckpointStats struct {
+	FirstEpoch int `json:"firstEpoch"`
+	LastEpoch  int `json:"lastEpoch"`
+}
+
+// WriteValueTo writes the stats to JSONWriter.
+func (gs *GenerateRangeCheckpointStats) WriteValueTo(jw *contentlog.JSONWriter) {
+	jw.BeginObjectField(gs.Kind())
+	jw.IntField("firstEpoch", gs.FirstEpoch)
+	jw.IntField("lastEpoch", gs.LastEpoch)
+	jw.EndObject()
+}
+
+// Summary generates a human readable summary for the stats.
+func (gs *GenerateRangeCheckpointStats) Summary() string {
+	return fmt.Sprintf("Generated a range checkpoint from epoch %v to %v", gs.FirstEpoch, gs.LastEpoch)
+}
+
+// Kind returns the kind name for the stats.
+func (gs *GenerateRangeCheckpointStats) Kind() string {
+	return generateRangeCheckpointStatsKind
+}


### PR DESCRIPTION
Maintenance is critical for healthy of the repository.
On the other hand, Maintenance is complex, because it runs multiple sub tasks each may generate different results according to the maintenance policy. The results may include deleting/combining/adding data/metadata to the repository.

It is worthy to add more observability for these tasks for below reasons:

- It is helpful for troubleshooting. Any data change to the repository is critical, the observability info helps to understand what happened during the maintenance and why that happened
- It is helpful for users to understand/predict the repo's behavior. The repo data may be stored in a public cloud for which costs are sensitive to scale/duration of data stored. On the other hand, repository has its own policy to manage the data, so the data is not deleted until it is safe enough according to the policy. The observability info helps users to understand how much data is in-use, how much data is out of use and when it is deleted

There will be a serial of PRs to add observability info for each sub task.
The current PR add the stats info for GenerateRangeCheckpoint sub task.