### PR TITLE
refactor(general): `diskCommitedContentIndexCache`

### DIFF
--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -37,7 +37,7 @@ func (c *diskCommittedContentIndexCache) indexBlobPath(indexBlobID blob.ID) stri
 func (c *diskCommittedContentIndexCache) openIndex(ctx context.Context, indexBlobID blob.ID) (index.Index, error) {
 	fullpath := c.indexBlobPath(indexBlobID)
 
-	f, closeMmap, err := c.mmapOpenWithRetry(ctx, fullpath)
+	f, closeMmap, err := c.mmapFile(ctx, fullpath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
No functional changes
- simplifies function name to `mmapFile` to better reflect what it does
- rename parameter to `filename` for clarity
- expands comment for clarity