### PR TITLE
feat(general): add stats to maintenance run - CompactSingleEpoch

### DIFF
--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -764,7 +764,7 @@ func (e *Manager) MaybeAdvanceWriteEpoch(ctx context.Context) (*maintenancestats
 			return nil, errors.Wrap(err, "error advancing epoch")
 		}
 
-		result.CurrentEpoch++
+		result.CurrentEpoch = cs.WriteEpoch + 1
 		result.WasAdvanced = true
 	}
 
@@ -1020,21 +1020,21 @@ func (e *Manager) getCompleteIndexSetForCommittedState(ctx context.Context, cs C
 
 // MaybeCompactSingleEpoch compacts the oldest epoch that is eligible for
 // compaction if there is one.
-func (e *Manager) MaybeCompactSingleEpoch(ctx context.Context) error {
+func (e *Manager) MaybeCompactSingleEpoch(ctx context.Context) (*maintenancestats.CompactSingleEpochStats, error) {
 	cs, err := e.committedState(ctx, 0)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	uncompacted, err := oldestUncompactedEpoch(cs)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !cs.isSettledEpochNumber(uncompacted) {
 		contentlog.Log1(ctx, e.log, "there are no uncompacted epochs eligible for compaction", logparam.Int("oldestUncompactedEpoch", uncompacted))
 
-		return nil
+		return nil, nil
 	}
 
 	uncompactedBlobs, ok := cs.UncompactedEpochSets[uncompacted]
@@ -1042,19 +1042,30 @@ func (e *Manager) MaybeCompactSingleEpoch(ctx context.Context) error {
 		// blobs for this epoch were not loaded in the current snapshot, get the list of blobs for this epoch
 		ue, err := blob.ListAllBlobs(ctx, e.st, UncompactedEpochBlobPrefix(uncompacted))
 		if err != nil {
-			return errors.Wrapf(err, "error listing uncompacted indexes for epoch %v", uncompacted)
+			return nil, errors.Wrapf(err, "error listing uncompacted indexes for epoch %v", uncompacted)
 		}
 
 		uncompactedBlobs = ue
 	}
 
-	contentlog.Log1(ctx, e.log, "starting single-epoch compaction for epoch", logparam.Int("uncompacted", uncompacted))
-
-	if err := e.compact(ctx, blob.IDsFromMetadata(uncompactedBlobs), compactedEpochBlobPrefix(uncompacted)); err != nil {
-		return errors.Wrapf(err, "unable to compact blobs for epoch %v: performance will be affected", uncompacted)
+	var uncompactedSize int64
+	for _, b := range uncompactedBlobs {
+		uncompactedSize += b.Length
 	}
 
-	return nil
+	result := &maintenancestats.CompactSingleEpochStats{
+		CompactedBlobCount: len(uncompactedBlobs),
+		CompactedBlobSize:  uncompactedSize,
+		Epoch:              uncompacted,
+	}
+
+	contentlog.Log1(ctx, e.log, "starting single-epoch compaction for epoch", result)
+
+	if err := e.compact(ctx, blob.IDsFromMetadata(uncompactedBlobs), compactedEpochBlobPrefix(uncompacted)); err != nil {
+		return nil, errors.Wrapf(err, "unable to compact blobs for epoch %v: performance will be affected", uncompacted)
+	}
+
+	return result, nil
 }
 
 func (e *Manager) getIndexesFromEpochInternal(ctx context.Context, cs CurrentSnapshot, epoch int) ([]blob.Metadata, error) {

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -353,7 +353,10 @@ func runTaskEpochAdvance(ctx context.Context, em *epoch.Manager, runParams RunPa
 func runTaskEpochMaintenanceQuick(ctx context.Context, em *epoch.Manager, runParams RunParameters, s *Schedule) error {
 	err := reportRunAndMaybeCheckContentIndex(ctx, runParams.rep, TaskEpochCompactSingle, s, func() (maintenancestats.Kind, error) {
 		userLog(ctx).Info("Compacting an eligible uncompacted epoch...")
-		return nil, errors.Wrap(em.MaybeCompactSingleEpoch(ctx), "error compacting single epoch")
+
+		stats, err := em.MaybeCompactSingleEpoch(ctx)
+
+		return stats, errors.Wrap(err, "error compacting single epoch")
 	})
 	if err != nil {
 		return err
@@ -377,7 +380,10 @@ func runTaskEpochMaintenanceFull(ctx context.Context, runParams RunParameters, s
 	// compact a single epoch
 	if err := reportRunAndMaybeCheckContentIndex(ctx, runParams.rep, TaskEpochCompactSingle, s, func() (maintenancestats.Kind, error) {
 		userLog(ctx).Info("Compacting an eligible uncompacted epoch...")
-		return nil, errors.Wrap(em.MaybeCompactSingleEpoch(ctx), "error compacting single epoch")
+
+		stats, err := em.MaybeCompactSingleEpoch(ctx)
+
+		return stats, errors.Wrap(err, "error compacting single epoch")
 	}); err != nil {
 		return err
 	}

--- a/repo/maintenancestats/builder.go
+++ b/repo/maintenancestats/builder.go
@@ -56,6 +56,8 @@ func BuildFromExtra(stats Extra) (Summarizer, error) {
 		result = &GenerateRangeCheckpointStats{}
 	case advanceEpochStatsKind:
 		result = &AdvanceEpochStats{}
+	case compactSingleEpochStatsKind:
+		result = &CompactSingleEpochStats{}
 	default:
 		return nil, errors.Wrapf(ErrUnSupportedStatKindError, "invalid kind for stats %v", stats)
 	}

--- a/repo/maintenancestats/builder_test.go
+++ b/repo/maintenancestats/builder_test.go
@@ -55,6 +55,18 @@ func TestBuildExtraSuccess(t *testing.T) {
 				Data: []byte(`{"currentEpoch":3,"wasAdvanced":true}`),
 			},
 		},
+		{
+			name: "CompactSingleEpochStats",
+			stats: &CompactSingleEpochStats{
+				CompactedBlobCount: 3,
+				CompactedBlobSize:  4096,
+				Epoch:              1,
+			},
+			expected: Extra{
+				Kind: compactSingleEpochStatsKind,
+				Data: []byte(`{"compactedBlobCount":3,"compactedBlobSize":4096,"epoch":1}`),
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -143,6 +155,18 @@ func TestBuildFromExtraSuccess(t *testing.T) {
 			expected: &AdvanceEpochStats{
 				CurrentEpoch: 3,
 				WasAdvanced:  true,
+			},
+		},
+		{
+			name: "CompactSingleEpochStats",
+			stats: Extra{
+				Kind: compactSingleEpochStatsKind,
+				Data: []byte(`{"compactedBlobCount":3,"compactedBlobSize":4096,"epoch":1}`),
+			},
+			expected: &CompactSingleEpochStats{
+				CompactedBlobCount: 3,
+				CompactedBlobSize:  4096,
+				Epoch:              1,
 			},
 		},
 	}

--- a/repo/maintenancestats/stats_compact_single_epoch.go
+++ b/repo/maintenancestats/stats_compact_single_epoch.go
@@ -1,0 +1,35 @@
+package maintenancestats
+
+import (
+	"fmt"
+
+	"github.com/kopia/kopia/internal/contentlog"
+)
+
+const compactSingleEpochStatsKind = "compactSingleEpochStats"
+
+// CompactSingleEpochStats are the stats for compacting an index epoch.
+type CompactSingleEpochStats struct {
+	CompactedBlobCount int   `json:"compactedBlobCount"`
+	CompactedBlobSize  int64 `json:"compactedBlobSize"`
+	Epoch              int   `json:"epoch"`
+}
+
+// WriteValueTo writes the stats to JSONWriter.
+func (cs *CompactSingleEpochStats) WriteValueTo(jw *contentlog.JSONWriter) {
+	jw.BeginObjectField(cs.Kind())
+	jw.IntField("compactedBlobCount", cs.CompactedBlobCount)
+	jw.Int64Field("compactedBlobSize", cs.CompactedBlobSize)
+	jw.IntField("epoch", cs.Epoch)
+	jw.EndObject()
+}
+
+// Summary generates a human readable summary for the stats.
+func (cs *CompactSingleEpochStats) Summary() string {
+	return fmt.Sprintf("Compacted %v(%v) index blobs for epoch %v", cs.CompactedBlobCount, cs.CompactedBlobSize, cs.Epoch)
+}
+
+// Kind returns the kind name for the stats.
+func (cs *CompactSingleEpochStats) Kind() string {
+	return compactSingleEpochStatsKind
+}


### PR DESCRIPTION
Maintenance is critical for healthy of the repository.
On the other hand, Maintenance is complex, because it runs multiple sub tasks each may generate different results according to the maintenance policy. The results may include deleting/combining/adding data/metadata to the repository.

It is worthy to add more observability for these tasks for below reasons:

- It is helpful for troubleshooting. Any data change to the repository is critical, the observability info helps to understand what happened during the maintenance and why that happened
- It is helpful for users to understand/predict the repo's behavior. The repo data may be stored in a public cloud for which costs are sensitive to scale/duration of data stored. On the other hand, repository has its own policy to manage the data, so the data is not deleted until it is safe enough according to the policy. The observability info helps users to understand how much data is in-use, how much data is out of use and when it is deleted

There will be a serial of PRs to add observability info for each sub task.
The current PR add the stats info for CompactSingleEpoch sub task.