### PR TITLE
refactor(general): fix field names in `CompactSingleEpochStats`

### DIFF
--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -1054,9 +1054,9 @@ func (e *Manager) MaybeCompactSingleEpoch(ctx context.Context) (*maintenancestat
 	}
 
 	result := &maintenancestats.CompactSingleEpochStats{
-		CompactedBlobCount: len(uncompactedBlobs),
-		CompactedBlobSize:  uncompactedSize,
-		Epoch:              uncompacted,
+		SupersededIndexBlobCount: len(uncompactedBlobs),
+		SupersededIndexTotalSize: uncompactedSize,
+		Epoch:                    uncompacted,
 	}
 
 	contentlog.Log1(ctx, e.log, "starting single-epoch compaction for epoch", result)

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -1018,7 +1018,7 @@ func TestMaybeCompactSingleEpoch(t *testing.T) {
 	for j := range newestEpochToCompact {
 		stats, err := te.mgr.MaybeCompactSingleEpoch(ctx)
 		require.NoError(t, err)
-		require.Equal(t, idxCount, stats.CompactedBlobCount)
+		require.Equal(t, idxCount, stats.SupersededIndexBlobCount)
 		require.Equal(t, j, stats.Epoch)
 
 		err = te.mgr.Refresh(ctx) // force state refresh
@@ -1244,7 +1244,7 @@ func TestMaybeGenerateRangeCheckpoint_FromCompactedEpochs(t *testing.T) {
 	for j := range newestEpochToCompact {
 		stats, err := te.mgr.MaybeCompactSingleEpoch(ctx)
 		require.NoError(t, err)
-		require.Equal(t, idxCount, stats.CompactedBlobCount)
+		require.Equal(t, idxCount, stats.SupersededIndexBlobCount)
 		require.Equal(t, j, stats.Epoch)
 
 		err = te.mgr.Refresh(ctx) // force state refresh

--- a/repo/maintenancestats/builder_test.go
+++ b/repo/maintenancestats/builder_test.go
@@ -58,13 +58,13 @@ func TestBuildExtraSuccess(t *testing.T) {
 		{
 			name: "CompactSingleEpochStats",
 			stats: &CompactSingleEpochStats{
-				CompactedBlobCount: 3,
-				CompactedBlobSize:  4096,
-				Epoch:              1,
+				SupersededIndexBlobCount: 3,
+				SupersededIndexTotalSize: 4096,
+				Epoch:                    1,
 			},
 			expected: Extra{
 				Kind: compactSingleEpochStatsKind,
-				Data: []byte(`{"compactedBlobCount":3,"compactedBlobSize":4096,"epoch":1}`),
+				Data: []byte(`{"supersededIndexBlobCount":3,"supersededIndexTotalSize":4096,"epoch":1}`),
 			},
 		},
 	}
@@ -161,12 +161,12 @@ func TestBuildFromExtraSuccess(t *testing.T) {
 			name: "CompactSingleEpochStats",
 			stats: Extra{
 				Kind: compactSingleEpochStatsKind,
-				Data: []byte(`{"compactedBlobCount":3,"compactedBlobSize":4096,"epoch":1}`),
+				Data: []byte(`{"supersededIndexBlobCount":3,"supersededIndexTotalSize":4096,"epoch":1}`),
 			},
 			expected: &CompactSingleEpochStats{
-				CompactedBlobCount: 3,
-				CompactedBlobSize:  4096,
-				Epoch:              1,
+				SupersededIndexBlobCount: 3,
+				SupersededIndexTotalSize: 4096,
+				Epoch:                    1,
 			},
 		},
 	}

--- a/repo/maintenancestats/stats_compact_single_epoch.go
+++ b/repo/maintenancestats/stats_compact_single_epoch.go
@@ -10,23 +10,23 @@ const compactSingleEpochStatsKind = "compactSingleEpochStats"
 
 // CompactSingleEpochStats are the stats for compacting an index epoch.
 type CompactSingleEpochStats struct {
-	CompactedBlobCount int   `json:"compactedBlobCount"`
-	CompactedBlobSize  int64 `json:"compactedBlobSize"`
-	Epoch              int   `json:"epoch"`
+	SupersededIndexBlobCount int   `json:"supersededIndexBlobCount"`
+	SupersededIndexTotalSize int64 `json:"supersededIndexTotalSize"`
+	Epoch                    int   `json:"epoch"`
 }
 
 // WriteValueTo writes the stats to JSONWriter.
 func (cs *CompactSingleEpochStats) WriteValueTo(jw *contentlog.JSONWriter) {
 	jw.BeginObjectField(cs.Kind())
-	jw.IntField("compactedBlobCount", cs.CompactedBlobCount)
-	jw.Int64Field("compactedBlobSize", cs.CompactedBlobSize)
+	jw.IntField("supersededIndexBlobCount", cs.SupersededIndexBlobCount)
+	jw.Int64Field("supersededIndexTotalSize", cs.SupersededIndexTotalSize)
 	jw.IntField("epoch", cs.Epoch)
 	jw.EndObject()
 }
 
 // Summary generates a human readable summary for the stats.
 func (cs *CompactSingleEpochStats) Summary() string {
-	return fmt.Sprintf("Compacted %v(%v) index blobs for epoch %v", cs.CompactedBlobCount, cs.CompactedBlobSize, cs.Epoch)
+	return fmt.Sprintf("Compacted %v(%v) index blobs for epoch %v", cs.SupersededIndexBlobCount, cs.SupersededIndexTotalSize, cs.Epoch)
 }
 
 // Kind returns the kind name for the stats.


### PR DESCRIPTION
- Followup to #4941