### PR TITLE
refactor(general): consistently use "pack" where possible

### DIFF
--- a/cli/command_blob_gc.go
+++ b/cli/command_blob_gc.go
@@ -33,13 +33,13 @@ func (c *commandBlobGC) setup(svc appServices, parent commandParent) {
 func (c *commandBlobGC) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
 	c.svc.dangerousCommand()
 
-	opts := maintenance.DeleteUnreferencedBlobsOptions{
+	opts := maintenance.DeleteUnreferencedPacksOptions{
 		DryRun:   c.delete != "yes",
 		Parallel: c.parallel,
 		Prefix:   blob.ID(c.prefix),
 	}
 
-	stats, err := maintenance.DeleteUnreferencedBlobs(ctx, rep, opts, c.safety)
+	stats, err := maintenance.DeleteUnreferencedPacks(ctx, rep, opts, c.safety)
 	if err != nil {
 		return errors.Wrap(err, "error deleting unreferenced blobs")
 	}

--- a/repo/maintenance/maintenance_safety.go
+++ b/repo/maintenance/maintenance_safety.go
@@ -26,7 +26,7 @@ type SafetyParameters struct {
 	DropContentFromIndexExtraMargin time.Duration
 
 	// Blob GC: Delete unused blobs above this age.
-	BlobDeleteMinAge time.Duration
+	PackDeleteMinAge time.Duration
 
 	// Blob GC: Drop incomplete session blobs above this age.
 	SessionExpirationAge time.Duration
@@ -43,7 +43,7 @@ var (
 	// delays, but it is safe only if no other kopia clients are running and storage backend is
 	// strongly consistent.
 	SafetyNone = SafetyParameters{
-		BlobDeleteMinAge:                 0,
+		PackDeleteMinAge:                 0,
 		DropContentFromIndexExtraMargin:  0,
 		MarginBetweenSnapshotGC:          0,
 		MinContentAgeSubjectToGC:         0,
@@ -56,7 +56,7 @@ var (
 	// SafetyFull has default safety parameters which allow safe GC concurrent with snapshotting
 	// by other Kopia clients.
 	SafetyFull = SafetyParameters{
-		BlobDeleteMinAge:                24 * time.Hour, //nolint:mnd
+		PackDeleteMinAge:                24 * time.Hour, //nolint:mnd
 		DropContentFromIndexExtraMargin: time.Hour,
 		MarginBetweenSnapshotGC:         4 * time.Hour,  //nolint:mnd
 		MinContentAgeSubjectToGC:        24 * time.Hour, //nolint:mnd

--- a/repo/maintenance/pack_gc_test.go
+++ b/repo/maintenance/pack_gc_test.go
@@ -30,7 +30,7 @@ var testHMACSecret = []byte{1, 2, 3}
 
 var testMasterKey = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 
-func (s *formatSpecificTestSuite) TestDeleteUnreferencedBlobs(t *testing.T) {
+func (s *formatSpecificTestSuite) TestDeleteUnreferencedPacks(t *testing.T) {
 	// set up fake clock which is initially synchronized to wall clock time
 	// and moved at the same speed but which can be moved forward.
 	ta := faketime.NewClockTimeWithOffset(0)
@@ -70,7 +70,7 @@ func (s *formatSpecificTestSuite) TestDeleteUnreferencedBlobs(t *testing.T) {
 	verifyBlobExists(t, env.RepositoryWriter.BlobStorage(), extraBlobID2)
 
 	// new blobs not will be deleted because of minimum age requirement
-	_, err = maintenance.DeleteUnreferencedBlobs(ctx, env.RepositoryWriter, maintenance.DeleteUnreferencedBlobsOptions{}, maintenance.SafetyFull)
+	_, err = maintenance.DeleteUnreferencedPacks(ctx, env.RepositoryWriter, maintenance.DeleteUnreferencedPacksOptions{}, maintenance.SafetyFull)
 	require.NoError(t, err)
 
 	verifyBlobExists(t, env.RepositoryWriter.BlobStorage(), extraBlobID1)
@@ -78,12 +78,12 @@ func (s *formatSpecificTestSuite) TestDeleteUnreferencedBlobs(t *testing.T) {
 
 	// mixed safety parameters
 	safetyFastDeleteLongSessionExpiration := maintenance.SafetyParameters{
-		BlobDeleteMinAge:     1,
+		PackDeleteMinAge:     1,
 		SessionExpirationAge: 4 * 24 * time.Hour,
 	}
 
 	// new blobs will be deleted
-	_, err = maintenance.DeleteUnreferencedBlobs(ctx, env.RepositoryWriter, maintenance.DeleteUnreferencedBlobsOptions{}, maintenance.SafetyNone)
+	_, err = maintenance.DeleteUnreferencedPacks(ctx, env.RepositoryWriter, maintenance.DeleteUnreferencedPacksOptions{}, maintenance.SafetyNone)
 	require.NoError(t, err)
 
 	verifyBlobNotFound(t, env.RepositoryWriter.BlobStorage(), extraBlobID1)
@@ -107,7 +107,7 @@ func (s *formatSpecificTestSuite) TestDeleteUnreferencedBlobs(t *testing.T) {
 		CheckpointTime: ta.NowFunc()(),
 	})
 
-	_, err = maintenance.DeleteUnreferencedBlobs(ctx, env.RepositoryWriter, maintenance.DeleteUnreferencedBlobsOptions{}, safetyFastDeleteLongSessionExpiration)
+	_, err = maintenance.DeleteUnreferencedPacks(ctx, env.RepositoryWriter, maintenance.DeleteUnreferencedPacksOptions{}, safetyFastDeleteLongSessionExpiration)
 	require.NoError(t, err)
 
 	verifyBlobExists(t, env.RepositoryWriter.BlobStorage(), extraBlobIDWithSession1)
@@ -119,7 +119,7 @@ func (s *formatSpecificTestSuite) TestDeleteUnreferencedBlobs(t *testing.T) {
 	// now finish session 2
 	env.RepositoryWriter.BlobStorage().DeleteBlob(ctx, session2Marker)
 
-	_, err = maintenance.DeleteUnreferencedBlobs(ctx, env.RepositoryWriter, maintenance.DeleteUnreferencedBlobsOptions{}, safetyFastDeleteLongSessionExpiration)
+	_, err = maintenance.DeleteUnreferencedPacks(ctx, env.RepositoryWriter, maintenance.DeleteUnreferencedPacksOptions{}, safetyFastDeleteLongSessionExpiration)
 	require.NoError(t, err)
 
 	verifyBlobExists(t, env.RepositoryWriter.BlobStorage(), extraBlobIDWithSession1)
@@ -131,7 +131,7 @@ func (s *formatSpecificTestSuite) TestDeleteUnreferencedBlobs(t *testing.T) {
 	// now move time into the future making session 1 timed out
 	ta.Advance(7 * 24 * time.Hour)
 
-	_, err = maintenance.DeleteUnreferencedBlobs(ctx, env.RepositoryWriter, maintenance.DeleteUnreferencedBlobsOptions{}, maintenance.SafetyFull)
+	_, err = maintenance.DeleteUnreferencedPacks(ctx, env.RepositoryWriter, maintenance.DeleteUnreferencedPacksOptions{}, maintenance.SafetyFull)
 	require.NoError(t, err)
 
 	verifyBlobNotFound(t, env.RepositoryWriter.BlobStorage(), extraBlobIDWithSession1)


### PR DESCRIPTION
In kopia, "blob" is a generic term to refer to either an object in an object storage provider, or a file in a file system storage provider. There are various types of blobs in a kopia repository.

In kopia, "pack" is used to refer to specific types of blobs, namely 'p' & 'q' pack blobs, that store
"content" data, as opposed to say, "index" blobs.

This change attempts to use the term "pack" consistently in the functions and types used for pack deletion.

Note that the corresponding task names, shown below, remain unchanged since these names are used in the persistent maintenance run metadata, and that is used to make decisions about the safety of the execution of those tasks.

```
	TaskDeleteOrphanedBlobsQuick     = "quick-delete-blobs"
	TaskDeleteOrphanedBlobsFull      = "full-delete-blobs"
```