### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.1
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.5
-	github.com/kopia/htmluibuild v0.0.1-0.20251023173116-207007d16d68
+	github.com/kopia/htmluibuild v0.0.1-0.20251105034914-f12567e61c09
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.5 h1:4cJuyH926If33BeDgiZpI5OU0pE+wUHZvMSyNGqN73Y=
 github.com/klauspost/reedsolomon v1.12.5/go.mod h1:LkXRjLYGM8K/iQfujYnaPeDmhZLqkrGUyG9p7zs5L68=
-github.com/kopia/htmluibuild v0.0.1-0.20251023173116-207007d16d68 h1:K+MpGBXAg/3VidXmoYLl1UxUyXCx3xwcBfPcFuaiF8Y=
-github.com/kopia/htmluibuild v0.0.1-0.20251023173116-207007d16d68/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20251105034914-f12567e61c09 h1:0TO/LYinyVZSCKQBB1KTG8F7zicg9yME+Ec3AUrp4i4=
+github.com/kopia/htmluibuild v0.0.1-0.20251105034914-f12567e61c09/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/2dd5d80653c9f69f483623a735c6aabf07fd2101...e3466375a38b8f5792dd8e1ba277755747c54284

* Tue 19:47 -0800 https://github.com/kopia/htmlui/commit/9d9fe5c dependabot[bot] build(deps-dev): bump eslint from 9.28.0 to 9.39.0
* Tue 19:47 -0800 https://github.com/kopia/htmlui/commit/a57c17c dependabot[bot] build(deps): bump react-router-dom from 7.7.1 to 7.9.5
* Tue 19:47 -0800 https://github.com/kopia/htmlui/commit/25e490c dependabot[bot] build(deps-dev): bump @vitejs/plugin-react from 4.7.0 to 5.1.0
* Tue 19:48 -0800 https://github.com/kopia/htmlui/commit/e346637 dependabot[bot] build(deps-dev): bump globals from 16.3.0 to 16.5.0

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Wed Nov  5 03:49:36 UTC 2025*
