### PR TITLE
feat(general): add stats to maintenance run - DeleteUnreferencedPacks

### DIFF
--- a/cli/command_blob_gc.go
+++ b/cli/command_blob_gc.go
@@ -39,12 +39,12 @@ func (c *commandBlobGC) run(ctx context.Context, rep repo.DirectRepositoryWriter
 		Prefix:   blob.ID(c.prefix),
 	}
 
-	n, err := maintenance.DeleteUnreferencedBlobs(ctx, rep, opts, c.safety)
+	stats, err := maintenance.DeleteUnreferencedBlobs(ctx, rep, opts, c.safety)
 	if err != nil {
 		return errors.Wrap(err, "error deleting unreferenced blobs")
 	}
 
-	if opts.DryRun && n > 0 {
+	if opts.DryRun && stats.UnreferencedPackCount > 0 {
 		log(ctx).Info("Pass --delete=yes to delete.")
 	}
 

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -469,24 +469,20 @@ func runTaskRewriteContentsFull(ctx context.Context, runParams RunParameters, s 
 
 func runTaskDeleteOrphanedBlobsFull(ctx context.Context, runParams RunParameters, s *Schedule, safety SafetyParameters) error {
 	return reportRunAndMaybeCheckContentIndex(ctx, runParams.rep, TaskDeleteOrphanedBlobsFull, s, func() (maintenancestats.Kind, error) {
-		_, err := DeleteUnreferencedBlobs(ctx, runParams.rep, DeleteUnreferencedBlobsOptions{
+		return DeleteUnreferencedBlobs(ctx, runParams.rep, DeleteUnreferencedBlobsOptions{
 			NotAfterTime: runParams.MaintenanceStartTime,
 			Parallel:     runParams.Params.ListParallelism,
 		}, safety)
-
-		return nil, err
 	})
 }
 
 func runTaskDeleteOrphanedBlobsQuick(ctx context.Context, runParams RunParameters, s *Schedule, safety SafetyParameters) error {
 	return reportRunAndMaybeCheckContentIndex(ctx, runParams.rep, TaskDeleteOrphanedBlobsQuick, s, func() (maintenancestats.Kind, error) {
-		_, err := DeleteUnreferencedBlobs(ctx, runParams.rep, DeleteUnreferencedBlobsOptions{
+		return DeleteUnreferencedBlobs(ctx, runParams.rep, DeleteUnreferencedBlobsOptions{
 			NotAfterTime: runParams.MaintenanceStartTime,
 			Prefix:       content.PackBlobIDPrefixSpecial,
 			Parallel:     runParams.Params.ListParallelism,
 		}, safety)
-
-		return nil, err
 	})
 }
 

--- a/repo/maintenancestats/builder.go
+++ b/repo/maintenancestats/builder.go
@@ -60,6 +60,8 @@ func BuildFromExtra(stats Extra) (Summarizer, error) {
 		result = &CompactSingleEpochStats{}
 	case compactIndexesStatsKind:
 		result = &CompactIndexesStats{}
+	case deleteUnreferencedPacksStatsKind:
+		result = &DeleteUnreferencedPacksStats{}
 	default:
 		return nil, errors.Wrapf(ErrUnSupportedStatKindError, "invalid kind for stats %v", stats)
 	}

--- a/repo/maintenancestats/builder_test.go
+++ b/repo/maintenancestats/builder_test.go
@@ -77,6 +77,21 @@ func TestBuildExtraSuccess(t *testing.T) {
 				Data: []byte(`{"droppedContentsDeletedBefore":"2025-01-01T00:00:00Z"}`),
 			},
 		},
+		{
+			name: "DeleteUnreferencedPacksStats",
+			stats: &DeleteUnreferencedPacksStats{
+				UnreferencedPackCount: 50,
+				UnreferencedTotalSize: 4096,
+				DeletedPackCount:      20,
+				DeletedTotalSize:      2048,
+				RetainedPackCount:     30,
+				RetainedTotalSize:     2048,
+			},
+			expected: Extra{
+				Kind: deleteUnreferencedPacksStatsKind,
+				Data: []byte(`{"unreferencedPackCount":50,"unreferencedTotalSize":4096,"deletedPackCount":20,"deletedTotalSize":2048,"retainedPackCount":30,"retainedTotalSize":2048}`),
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -187,6 +202,21 @@ func TestBuildFromExtraSuccess(t *testing.T) {
 			},
 			expected: &CompactIndexesStats{
 				DroppedContentsDeletedBefore: time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "DeleteUnreferencedPacksStats",
+			stats: Extra{
+				Kind: deleteUnreferencedPacksStatsKind,
+				Data: []byte(`{"unreferencedPackCount":50,"unreferencedTotalSize":4096,"deletedPackCount":20,"deletedTotalSize":2048,"retainedPackCount":30,"retainedTotalSize":2048}`),
+			},
+			expected: &DeleteUnreferencedPacksStats{
+				UnreferencedPackCount: 50,
+				UnreferencedTotalSize: 4096,
+				DeletedPackCount:      20,
+				DeletedTotalSize:      2048,
+				RetainedPackCount:     30,
+				RetainedTotalSize:     2048,
 			},
 		},
 	}

--- a/repo/maintenancestats/stats_delete_unreferenced_packs.go
+++ b/repo/maintenancestats/stats_delete_unreferenced_packs.go
@@ -1,0 +1,41 @@
+package maintenancestats
+
+import (
+	"fmt"
+
+	"github.com/kopia/kopia/internal/contentlog"
+)
+
+const deleteUnreferencedPacksStatsKind = "deleteUnreferencedPacksStats"
+
+// DeleteUnreferencedPacksStats are the stats for deleting unreferenced packs.
+type DeleteUnreferencedPacksStats struct {
+	UnreferencedPackCount uint32 `json:"unreferencedPackCount"`
+	UnreferencedTotalSize int64  `json:"unreferencedTotalSize"`
+	DeletedPackCount      uint32 `json:"deletedPackCount"`
+	DeletedTotalSize      int64  `json:"deletedTotalSize"`
+	RetainedPackCount     uint32 `json:"retainedPackCount"`
+	RetainedTotalSize     int64  `json:"retainedTotalSize"`
+}
+
+// WriteValueTo writes the stats to JSONWriter.
+func (ds *DeleteUnreferencedPacksStats) WriteValueTo(jw *contentlog.JSONWriter) {
+	jw.BeginObjectField(ds.Kind())
+	jw.UInt32Field("unreferencedPackCount", ds.UnreferencedPackCount)
+	jw.Int64Field("unreferencedTotalSize", ds.UnreferencedTotalSize)
+	jw.UInt32Field("deletedPackCount", ds.DeletedPackCount)
+	jw.Int64Field("deletedTotalSize", ds.DeletedTotalSize)
+	jw.UInt32Field("retainedPackCount", ds.RetainedPackCount)
+	jw.Int64Field("retainedTotalSize", ds.RetainedTotalSize)
+	jw.EndObject()
+}
+
+// Summary generates a human readable summary for the stats.
+func (ds *DeleteUnreferencedPacksStats) Summary() string {
+	return fmt.Sprintf("Found %v(%v) unreferenced pack blobs, deleted %v(%v) and retained %v(%v).", ds.UnreferencedPackCount, ds.UnreferencedTotalSize, ds.DeletedPackCount, ds.DeletedTotalSize, ds.RetainedPackCount, ds.RetainedTotalSize)
+}
+
+// Kind returns the kind name for the stats.
+func (ds *DeleteUnreferencedPacksStats) Kind() string {
+	return deleteUnreferencedPacksStatsKind
+}


### PR DESCRIPTION
Maintenance is critical for healthy of the repository.
On the other hand, Maintenance is complex, because it runs multiple sub tasks each may generate different results according to the maintenance policy. The results may include deleting/combining/adding data/metadata to the repository.

It is worthy to add more observability for these tasks for below reasons:

- It is helpful for troubleshooting. Any data change to the repository is critical, the observability info helps to understand what happened during the maintenance and why that happened
- It is helpful for users to understand/predict the repo's behavior. The repo data may be stored in a public cloud for which costs are sensitive to scale/duration of data stored. On the other hand, repository has its own policy to manage the data, so the data is not deleted until it is safe enough according to the policy. The observability info helps users to understand how much data is in-use, how much data is out of use and when it is deleted

There will be a serial of PRs to add observability info for each sub task.
The current PR add the stats info for DeleteUnreferencedPacks sub task.