### PR TITLE
feat(general): add stats to maintenance run - CleanupLogs

### DIFF
--- a/cli/command_logs_cleanup.go
+++ b/cli/command_logs_cleanup.go
@@ -31,7 +31,7 @@ func (c *commandLogsCleanup) setup(svc appServices, parent commandParent) {
 func (c *commandLogsCleanup) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
 	rep.LogManager().Disable()
 
-	toDelete, err := maintenance.CleanupLogs(ctx, rep, maintenance.LogRetentionOptions{
+	stats, err := maintenance.CleanupLogs(ctx, rep, maintenance.LogRetentionOptions{
 		MaxTotalSize: c.maxTotalSizeMB << 20, //nolint:mnd
 		MaxCount:     c.maxCount,
 		MaxAge:       c.maxAge,
@@ -41,11 +41,11 @@ func (c *commandLogsCleanup) run(ctx context.Context, rep repo.DirectRepositoryW
 		return errors.Wrap(err, "error expiring logs")
 	}
 
-	if len(toDelete) > 0 {
+	if stats.ToDeleteBlobCount > 0 {
 		if c.dryRun {
-			log(ctx).Infof("Would delete %v logs.", len(toDelete))
+			log(ctx).Infof("Would delete %v logs.", stats.ToDeleteBlobCount)
 		} else {
-			log(ctx).Infof("Deleted %v logs.", len(toDelete))
+			log(ctx).Infof("Deleted %v logs.", stats.DeletedBlobCount)
 		}
 	} else {
 		log(ctx).Info("No logs found to delete.")

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -332,11 +332,11 @@ func notDeletingOrphanedBlobs(ctx context.Context, log *contentlog.Logger, s *Sc
 
 func runTaskCleanupLogs(ctx context.Context, runParams RunParameters, s *Schedule) error {
 	return ReportRun(ctx, runParams.rep, TaskCleanupLogs, s, func() (maintenancestats.Kind, error) {
-		deleted, err := CleanupLogs(ctx, runParams.rep, runParams.Params.LogRetention.OrDefault())
+		stats, err := CleanupLogs(ctx, runParams.rep, runParams.Params.LogRetention.OrDefault())
 
-		userLog(ctx).Infof("Cleaned up %v logs.", len(deleted))
+		userLog(ctx).Infof("Cleaned up %v logs.", stats.DeletedBlobCount)
 
-		return nil, err
+		return stats, err
 	})
 }
 

--- a/repo/maintenancestats/builder.go
+++ b/repo/maintenancestats/builder.go
@@ -64,6 +64,8 @@ func BuildFromExtra(stats Extra) (Summarizer, error) {
 		result = &DeleteUnreferencedPacksStats{}
 	case extendBlobRetentionStatsKind:
 		result = &ExtendBlobRetentionStats{}
+	case cleanupLogsStatsKind:
+		result = &CleanupLogsStats{}
 	default:
 		return nil, errors.Wrapf(ErrUnSupportedStatKindError, "invalid kind for stats %v", stats)
 	}

--- a/repo/maintenancestats/builder_test.go
+++ b/repo/maintenancestats/builder_test.go
@@ -104,6 +104,21 @@ func TestBuildExtraSuccess(t *testing.T) {
 				Data: []byte(`{"toExtendBlobCount":10,"extendedBlobCount":10,"retentionPeriod":"360h0m0s"}`),
 			},
 		},
+		{
+			name: "CleanupLogsStats",
+			stats: &CleanupLogsStats{
+				ToDeleteBlobCount: 10,
+				ToDeleteBlobSize:  1024,
+				DeletedBlobCount:  5,
+				DeletedBlobSize:   512,
+				RetainedBlobCount: 20,
+				RetainedBlobSize:  2048,
+			},
+			expected: Extra{
+				Kind: cleanupLogsStatsKind,
+				Data: []byte(`{"toDeleteBlobCount":10,"toDeleteBlobSize":1024,"deletedBlobCount":5,"deletedBlobSize":512,"retainedBlobCount":20,"retainedBlobSize":2048}`),
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -241,6 +256,21 @@ func TestBuildFromExtraSuccess(t *testing.T) {
 				ToExtendBlobCount: 10,
 				ExtendedBlobCount: 10,
 				RetentionPeriod:   (time.Hour * 24 * 15).String(),
+			},
+		},
+		{
+			name: "CleanupLogsStats",
+			stats: Extra{
+				Kind: cleanupLogsStatsKind,
+				Data: []byte(`{"toDeleteBlobCount":10,"toDeleteBlobSize":1024,"retainedBlobCount":20,"retainedBlobSize":2048,"deletedBlobCount":5,"deletedBlobSize":512}`),
+			},
+			expected: &CleanupLogsStats{
+				ToDeleteBlobCount: 10,
+				ToDeleteBlobSize:  1024,
+				RetainedBlobCount: 20,
+				RetainedBlobSize:  2048,
+				DeletedBlobCount:  5,
+				DeletedBlobSize:   512,
 			},
 		},
 	}

--- a/repo/maintenancestats/stats_clean_up_log.go
+++ b/repo/maintenancestats/stats_clean_up_log.go
@@ -1,0 +1,41 @@
+package maintenancestats
+
+import (
+	"fmt"
+
+	"github.com/kopia/kopia/internal/contentlog"
+)
+
+const cleanupLogsStatsKind = "cleanupLogsStats"
+
+// CleanupLogsStats are the stats for cleanning up logs.
+type CleanupLogsStats struct {
+	ToDeleteBlobCount int   `json:"toDeleteBlobCount"`
+	ToDeleteBlobSize  int64 `json:"toDeleteBlobSize"`
+	DeletedBlobCount  int   `json:"deletedBlobCount"`
+	DeletedBlobSize   int64 `json:"deletedBlobSize"`
+	RetainedBlobCount int   `json:"retainedBlobCount"`
+	RetainedBlobSize  int64 `json:"retainedBlobSize"`
+}
+
+// WriteValueTo writes the stats to JSONWriter.
+func (cs *CleanupLogsStats) WriteValueTo(jw *contentlog.JSONWriter) {
+	jw.BeginObjectField(cs.Kind())
+	jw.IntField("toDeleteBlobCount", cs.ToDeleteBlobCount)
+	jw.Int64Field("toDeleteBlobSize", cs.ToDeleteBlobSize)
+	jw.IntField("deletedBlobCount", cs.DeletedBlobCount)
+	jw.Int64Field("deletedBlobSize", cs.DeletedBlobSize)
+	jw.IntField("retainedBlobCount", cs.RetainedBlobCount)
+	jw.Int64Field("retainedBlobSize", cs.RetainedBlobSize)
+	jw.EndObject()
+}
+
+// Summary generates a human readable summary for the stats.
+func (cs *CleanupLogsStats) Summary() string {
+	return fmt.Sprintf("Found %v(%v) logs blobs for deletion and deleted %v(%v) of them. Retained %v(%v) log blobs.", cs.ToDeleteBlobCount, cs.ToDeleteBlobSize, cs.DeletedBlobCount, cs.DeletedBlobSize, cs.RetainedBlobCount, cs.RetainedBlobSize)
+}
+
+// Kind returns the kind name for the stats.
+func (cs *CleanupLogsStats) Kind() string {
+	return cleanupLogsStatsKind
+}


### PR DESCRIPTION
Maintenance is critical for healthy of the repository.
On the other hand, Maintenance is complex, because it runs multiple sub tasks each may generate different results according to the maintenance policy. The results may include deleting/combining/adding data/metadata to the repository.

It is worthy to add more observability for these tasks for below reasons:

- It is helpful for troubleshooting. Any data change to the repository is critical, the observability info helps to understand what happened during the maintenance and why that happened
- It is helpful for users to understand/predict the repo's behavior. The repo data may be stored in a public cloud for which costs are sensitive to scale/duration of data stored. On the other hand, repository has its own policy to manage the data, so the data is not deleted until it is safe enough according to the policy. The observability info helps users to understand how much data is in-use, how much data is out of use and when it is deleted

There will be a serial of PRs to add observability info for each sub task.
The current PR add the stats info for CleanupLogs sub task.