### PR TITLE
feat(general): add stats to maintenance run - RewriteContents

### DIFF
--- a/cli/command_content_rewrite.go
+++ b/cli/command_content_rewrite.go
@@ -48,8 +48,7 @@ func (c *commandContentRewrite) runContentRewriteCommand(ctx context.Context, re
 		return err
 	}
 
-	//nolint:wrapcheck
-	return maintenance.RewriteContents(ctx, rep, &maintenance.RewriteContentsOptions{
+	_, err = maintenance.RewriteContents(ctx, rep, &maintenance.RewriteContentsOptions{
 		ContentIDRange: c.contentRange.contentIDRange(),
 		ContentIDs:     contentIDs,
 		FormatVersion:  c.contentRewriteFormatVersion,
@@ -58,6 +57,8 @@ func (c *commandContentRewrite) runContentRewriteCommand(ctx context.Context, re
 		ShortPacks:     c.contentRewriteShortPacks,
 		DryRun:         c.contentRewriteDryRun,
 	}, c.contentRewriteSafety)
+
+	return errors.Wrap(err, "error rewriting contents")
 }
 
 func toContentIDs(s []string) ([]content.ID, error) {

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -450,7 +450,7 @@ func runTaskDropDeletedContentsFull(ctx context.Context, runParams RunParameters
 
 func runTaskRewriteContentsQuick(ctx context.Context, runParams RunParameters, s *Schedule, safety SafetyParameters) error {
 	return reportRunAndMaybeCheckContentIndex(ctx, runParams.rep, TaskRewriteContentsQuick, s, func() (maintenancestats.Kind, error) {
-		return nil, RewriteContents(ctx, runParams.rep, &RewriteContentsOptions{
+		return RewriteContents(ctx, runParams.rep, &RewriteContentsOptions{
 			ContentIDRange: index.AllPrefixedIDs,
 			PackPrefix:     content.PackBlobIDPrefixSpecial,
 			ShortPacks:     true,
@@ -460,7 +460,7 @@ func runTaskRewriteContentsQuick(ctx context.Context, runParams RunParameters, s
 
 func runTaskRewriteContentsFull(ctx context.Context, runParams RunParameters, s *Schedule, safety SafetyParameters) error {
 	return reportRunAndMaybeCheckContentIndex(ctx, runParams.rep, TaskRewriteContentsFull, s, func() (maintenancestats.Kind, error) {
-		return nil, RewriteContents(ctx, runParams.rep, &RewriteContentsOptions{
+		return RewriteContents(ctx, runParams.rep, &RewriteContentsOptions{
 			ContentIDRange: index.AllIDs,
 			ShortPacks:     true,
 		}, safety)

--- a/repo/maintenancestats/builder.go
+++ b/repo/maintenancestats/builder.go
@@ -66,6 +66,8 @@ func BuildFromExtra(stats Extra) (Summarizer, error) {
 		result = &ExtendBlobRetentionStats{}
 	case cleanupLogsStatsKind:
 		result = &CleanupLogsStats{}
+	case rewriteContentsStatsKind:
+		result = &RewriteContentsStats{}
 	default:
 		return nil, errors.Wrapf(ErrUnSupportedStatKindError, "invalid kind for stats %v", stats)
 	}

--- a/repo/maintenancestats/builder_test.go
+++ b/repo/maintenancestats/builder_test.go
@@ -119,6 +119,21 @@ func TestBuildExtraSuccess(t *testing.T) {
 				Data: []byte(`{"toDeleteBlobCount":10,"toDeleteBlobSize":1024,"deletedBlobCount":5,"deletedBlobSize":512,"retainedBlobCount":20,"retainedBlobSize":2048}`),
 			},
 		},
+		{
+			name: "RewriteContentsStats",
+			stats: &RewriteContentsStats{
+				ToRewriteContentCount: 30,
+				ToRewriteContentSize:  3092,
+				RewrittenContentCount: 10,
+				RewrittenContentSize:  1024,
+				RetainedContentCount:  20,
+				RetainedContentSize:   2048,
+			},
+			expected: Extra{
+				Kind: rewriteContentsStatsKind,
+				Data: []byte(`{"toRewriteContentCount":30,"toRewriteContentSize":3092,"rewrittenContentCount":10,"rewrittenContentSize":1024,"retainedContentCount":20,"retainedContentSize":2048}`),
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -271,6 +286,21 @@ func TestBuildFromExtraSuccess(t *testing.T) {
 				RetainedBlobSize:  2048,
 				DeletedBlobCount:  5,
 				DeletedBlobSize:   512,
+			},
+		},
+		{
+			name: "RewriteContentsStats",
+			stats: Extra{
+				Kind: rewriteContentsStatsKind,
+				Data: []byte(`{"toRewriteContentCount":30,"toRewriteContentSize":3092,"rewrittenContentCount":10,"rewrittenContentSize":1024,"retainedContentCount":20,"retainedContentSize":2048}`),
+			},
+			expected: &RewriteContentsStats{
+				ToRewriteContentCount: 30,
+				ToRewriteContentSize:  3092,
+				RewrittenContentCount: 10,
+				RewrittenContentSize:  1024,
+				RetainedContentCount:  20,
+				RetainedContentSize:   2048,
 			},
 		},
 	}

--- a/repo/maintenancestats/stats_delete_unreferenced_packs.go
+++ b/repo/maintenancestats/stats_delete_unreferenced_packs.go
@@ -32,7 +32,8 @@ func (ds *DeleteUnreferencedPacksStats) WriteValueTo(jw *contentlog.JSONWriter) 
 
 // Summary generates a human readable summary for the stats.
 func (ds *DeleteUnreferencedPacksStats) Summary() string {
-	return fmt.Sprintf("Found %v(%v) unreferenced pack blobs, deleted %v(%v) and retained %v(%v).", ds.UnreferencedPackCount, ds.UnreferencedTotalSize, ds.DeletedPackCount, ds.DeletedTotalSize, ds.RetainedPackCount, ds.RetainedTotalSize)
+	return fmt.Sprintf("Found %v(%v) unreferenced pack blobs to delete and deleted %v(%v). Retained %v(%v) unreferenced pack blobs.",
+		ds.UnreferencedPackCount, ds.UnreferencedTotalSize, ds.DeletedPackCount, ds.DeletedTotalSize, ds.RetainedPackCount, ds.RetainedTotalSize)
 }
 
 // Kind returns the kind name for the stats.

--- a/repo/maintenancestats/stats_rewrite_contents.go
+++ b/repo/maintenancestats/stats_rewrite_contents.go
@@ -1,0 +1,42 @@
+package maintenancestats
+
+import (
+	"fmt"
+
+	"github.com/kopia/kopia/internal/contentlog"
+)
+
+const rewriteContentsStatsKind = "rewriteContentsStats"
+
+// RewriteContentsStats are the stats for rewritting contents.
+type RewriteContentsStats struct {
+	ToRewriteContentCount int   `json:"toRewriteContentCount"`
+	ToRewriteContentSize  int64 `json:"toRewriteContentSize"`
+	RewrittenContentCount int   `json:"rewrittenContentCount"`
+	RewrittenContentSize  int64 `json:"rewrittenContentSize"`
+	RetainedContentCount  int   `json:"retainedContentCount"`
+	RetainedContentSize   int64 `json:"retainedContentSize"`
+}
+
+// WriteValueTo writes the stats to JSONWriter.
+func (rs *RewriteContentsStats) WriteValueTo(jw *contentlog.JSONWriter) {
+	jw.BeginObjectField(rs.Kind())
+	jw.IntField("toRewriteContentCount", rs.ToRewriteContentCount)
+	jw.Int64Field("toRewriteContentSize", rs.ToRewriteContentSize)
+	jw.IntField("rewrittenContentCount", rs.RewrittenContentCount)
+	jw.Int64Field("rewrittenContentSize", rs.RewrittenContentSize)
+	jw.IntField("retainedContentCount", rs.RetainedContentCount)
+	jw.Int64Field("retainedContentSize", rs.RetainedContentSize)
+	jw.EndObject()
+}
+
+// Summary generates a human readable summary for the stats.
+func (rs *RewriteContentsStats) Summary() string {
+	return fmt.Sprintf("Found %v(%v) contents to rewrite, and rewritten %v(%v). Retained %v(%v) contents from rewrite",
+		rs.ToRewriteContentCount, rs.ToRewriteContentSize, rs.RewrittenContentCount, rs.RewrittenContentSize, rs.RetainedContentCount, rs.RetainedContentSize)
+}
+
+// Kind returns the kind name for the stats.
+func (rs *RewriteContentsStats) Kind() string {
+	return rewriteContentsStatsKind
+}


### PR DESCRIPTION
Maintenance is critical for healthy of the repository.
On the other hand, Maintenance is complex, because it runs multiple sub tasks each may generate different results according to the maintenance policy. The results may include deleting/combining/adding data/metadata to the repository.

It is worthy to add more observability for these tasks for below reasons:

- It is helpful for troubleshooting. Any data change to the repository is critical, the observability info helps to understand what happened during the maintenance and why that happened
- It is helpful for users to understand/predict the repo's behavior. The repo data may be stored in a public cloud for which costs are sensitive to scale/duration of data stored. On the other hand, repository has its own policy to manage the data, so the data is not deleted until it is safe enough according to the policy. The observability info helps users to understand how much data is in-use, how much data is out of use and when it is deleted

There will be a serial of PRs to add observability info for each sub task.
The current PR add the stats info for RewriteContents sub task.