### PR TITLE
fix(ci): use safer `t.Setenv`

### DIFF
--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -256,9 +256,7 @@ func TestServerStartAsyncRepoConnect(t *testing.T) {
 }
 
 func TestServerCreateAndConnectViaAPI(t *testing.T) {
-	t.Parallel()
-
-	os.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "true")
+	t.Setenv("KOPIA_UPGRADE_LOCK_ENABLED", "true")
 
 	ctx := testlogging.Context(t)
 


### PR DESCRIPTION
`TestServerCreateAndConnectViaAPI` now runs sequentially as required by `t.Setenv` to avoid conflicts with other tests.