### PR TITLE
chore(ci): enable `modernize:omitzero` linter setting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,9 +80,6 @@ linters:
         - (*go.uber.org/zap.SugaredLogger).With
     misspell:
       locale: US
-    modernize:
-      disable:
-        - omitzero
     wsl_v5:
       allow-whole-block: true
       disable:

--- a/snapshot/policy/compression_policy.go
+++ b/snapshot/policy/compression_policy.go
@@ -28,8 +28,8 @@ type MetadataCompressionPolicy struct {
 // CompressionPolicyDefinition specifies which policy definition provided the value of a particular field.
 type CompressionPolicyDefinition struct {
 	CompressorName snapshot.SourceInfo `json:"compressorName,omitzero"`
-	OnlyCompress   snapshot.SourceInfo `json:"onlyCompress,omitempty"`
-	NeverCompress  snapshot.SourceInfo `json:"neverCompress,omitempty"`
+	OnlyCompress   snapshot.SourceInfo `json:"onlyCompress,omitempty"`  //nolint:modernize
+	NeverCompress  snapshot.SourceInfo `json:"neverCompress,omitempty"` //nolint:modernize
 	MinSize        snapshot.SourceInfo `json:"minSize,omitzero"`
 	MaxSize        snapshot.SourceInfo `json:"maxSize,omitzero"`
 }

--- a/snapshot/policy/files_policy.go
+++ b/snapshot/policy/files_policy.go
@@ -15,9 +15,9 @@ type FilesPolicy struct {
 
 // FilesPolicyDefinition specifies which policy definition provided the value of a particular field.
 type FilesPolicyDefinition struct {
-	IgnoreRules            snapshot.SourceInfo `json:"ignore,omitempty"`
+	IgnoreRules            snapshot.SourceInfo `json:"ignore,omitempty"` //nolint:modernize
 	NoParentIgnoreRules    snapshot.SourceInfo `json:"noParentIgnore,omitzero"`
-	DotIgnoreFiles         snapshot.SourceInfo `json:"ignoreDotFiles,omitempty"`
+	DotIgnoreFiles         snapshot.SourceInfo `json:"ignoreDotFiles,omitempty"` //nolint:modernize
 	NoParentDotIgnoreFiles snapshot.SourceInfo `json:"noParentDotFiles,omitzero"`
 	IgnoreCacheDirectories snapshot.SourceInfo `json:"ignoreCacheDirs,omitzero"`
 	MaxFileSize            snapshot.SourceInfo `json:"maxFileSize,omitzero"`

--- a/snapshot/policy/scheduling_policy.go
+++ b/snapshot/policy/scheduling_policy.go
@@ -74,8 +74,8 @@ type SchedulingPolicy struct {
 // SchedulingPolicyDefinition specifies which policy definition provided the value of a particular field.
 type SchedulingPolicyDefinition struct {
 	IntervalSeconds snapshot.SourceInfo `json:"intervalSeconds,omitzero"`
-	TimesOfDay      snapshot.SourceInfo `json:"timeOfDay,omitempty"`
-	Cron            snapshot.SourceInfo `json:"cron,omitempty"`
+	TimesOfDay      snapshot.SourceInfo `json:"timeOfDay,omitempty"` //nolint:modernize
+	Cron            snapshot.SourceInfo `json:"cron,omitempty"`      //nolint:modernize
 	Manual          snapshot.SourceInfo `json:"manual,omitzero"`
 	RunMissed       snapshot.SourceInfo `json:"runMissed,omitzero"`
 }


### PR DESCRIPTION
The `//nolint:modernize` annotations are needed to maintain equivalence between the policy "value" and policy "definition" structs.

- #4910
- #4973