### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.1
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.12.5
-	github.com/kopia/htmluibuild v0.0.1-0.20251105034914-f12567e61c09
+	github.com/kopia/htmluibuild v0.0.1-0.20251116050943-21e0ff6b9f53
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.12.5 h1:4cJuyH926If33BeDgiZpI5OU0pE+wUHZvMSyNGqN73Y=
 github.com/klauspost/reedsolomon v1.12.5/go.mod h1:LkXRjLYGM8K/iQfujYnaPeDmhZLqkrGUyG9p7zs5L68=
-github.com/kopia/htmluibuild v0.0.1-0.20251105034914-f12567e61c09 h1:0TO/LYinyVZSCKQBB1KTG8F7zicg9yME+Ec3AUrp4i4=
-github.com/kopia/htmluibuild v0.0.1-0.20251105034914-f12567e61c09/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20251116050943-21e0ff6b9f53 h1:VXelG7g4eGoMncbdr5TK7QALrY7vU5+FJnJ3jh0z45U=
+github.com/kopia/htmluibuild v0.0.1-0.20251116050943-21e0ff6b9f53/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/e3466375a38b8f5792dd8e1ba277755747c54284...05c14db09d899c9b66a9e3ef88d614972a04c020

* Sat 21:08 -0800 https://github.com/kopia/htmlui/commit/05c14db dependabot[bot] build(deps-dev): bump js-yaml from 4.1.0 to 4.1.1

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Sun Nov 16 05:10:07 UTC 2025*
