### PR TITLE
feat(snapshots): handle birthtime store and restore on available oses

### DIFF
--- a/cli/command_policy_set_upload.go
+++ b/cli/command_policy_set_upload.go
@@ -12,12 +12,14 @@ type policyUploadFlags struct {
 	maxParallelUploads            string
 	maxParallelFileReads          string
 	parallelizeUploadAboveSizeMiB string
+	preserveBirthTime             string
 }
 
 func (c *policyUploadFlags) setup(cmd *kingpin.CmdClause) {
 	cmd.Flag("max-parallel-file-reads", "Maximum number of parallel file reads").StringVar(&c.maxParallelFileReads)
 	cmd.Flag("max-parallel-snapshots", "Maximum number of parallel snapshots (server, KopiaUI only)").StringVar(&c.maxParallelUploads)
 	cmd.Flag("parallel-upload-above-size-mib", "Use parallel uploads above size").StringVar(&c.parallelizeUploadAboveSizeMiB)
+	cmd.Flag("preserve-birth-time", "Capture and restore file birth time on supported platforms ('true', 'false', 'inherit')").EnumVar(&c.preserveBirthTime, booleanEnumValues...)
 }
 
 func (c *policyUploadFlags) setUploadPolicyFromFlags(ctx context.Context, up *policy.UploadPolicy, changeCount *int) error {
@@ -29,5 +31,9 @@ func (c *policyUploadFlags) setUploadPolicyFromFlags(ctx context.Context, up *po
 		return err
 	}
 
-	return applyOptionalInt64MiB(ctx, "parallel upload above size", &up.ParallelUploadAboveSize, c.parallelizeUploadAboveSizeMiB, changeCount)
+	if err := applyOptionalInt64MiB(ctx, "parallel upload above size", &up.ParallelUploadAboveSize, c.parallelizeUploadAboveSizeMiB, changeCount); err != nil {
+		return err
+	}
+
+	return applyPolicyBoolPtr(ctx, "preserve birth time", &up.PreserveBirthTime, c.preserveBirthTime, changeCount)
 }

--- a/cli/command_policy_show.go
+++ b/cli/command_policy_show.go
@@ -277,6 +277,7 @@ func appendUploadPolicyRows(rows []policyTableRow, p *policy.Policy, def *policy
 		policyTableRow{"  Max parallel snapshots (server/UI):", valueOrNotSet(p.UploadPolicy.MaxParallelSnapshots), definitionPointToString(p.Target(), def.UploadPolicy.MaxParallelSnapshots)},
 		policyTableRow{"  Max parallel file reads:", valueOrNotSet(p.UploadPolicy.MaxParallelFileReads), definitionPointToString(p.Target(), def.UploadPolicy.MaxParallelFileReads)},
 		policyTableRow{"  Parallel upload above size:", valueOrNotSetOptionalInt64Bytes(p.UploadPolicy.ParallelUploadAboveSize), definitionPointToString(p.Target(), def.UploadPolicy.ParallelUploadAboveSize)},
+		policyTableRow{"  Preserve birth time:", boolToString(p.UploadPolicy.PreserveBirthTime.OrDefault(false)), definitionPointToString(p.Target(), def.UploadPolicy.PreserveBirthTime)},
 	)
 }
 

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -34,6 +35,20 @@ type OwnerInfo struct {
 type DeviceInfo struct {
 	Dev  uint64 `json:"dev"`
 	Rdev uint64 `json:"rdev"`
+}
+
+// EntryWithBirthTime is optionally implemented by Entry to provide birth time (creation time).
+type EntryWithBirthTime interface {
+	Entry
+	BirthTime() time.Time
+}
+
+// GetBirthTime extracts birth time from an entry if available, otherwise returns zero time.
+func GetBirthTime(e Entry) time.Time {
+	if ewb, ok := e.(EntryWithBirthTime); ok {
+		return ewb.BirthTime()
+	}
+	return time.Time{}
 }
 
 // Reader allows reading from a file and retrieving its up-to-date file info.

--- a/fs/ignorefs/ignorefs.go
+++ b/fs/ignorefs/ignorefs.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -150,6 +151,15 @@ func (d *ignoreDirectory) DirEntryOrNil(ctx context.Context) (*snapshot.DirEntry
 	}
 	// Ignored directories do not have DirEntry objects.
 	return nil, nil
+}
+
+// BirthTime returns the birth time of the wrapped directory if available.
+// This ensures that ignoreDirectory preserves the EntryWithBirthTime interface.
+func (d *ignoreDirectory) BirthTime() time.Time {
+	if ewb, ok := d.Directory.(fs.EntryWithBirthTime); ok {
+		return ewb.BirthTime()
+	}
+	return time.Time{}
 }
 
 type ignoreDirIterator struct {

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -14,12 +14,13 @@ import (
 const numEntriesToRead = 100 // number of directory entries to read in one shot
 
 type filesystemEntry struct {
-	name       string
-	size       int64
-	mtimeNanos int64
-	mode       os.FileMode
-	owner      fs.OwnerInfo
-	device     fs.DeviceInfo
+	name        string
+	size        int64
+	mtimeNanos  int64
+	btimeNanos  int64
+	mode        os.FileMode
+	owner       fs.OwnerInfo
+	device      fs.DeviceInfo
 
 	prefix string
 }
@@ -42,6 +43,14 @@ func (e *filesystemEntry) Size() int64 {
 
 func (e *filesystemEntry) ModTime() time.Time {
 	return time.Unix(0, e.mtimeNanos)
+}
+
+func (e *filesystemEntry) BirthTime() time.Time {
+	if e.btimeNanos == 0 {
+		// Birth time not available or not supported
+		return time.Time{}
+	}
+	return time.Unix(0, e.btimeNanos)
 }
 
 func (e *filesystemEntry) Sys() any {

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -14,13 +14,13 @@ import (
 const numEntriesToRead = 100 // number of directory entries to read in one shot
 
 type filesystemEntry struct {
-	name        string
-	size        int64
-	mtimeNanos  int64
-	btimeNanos  int64
-	mode        os.FileMode
-	owner       fs.OwnerInfo
-	device      fs.DeviceInfo
+	name       string
+	size       int64
+	mtimeNanos int64
+	btimeNanos int64
+	mode       os.FileMode
+	owner      fs.OwnerInfo
+	device     fs.DeviceInfo
 
 	prefix string
 }

--- a/fs/localfs/local_fs_btime_darwin.go
+++ b/fs/localfs/local_fs_btime_darwin.go
@@ -1,0 +1,10 @@
+package localfs
+
+import (
+	"syscall"
+)
+
+func platformSpecificBirthTimeFromStat(stat *syscall.Stat_t, _ string) int64 {
+	// macOS has Birthtimespec field
+	return stat.Birthtimespec.Sec*int64(1e9) + int64(stat.Birthtimespec.Nsec)
+}

--- a/fs/localfs/local_fs_btime_freebsd.go
+++ b/fs/localfs/local_fs_btime_freebsd.go
@@ -1,0 +1,10 @@
+package localfs
+
+import (
+	"syscall"
+)
+
+func platformSpecificBirthTimeFromStat(stat *syscall.Stat_t, _ string) int64 {
+	// FreeBSD has Birthtimespec field (similar to macOS)
+	return stat.Birthtimespec.Sec*int64(1e9) + int64(stat.Birthtimespec.Nsec)
+}

--- a/fs/localfs/local_fs_btime_linux.go
+++ b/fs/localfs/local_fs_btime_linux.go
@@ -1,0 +1,29 @@
+package localfs
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// platformSpecificBirthTimeFromStat retrieves birth time using statx(2).
+// Requires Linux kernel 4.11+ and filesystem support (e.g., ext4 with btime, btrfs, xfs).
+// Returns 0 if birth time is unavailable (older kernels, unsupported filesystems like ext3).
+func platformSpecificBirthTimeFromStat(_ *syscall.Stat_t, path string) int64 {
+	// Linux doesn't have birth time in syscall.Stat_t
+	var statx unix.Statx_t
+
+	err := unix.Statx(unix.AT_FDCWD, path, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_BTIME, &statx)
+	if err != nil {
+		// statx might fail on older kernels (< 4.11) or filesystems that don't support it
+		return 0
+	}
+
+	if statx.Mask&unix.STATX_BTIME == 0 {
+		// Filesystem doesn't support birth time (e.g., ext3, older ext4)
+		return 0
+	}
+
+	// Convert statx timestamp to nanoseconds
+	return statx.Btime.Sec*1e9 + int64(statx.Btime.Nsec)
+}

--- a/fs/localfs/local_fs_btime_unix.go
+++ b/fs/localfs/local_fs_btime_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows && !darwin && !freebsd && !linux
+
+package localfs
+
+import (
+	"syscall"
+)
+
+// platformSpecificBirthTimeFromStat is a fallback for Unix systems without birth time support.
+// This applies to: OpenBSD, NetBSD, Solaris, AIX, and other Unix-like systems.
+func platformSpecificBirthTimeFromStat(_ *syscall.Stat_t, _ string) int64 {
+	// Birth time not supported on this platform
+	return 0
+}

--- a/fs/localfs/local_fs_nonwindows.go
+++ b/fs/localfs/local_fs_nonwindows.go
@@ -32,6 +32,14 @@ func platformSpecificDeviceInfo(fi os.FileInfo) fs.DeviceInfo {
 	return oi
 }
 
+func platformSpecificBirthTime(fi os.FileInfo, path string) int64 {
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0
+	}
+	return platformSpecificBirthTimeFromStat(stat, path)
+}
+
 // Direct Windows volume paths (e.g. Shadow Copy) require a trailing separator.
 // The non-windows implementation can be optimized away by the compiler.
 func trailingSeparator(_ *filesystemDirectory) string {

--- a/fs/localfs/local_fs_os.go
+++ b/fs/localfs/local_fs_os.go
@@ -190,6 +190,7 @@ func newEntry(basename string, fi os.FileInfo, prefix string) filesystemEntry {
 		TrimShallowSuffix(basename),
 		fi.Size(),
 		fi.ModTime().UnixNano(),
+		platformSpecificBirthTime(fi, prefix+basename),
 		fi.Mode(),
 		platformSpecificOwnerInfo(fi),
 		platformSpecificDeviceInfo(fi),

--- a/fs/localfs/local_fs_windows.go
+++ b/fs/localfs/local_fs_windows.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"syscall"
 
 	"github.com/kopia/kopia/fs"
 )
@@ -18,6 +19,16 @@ func platformSpecificDeviceInfo(_ os.FileInfo) fs.DeviceInfo {
 	return fs.DeviceInfo{}
 }
 
+func platformSpecificBirthTime(fi os.FileInfo, _ string) int64 {
+	if stat, ok := fi.Sys().(*syscall.Win32FileAttributeData); ok {
+		// Windows stores creation time in the Filetime structure
+		// Convert from Windows FILETIME (100-nanosecond intervals since Jan 1, 1601)
+		// to Unix nanoseconds (nanoseconds since Jan 1, 1970)
+		return stat.CreationTime.Nanoseconds()
+	}
+	return 0
+}
+
 // Direct Windows volume paths (e.g. Shadow Copy) require a trailing separator.
 func trailingSeparator(fsd *filesystemDirectory) string {
 	// is fsd a Windows VSS Volume and has no trailing separator?
@@ -25,6 +36,7 @@ func trailingSeparator(fsd *filesystemDirectory) string {
 		fsd.prefix == `\\?\GLOBALROOT\Device\` &&
 		strings.HasPrefix(fsd.Name(), "HarddiskVolumeShadowCopy") &&
 		!strings.HasSuffix(fsd.Name(), separatorStr) {
+
 		return separatorStr
 	}
 

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -19,12 +19,13 @@ const (
 
 // virtualEntry is an in-memory implementation of a directory entry.
 type virtualEntry struct {
-	name    string
-	mode    os.FileMode
-	size    int64
-	modTime time.Time
-	owner   fs.OwnerInfo
-	device  fs.DeviceInfo
+	name      string
+	mode      os.FileMode
+	size      int64
+	modTime   time.Time
+	birthTime time.Time
+	owner     fs.OwnerInfo
+	device    fs.DeviceInfo
 }
 
 func (e *virtualEntry) Name() string {
@@ -61,6 +62,10 @@ func (e *virtualEntry) Device() fs.DeviceInfo {
 
 func (e *virtualEntry) LocalFilesystemPath() string {
 	return ""
+}
+
+func (e *virtualEntry) BirthTime() time.Time {
+	return e.birthTime
 }
 
 func (e *virtualEntry) Close() {
@@ -187,9 +192,23 @@ func StreamingFileWithModTimeFromReader(name string, t time.Time, reader io.Read
 	}
 }
 
+// StreamingFileWithBirthTimeFromReader returns a streaming file with given name, birth time, modified time, and reader.
+func StreamingFileWithBirthTimeFromReader(name string, btime, mtime time.Time, reader io.ReadCloser) fs.StreamingFile {
+	return &virtualFile{
+		virtualEntry: virtualEntry{
+			name:      name,
+			mode:      defaultPermissions,
+			modTime:   mtime,
+			birthTime: btime,
+		},
+		reader: reader,
+	}
+}
+
 var (
-	_ fs.Directory     = &staticDirectory{}
-	_ fs.Directory     = &streamingDirectory{}
-	_ fs.StreamingFile = &virtualFile{}
-	_ fs.Entry         = &virtualEntry{}
+	_ fs.Directory          = &staticDirectory{}
+	_ fs.Directory          = &streamingDirectory{}
+	_ fs.StreamingFile      = &virtualFile{}
+	_ fs.Entry              = &virtualEntry{}
+	_ fs.EntryWithBirthTime = &virtualEntry{}
 )

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -36,12 +36,13 @@ func (c readerSeekerCloser) Close() error {
 }
 
 type entry struct {
-	name    string
-	mode    os.FileMode
-	size    int64
-	modTime time.Time
-	owner   fs.OwnerInfo
-	device  fs.DeviceInfo
+	name      string
+	mode      os.FileMode
+	size      int64
+	modTime   time.Time
+	birthTime time.Time
+	owner     fs.OwnerInfo
+	device    fs.DeviceInfo
 }
 
 func (e *entry) Name() string {
@@ -80,6 +81,10 @@ func (e *entry) LocalFilesystemPath() string {
 	return ""
 }
 
+func (e *entry) BirthTime() time.Time {
+	return e.birthTime
+}
+
 func (e *entry) Close() {
 }
 
@@ -91,6 +96,11 @@ type Directory struct {
 	children     []fs.Entry
 	readdirError error
 	onReaddir    func()
+}
+
+// SetBirthTime sets the birth time of a directory.
+func (imd *Directory) SetBirthTime(t time.Time) {
+	imd.birthTime = t
 }
 
 // AddFileLines adds a mock file with the specified name, text content and permissions.
@@ -358,6 +368,11 @@ type File struct {
 	source func() (ReaderSeekerCloser, error)
 }
 
+// SetBirthTime sets the birth time of a file.
+func (imf *File) SetBirthTime(t time.Time) {
+	imf.birthTime = t
+}
+
 // SetContents changes the contents of a given file.
 func (imf *File) SetContents(b []byte) {
 	imf.source = func() (ReaderSeekerCloser, error) {
@@ -454,8 +469,11 @@ func (e *ErrorEntry) ErrorInfo() error {
 }
 
 var (
-	_ fs.Directory  = &Directory{}
-	_ fs.File       = &File{}
-	_ fs.Symlink    = &Symlink{}
-	_ fs.ErrorEntry = &ErrorEntry{}
+	_ fs.Directory          = &Directory{}
+	_ fs.File               = &File{}
+	_ fs.Symlink            = &Symlink{}
+	_ fs.ErrorEntry         = &ErrorEntry{}
+	_ fs.EntryWithBirthTime = &Directory{}
+	_ fs.EntryWithBirthTime = &File{}
+	_ fs.EntryWithBirthTime = &Symlink{}
 )

--- a/snapshot/manifest.go
+++ b/snapshot/manifest.go
@@ -124,6 +124,7 @@ type DirEntry struct {
 	Permissions Permissions          `json:"mode,omitempty"`
 	FileSize    int64                `json:"size,omitempty"`
 	ModTime     fs.UTCTimestamp      `json:"mtime,omitempty"`
+	BirthTime   *fs.UTCTimestamp     `json:"btime,omitempty"`
 	UserID      uint32               `json:"uid,omitempty"`
 	GroupID     uint32               `json:"gid,omitempty"`
 	ObjectID    object.ID            `json:"obj"`

--- a/snapshot/policy/upload_policy.go
+++ b/snapshot/policy/upload_policy.go
@@ -11,6 +11,7 @@ type UploadPolicy struct {
 	MaxParallelSnapshots    *OptionalInt   `json:"maxParallelSnapshots,omitempty"`
 	MaxParallelFileReads    *OptionalInt   `json:"maxParallelFileReads,omitempty"`
 	ParallelUploadAboveSize *OptionalInt64 `json:"parallelUploadAboveSize,omitempty"`
+	PreserveBirthTime       *OptionalBool  `json:"preserveBirthTime,omitempty"`
 }
 
 // UploadPolicyDefinition specifies which policy definition provided the value of a particular field.
@@ -18,6 +19,7 @@ type UploadPolicyDefinition struct {
 	MaxParallelSnapshots    snapshot.SourceInfo `json:"maxParallelSnapshots,omitempty"`
 	MaxParallelFileReads    snapshot.SourceInfo `json:"maxParallelFileReads,omitempty"`
 	ParallelUploadAboveSize snapshot.SourceInfo `json:"parallelUploadAboveSize,omitempty"`
+	PreserveBirthTime       snapshot.SourceInfo `json:"preserveBirthTime,omitempty"`
 }
 
 // Merge applies default values from the provided policy.
@@ -25,6 +27,7 @@ func (p *UploadPolicy) Merge(src UploadPolicy, def *UploadPolicyDefinition, si s
 	mergeOptionalInt(&p.MaxParallelSnapshots, src.MaxParallelSnapshots, &def.MaxParallelSnapshots, si)
 	mergeOptionalInt(&p.MaxParallelFileReads, src.MaxParallelFileReads, &def.MaxParallelFileReads, si)
 	mergeOptionalInt64(&p.ParallelUploadAboveSize, src.ParallelUploadAboveSize, &def.ParallelUploadAboveSize, si)
+	mergeOptionalBool(&p.PreserveBirthTime, src.PreserveBirthTime, &def.PreserveBirthTime, si)
 }
 
 // ValidateUploadPolicy returns an error if manual field is set along with Upload fields.

--- a/snapshot/restore/local_fs_output.go
+++ b/snapshot/restore/local_fs_output.go
@@ -279,7 +279,7 @@ func (o *FilesystemOutput) setAttributes(targetPath string, e fs.Entry, modclear
 	var (
 		osChmod   = os.Chmod
 		osChown   = os.Chown
-		osChtimes = os.Chtimes
+		osChtimes = chtimes
 	)
 
 	// symbolic links require special handling that is OS-specific and sometimes unsupported
@@ -306,8 +306,8 @@ func (o *FilesystemOutput) setAttributes(targetPath string, e fs.Entry, modclear
 	}
 
 	if o.shouldUpdateTimes(le, e) {
-		if err = o.maybeIgnorePermissionError(osChtimes(targetPath, e.ModTime(), e.ModTime())); err != nil {
-			return errors.Wrap(err, "could not change mod time on "+targetPath)
+		if err = o.maybeIgnorePermissionError(osChtimes(targetPath, fs.GetBirthTime(e), e.ModTime(), e.ModTime())); err != nil {
+			return errors.Wrap(err, "could not change times on "+targetPath)
 		}
 	}
 
@@ -352,7 +352,11 @@ func (o *FilesystemOutput) shouldUpdateTimes(local, remote fs.Entry) bool {
 		return false
 	}
 
-	return !local.ModTime().Equal(remote.ModTime())
+	if !local.ModTime().Equal(remote.ModTime()) {
+		return true
+	}
+
+	return !fs.GetBirthTime(local).Equal(fs.GetBirthTime(remote))
 }
 
 func isWindows() bool {

--- a/snapshot/restore/local_fs_output_darwin.go
+++ b/snapshot/restore/local_fs_output_darwin.go
@@ -2,8 +2,11 @@ package restore
 
 import (
 	"os"
+	"syscall"
 	"time"
+	"unsafe"
 
+	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -17,10 +20,91 @@ func symlinkChmod(path string, mode os.FileMode) error {
 	return unix.Fchmodat(unix.AT_FDCWD, path, uint32(mode), unix.AT_SYMLINK_NOFOLLOW)
 }
 
-func symlinkChtimes(linkPath string, atime, mtime time.Time) error {
+func symlinkChtimes(linkPath string, _, atime, mtime time.Time) error {
+	// macOS Lutimes only supports atime and mtime, birth time cannot be set on symlinks
 	//nolint:wrapcheck
 	return unix.Lutimes(linkPath, []unix.Timeval{
 		unix.NsecToTimeval(atime.UnixNano()),
 		unix.NsecToTimeval(mtime.UnixNano()),
 	})
+}
+
+func chtimes(path string, btime, atime, mtime time.Time) error {
+	// When btime is not set (Go zero time, indicating snapshots without btime support),
+	// just use os.Chtimes to set atime/mtime and leave btime as-is (OS sets to file creation time).
+	if btime.IsZero() {
+		//nolint:wrapcheck
+		return os.Chtimes(path, atime, mtime)
+	}
+
+	return setFileTimes(path, btime, atime, mtime)
+}
+
+// ChtimesExact is exported for testing purposes - sets times exactly as provided.
+func ChtimesExact(path string, btime, atime, mtime time.Time) error {
+	return setFileTimes(path, btime, atime, mtime)
+}
+
+// setFileTimes sets the birth, access, and modification times for a file on macOS.
+func setFileTimes(path string, btime, atime, mtime time.Time) error {
+	// First set atime and mtime using standard os.Chtimes
+	if err := os.Chtimes(path, atime, mtime); err != nil {
+		return errors.Wrap(err, "unable to set atime/mtime")
+	}
+
+	// Birth time setting is best-effort on macOS.
+	// Expected errors: EPERM (SIP-protected or restricted paths),
+	// ENOTSUP (unsupported filesystem like NFS, SMB, or certain APFS configurations).
+	_ = setBirthTime(path, btime)
+
+	return nil
+}
+
+// macOS setattrlist structures and constants.
+const (
+	attrBitMapCount = 5
+	attrCmnCrtime   = 0x00000200
+)
+
+type attrlist struct {
+	bitmapcount uint16
+	reserved    uint16
+	commonattr  uint32
+	volattr     uint32
+	dirattr     uint32
+	fileattr    uint32
+	forkattr    uint32
+}
+
+func setBirthTime(path string, btime time.Time) error {
+	attrs := attrlist{
+		bitmapcount: attrBitMapCount,
+		commonattr:  attrCmnCrtime,
+	}
+
+	crtime := syscall.Timespec{
+		Sec:  btime.Unix(),
+		Nsec: btime.UnixNano() % 1e9,
+	}
+
+	pathPtr, err := unix.BytePtrFromString(path)
+	if err != nil {
+		return errors.Wrap(err, "unable to convert path to C string")
+	}
+
+	_, _, errno := unix.Syscall6(
+		unix.SYS_SETATTRLIST,
+		uintptr(unsafe.Pointer(pathPtr)),
+		uintptr(unsafe.Pointer(&attrs)),
+		uintptr(unsafe.Pointer(&crtime)),
+		unsafe.Sizeof(crtime),
+		0, // options
+		0,
+	)
+
+	if errno != 0 {
+		return errors.Wrapf(errno, "setattrlist failed for %s", path)
+	}
+
+	return nil
 }

--- a/snapshot/restore/local_fs_output_windows.go
+++ b/snapshot/restore/local_fs_output_windows.go
@@ -20,28 +20,64 @@ func symlinkChmod(path string, mode os.FileMode) error {
 	return nil
 }
 
-func symlinkChtimes(linkPath string, atime, mtime time.Time) error {
+func symlinkChtimes(linkPath string, btime, atime, mtime time.Time) error {
+	return setFileTimes(linkPath, btime, atime, mtime, true)
+}
+
+func chtimes(path string, btime, atime, mtime time.Time) error {
+	// When btime is not set (Go zero time, indicating snapshots without btime support),
+	// just use os.Chtimes to set atime/mtime and leave btime as-is (OS sets to file creation time).
+	if btime.IsZero() {
+		//nolint:wrapcheck
+		return os.Chtimes(path, atime, mtime)
+	}
+
+	return setFileTimes(path, btime, atime, mtime, false)
+}
+
+// ChtimesExact is exported for testing purposes - sets times exactly as provided without fallback.
+func ChtimesExact(path string, btime, atime, mtime time.Time) error {
+	return setFileTimes(path, btime, atime, mtime, false)
+}
+
+// setFileTimes sets the creation, access, and modification times for a file or symlink on Windows.
+func setFileTimes(path string, btime, atime, mtime time.Time, isSymlink bool) error {
+	// Convert times to Windows FILETIME format
+	ftc := windows.NsecToFiletime(btime.UnixNano())
 	fta := windows.NsecToFiletime(atime.UnixNano())
 	ftw := windows.NsecToFiletime(mtime.UnixNano())
 
-	linkPath = ospath.SafeLongFilename(linkPath)
+	path = ospath.SafeLongFilename(path)
 
-	fn, err := windows.UTF16PtrFromString(linkPath)
+	fn, err := windows.UTF16PtrFromString(path)
 	if err != nil {
 		return errors.Wrap(err, "UTF16PtrFromString")
 	}
 
+	var (
+		access uint32
+		flags  uint32
+	)
+
+	if isSymlink {
+		access = windows.GENERIC_READ | windows.GENERIC_WRITE
+		flags = windows.FILE_FLAG_OPEN_REPARSE_POINT
+	} else {
+		access = windows.FILE_WRITE_ATTRIBUTES
+		flags = windows.FILE_FLAG_BACKUP_SEMANTICS
+	}
+
 	h, err := windows.CreateFile(
-		fn, windows.GENERIC_READ|windows.GENERIC_WRITE,
+		fn, access,
 		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
 		nil, windows.OPEN_EXISTING,
-		windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+		flags, 0)
 	if err != nil {
-		return errors.Wrapf(err, "CreateFile error on %v", linkPath)
+		return errors.Wrapf(err, "CreateFile error on %v", path)
 	}
 
 	defer windows.CloseHandle(h) //nolint:errcheck
 
 	//nolint:wrapcheck
-	return windows.SetFileTime(h, &ftw, &fta, &ftw)
+	return windows.SetFileTime(h, &ftc, &fta, &ftw)
 }

--- a/snapshot/restore/restore_btime_test.go
+++ b/snapshot/restore/restore_btime_test.go
@@ -1,0 +1,397 @@
+package restore_test
+
+import (
+	"context"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/fs/localfs"
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/restore"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+	"github.com/kopia/kopia/snapshot/upload"
+)
+
+// TestBirthTimeSnapshotAndRestore validates birthtime support across snapshot/restore lifecycle.
+// Tests four scenarios:
+// 1. Old snapshot without btime (backward compatibility)
+// 2. New snapshot with btime (full restore preservation)
+// 3. Metadata-only update (photo date fix use case)
+// 4. Shallow restore with btime (placeholder files)
+func TestBirthTimeSnapshotAndRestore(t *testing.T) {
+	// Setup test environment
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	sourceDir := t.TempDir()
+
+	canRestoreBirthTime := runtime.GOOS == "windows" || runtime.GOOS == "darwin"
+
+	// Create test file with known birthtime and mtime
+	testFile := setupTestFile(t, sourceDir)
+	originalBtime, originalDirBtime, mtime := captureOriginalTimes(t, testFile, sourceDir)
+
+	// SCENARIO 1: Old snapshot without birthtime support (backward compatibility)
+	t.Log("=== Scenario 1: Old snapshot without btime (simulating old Kopia) ===")
+	oldSnapshot := createOldStyleSnapshot(t, ctx, env.RepositoryWriter, sourceDir)
+	verifyOldSnapshotRestore(t, ctx, env.RepositoryWriter, oldSnapshot, canRestoreBirthTime)
+
+	// SCENARIO 2: New snapshot with birthtime support (full restore)
+	t.Log("=== Scenario 2: New snapshot with full btime support ===")
+	newSnapshot := createSnapshot(t, ctx, env.RepositoryWriter, sourceDir)
+	verifyBirthtimePreservation(t, ctx, env.RepositoryWriter, newSnapshot,
+		originalBtime, originalDirBtime, mtime, canRestoreBirthTime)
+
+	// SCENARIO 3: Metadata-only update (birthtime changed on source without content change,
+	// e.g. user corrects a file's creation date before taking a new snapshot)
+	if canRestoreBirthTime {
+		t.Log("=== Scenario 3: Birthtime metadata update without content re-upload ===")
+		verifyMetadataOnlyUpdate(t, ctx, env.RepositoryWriter, sourceDir, testFile,
+			newSnapshot, originalBtime, originalDirBtime, mtime)
+	}
+
+	// SCENARIO 4: Shallow restore (placeholder files should also have correct btime)
+	t.Log("=== Scenario 4: Shallow restore with btime ===")
+	verifyShallowRestoreBirthtime(t, ctx, env.RepositoryWriter, newSnapshot,
+		originalBtime, originalDirBtime, mtime, canRestoreBirthTime)
+}
+
+// setupTestFile creates a test file with distinct birthtime and mtime.
+func setupTestFile(t *testing.T, dir string) string {
+	t.Helper()
+
+	testFile := filepath.Join(dir, "dummy.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("test"), 0o644))
+
+	// Set mtime to 1 minute in the future to differentiate from birth time
+	futureTime := clock.Now().Add(1 * time.Minute)
+	require.NoError(t, os.Chtimes(testFile, futureTime, futureTime))
+
+	return testFile
+}
+
+// captureOriginalTimes captures birthtime and mtime from source file and directory.
+func captureOriginalTimes(t *testing.T, file, dir string) (fileBtime, dirBtime time.Time, mtime time.Time) {
+	t.Helper()
+
+	fileEntry, err := localfs.NewEntry(file)
+	require.NoError(t, err)
+	fileBtime = fs.GetBirthTime(fileEntry)
+	mtime = fileEntry.ModTime()
+
+	dirEntry, err := localfs.NewEntry(dir)
+	require.NoError(t, err)
+	dirBtime = fs.GetBirthTime(dirEntry)
+
+	t.Logf("Original times - file btime: %v, mtime: %v", fileBtime, mtime)
+	t.Logf("Original times - dir btime: %v", dirBtime)
+
+	return fileBtime, dirBtime, mtime
+}
+
+// createOldStyleSnapshot creates a snapshot and removes btime to simulate old Kopia version.
+func createOldStyleSnapshot(t *testing.T, ctx context.Context, rep repo.RepositoryWriter, sourceDir string) *snapshot.Manifest {
+	t.Helper()
+
+	snap := createSnapshot(t, ctx, rep, sourceDir)
+
+	// Simulate old repo without btime: clear BirthTime from all entries in the snapshot tree.
+	clearBirthTime(snap.RootEntry)
+	_, err := snapshot.SaveSnapshot(ctx, rep, snap)
+	require.NoError(t, err)
+
+	t.Log("Created old-style snapshot (btime = nil on all entries)")
+	return snap
+}
+
+// clearBirthTime clears BirthTime on the provided directory entry.
+// Note: child entries are stored as separate objects in the repo (written during upload)
+// and cannot be modified from the manifest alone. Clearing the root entry's BirthTime
+// is sufficient to simulate an old-style snapshot for backward compatibility testing.
+func clearBirthTime(e *snapshot.DirEntry) {
+	if e == nil {
+		return
+	}
+
+	e.BirthTime = nil
+}
+
+// verifyOldSnapshotRestore verifies that restoring old snapshots without btime works correctly.
+func verifyOldSnapshotRestore(t *testing.T, ctx context.Context, rep repo.RepositoryWriter,
+	snap *snapshot.Manifest, canRestoreBirthTime bool) {
+	t.Helper()
+
+	restoreDir := t.TempDir()
+	restoreSnapshot(t, ctx, rep, snap, restoreDir)
+
+	restoredDirEntry, err := localfs.NewEntry(restoreDir)
+	require.NoError(t, err)
+	restoredDirBtime := fs.GetBirthTime(restoredDirEntry)
+
+	t.Logf("Restored dir btime from old snapshot: %v", restoredDirBtime)
+
+	if canRestoreBirthTime {
+		// For old snapshots without btime, OS sets btime to file creation time (now)
+		assertTimeIsRecent(t, restoredDirBtime, "dir btime should be recent (file creation time)")
+	}
+}
+
+// verifyBirthtimePreservation verifies that birthtimes are correctly preserved during snapshot/restore.
+func verifyBirthtimePreservation(t *testing.T, ctx context.Context, rep repo.RepositoryWriter,
+	snap *snapshot.Manifest, expectedFileBtime, expectedDirBtime, expectedMtime time.Time,
+	canRestoreBirthTime bool) {
+	t.Helper()
+
+	restoreDir := t.TempDir()
+	restoreSnapshot(t, ctx, rep, snap, restoreDir)
+
+	// Verify file times (full restore, not shallow placeholder)
+	restoredFile := filepath.Join(restoreDir, "dummy.txt")
+	fileEntry, err := localfs.NewEntry(restoredFile)
+	require.NoError(t, err)
+	restoredFileBtime := fs.GetBirthTime(fileEntry)
+	restoredMtime := fileEntry.ModTime()
+
+	// Verify directory times
+	dirEntry, err := localfs.NewEntry(restoreDir)
+	require.NoError(t, err)
+	restoredDirBtime := fs.GetBirthTime(dirEntry)
+
+	t.Logf("Restored times - file btime: %v, mtime: %v", restoredFileBtime, restoredMtime)
+	t.Logf("Restored times - dir btime: %v", restoredDirBtime)
+
+	// mtime should always be restored correctly
+	require.Equal(t, expectedMtime, restoredMtime, "mtime should match")
+
+	if canRestoreBirthTime {
+		// On Windows/macOS, birth time should be preserved
+		require.Equal(t, expectedFileBtime, restoredFileBtime, "file birth time should match on "+runtime.GOOS)
+		require.Equal(t, expectedDirBtime, restoredDirBtime, "directory birth time should match on "+runtime.GOOS)
+	} else {
+		// On Linux, birthtime cannot be set during restore.
+		// Birthtime will be set to file creation time (approximately now).
+		// The birthtime stored in snapshots is still useful for:
+		// - Cross-platform restore (Linux -> macOS/Windows)
+		// - Future Linux kernel support for birthtime setting
+		assertTimeIsRecent(t, restoredFileBtime, "file btime should be recent on "+runtime.GOOS)
+		assertTimeIsRecent(t, restoredDirBtime, "dir btime should be recent on "+runtime.GOOS)
+	}
+}
+
+// verifyMetadataOnlyUpdate tests that changing only birthtime doesn't trigger content re-upload
+// and that the snapshot cache is properly updated.
+//
+// Technical note: Kopia's cache key is based on mtime (not btime), so btime-only changes
+// still allow cache hits. The updated btime is captured in the new snapshot's DirEntry.
+func verifyMetadataOnlyUpdate(t *testing.T, ctx context.Context, rep repo.RepositoryWriter,
+	sourceDir, testFile string, previousSnapshot *snapshot.Manifest,
+	originalFileBtime, originalDirBtime, mtime time.Time) {
+	t.Helper()
+
+	// Update birthtimes (simulating, for instance, photo create date correction from exif)
+	newFileBtime := originalFileBtime.Add(-24 * time.Hour)
+	newDirBtime := originalDirBtime.Add(-48 * time.Hour)
+	updateBirthtimes(t, testFile, sourceDir, newFileBtime, newDirBtime, mtime)
+
+	// Verify birthtimes were updated
+	updatedFileBtime, updatedDirBtime := verifyBirthtimesUpdated(t, testFile, sourceDir,
+		newFileBtime, newDirBtime)
+
+	// Create new snapshot
+	newSnapshot := createSnapshot(t, ctx, rep, sourceDir)
+	t.Log("Created snapshot after birthtime-only changes")
+
+	// Verify metadata updated in snapshot without content re-upload
+	verifySnapshotMetadataUpdate(t, ctx, rep, previousSnapshot, newSnapshot,
+		updatedFileBtime, updatedDirBtime)
+
+	t.Log("SUCCESS: Birthtime metadata updated for both file and directory without re-uploading content")
+}
+
+// verifyShallowRestoreBirthtime verifies that shallow restore (placeholder files) also preserves btime.
+func verifyShallowRestoreBirthtime(t *testing.T, ctx context.Context, rep repo.RepositoryWriter,
+	snap *snapshot.Manifest, expectedFileBtime, expectedDirBtime, expectedMtime time.Time,
+	canRestoreBirthTime bool) {
+	t.Helper()
+
+	restoreDir := t.TempDir()
+	restoreSnapshotShallow(t, ctx, rep, snap, restoreDir)
+
+	// Shallow restore creates placeholder files with .kopia-entry suffix
+	restoredFile := filepath.Join(restoreDir, "dummy.txt"+localfs.ShallowEntrySuffix)
+	fileEntry, err := localfs.NewEntry(restoredFile)
+	require.NoError(t, err)
+	restoredFileBtime := fs.GetBirthTime(fileEntry)
+	restoredMtime := fileEntry.ModTime()
+
+	dirEntry, err := localfs.NewEntry(restoreDir)
+	require.NoError(t, err)
+	restoredDirBtime := fs.GetBirthTime(dirEntry)
+
+	t.Logf("Shallow restored times - file btime: %v, mtime: %v", restoredFileBtime, restoredMtime)
+	t.Logf("Shallow restored times - dir btime: %v", restoredDirBtime)
+
+	require.Equal(t, expectedMtime, restoredMtime, "shallow restore mtime should match")
+
+	if canRestoreBirthTime {
+		require.Equal(t, expectedFileBtime, restoredFileBtime, "shallow restore file btime should match on "+runtime.GOOS)
+		require.Equal(t, expectedDirBtime, restoredDirBtime, "shallow restore dir btime should match on "+runtime.GOOS)
+	} else {
+		assertTimeIsRecent(t, restoredFileBtime, "shallow restore file btime should be recent on "+runtime.GOOS)
+		assertTimeIsRecent(t, restoredDirBtime, "shallow restore dir btime should be recent on "+runtime.GOOS)
+	}
+}
+
+// updateBirthtimes changes birthtimes on file and directory without changing content or mtime.
+func updateBirthtimes(t *testing.T, file, dir string, fileBtime, dirBtime, mtime time.Time) {
+	t.Helper()
+
+	require.NoError(t, restore.ChtimesExact(file, fileBtime, mtime, mtime))
+	require.NoError(t, restore.ChtimesExact(dir, dirBtime, mtime, mtime))
+
+	t.Logf("Updated file btime to: %v", fileBtime)
+	t.Logf("Updated dir btime to: %v", dirBtime)
+}
+
+// verifyBirthtimesUpdated confirms that birthtimes were successfully changed.
+func verifyBirthtimesUpdated(t *testing.T, file, dir string, expectedFileBtime, expectedDirBtime time.Time) (time.Time, time.Time) {
+	t.Helper()
+
+	fileEntry, err := localfs.NewEntry(file)
+	require.NoError(t, err)
+	actualFileBtime := fs.GetBirthTime(fileEntry)
+
+	dirEntry, err := localfs.NewEntry(dir)
+	require.NoError(t, err)
+	actualDirBtime := fs.GetBirthTime(dirEntry)
+
+	require.Equal(t, expectedFileBtime.Unix(), actualFileBtime.Unix(), "file birthtime should be updated")
+	require.Equal(t, expectedDirBtime.Unix(), actualDirBtime.Unix(), "dir birthtime should be updated")
+
+	return actualFileBtime, actualDirBtime
+}
+
+// verifySnapshotMetadataUpdate verifies that snapshot captured updated birthtimes without re-uploading content.
+func verifySnapshotMetadataUpdate(t *testing.T, ctx context.Context, rep repo.RepositoryWriter,
+	oldSnapshot, newSnapshot *snapshot.Manifest, expectedFileBtime, expectedDirBtime time.Time) {
+	t.Helper()
+
+	// Get file entry from old snapshot
+	oldFile := getFileFromSnapshot(t, ctx, rep, oldSnapshot, "dummy.txt")
+
+	// Get file entry from new snapshot
+	newFile := getFileFromSnapshot(t, ctx, rep, newSnapshot, "dummy.txt")
+	newRoot, err := snapshotfs.SnapshotRoot(rep, newSnapshot)
+	require.NoError(t, err)
+
+	// Verify birthtimes updated in snapshot
+	newFileBtime := fs.GetBirthTime(newFile)
+	newDirBtime := fs.GetBirthTime(newRoot)
+
+	require.Equal(t, expectedFileBtime.Unix(), newFileBtime.Unix(), "file snapshot should reflect updated birthtime")
+	require.Equal(t, expectedDirBtime.Unix(), newDirBtime.Unix(), "dir snapshot should reflect updated birthtime")
+
+	// Verify content NOT re-uploaded by comparing ObjectIDs
+	oldDirEntry := oldFile.(snapshot.HasDirEntry).DirEntry()
+	newDirEntry := newFile.(snapshot.HasDirEntry).DirEntry()
+
+	require.Equal(t, oldDirEntry.ObjectID, newDirEntry.ObjectID,
+		"ObjectID should be identical (content not re-uploaded, only metadata changed)")
+}
+
+// getFileFromSnapshot retrieves a file entry from a snapshot by name.
+func getFileFromSnapshot(t *testing.T, ctx context.Context, rep repo.RepositoryWriter,
+	snap *snapshot.Manifest, fileName string) fs.File {
+	t.Helper()
+
+	root, err := snapshotfs.SnapshotRoot(rep, snap)
+	require.NoError(t, err)
+
+	rootDir, ok := root.(fs.Directory)
+	require.True(t, ok, "root should be a directory")
+
+	fileEntry, err := rootDir.Child(ctx, fileName)
+	require.NoError(t, err)
+
+	file, ok := fileEntry.(fs.File)
+	require.True(t, ok, "entry should be a file")
+
+	return file
+}
+
+// restoreSnapshot performs a full restore of a snapshot to the specified directory.
+func restoreSnapshot(t *testing.T, ctx context.Context, rep repo.RepositoryWriter,
+	snap *snapshot.Manifest, targetDir string) {
+	t.Helper()
+
+	restoreSnapshotWithDepth(t, ctx, rep, snap, targetDir, math.MaxInt32)
+}
+
+// restoreSnapshotShallow performs a shallow restore of a snapshot to the specified directory.
+func restoreSnapshotShallow(t *testing.T, ctx context.Context, rep repo.RepositoryWriter,
+	snap *snapshot.Manifest, targetDir string) {
+	t.Helper()
+
+	restoreSnapshotWithDepth(t, ctx, rep, snap, targetDir, 0)
+}
+
+// restoreSnapshotWithDepth restores a snapshot with the given RestoreDirEntryAtDepth.
+func restoreSnapshotWithDepth(t *testing.T, ctx context.Context, rep repo.RepositoryWriter,
+	snap *snapshot.Manifest, targetDir string, depth int32) {
+	t.Helper()
+
+	root, err := snapshotfs.SnapshotRoot(rep, snap)
+	require.NoError(t, err)
+
+	output := restore.FilesystemOutput{
+		TargetPath:             targetDir,
+		OverwriteDirectories:   true,
+		OverwriteFiles:         true,
+		OverwriteSymlinks:      true,
+		IgnorePermissionErrors: true,
+	}
+	require.NoError(t, output.Init(ctx))
+
+	_, err = restore.Entry(ctx, rep, &output, root, restore.Options{
+		RestoreDirEntryAtDepth: depth,
+	})
+	require.NoError(t, err)
+}
+
+// assertTimeIsRecent verifies that a time is recent enough for the test to be valid.
+func assertTimeIsRecent(t *testing.T, timeToCheck time.Time, message string) {
+	t.Helper()
+
+	timeSince := clock.Now().Sub(timeToCheck)
+	require.GreaterOrEqual(t, timeSince, time.Duration(0), message+" (should not be in the future)")
+	require.Less(t, timeSince, 2*time.Minute, message+" (should be within last 2 minutes)")
+}
+
+// createSnapshot creates a snapshot of the source directory.
+func createSnapshot(t *testing.T, ctx context.Context, rep repo.RepositoryWriter, sourceDir string) *snapshot.Manifest {
+	t.Helper()
+
+	source, err := localfs.Directory(sourceDir)
+	require.NoError(t, err)
+
+	u := upload.NewUploader(rep)
+	man, err := u.Upload(ctx, source, nil, snapshot.SourceInfo{
+		Path:     sourceDir,
+		Host:     "test-host",
+		UserName: "test-user",
+	})
+	require.NoError(t, err)
+
+	_, err = snapshot.SaveSnapshot(ctx, rep, man)
+	require.NoError(t, err)
+
+	return man
+}

--- a/snapshot/restore/restore_btime_test.go
+++ b/snapshot/restore/restore_btime_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kopia/kopia/internal/repotesting"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/policy"
 	"github.com/kopia/kopia/snapshot/restore"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 	"github.com/kopia/kopia/snapshot/upload"
@@ -383,7 +384,10 @@ func createSnapshot(t *testing.T, ctx context.Context, rep repo.RepositoryWriter
 	require.NoError(t, err)
 
 	u := upload.NewUploader(rep)
-	man, err := u.Upload(ctx, source, nil, snapshot.SourceInfo{
+	policyTree := policy.BuildTree(nil, &policy.Policy{
+		UploadPolicy: policy.UploadPolicy{PreserveBirthTime: policy.NewOptionalBool(true)},
+	})
+	man, err := u.Upload(ctx, source, policyTree, snapshot.SourceInfo{
 		Path:     sourceDir,
 		Host:     "test-host",
 		UserName: "test-user",

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -60,6 +60,13 @@ func (e *repositoryEntry) ModTime() time.Time {
 	return e.metadata.ModTime.ToTime()
 }
 
+func (e *repositoryEntry) BirthTime() time.Time {
+	if e.metadata.BirthTime == nil {
+		return time.Time{}
+	}
+	return e.metadata.BirthTime.ToTime()
+}
+
 func (e *repositoryEntry) ObjectID() object.ID {
 	return e.metadata.ObjectID
 }

--- a/snapshot/upload/upload.go
+++ b/snapshot/upload/upload.go
@@ -95,6 +95,11 @@ type Uploader struct {
 	// When set to true, do not ignore any files, regardless of policy settings.
 	DisableIgnoreRules bool
 
+	// When set to true, birth time (file creation time) is captured during upload
+	// and restored during restore on platforms that support it.
+	// Controlled by UploadPolicy.PreserveBirthTime; default false.
+	PreserveBirthTime bool
+
 	// Labels to apply to every checkpoint made for this snapshot.
 	CheckpointLabels map[string]string
 
@@ -260,7 +265,7 @@ func (u *Uploader) uploadFileData(ctx context.Context, parentCheckpointRegistry 
 			return nil, nil
 		}
 
-		return newDirEntry(f, fname, checkpointID)
+		return u.newDirEntry(f, fname, checkpointID)
 	})
 
 	defer parentCheckpointRegistry.removeCheckpointCallback(fname)
@@ -286,7 +291,7 @@ func (u *Uploader) uploadFileData(ctx context.Context, parentCheckpointRegistry 
 		return nil, errors.Wrap(err, "unable to get result")
 	}
 
-	de, err := newDirEntry(f, fname, r)
+	de, err := u.newDirEntry(f, fname, r)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create dir entry")
 	}
@@ -328,7 +333,7 @@ func (u *Uploader) uploadSymlinkInternal(ctx context.Context, relativePath strin
 		return nil, errors.Wrap(err, "unable to get result")
 	}
 
-	de, err := newDirEntry(f, f.Name(), r)
+	de, err := u.newDirEntry(f, f.Name(), r)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create dir entry")
 	}
@@ -376,7 +381,7 @@ func (u *Uploader) uploadStreamingFileInternal(ctx context.Context, relativePath
 		return nil, errors.Wrap(err, "unable to get result")
 	}
 
-	de, err := newDirEntry(f, f.Name(), r)
+	de, err := u.newDirEntry(f, f.Name(), r)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create dir entry")
 	}
@@ -435,8 +440,8 @@ func (u *Uploader) copyWithProgress(dst io.Writer, src io.Reader) (int64, error)
 }
 
 // newDirEntryWithSummary makes DirEntry objects for directory Entries that need a DirectorySummary.
-func newDirEntryWithSummary(d fs.Entry, oid object.ID, summ *fs.DirectorySummary) (*snapshot.DirEntry, error) {
-	de, err := newDirEntry(d, d.Name(), oid)
+func (u *Uploader) newDirEntryWithSummary(d fs.Entry, oid object.ID, summ *fs.DirectorySummary) (*snapshot.DirEntry, error) {
+	de, err := u.newDirEntry(d, d.Name(), oid)
 	if err != nil {
 		return nil, err
 	}
@@ -496,13 +501,15 @@ func newDirEntryBase(md fs.Entry, fname string, oid object.ID) (*snapshot.DirEnt
 }
 
 // newDirEntry makes DirEntry objects for any type of Entry.
-func newDirEntry(md fs.Entry, fname string, oid object.ID) (*snapshot.DirEntry, error) {
+func (u *Uploader) newDirEntry(md fs.Entry, fname string, oid object.ID) (*snapshot.DirEntry, error) {
 	de, err := newDirEntryBase(md, fname, oid)
 	if err != nil {
 		return nil, err
 	}
 
-	setBirthTime(de, md)
+	if u.PreserveBirthTime {
+		setBirthTime(de, md)
+	}
 
 	return de, nil
 }
@@ -511,43 +518,40 @@ func newDirEntry(md fs.Entry, fname string, oid object.ID) (*snapshot.DirEntry, 
 // previous snapshots. It ensures file sizes are populated correctly for
 // StreamingFiles and handles birthtime intelligently to preserve cached
 // birthtime when current filesystem lacks btime support.
-func newCachedDirEntry(md, cached fs.Entry, fname string) (*snapshot.DirEntry, error) {
+func (u *Uploader) newCachedDirEntry(md, cached fs.Entry, fname string) (*snapshot.DirEntry, error) {
 	hoid, ok := cached.(object.HasObjectID)
 	if !ok {
 		return nil, errors.New("cached entry does not implement HasObjectID")
 	}
 
-	var de *snapshot.DirEntry
-	var err error
-
 	if _, ok := md.(fs.StreamingFile); ok {
-		// For StreamingFiles, use cached entry for size/type
-		de, err = newDirEntryBase(cached, fname, hoid.ObjectID())
+		de, err := newDirEntryBase(cached, fname, hoid.ObjectID())
 		if err != nil {
 			return nil, err
 		}
 
-		cachedBtime := getBirthTime(cached)
-		currentBtime := getBirthTime(md)
+		if u.PreserveBirthTime {
+			cachedBtime := getBirthTime(cached)
+			currentBtime := getBirthTime(md)
 
-		// Use current btime if available and it's new information (upgrade or change)
-		if currentBtime != nil && (cachedBtime == nil || *cachedBtime != *currentBtime) {
-			de.BirthTime = currentBtime
-		} else if cachedBtime != nil {
-			// Preserve cached btime (either same as current, or current unavailable)
-			de.BirthTime = cachedBtime
-		}
-	} else {
-		// For other types, use current metadata directly (birthtime set from filesystem in newDirEntry)
-		de, err = newDirEntry(md, fname, hoid.ObjectID())
-		if err != nil {
-			return nil, err
+			if currentBtime != nil && (cachedBtime == nil || *cachedBtime != *currentBtime) {
+				de.BirthTime = currentBtime
+			} else if cachedBtime != nil {
+				de.BirthTime = cachedBtime
+			}
 		}
 
-		// If current filesystem lacks btime support, preserve cached btime from previous snapshot.
-		if de.BirthTime == nil {
-			de.BirthTime = getBirthTime(cached)
-		}
+		return de, nil
+	}
+
+	de, err := u.newDirEntry(md, fname, hoid.ObjectID())
+	if err != nil {
+		return nil, err
+	}
+
+	// If current filesystem lacks btime support, preserve cached btime from previous snapshot.
+	if u.PreserveBirthTime && de.BirthTime == nil {
+		de.BirthTime = getBirthTime(cached)
 	}
 
 	return de, nil
@@ -565,7 +569,7 @@ func (u *Uploader) uploadFileWithCheckpointing(ctx context.Context, relativePath
 		return nil, err
 	}
 
-	return newDirEntryWithSummary(file, res.ObjectID, &fs.DirectorySummary{
+	return u.newDirEntryWithSummary(file, res.ObjectID, &fs.DirectorySummary{
 		TotalFileCount: 1,
 		TotalFileSize:  res.FileSize,
 		MaxModTime:     res.ModTime,
@@ -918,7 +922,7 @@ func (u *Uploader) processSingle(
 			atomic.AddInt64(&u.stats.TotalFileSize, cachedEntry.Size())
 			u.Progress.CachedFile(entryRelativePath, cachedEntry.Size())
 
-			cachedDirEntry, err := newCachedDirEntry(entry, cachedEntry, entry.Name())
+			cachedDirEntry, err := u.newCachedDirEntry(entry, cachedEntry, entry.Name())
 
 			u.Progress.FinishedFile(entryRelativePath, err)
 
@@ -1256,7 +1260,7 @@ func uploadDirInternal(
 			return nil, errors.Wrap(err, "error writing dir manifest")
 		}
 
-		return newDirEntryWithSummary(directory, oid, checkpointManifest.Summary)
+		return u.newDirEntryWithSummary(directory, oid, checkpointManifest.Summary)
 	})
 	defer thisCheckpointRegistry.removeCheckpointCallback(directory.Name())
 
@@ -1271,7 +1275,7 @@ func uploadDirInternal(
 		return nil, errors.Wrapf(err, "error writing dir manifest: %v", directory.Name())
 	}
 
-	return newDirEntryWithSummary(directory, oid, dirManifest.Summary)
+	return u.newDirEntryWithSummary(directory, oid, dirManifest.Summary)
 }
 
 func (u *Uploader) reportErrorAndMaybeCancel(err error, isIgnored bool, dmb *snapshotfs.DirManifestBuilder, entryRelativePath string) {
@@ -1348,7 +1352,7 @@ func (u *Uploader) Upload(
 	}
 
 	u.traceEnabled = span.IsRecording()
-
+	u.PreserveBirthTime = policyTree.EffectivePolicy().UploadPolicy.PreserveBirthTime.OrDefault(false)
 	u.Progress.UploadStarted()
 	defer u.Progress.UploadFinished()
 

--- a/snapshot/upload/upload_newcacheddirentry_test.go
+++ b/snapshot/upload/upload_newcacheddirentry_test.go
@@ -1,0 +1,160 @@
+package upload
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/repo/object"
+)
+
+// mockFileBase provides common fs.Entry fields for test mocks.
+type mockFileBase struct {
+	name    string
+	mode    os.FileMode
+	size    int64
+	modTime time.Time
+}
+
+func (e *mockFileBase) Name() string                { return e.name }
+func (e *mockFileBase) IsDir() bool                 { return false }
+func (e *mockFileBase) Mode() os.FileMode           { return e.mode }
+func (e *mockFileBase) ModTime() time.Time          { return e.modTime }
+func (e *mockFileBase) Size() int64                 { return e.size }
+func (e *mockFileBase) Sys() any                    { return nil }
+func (e *mockFileBase) Owner() fs.OwnerInfo         { return fs.OwnerInfo{} }
+func (e *mockFileBase) Device() fs.DeviceInfo       { return fs.DeviceInfo{} }
+func (e *mockFileBase) LocalFilesystemPath() string { return "" }
+func (e *mockFileBase) Close()                      {}
+
+func (e *mockFileBase) Open(_ context.Context) (fs.Reader, error) {
+	return nil, nil
+}
+
+// mockFileNoBtime implements fs.File but NOT fs.EntryWithBirthTime,
+// simulating a filesystem without btime support (e.g., older Linux kernels < 4.11,
+// or filesystems like tmpfs/NFS that don't report STATX_BTIME).
+type mockFileNoBtime struct {
+	mockFileBase
+}
+
+// mockFileWithBtime implements fs.File AND fs.EntryWithBirthTime,
+// simulating a filesystem with btime support (e.g., Windows, macOS).
+type mockFileWithBtime struct {
+	mockFileBase
+	birthTime time.Time
+}
+
+func (e *mockFileWithBtime) BirthTime() time.Time { return e.birthTime }
+
+// mockCachedFileWithBtime adds HasObjectID to mockFileWithBtime,
+// simulating a cached snapshot entry with btime.
+type mockCachedFileWithBtime struct {
+	mockFileWithBtime
+	objectID object.ID
+}
+
+func (e *mockCachedFileWithBtime) ObjectID() object.ID { return e.objectID }
+
+// mockCachedFileNoBtime adds HasObjectID to mockFileNoBtime,
+// simulating a cached snapshot entry without btime (old Kopia version).
+type mockCachedFileNoBtime struct {
+	mockFileNoBtime
+	objectID object.ID
+}
+
+func (e *mockCachedFileNoBtime) ObjectID() object.ID { return e.objectID }
+
+// Verify interface compliance.
+var (
+	_ fs.File               = &mockFileNoBtime{}
+	_ fs.File               = &mockFileWithBtime{}
+	_ fs.EntryWithBirthTime = &mockFileWithBtime{}
+	_ object.HasObjectID    = &mockCachedFileWithBtime{}
+	_ object.HasObjectID    = &mockCachedFileNoBtime{}
+)
+
+// TestNewCachedDirEntry_PreservesCachedBtime_WhenCurrentLacksBtime simulates a scenario where
+// a previous snapshot captured btime (e.g., on macOS/Windows or Linux ext4/btrfs), but the
+// current filesystem doesn't report btime (e.g., tmpfs, NFS, or older kernel). The cached
+// btime should be preserved in the new snapshot rather than silently dropped.
+func TestNewCachedDirEntry_PreservesCachedBtime_WhenCurrentLacksBtime(t *testing.T) {
+	t.Parallel()
+
+	cachedBtime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	mtime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	cached := &mockCachedFileWithBtime{
+		mockFileWithBtime: mockFileWithBtime{
+			mockFileBase: mockFileBase{name: "file.txt", mode: 0o644, size: 100, modTime: mtime},
+			birthTime:    cachedBtime,
+		},
+	}
+
+	// Current entry has NO btime (e.g., tmpfs, NFS, or older kernel without STATX_BTIME)
+	current := &mockFileNoBtime{
+		mockFileBase: mockFileBase{name: "file.txt", mode: 0o644, size: 100, modTime: mtime},
+	}
+
+	de, err := newCachedDirEntry(current, cached, "file.txt")
+	require.NoError(t, err)
+	require.NotNil(t, de.BirthTime, "cached btime should be preserved when current FS lacks btime")
+	require.Equal(t, cachedBtime, de.BirthTime.ToTime().UTC(),
+		"preserved btime should match the cached value")
+}
+
+// TestNewCachedDirEntry_UsesCurrentBtime_WhenAvailable verifies that when the current
+// filesystem provides btime, it takes precedence over cached btime (e.g., user corrected
+// a file's creation date).
+func TestNewCachedDirEntry_UsesCurrentBtime_WhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	cachedBtime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	currentBtime := time.Date(2024, 3, 20, 8, 0, 0, 0, time.UTC)
+	mtime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	cached := &mockCachedFileWithBtime{
+		mockFileWithBtime: mockFileWithBtime{
+			mockFileBase: mockFileBase{name: "file.txt", mode: 0o644, size: 100, modTime: mtime},
+			birthTime:    cachedBtime,
+		},
+	}
+
+	// Current entry has different btime (e.g., user corrected creation date)
+	current := &mockFileWithBtime{
+		mockFileBase: mockFileBase{name: "file.txt", mode: 0o644, size: 100, modTime: mtime},
+		birthTime:    currentBtime,
+	}
+
+	de, err := newCachedDirEntry(current, cached, "file.txt")
+	require.NoError(t, err)
+	require.NotNil(t, de.BirthTime, "btime should be set")
+	require.Equal(t, currentBtime, de.BirthTime.ToTime().UTC(),
+		"current btime should take precedence when available")
+}
+
+// TestNewCachedDirEntry_NoBtime_WhenNeitherHasBtime verifies that when neither the current
+// nor cached entry has btime (e.g., old Kopia version on a filesystem without btime), btime remains nil.
+func TestNewCachedDirEntry_NoBtime_WhenNeitherHasBtime(t *testing.T) {
+	t.Parallel()
+
+	mtime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	cached := &mockCachedFileNoBtime{
+		mockFileNoBtime: mockFileNoBtime{
+			mockFileBase: mockFileBase{name: "file.txt", mode: 0o644, size: 100, modTime: mtime},
+		},
+	}
+
+	current := &mockFileNoBtime{
+		mockFileBase: mockFileBase{name: "file.txt", mode: 0o644, size: 100, modTime: mtime},
+	}
+
+	de, err := newCachedDirEntry(current, cached, "file.txt")
+	require.NoError(t, err)
+	require.Nil(t, de.BirthTime, "btime should remain nil when neither entry has it")
+}

--- a/snapshot/upload/upload_newcacheddirentry_test.go
+++ b/snapshot/upload/upload_newcacheddirentry_test.go
@@ -78,6 +78,11 @@ var (
 	_ object.HasObjectID    = &mockCachedFileNoBtime{}
 )
 
+// btimeUploader returns a minimal Uploader with birth time preservation enabled for testing.
+func btimeUploader() *Uploader {
+	return &Uploader{PreserveBirthTime: true}
+}
+
 // TestNewCachedDirEntry_PreservesCachedBtime_WhenCurrentLacksBtime simulates a scenario where
 // a previous snapshot captured btime (e.g., on macOS/Windows or Linux ext4/btrfs), but the
 // current filesystem doesn't report btime (e.g., tmpfs, NFS, or older kernel). The cached
@@ -100,7 +105,7 @@ func TestNewCachedDirEntry_PreservesCachedBtime_WhenCurrentLacksBtime(t *testing
 		mockFileBase: mockFileBase{name: "file.txt", mode: 0o644, size: 100, modTime: mtime},
 	}
 
-	de, err := newCachedDirEntry(current, cached, "file.txt")
+	de, err := btimeUploader().newCachedDirEntry(current, cached, "file.txt")
 	require.NoError(t, err)
 	require.NotNil(t, de.BirthTime, "cached btime should be preserved when current FS lacks btime")
 	require.Equal(t, cachedBtime, de.BirthTime.ToTime().UTC(),
@@ -130,7 +135,7 @@ func TestNewCachedDirEntry_UsesCurrentBtime_WhenAvailable(t *testing.T) {
 		birthTime:    currentBtime,
 	}
 
-	de, err := newCachedDirEntry(current, cached, "file.txt")
+	de, err := btimeUploader().newCachedDirEntry(current, cached, "file.txt")
 	require.NoError(t, err)
 	require.NotNil(t, de.BirthTime, "btime should be set")
 	require.Equal(t, currentBtime, de.BirthTime.ToTime().UTC(),
@@ -154,7 +159,7 @@ func TestNewCachedDirEntry_NoBtime_WhenNeitherHasBtime(t *testing.T) {
 		mockFileBase: mockFileBase{name: "file.txt", mode: 0o644, size: 100, modTime: mtime},
 	}
 
-	de, err := newCachedDirEntry(current, cached, "file.txt")
+	de, err := btimeUploader().newCachedDirEntry(current, cached, "file.txt")
 	require.NoError(t, err)
 	require.Nil(t, de.BirthTime, "btime should remain nil when neither entry has it")
 }

--- a/snapshot/upload/upload_test.go
+++ b/snapshot/upload/upload_test.go
@@ -1857,7 +1857,9 @@ func TestUpload_BirthTime_RegularFile(t *testing.T) {
 	f.SetBirthTime(validBtime)
 
 	u := NewUploader(th.repo)
-	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+	policyTree := policy.BuildTree(nil, &policy.Policy{
+		UploadPolicy: policy.UploadPolicy{PreserveBirthTime: policy.NewOptionalBool(true)},
+	})
 
 	// First upload (no previous) - birthtime should be captured.
 	s1, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{})
@@ -1899,7 +1901,9 @@ func TestUpload_BirthTime_StreamingFile(t *testing.T) {
 
 	u := NewUploader(th.repo)
 	u.ForceHashPercentage = 0
-	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+	policyTree := policy.BuildTree(nil, &policy.Policy{
+		UploadPolicy: policy.UploadPolicy{PreserveBirthTime: policy.NewOptionalBool(true)},
+	})
 
 	// First upload - birthtime should be captured.
 	staticRoot := virtualfs.NewStaticDirectory("rootdir", []fs.Entry{
@@ -1922,6 +1926,31 @@ func TestUpload_BirthTime_StreamingFile(t *testing.T) {
 
 	btime2 := findChildBirthTime(t, ctx, th.repo, s2.RootEntry, "stream.txt")
 	require.Equal(t, validBtime.Unix(), btime2.Unix(), "cached upload should preserve birthtime")
+}
+
+func TestUpload_BirthTime_DisabledByPolicy(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+	th := newUploadTestHarness(ctx, t)
+
+	t.Cleanup(th.cleanup)
+
+	validBtime := time.Date(2020, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	sourceDir := mockfs.NewDirectory()
+	f := sourceDir.AddFile("test.txt", []byte("content"), defaultPermissions)
+	f.SetBirthTime(validBtime)
+
+	u := NewUploader(th.repo)
+	// Default policy: PreserveBirthTime is not set, defaults to false.
+	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+
+	s1, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{})
+	require.NoError(t, err)
+
+	btime := findChildBirthTime(t, ctx, th.repo, s1.RootEntry, "test.txt")
+	require.True(t, btime.IsZero(), "birth time should not be stored when policy does not enable it")
 }
 
 func TestUpload_BirthTime_NoBirthTime(t *testing.T) {

--- a/snapshot/upload/upload_test.go
+++ b/snapshot/upload/upload_test.go
@@ -1819,3 +1819,129 @@ func verifyLogDetails(t *testing.T, desc string, wantDetailKeys []string, keysAn
 	sort.Strings(wantDetailKeys)
 	require.Equal(t, wantDetailKeys, gotDetailKeys, "invalid details for "+desc)
 }
+
+// findChildBirthTime reads back a snapshot directory from the repo and returns the BirthTime
+// of the named child entry. Returns zero time if the child has no birthtime.
+func findChildBirthTime(t *testing.T, ctx context.Context, rep repo.Repository, rootEntry *snapshot.DirEntry, childName string) time.Time {
+	t.Helper()
+
+	dir := testutil.EnsureType[fs.Directory](t, snapshotfs.EntryFromDirEntry(rep, rootEntry))
+
+	var found fs.Entry
+
+	require.NoError(t, fs.IterateEntries(ctx, dir, func(_ context.Context, e fs.Entry) error {
+		if e.Name() == childName {
+			found = e
+		}
+
+		return nil
+	}))
+
+	require.NotNil(t, found, "child %q not found in snapshot", childName)
+
+	return fs.GetBirthTime(found)
+}
+
+func TestUpload_BirthTime_RegularFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+	th := newUploadTestHarness(ctx, t)
+
+	t.Cleanup(th.cleanup)
+
+	validBtime := time.Date(2020, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	sourceDir := mockfs.NewDirectory()
+	f := sourceDir.AddFile("test.txt", []byte("content"), defaultPermissions)
+	f.SetBirthTime(validBtime)
+
+	u := NewUploader(th.repo)
+	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+
+	// First upload (no previous) - birthtime should be captured.
+	s1, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{})
+	require.NoError(t, err)
+
+	btime1 := findChildBirthTime(t, ctx, th.repo, s1.RootEntry, "test.txt")
+	require.Equal(t, validBtime.Unix(), btime1.Unix(), "first upload should capture birthtime")
+
+	// Second upload with s1 as previous (cached path) - birthtime should be preserved.
+	s2, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{}, s1)
+	require.NoError(t, err)
+
+	btime2 := findChildBirthTime(t, ctx, th.repo, s2.RootEntry, "test.txt")
+	require.Equal(t, validBtime.Unix(), btime2.Unix(), "cached upload should preserve birthtime")
+
+	// Change birthtime on source (keep mtime same so cache key matches).
+	newBtime := time.Date(2021, 6, 20, 14, 45, 0, 0, time.UTC)
+	f.SetBirthTime(newBtime)
+
+	// Third upload with s2 as previous - should capture the updated birthtime.
+	s3, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{}, s2)
+	require.NoError(t, err)
+
+	btime3 := findChildBirthTime(t, ctx, th.repo, s3.RootEntry, "test.txt")
+	require.Equal(t, newBtime.Unix(), btime3.Unix(), "should capture updated birthtime")
+}
+
+func TestUpload_BirthTime_StreamingFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+	th := newUploadTestHarness(ctx, t)
+
+	t.Cleanup(th.cleanup)
+
+	validBtime := time.Date(2020, 1, 15, 10, 30, 0, 0, time.UTC)
+	mtime := time.Date(2021, 1, 2, 3, 4, 5, 0, time.UTC)
+	content := []byte("streaming content")
+
+	u := NewUploader(th.repo)
+	u.ForceHashPercentage = 0
+	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+
+	// First upload - birthtime should be captured.
+	staticRoot := virtualfs.NewStaticDirectory("rootdir", []fs.Entry{
+		virtualfs.StreamingFileWithBirthTimeFromReader("stream.txt", validBtime, mtime, io.NopCloser(bytes.NewReader(content))),
+	})
+
+	s1, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{})
+	require.NoError(t, err)
+
+	btime1 := findChildBirthTime(t, ctx, th.repo, s1.RootEntry, "stream.txt")
+	require.Equal(t, validBtime.Unix(), btime1.Unix(), "first upload should capture birthtime")
+
+	// Second upload with previous manifest (triggers cached streaming file path).
+	staticRoot = virtualfs.NewStaticDirectory("rootdir", []fs.Entry{
+		virtualfs.StreamingFileWithBirthTimeFromReader("stream.txt", validBtime, mtime, io.NopCloser(bytes.NewReader(content))),
+	})
+
+	s2, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{}, s1)
+	require.NoError(t, err)
+
+	btime2 := findChildBirthTime(t, ctx, th.repo, s2.RootEntry, "stream.txt")
+	require.Equal(t, validBtime.Unix(), btime2.Unix(), "cached upload should preserve birthtime")
+}
+
+func TestUpload_BirthTime_NoBirthTime(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+	th := newUploadTestHarness(ctx, t)
+
+	t.Cleanup(th.cleanup)
+
+	sourceDir := mockfs.NewDirectory()
+	sourceDir.AddFile("test.txt", []byte("content"), defaultPermissions)
+	// No SetBirthTime called - birthtime is zero.
+
+	u := NewUploader(th.repo)
+	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+
+	s1, err := u.Upload(ctx, sourceDir, policyTree, snapshot.SourceInfo{})
+	require.NoError(t, err)
+
+	btime := findChildBirthTime(t, ctx, th.repo, s1.RootEntry, "test.txt")
+	require.True(t, btime.IsZero(), "zero birthtime should result in no birthtime in snapshot")
+}


### PR DESCRIPTION
As discussed in #1908 here is a proposal to handle birthtime (btime / crtime).

Here is a summary of some "interesting" questions :

1.  Store or not store for oses that do not support write btime ?
The proposition follows "store what you can, restore what you can" philosophy, which means that linux users will have their repo grow to ~20byte per file to store btime even if for now they won't be able to use it upon restore...
That also means that a linux backup can be restored on mac with correct btime... Probably very rare situation ...

> I've been thinking about a policy to enable btime... that could be another way...

2. Update btime if changed on fs ?
Not doing that may help keep a better linux history as only first btime would be taken into account... But coherence has been preferred to make backup match fs... So if btime of a file changes, it will be reflected into any existing entry...

3. Nil or unix(0) as no btime
The proposition uses a pointer to correctly identify missing btime and 0 btime even if a file with a timestamp of 1.1.1970 would be surprising...

4. UI : reflect btime in UI / cli ?
For my personal usage, I don't need to see this information (I discovered that btime wasnt handled upon a restore...), but I could see value in that. Please tell me if you want that too

Beside the unit test, I have been able to validate various scenarios on Linux (docker golang image), macos sonoma 14.4.1 and windows10-64bits: old repo with new snapshot => old/new can restore (and only new keeps btimes)

I hope that the idea to handle btime is still relevant (for what I know, this would also be a + for kopia compared to restic) (and because I miss this feature ;-)) and wait for any comment / question / suggestion to make btime support happen for the best of the community.

closes #1908 