### PR TITLE
refactor(repository): expose repository public API

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/passwordpersist"
 	"github.com/kopia/kopia/internal/releasable"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/notification"
 	"github.com/kopia/kopia/notification/notifydata"
 	"github.com/kopia/kopia/notification/notifytemplate"
@@ -441,7 +442,7 @@ func assertDirectRepository(act func(ctx context.Context, rep repo.DirectReposit
 
 func (c *App) directRepositoryWriteAction(act func(ctx context.Context, rep repo.DirectRepositoryWriter) error) func(ctx *kingpin.ParseContext) error {
 	return c.repositoryAction(assertDirectRepository(func(ctx context.Context, rep repo.DirectRepository) error {
-		rep.LogManager().Enable()
+		rep.(repolog.Provider).LogManager().Enable()
 
 		return repo.DirectWriteSession(ctx, rep, repo.WriteSessionOptions{
 			Purpose:  "cli:" + c.currentActionName(),

--- a/cli/command_logs_cleanup.go
+++ b/cli/command_logs_cleanup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/maintenance"
 )
@@ -29,7 +30,7 @@ func (c *commandLogsCleanup) setup(svc appServices, parent commandParent) {
 }
 
 func (c *commandLogsCleanup) run(ctx context.Context, rep repo.DirectRepositoryWriter) error {
-	rep.LogManager().Disable()
+	rep.(repolog.Provider).LogManager().Disable()
 
 	stats, err := maintenance.CleanupLogs(ctx, rep, maintenance.LogRetentionOptions{
 		MaxTotalSize: c.maxTotalSizeMB << 20, //nolint:mnd

--- a/internal/repodiag/repolog/log_provider.go
+++ b/internal/repodiag/repolog/log_provider.go
@@ -1,0 +1,7 @@
+package repolog
+
+import "github.com/kopia/kopia/internal/repodiag"
+
+type Provider interface {
+	LogManager() *repodiag.LogManager
+}

--- a/internal/server/grpc_session.go
+++ b/internal/server/grpc_session.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kopia/kopia/internal/contentlog/logparam"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/internal/grpcapi"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/notification"
 	"github.com/kopia/kopia/notification/notifydata"
 	"github.com/kopia/kopia/repo"
@@ -92,7 +93,7 @@ func (s *Server) Session(srv grpcapi.KopiaRepository_SessionServer) error {
 		return status.Errorf(codes.Unavailable, "not connected to a direct repository")
 	}
 
-	log := dr.LogManager().NewLogger("grpc-session")
+	log := dr.(repolog.Provider).LogManager().NewLogger("grpc-session")
 	ctx = contentlog.WithParams(ctx, logparam.String("span:server-session", contentlog.RandomSpanID()))
 
 	usernameAtHostname, err := s.authenticateGRPCSession(ctx, dr)

--- a/repo/maintenance/blob_retain.go
+++ b/repo/maintenance/blob_retain.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kopia/kopia/internal/contentlog"
 	"github.com/kopia/kopia/internal/contentlog/logparam"
 	"github.com/kopia/kopia/internal/impossible"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/format"
@@ -32,7 +33,7 @@ type ExtendBlobRetentionTimeOptions struct {
 func extendBlobRetentionTime(ctx context.Context, rep repo.DirectRepositoryWriter, opt ExtendBlobRetentionTimeOptions) (*maintenancestats.ExtendBlobRetentionStats, error) {
 	ctx = contentlog.WithParams(ctx,
 		logparam.String("span:blob-retain", contentlog.RandomSpanID()))
-	log := rep.LogManager().NewLogger("maintenance-blob-retain")
+	log := rep.(repolog.Provider).LogManager().NewLogger("maintenance-blob-retain")
 
 	blobCfg, err := rep.FormatManager().BlobCfgBlob(ctx)
 	if err != nil {

--- a/repo/maintenance/cleanup_logs.go
+++ b/repo/maintenance/cleanup_logs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/contentlog"
 	"github.com/kopia/kopia/internal/contentlog/logparam"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/maintenancestats"
@@ -48,7 +49,7 @@ func CleanupLogs(ctx context.Context, rep repo.DirectRepositoryWriter, opt LogRe
 	ctx = contentlog.WithParams(ctx,
 		logparam.String("span:cleanup-logs", contentlog.RandomSpanID()))
 
-	log := rep.LogManager().NewLogger("maintenance-cleanup-logs")
+	log := rep.(repolog.Provider).LogManager().NewLogger("maintenance-cleanup-logs")
 
 	if opt.TimeFunc == nil {
 		opt.TimeFunc = clock.Now

--- a/repo/maintenance/content_rewrite.go
+++ b/repo/maintenance/content_rewrite.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kopia/kopia/internal/contentlog"
 	"github.com/kopia/kopia/internal/contentlog/logparam"
 	"github.com/kopia/kopia/internal/contentparam"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/internal/stats"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
@@ -49,7 +50,7 @@ func RewriteContents(ctx context.Context, rep repo.DirectRepositoryWriter, opt *
 	ctx = contentlog.WithParams(ctx,
 		logparam.String("span:content-rewrite", contentlog.RandomSpanID()))
 
-	log := rep.LogManager().NewLogger("maintenance-content-rewrite")
+	log := rep.(repolog.Provider).LogManager().NewLogger("maintenance-content-rewrite")
 
 	if opt == nil {
 		return nil, errors.New("missing options")

--- a/repo/maintenance/drop_deleted_contents.go
+++ b/repo/maintenance/drop_deleted_contents.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kopia/kopia/internal/contentlog"
 	"github.com/kopia/kopia/internal/contentlog/logparam"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/content/indexblob"
 	"github.com/kopia/kopia/repo/maintenancestats"
@@ -16,7 +17,7 @@ func dropDeletedContents(ctx context.Context, rep repo.DirectRepositoryWriter, d
 	ctx = contentlog.WithParams(ctx,
 		logparam.String("span:drop-deleted-contents", contentlog.RandomSpanID()))
 
-	log := rep.LogManager().NewLogger("maintenance-drop-deleted-contents")
+	log := rep.(repolog.Provider).LogManager().NewLogger("maintenance-drop-deleted-contents")
 
 	contentlog.Log1(ctx, log, "Dropping deleted contents", logparam.Time("dropDeletedBefore", dropDeletedBefore))
 

--- a/repo/maintenance/index_compaction.go
+++ b/repo/maintenance/index_compaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/kopia/kopia/internal/contentlog"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/repo/content/indexblob"
 	"github.com/kopia/kopia/repo/maintenancestats"
 )
@@ -11,7 +12,7 @@ import (
 // runTaskIndexCompactionQuick rewrites index blobs to reduce their count but does not drop any contents.
 func runTaskIndexCompactionQuick(ctx context.Context, runParams RunParameters, s *Schedule, safety SafetyParameters) error {
 	return reportRunAndMaybeCheckContentIndex(ctx, runParams.rep, TaskIndexCompaction, s, func() (maintenancestats.Kind, error) {
-		log := runParams.rep.LogManager().NewLogger("maintenance-index-compaction")
+		log := runParams.rep.(repolog.Provider).LogManager().NewLogger("maintenance-index-compaction")
 
 		contentlog.Log(ctx, log, "Compacting indexes...")
 

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kopia/kopia/internal/contentlog"
 	"github.com/kopia/kopia/internal/contentlog/logparam"
 	"github.com/kopia/kopia/internal/epoch"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/content/index"
@@ -257,7 +258,7 @@ func Run(ctx context.Context, runParams RunParameters, safety SafetyParameters) 
 }
 
 func runQuickMaintenance(ctx context.Context, runParams RunParameters, safety SafetyParameters) error {
-	log := runParams.rep.LogManager().NewLogger("maintenance-quick")
+	log := runParams.rep.(repolog.Provider).LogManager().NewLogger("maintenance-quick")
 
 	s, err := GetSchedule(ctx, runParams.rep)
 	if err != nil {
@@ -432,7 +433,7 @@ func runTaskEpochMaintenanceFull(ctx context.Context, runParams RunParameters, s
 func runTaskDropDeletedContentsFull(ctx context.Context, runParams RunParameters, s *Schedule, safety SafetyParameters) error {
 	var safeDropTime time.Time
 
-	log := runParams.rep.LogManager().NewLogger("maintenance-drop-deleted-contents")
+	log := runParams.rep.(repolog.Provider).LogManager().NewLogger("maintenance-drop-deleted-contents")
 
 	if safety.RequireTwoGCCycles {
 		safeDropTime = findSafeDropTime(s.Runs[TaskSnapshotGarbageCollection], safety)
@@ -499,7 +500,7 @@ func runTaskExtendBlobRetentionTimeFull(ctx context.Context, runParams RunParame
 }
 
 func runFullMaintenance(ctx context.Context, runParams RunParameters, safety SafetyParameters) error {
-	log := runParams.rep.LogManager().NewLogger("maintenance-full")
+	log := runParams.rep.(repolog.Provider).LogManager().NewLogger("maintenance-full")
 
 	s, err := GetSchedule(ctx, runParams.rep)
 	if err != nil {

--- a/repo/maintenance/pack_gc.go
+++ b/repo/maintenance/pack_gc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kopia/kopia/internal/blobparam"
 	"github.com/kopia/kopia/internal/contentlog"
 	"github.com/kopia/kopia/internal/contentlog/logparam"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/internal/stats"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
@@ -32,7 +33,7 @@ func DeleteUnreferencedPacks(ctx context.Context, rep repo.DirectRepositoryWrite
 	ctx = contentlog.WithParams(ctx,
 		logparam.String("span:pack-gc", contentlog.RandomSpanID()))
 
-	log := rep.LogManager().NewLogger("maintenance-pack-gc")
+	log := rep.(repolog.Provider).LogManager().NewLogger("maintenance-pack-gc")
 
 	if opt.Parallel == 0 {
 		opt.Parallel = 16

--- a/repo/notification.go
+++ b/repo/notification.go
@@ -1,0 +1,13 @@
+// Package notification provides a mechanism to send notifications for various events.
+package repo
+
+import (
+	"context"
+
+	"github.com/kopia/kopia/internal/grpcapi"
+)
+
+// RemoteNotifications is an interface implemented by repository clients that support remote notifications.
+type RemoteNotifications interface {
+	SendNotification(ctx context.Context, templateName string, templateDataJSON []byte, templateDataType grpcapi.NotificationEventArgType, severity int32) error
+}

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/crypto"
-	"github.com/kopia/kopia/internal/grpcapi"
 	"github.com/kopia/kopia/internal/metrics"
 	"github.com/kopia/kopia/internal/repodiag"
 	"github.com/kopia/kopia/repo/blob"
@@ -25,79 +24,6 @@ import (
 )
 
 var tracer = otel.Tracer("kopia/repository")
-
-// Repository exposes public API of Kopia repository, including objects and manifests.
-//
-//nolint:interfacebloat
-type Repository interface {
-	OpenObject(ctx context.Context, id object.ID) (object.Reader, error)
-	VerifyObject(ctx context.Context, id object.ID) ([]content.ID, error)
-	GetManifest(ctx context.Context, id manifest.ID, data any) (*manifest.EntryMetadata, error)
-	FindManifests(ctx context.Context, labels map[string]string) ([]*manifest.EntryMetadata, error)
-	ContentInfo(ctx context.Context, contentID content.ID) (content.Info, error)
-	PrefetchContents(ctx context.Context, contentIDs []content.ID, hint string) []content.ID
-	PrefetchObjects(ctx context.Context, objectIDs []object.ID, hint string) ([]content.ID, error)
-	Time() time.Time
-	ClientOptions() ClientOptions
-	NewWriter(ctx context.Context, opt WriteSessionOptions) (context.Context, RepositoryWriter, error)
-	UpdateDescription(d string)
-	Refresh(ctx context.Context) error
-	Close(ctx context.Context) error
-}
-
-// RepositoryWriter provides methods to write to a repository.
-type RepositoryWriter interface {
-	Repository
-
-	NewObjectWriter(ctx context.Context, opt object.WriterOptions) object.Writer
-	ConcatenateObjects(ctx context.Context, objectIDs []object.ID, opt ConcatenateOptions) (object.ID, error)
-	PutManifest(ctx context.Context, labels map[string]string, payload any) (manifest.ID, error)
-	ReplaceManifests(ctx context.Context, labels map[string]string, payload any) (manifest.ID, error)
-	DeleteManifest(ctx context.Context, id manifest.ID) error
-	OnSuccessfulFlush(callback RepositoryWriterCallback)
-	Flush(ctx context.Context) error
-}
-
-// RemoteRetentionPolicy is an interface implemented by repository clients that support remote retention policy.
-// when implemented, the repository server will invoke ApplyRetentionPolicy() server-side.
-type RemoteRetentionPolicy interface {
-	ApplyRetentionPolicy(ctx context.Context, sourcePath string, reallyDelete bool) ([]manifest.ID, error)
-}
-
-// RemoteNotifications is an interface implemented by repository clients that support remote notifications.
-type RemoteNotifications interface {
-	SendNotification(ctx context.Context, templateName string, templateDataJSON []byte, templateDataType grpcapi.NotificationEventArgType, severity int32) error
-}
-
-// DirectRepository provides additional low-level repository functionality.
-//
-//nolint:interfacebloat
-type DirectRepository interface {
-	Repository
-
-	ObjectFormat() format.ObjectFormat
-	FormatManager() *format.Manager
-	BlobReader() blob.Reader
-	BlobVolume() blob.Volume
-	ContentReader() content.Reader
-	IndexBlobs(ctx context.Context, includeInactive bool) ([]indexblob.Metadata, error)
-	NewDirectWriter(ctx context.Context, opt WriteSessionOptions) (context.Context, DirectRepositoryWriter, error)
-	UniqueID() []byte
-	ConfigFilename() string
-	DeriveKey(purpose string, keyLength int) ([]byte, error)
-	Token(password string) (string, error)
-	Throttler() throttling.SettableThrottler
-	DisableIndexRefresh()
-	LogManager() *repodiag.LogManager
-}
-
-// DirectRepositoryWriter provides low-level write access to the repository.
-type DirectRepositoryWriter interface {
-	RepositoryWriter
-	DirectRepository
-	BlobStorage() blob.Storage
-	ContentManager() *content.WriteManager
-}
 
 type immutableDirectRepositoryParameters struct {
 	configFile      string
@@ -400,39 +326,6 @@ func (r *directRepository) OnSuccessfulFlush(callback RepositoryWriterCallback) 
 	r.afterFlush = append(r.afterFlush, callback)
 }
 
-// WriteSessionOptions describes options for a write session.
-type WriteSessionOptions struct {
-	Purpose        string
-	FlushOnFailure bool        // whether to flush regardless of write session result.
-	OnUpload       func(int64) // function to invoke after completing each upload in the session.
-}
-
-// WriteSession executes the provided callback in a repository writer created for the purpose and flushes writes.
-func WriteSession(ctx context.Context, r Repository, opt WriteSessionOptions, cb func(ctx context.Context, w RepositoryWriter) error) error {
-	ctx, span := tracer.Start(ctx, "WriteSession:"+opt.Purpose)
-	defer span.End()
-
-	ctx, w, err := r.NewWriter(ctx, opt)
-	if err != nil {
-		return errors.Wrap(err, "unable to create writer")
-	}
-
-	return handleWriteSessionResult(ctx, w, opt, cb(ctx, w))
-}
-
-// DirectWriteSession executes the provided callback in a DirectRepositoryWriter created for the purpose and flushes writes.
-func DirectWriteSession(ctx context.Context, r DirectRepository, opt WriteSessionOptions, cb func(ctx context.Context, dw DirectRepositoryWriter) error) error {
-	ctx, span := tracer.Start(ctx, "DirectWriteSession:"+opt.Purpose)
-	defer span.End()
-
-	ctx, w, err := r.NewDirectWriter(ctx, opt)
-	if err != nil {
-		return errors.Wrap(err, "unable to create direct writer")
-	}
-
-	return handleWriteSessionResult(ctx, w, opt, cb(ctx, w))
-}
-
 // replaceManifestsHelper is a helper that deletes all manifests matching provided labels and replaces them with the provided one.
 func replaceManifestsHelper(ctx context.Context, rep RepositoryWriter, labels map[string]string, payload any) (manifest.ID, error) {
 	const minReplaceManifestTimeDelta = 100 * time.Millisecond
@@ -457,22 +350,6 @@ func replaceManifestsHelper(ctx context.Context, rep RepositoryWriter, labels ma
 
 	//nolint:wrapcheck
 	return rep.PutManifest(ctx, labels, payload)
-}
-
-func handleWriteSessionResult(ctx context.Context, w RepositoryWriter, opt WriteSessionOptions, resultErr error) error {
-	defer func() {
-		if err := w.Close(ctx); err != nil {
-			log(ctx).Errorf("error closing writer: %v", err)
-		}
-	}()
-
-	if resultErr == nil || opt.FlushOnFailure {
-		if err := w.Flush(ctx); err != nil {
-			return errors.Wrap(err, "error flushing writer")
-		}
-	}
-
-	return resultErr
 }
 
 func defaultTime(f func() time.Time) func() time.Time {

--- a/repo/repository_api.go
+++ b/repo/repository_api.go
@@ -1,0 +1,131 @@
+package repo
+
+import (
+	"context"
+	"time"
+
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/throttling"
+	"github.com/kopia/kopia/repo/content"
+	"github.com/kopia/kopia/repo/content/indexblob"
+	"github.com/kopia/kopia/repo/format"
+	"github.com/kopia/kopia/repo/manifest"
+	"github.com/kopia/kopia/repo/object"
+	"github.com/pkg/errors"
+)
+
+// Repository exposes public API of Kopia repository, including objects and manifests.
+//
+//nolint:interfacebloat
+type Repository interface {
+	OpenObject(ctx context.Context, id object.ID) (object.Reader, error)
+	VerifyObject(ctx context.Context, id object.ID) ([]content.ID, error)
+	GetManifest(ctx context.Context, id manifest.ID, data any) (*manifest.EntryMetadata, error)
+	FindManifests(ctx context.Context, labels map[string]string) ([]*manifest.EntryMetadata, error)
+	ContentInfo(ctx context.Context, contentID content.ID) (content.Info, error)
+	PrefetchContents(ctx context.Context, contentIDs []content.ID, hint string) []content.ID
+	PrefetchObjects(ctx context.Context, objectIDs []object.ID, hint string) ([]content.ID, error)
+	Time() time.Time
+	ClientOptions() ClientOptions
+	NewWriter(ctx context.Context, opt WriteSessionOptions) (context.Context, RepositoryWriter, error)
+	UpdateDescription(d string)
+	Refresh(ctx context.Context) error
+	Close(ctx context.Context) error
+}
+
+// RepositoryWriter provides methods to write to a repository.
+type RepositoryWriter interface {
+	Repository
+
+	NewObjectWriter(ctx context.Context, opt object.WriterOptions) object.Writer
+	ConcatenateObjects(ctx context.Context, objectIDs []object.ID, opt ConcatenateOptions) (object.ID, error)
+	PutManifest(ctx context.Context, labels map[string]string, payload any) (manifest.ID, error)
+	ReplaceManifests(ctx context.Context, labels map[string]string, payload any) (manifest.ID, error)
+	DeleteManifest(ctx context.Context, id manifest.ID) error
+	OnSuccessfulFlush(callback RepositoryWriterCallback)
+	Flush(ctx context.Context) error
+}
+
+// RemoteRetentionPolicy is an interface implemented by repository clients that support remote retention policy.
+// when implemented, the repository server will invoke ApplyRetentionPolicy() server-side.
+type RemoteRetentionPolicy interface {
+	ApplyRetentionPolicy(ctx context.Context, sourcePath string, reallyDelete bool) ([]manifest.ID, error)
+}
+
+// DirectRepository provides additional low-level repository functionality.
+//
+//nolint:interfacebloat
+type DirectRepository interface {
+	Repository
+
+	ObjectFormat() format.ObjectFormat
+	FormatManager() *format.Manager
+	BlobReader() blob.Reader
+	BlobVolume() blob.Volume
+	ContentReader() content.Reader
+	IndexBlobs(ctx context.Context, includeInactive bool) ([]indexblob.Metadata, error)
+	NewDirectWriter(ctx context.Context, opt WriteSessionOptions) (context.Context, DirectRepositoryWriter, error)
+	UniqueID() []byte
+	ConfigFilename() string
+	DeriveKey(purpose string, keyLength int) ([]byte, error)
+	Token(password string) (string, error)
+	Throttler() throttling.SettableThrottler
+	DisableIndexRefresh()
+}
+
+// DirectRepositoryWriter provides low-level write access to the repository.
+type DirectRepositoryWriter interface {
+	RepositoryWriter
+	DirectRepository
+	BlobStorage() blob.Storage
+	ContentManager() *content.WriteManager
+}
+
+// WriteSessionOptions describes options for a write session.
+type WriteSessionOptions struct {
+	Purpose        string
+	FlushOnFailure bool        // whether to flush regardless of write session result.
+	OnUpload       func(int64) // function to invoke after completing each upload in the session.
+}
+
+// WriteSession executes the provided callback in a repository writer created for the purpose and flushes writes.
+func WriteSession(ctx context.Context, r Repository, opt WriteSessionOptions, cb func(ctx context.Context, w RepositoryWriter) error) error {
+	ctx, span := tracer.Start(ctx, "WriteSession:"+opt.Purpose)
+	defer span.End()
+
+	ctx, w, err := r.NewWriter(ctx, opt)
+	if err != nil {
+		return errors.Wrap(err, "unable to create writer")
+	}
+
+	return handleWriteSessionResult(ctx, w, opt, cb(ctx, w))
+}
+
+// DirectWriteSession executes the provided callback in a DirectRepositoryWriter created for the purpose and flushes writes.
+func DirectWriteSession(ctx context.Context, r DirectRepository, opt WriteSessionOptions, cb func(ctx context.Context, dw DirectRepositoryWriter) error) error {
+	ctx, span := tracer.Start(ctx, "DirectWriteSession:"+opt.Purpose)
+	defer span.End()
+
+	ctx, w, err := r.NewDirectWriter(ctx, opt)
+	if err != nil {
+		return errors.Wrap(err, "unable to create direct writer")
+	}
+
+	return handleWriteSessionResult(ctx, w, opt, cb(ctx, w))
+}
+
+func handleWriteSessionResult(ctx context.Context, w RepositoryWriter, opt WriteSessionOptions, resultErr error) error {
+	defer func() {
+		if err := w.Close(ctx); err != nil {
+			log(ctx).Errorf("error closing writer: %v", err)
+		}
+	}()
+
+	if resultErr == nil || opt.FlushOnFailure {
+		if err := w.Flush(ctx); err != nil {
+			return errors.Wrap(err, "error flushing writer")
+		}
+	}
+
+	return resultErr
+}

--- a/snapshot/snapshotgc/gc.go
+++ b/snapshot/snapshotgc/gc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kopia/kopia/internal/contentlog"
 	"github.com/kopia/kopia/internal/contentlog/logparam"
 	"github.com/kopia/kopia/internal/contentparam"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/internal/stats"
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo"
@@ -90,7 +91,7 @@ func runInternal(ctx context.Context, rep repo.DirectRepositoryWriter, gcDelete 
 	ctx = contentlog.WithParams(ctx,
 		logparam.String("span:snapshot-gc", contentlog.RandomSpanID()))
 
-	log := rep.LogManager().NewLogger("maintenance-snapshot-gc")
+	log := rep.(repolog.Provider).LogManager().NewLogger("maintenance-snapshot-gc")
 
 	used, serr := bigmap.NewSet(ctx)
 	if serr != nil {

--- a/snapshot/snapshotmaintenance/snapshotmaintenance.go
+++ b/snapshot/snapshotmaintenance/snapshotmaintenance.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/maintenance"
 	"github.com/kopia/kopia/snapshot/snapshotgc"
@@ -20,7 +21,7 @@ func Run(ctx context.Context, dr repo.DirectRepositoryWriter, mode maintenance.M
 		return ErrReadonly
 	}
 
-	dr.LogManager().Enable()
+	dr.(repolog.Provider).LogManager().Enable()
 
 	//nolint:wrapcheck
 	return maintenance.RunExclusive(ctx, dr, mode, force,

--- a/snapshot/upload/upload.go
+++ b/snapshot/upload/upload.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kopia/kopia/internal/contentlog"
 	"github.com/kopia/kopia/internal/contentlog/logparam"
 	"github.com/kopia/kopia/internal/iocopy"
+	"github.com/kopia/kopia/internal/repodiag/repolog"
 	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/internal/workshare"
 	"github.com/kopia/kopia/repo"
@@ -1266,7 +1267,7 @@ func (u *Uploader) Upload(
 
 	ctx = contentlog.WithParams(ctx, logparam.String("span:upload", contentlog.HashSpanID(sourceInfo.String())))
 
-	if dr, ok := u.repo.(repo.DirectRepository); ok {
+	if dr, ok := u.repo.(repolog.Provider); ok {
 		log := dr.LogManager().NewLogger("uploader")
 
 		contentlog.Log(ctx, log, "uploading started")


### PR DESCRIPTION
Some recent changes has broken some repository public API to be fully used by 3rd as some internal packages are involved in the method signature.

Making below changes to fix them:
1. Move the pure public API to a dedicated file `repository_api.go`
2. Remove `LogManager() *repodiag.LogManager` method from `DirectRepository` as `repodiag.LogManager` is an internal package
3. Move `RemoteNotifications` interface to a dedicated file `notification.go` as it includes `grpcapi` internal package and also it doesn't look like a common repository interface
4. Add a new interface `repolog.Provider` into an internal package for internal callers to retrieve `LogManager`