### PR TITLE
feat(server): add user management http endpoints

### DIFF
--- a/internal/server/api_users.go
+++ b/internal/server/api_users.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+	"github.com/pkg/errors"
+)
+
+func handleListUsers(ctx context.Context, rc requestContext) (any, *apiError) {
+	profiles, err := user.ListUserProfiles(ctx, rc.rep)
+
+	if err != nil {
+		return nil, internalServerError(err)
+	}
+
+	if profiles == nil {
+		profiles = []*user.Profile{}
+	}
+
+	resp := &serverapi.ProfilesResponse{
+		Profiles: []*serverapi.Profile{},
+	}
+
+	for _, profile := range profiles {
+		pf := fillProfile(profile)
+		resp.Profiles = append(resp.Profiles, &pf)
+	}
+
+	return resp, nil
+}
+
+func handleGetUser(ctx context.Context, rc requestContext) (any, *apiError) {
+	username := rc.muxVar("username")
+	usr, err := user.GetUserProfile(ctx, rc.rep, username)
+
+	if err != nil {
+		if errors.Is(err, user.ErrUserNotFound) {
+			return nil, notFoundError(err.Error())
+		}
+		return nil, internalServerError(err)
+	}
+
+	pf := fillProfile(usr)
+	return &pf, nil
+}
+
+func handleDeleteUser(ctx context.Context, rc requestContext) (any, *apiError) {
+	username := rc.muxVar("username")
+
+	if _, err := user.GetUserProfile(ctx, rc.rep, username); errors.Is(err, user.ErrUserNotFound) {
+		return nil, notFoundError(err.Error())
+	}
+
+	if err := repo.WriteSession(ctx, rc.rep, repo.WriteSessionOptions{
+		Purpose: "handleDeleteUser",
+	}, func(ctx context.Context, w repo.RepositoryWriter) error {
+		return user.DeleteUserProfile(ctx, w, username)
+	}); err != nil {
+		return nil, internalServerError(errors.Wrap(err, "unable to delete user"))
+	}
+
+	return &serverapi.Empty{}, nil
+}
+
+func handleAddUser(ctx context.Context, rc requestContext) (any, *apiError) {
+	req := &serverapi.AddProfileRequest{}
+	if err := json.Unmarshal(rc.body, req); err != nil {
+		return nil, requestError(serverapi.ErrorMalformedRequest, "malformed request body")
+	}
+
+	if err := user.ValidateUsername(req.Username); err != nil {
+		return nil, requestError(serverapi.ErrorInvalidUsername, err.Error())
+	}
+
+	if err := repo.WriteSession(ctx, rc.rep, repo.WriteSessionOptions{
+		Purpose: "handleAddUser",
+	}, func(ctx context.Context, w repo.RepositoryWriter) error {
+		np, err := user.GetNewProfile(ctx, w, req.Username)
+		if err != nil {
+			if errors.Is(err, user.ErrUserAlreadyExists) {
+				return err
+			}
+			return err
+		}
+
+		if err := np.SetPassword(req.Password); err != nil {
+			return err
+		}
+
+		if err := user.SetUserProfile(ctx, w, np); err != nil {
+			return errors.Wrap(err, "error setting user profile")
+		}
+		return nil
+	}); err != nil {
+		return nil, internalServerError(err)
+	}
+
+	rc.srv.Refresh()
+
+	usr, err := user.GetUserProfile(ctx, rc.rep, req.Username)
+	if err != nil {
+		return nil, internalServerError(err)
+	}
+
+	pf := fillProfile(usr)
+	return &pf, nil
+}
+
+func handleUpdatePasswordUser(ctx context.Context, rc requestContext) (any, *apiError) {
+	username := rc.muxVar("username")
+	req := &serverapi.UpdateProfilePasswordRequest{}
+
+	if err := json.Unmarshal(rc.body, req); err != nil {
+		return nil, requestError(serverapi.ErrorMalformedRequest, "malformed request body")
+	}
+
+	usr, err := user.GetUserProfile(ctx, rc.rep, username)
+	if err != nil {
+		if errors.Is(err, user.ErrUserNotFound) {
+			return nil, notFoundError(err.Error())
+		}
+		return nil, internalServerError(err)
+	}
+
+	if err := usr.SetPassword(req.Password); err != nil {
+		return nil, internalServerError(err)
+	}
+
+	pf := fillProfile(usr)
+	return &pf, nil
+}
+
+func fillProfile(usr *user.Profile) serverapi.Profile {
+	usernameParts := strings.Split(usr.Username, "@")
+	return serverapi.Profile{
+		Username: usr.Username,
+		User:     usernameParts[0],
+		Hostname: usernameParts[1],
+	}
+}

--- a/internal/server/api_users_test.go
+++ b/internal/server/api_users_test.go
@@ -1,0 +1,311 @@
+package server_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kopia/kopia/internal/apiclient"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/servertesting"
+	"github.com/kopia/kopia/internal/user"
+	"github.com/kopia/kopia/repo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListUsersReturnsEmpty(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	var p = &serverapi.ProfilesResponse{}
+	require.NoError(t, cli.Get(ctx, "users", nil, &p))
+	require.Len(t, p.Profiles, 0)
+}
+
+func TestListUsersReturnsWhenExists(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+
+	require.NoError(t, addInitialUser(ctx, env.Repository, "user1@host1"))
+
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	var p = &serverapi.ProfilesResponse{}
+	require.NoError(t, cli.Get(ctx, "users", nil, &p))
+	require.Len(t, p.Profiles, 1)
+}
+
+func TestGetReturnsWhenExists(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+
+	require.NoError(t, addInitialUser(ctx, env.Repository, "user1@host1"))
+
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	var p = &serverapi.Profile{}
+	require.NoError(t, cli.Get(ctx, "users/"+"user1@host1", nil, &p))
+
+	require.Equal(t, "user1", p.User)
+	require.Equal(t, "host1", p.Hostname)
+	require.Equal(t, "user1@host1", p.Username)
+}
+
+func TestGetReturnsErrorWhenNotExists(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+	notFound := apiclient.HTTPStatusError{HTTPStatusCode: 404, ErrorMessage: "404 Not Found: user1@host2: user not found"}
+
+	var p = &serverapi.Profile{}
+	require.ErrorIs(t, cli.Get(ctx, "users/"+"user1@host2", nil, &p), notFound)
+}
+
+func DeleteUserReturnsErrorWhenNotExists(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+	notFound := apiclient.HTTPStatusError{HTTPStatusCode: 404, ErrorMessage: "404 Not Found: user1@host2: user not found"}
+
+	require.ErrorIs(t, cli.Delete(ctx, "users/"+"user1@host2", nil, nil, &serverapi.Empty{}), notFound)
+}
+
+func TestDeleteUserDeletesWhenUserExists(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+
+	require.NoError(t, addInitialUser(ctx, env.Repository, "user1@host1"))
+
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	require.NoError(t, cli.Delete(ctx, "users/"+"user1@host1", nil, nil, &serverapi.Empty{}))
+
+	usr, err := user.GetUserProfile(ctx, env.Repository, "user1@host1")
+	require.NotNil(t, err)
+	require.Nil(t, usr)
+
+}
+
+func TestAddUserInvalidBodyReturnsError(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	badReq := apiclient.HTTPStatusError{HTTPStatusCode: 400, ErrorMessage: "400 Bad Request: malformed request body"}
+	require.ErrorIs(t, cli.Post(ctx, "users", "", badReq), badReq)
+
+}
+func TestAddUserInvalidUsernameReturnsError(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	badReq := apiclient.HTTPStatusError{HTTPStatusCode: 400, ErrorMessage: "400 Bad Request: username must be specified as lowercase 'user@hostname'"}
+	var r = &serverapi.AddProfileRequest{
+		Username: "dummy",
+		Password: "dummy",
+	}
+	require.ErrorIs(t, cli.Post(ctx, "users", r, badReq), badReq)
+
+}
+func TestAddUserReturnsErrorWhenExists(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+	require.NoError(t, addInitialUser(ctx, env.Repository, "user1@host1"))
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	serverErr := apiclient.HTTPStatusError{HTTPStatusCode: 500, ErrorMessage: "500 Internal Server Error: internal server error: user1@host1: user already exists"}
+	var r = &serverapi.AddProfileRequest{
+		Username: "user1@host1",
+		Password: "dummy",
+	}
+	require.ErrorIs(t, cli.Post(ctx, "users", r, serverErr), serverErr)
+}
+func TestAddUserReturnsNewUser(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	var r = &serverapi.AddProfileRequest{
+		Username: "user1@host1",
+		Password: "dummy",
+	}
+	var p = &serverapi.Profile{}
+
+	err = cli.Post(ctx, "users", r, p)
+	require.Nil(t, err)
+	require.Equal(t, "user1", p.User)
+	require.Equal(t, "host1", p.Hostname)
+	require.Equal(t, "user1@host1", p.Username)
+}
+
+func TestUpdatePasswordInvalidBodyReturnsError(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+
+	require.NoError(t, addInitialUser(ctx, env.Repository, "user1@host1"))
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	badReq := apiclient.HTTPStatusError{HTTPStatusCode: 400, ErrorMessage: "400 Bad Request: malformed request body"}
+	require.ErrorIs(t, cli.Put(ctx, "users/"+"user1@host1", "", badReq), badReq)
+}
+
+func TestUpdatePasswordReturnsErrorWhenNotExists(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	serverErr := apiclient.HTTPStatusError{HTTPStatusCode: 404, ErrorMessage: "404 Not Found: user1@host1: user not found"}
+	var r = &serverapi.UpdateProfilePasswordRequest{
+		Password: "dummy",
+	}
+	require.ErrorIs(t, cli.Put(ctx, "users/"+"user1@host1", r, serverErr), serverErr)
+}
+
+func TestUpdatePasswordReturns(t *testing.T) {
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant)
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:                             srvInfo.BaseURL,
+		TrustedServerCertificateFingerprint: srvInfo.TrustedServerCertificateFingerprint,
+		Username:                            servertesting.TestUIUsername,
+		Password:                            servertesting.TestUIPassword,
+	})
+	require.NoError(t, addInitialUser(ctx, env.Repository, "user1@host1"))
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	var r = &serverapi.UpdateProfilePasswordRequest{
+		Password: "dummy",
+	}
+	var res = &serverapi.Profile{}
+	require.NoError(t, cli.Put(ctx, "users/"+"user1@host1", r, res))
+	require.Equal(t, "user1", res.User)
+	require.Equal(t, "host1", res.Hostname)
+	require.Equal(t, "user1@host1", res.Username)
+}
+
+func addInitialUser(ctx context.Context, rp repo.Repository, username string) error {
+	return repo.WriteSession(ctx, rp, repo.WriteSessionOptions{},
+		func(ctx context.Context, w repo.RepositoryWriter) error {
+			testProfile := user.Profile{
+				Username:            username,
+				PasswordHashVersion: user.ScryptHashVersion,
+			}
+
+			err := testProfile.SetPassword("password1")
+			if err != nil {
+				return err
+			}
+
+			err = user.SetUserProfile(ctx, w, &testProfile)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -172,6 +172,13 @@ func (s *Server) SetupHTMLUIAPIHandlers(m *mux.Router) {
 	m.HandleFunc("/api/v1/notificationProfiles", s.handleUI(handleNotificationProfileList)).Methods(http.MethodGet)
 
 	m.HandleFunc("/api/v1/testNotificationProfile", s.handleUI(handleNotificationProfileTest)).Methods(http.MethodPost)
+
+	// Users
+	m.HandleFunc("/api/v1/users", s.handleUI(handleListUsers)).Methods(http.MethodGet)
+	m.HandleFunc("/api/v1/users", s.handleUI(handleAddUser)).Methods(http.MethodPost)
+	m.HandleFunc("/api/v1/users/{username}", s.handleUI(handleGetUser)).Methods(http.MethodGet)
+	m.HandleFunc("/api/v1/users/{username}", s.handleUI(handleDeleteUser)).Methods(http.MethodDelete)
+	m.HandleFunc("/api/v1/users/{username}", s.handleUI(handleUpdatePasswordUser)).Methods(http.MethodPut)
 }
 
 // SetupControlAPIHandlers registers control API handlers.

--- a/internal/serverapi/serverapi.go
+++ b/internal/serverapi/serverapi.go
@@ -93,6 +93,7 @@ const (
 	ErrorPathNotFound       APIErrorCode = "PATH_NOT_FOUND"
 	ErrorStorageConnection  APIErrorCode = "STORAGE_CONNECTION"
 	ErrorAccessDenied       APIErrorCode = "ACCESS_DENIED"
+	ErrorInvalidUsername    APIErrorCode = "INVALID_USERNAME"
 )
 
 // ErrorResponse represents error response.
@@ -296,4 +297,27 @@ type UIPreferences struct {
 	PageSize               int    `json:"pageSize"`               // A page size; the actual possible values will only be provided by the frontend
 	Language               string `json:"language"`               // Specifies the language used by the UI
 	Locale                 string `json:"locale"`                 // Specifies the locale used by the UI for formatting numbers and dates
+}
+
+// Profile represents a repository user.
+type Profile struct {
+	Username string `json:"username"`
+	User     string `json:"name"`
+	Hostname string `json:"host"`
+}
+
+// ProfilesResponse contains a list of repository users.
+type ProfilesResponse struct {
+	Profiles []*Profile `json:"profiles"`
+}
+
+// AddProfileRequest contains request to add a new repository user.
+type AddProfileRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// UpdateProfilePasswordRequest contains request to update a repository user's password
+type UpdateProfilePasswordRequest struct {
+	Password string `json:"password"`
 }


### PR DESCRIPTION
## Summary

This change introduces HTTP endpoints for managing users/profiles. Some of the reasoning for is described in https://github.com/kopia/kopia/issues/5079 , but mainly I want to control parts of Kopia  from a custom interface that does not have access to executing the CLI commands.

I am a bit unsure if this is added in the right place and way, so any pointers to mistakes and changes are welcome

## Changes

It add support for:
- Listing profiles: `GET /api/v1/users`
- Getting a profile by username `GET /api/v1/users/<username>`
- Adding new profiles `POST /api/v1/users`
- Deleting profiles `DELETE /api/v1/users/<username>`
- Updating profile password `PATCH /api/v1/users/<username>`

<details>

<summary>Expand for full API docs / example</summary>

### List users

**Request**
`GET /api/v1/users`

**Response**

```json
{
  "profiles": [
    {
      "username": "main@host1",
      "name": "main",
      "host": "host1"
    }
  ]
}
```

### Get user info

**Request**
`GET /api/v1/users/main@host1`

**Response**

```json
{
  "username": "main@host1",
  "name": "main",
  "host": "host1"
}
```

### Delete user

**Request**
`DELETE /api/v1/users/main@host1`

**Response**

```json
{}
```

### Add user

**Request**
`POST /api/v1/users`

```json
{
  "username": "main@host22",
  "password": "dummy"
}
```

**Response**

```json
{
  "username": "main@host22",
  "name": "main",
  "host": "host22"
}
```

### Update password

**Request**
`PUT /api/v1/users/main@host1`

```json
{
  "password": "newdummy"
}
```

</details>