### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.3
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.13.1
-	github.com/kopia/htmluibuild v0.0.1-0.20251125011029-7f1c3f84f29d
+	github.com/kopia/htmluibuild v0.0.1-0.20260204055701-cfa4cf572030
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.13.1 h1:9C1FiyTS0GWU0gz9oclrFrXtK0BJE6Cg5s/gihsr2jw=
 github.com/klauspost/reedsolomon v1.13.1/go.mod h1:ggJT9lc71Vu+cSOPBlxGvBN6TfAS77qB4fp8vJ05NSA=
-github.com/kopia/htmluibuild v0.0.1-0.20251125011029-7f1c3f84f29d h1:U3VB/cDMsPW4zB4JRFbVRDzIpPytt889rJUKAG40NPA=
-github.com/kopia/htmluibuild v0.0.1-0.20251125011029-7f1c3f84f29d/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260204055701-cfa4cf572030 h1:dib7t4FiGe+HSuq9AweSiVjrXn/d7p6eoIZ2gmtM5BI=
+github.com/kopia/htmluibuild v0.0.1-0.20260204055701-cfa4cf572030/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/00007b1667f4fb02aee448a54dee2e5c3990b6af...88c4d30f57ad3e79d28ca49e774cb4c80a239fe0

* Tue 21:51 -0800 https://github.com/kopia/htmlui/commit/5f6cd72 dependabot[bot] build(deps-dev): bump typescript-eslint from 8.33.0 to 8.51.0
* Tue 21:51 -0800 https://github.com/kopia/htmlui/commit/df2cb29 dependabot[bot] build(deps): bump react-router and react-router-dom
* Tue 21:52 -0800 https://github.com/kopia/htmlui/commit/83cf8f7 dependabot[bot] build(deps-dev): bump prettier from 3.6.2 to 3.7.4
* Tue 21:55 -0800 https://github.com/kopia/htmlui/commit/3c759c7 dependabot[bot] build(deps-dev): bump lodash from 4.17.21 to 4.17.23
* Tue 21:55 -0800 https://github.com/kopia/htmlui/commit/88c4d30 dependabot[bot] build(deps-dev): bump typescript from 5.8.3 to 5.9.3

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Wed Feb  4 05:57:40 UTC 2026*
