### PR TITLE
feat: add configurable KDF parameters for PBKDF2 and scrypt

### DIFF
--- a/cli/command_repository_change_password.go
+++ b/cli/command_repository_change_password.go
@@ -5,11 +5,15 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/repo"
 )
 
 type commandRepositoryChangePassword struct {
-	newPassword string
+	newPassword   string
+	newKDF        string
+	newIterations int
+	newMemoryMB   int
 
 	svc advancedAppServices
 }
@@ -17,6 +21,9 @@ type commandRepositoryChangePassword struct {
 func (c *commandRepositoryChangePassword) setup(svc advancedAppServices, parent commandParent) {
 	cmd := parent.Command("change-password", "Change repository password")
 	cmd.Flag("new-password", "New password").Envar(svc.EnvName("KOPIA_NEW_PASSWORD")).StringVar(&c.newPassword)
+	cmd.Flag("pbkdf", "Password-based key derivation algorithm (pbkdf2 or scrypt, optional)").Default("").PlaceHolder("ALGO").StringVar(&c.newKDF)
+	cmd.Flag("pbkdf-iter", "Number of iterations for PBKDF2 (default: 600000)").Default("0").PlaceHolder("ITERATIONS").IntVar(&c.newIterations)
+	cmd.Flag("pbkdf-memory", "Memory cost in MB for scrypt (default: 64MB)").Default("0").PlaceHolder("MB").IntVar(&c.newMemoryMB)
 
 	c.svc = svc
 	cmd.Action(svc.directRepositoryWriteAction(c.run))
@@ -36,7 +43,15 @@ func (c *commandRepositoryChangePassword) run(ctx context.Context, rep repo.Dire
 		newPass = c.newPassword
 	}
 
-	if err := rep.FormatManager().ChangePassword(ctx, newPass); err != nil {
+	// Validate KDF flags are consistent
+	if c.newKDF == crypto.PBKDF2 && c.newMemoryMB > 0 {
+		return errors.New("--pbkdf-memory cannot be used with --pbkdf=pbkdf2")
+	}
+	if c.newKDF == crypto.Scrypt && c.newIterations > 0 {
+		return errors.New("--pbkdf-iter cannot be used with --pbkdf=scrypt")
+	}
+
+	if err := rep.FormatManager().ChangePassword(ctx, newPass, c.newKDF, c.newIterations, c.newMemoryMB); err != nil {
 		return errors.Wrap(err, "unable to change password")
 	}
 

--- a/internal/crypto/pb_key_deriver_pbkdf2.go
+++ b/internal/crypto/pb_key_deriver_pbkdf2.go
@@ -3,13 +3,17 @@ package crypto
 import (
 	"crypto/pbkdf2"
 	"crypto/sha256"
+	"fmt"
 
 	"github.com/pkg/errors"
 )
 
 const (
-	// Pbkdf2Algorithm is the key for the pbkdf algorithm.
+	// Pbkdf2Algorithm is the full algorithm name for PBKDF2.
 	Pbkdf2Algorithm = "pbkdf2-sha256-600000"
+
+	// PBKDF2 is the short name for PBKDF2, used in CLI flags.
+	PBKDF2 = "pbkdf2"
 
 	// A good rule of thumb is to use a salt that is the same size
 	// as the output of the hash function. For example, the output of SHA256
@@ -28,6 +32,25 @@ func init() {
 		iterations:    pbkdf2Sha256Iterations,
 		minSaltLength: pbkdf2Sha256MinSaltLength,
 	})
+}
+
+// NewPBKDF2KeyDeriverWithIterations creates a new PBKDF2 key deriver with the specified number of iterations.
+// The algorithm name is unique to the iteration count, allowing multiple configurations to coexist.
+// If the algorithm is already registered, returns the existing algorithm name.
+func NewPBKDF2KeyDeriverWithIterations(iterations int) string {
+	algorithmName := fmt.Sprintf("pbkdf2-sha256-%d", iterations)
+
+	// Check if already registered
+	if _, ok := keyDerivers[algorithmName]; ok {
+		return algorithmName
+	}
+
+	registerPBKeyDeriver(algorithmName, &pbkdf2KeyDeriver{
+		iterations:    iterations,
+		minSaltLength: pbkdf2Sha256MinSaltLength,
+	})
+
+	return algorithmName
 }
 
 type pbkdf2KeyDeriver struct {

--- a/internal/crypto/pb_key_deriver_pbkdf2_test.go
+++ b/internal/crypto/pb_key_deriver_pbkdf2_test.go
@@ -1,0 +1,61 @@
+package crypto_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/crypto"
+)
+
+func TestNewPBKDF2KeyDeriverWithIterations(t *testing.T) {
+	t.Run("creates custom algorithm with specified iterations", func(t *testing.T) {
+		const customIterations = 100000
+		algoName := crypto.NewPBKDF2KeyDeriverWithIterations(customIterations)
+
+		expectedName := "pbkdf2-sha256-100000"
+		require.Equal(t, expectedName, algoName)
+
+		// Verify the algorithm is registered and works
+		salt := []byte("0123456789012345")
+		key, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, algoName)
+		require.NoError(t, err)
+		require.Len(t, key, 32)
+	})
+
+	t.Run("creates different algorithms for different iterations", func(t *testing.T) {
+		algo1 := crypto.NewPBKDF2KeyDeriverWithIterations(100000)
+		algo2 := crypto.NewPBKDF2KeyDeriverWithIterations(200000)
+
+		require.NotEqual(t, algo1, algo2)
+
+		salt := []byte("0123456789012345")
+		key1, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, algo1)
+		require.NoError(t, err)
+
+		key2, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, algo2)
+		require.NoError(t, err)
+
+		require.NotEqual(t, key1, key2)
+	})
+
+	t.Run("same iterations produce same key", func(t *testing.T) {
+		algoName := crypto.NewPBKDF2KeyDeriverWithIterations(150000)
+		salt := []byte("0123456789012345")
+
+		key1, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, algoName)
+		require.NoError(t, err)
+
+		key2, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, algoName)
+		require.NoError(t, err)
+
+		require.Equal(t, key1, key2)
+	})
+}
+
+func TestDefaultPBKDF2AlgorithmStillWorks(t *testing.T) {
+	salt := []byte("0123456789012345")
+	key, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, crypto.Pbkdf2Algorithm)
+	require.NoError(t, err)
+	require.Len(t, key, 32)
+}

--- a/internal/crypto/pb_key_deriver_scrypt_test.go
+++ b/internal/crypto/pb_key_deriver_scrypt_test.go
@@ -1,0 +1,67 @@
+package crypto_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/crypto"
+)
+
+func TestNewScryptKeyDeriverWithMemory(t *testing.T) {
+	t.Run("creates custom algorithm with specified memory", func(t *testing.T) {
+		algoName := crypto.NewScryptKeyDeriverWithMemory(64)
+
+		require.Equal(t, "scrypt-65536-8-1", algoName)
+
+		// Verify the algorithm is registered and works
+		salt := []byte("0123456789012345")
+		key, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, algoName)
+		require.NoError(t, err)
+		require.Len(t, key, 32)
+	})
+
+	t.Run("creates different algorithms for different memory", func(t *testing.T) {
+		algo128 := crypto.NewScryptKeyDeriverWithMemory(128)
+		algo32 := crypto.NewScryptKeyDeriverWithMemory(32)
+
+		require.NotEqual(t, algo128, algo32)
+
+		salt := []byte("0123456789012345")
+		key128, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, algo128)
+		require.NoError(t, err)
+
+		key32, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, algo32)
+		require.NoError(t, err)
+
+		require.NotEqual(t, key128, key32)
+	})
+
+	t.Run("same memory produces same key", func(t *testing.T) {
+		algoName := crypto.NewScryptKeyDeriverWithMemory(128)
+		salt := []byte("0123456789012345")
+
+		key1, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, algoName)
+		require.NoError(t, err)
+
+		key2, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, algoName)
+		require.NoError(t, err)
+
+		require.Equal(t, key1, key2)
+	})
+
+	t.Run("calculates N correctly for various memory sizes", func(t *testing.T) {
+		algo32 := crypto.NewScryptKeyDeriverWithMemory(32)
+		require.Equal(t, "scrypt-32768-8-1", algo32)
+
+		algo256 := crypto.NewScryptKeyDeriverWithMemory(256)
+		require.Equal(t, "scrypt-262144-8-1", algo256)
+	})
+}
+
+func TestDefaultScryptAlgorithmStillWorks(t *testing.T) {
+	salt := []byte("0123456789012345")
+	key, err := crypto.DeriveKeyFromPassword("testpassword", salt, 32, crypto.ScryptAlgorithm)
+	require.NoError(t, err)
+	require.Len(t, key, 32)
+}

--- a/internal/crypto/pb_key_derivers.go
+++ b/internal/crypto/pb_key_derivers.go
@@ -23,8 +23,41 @@ func registerPBKeyDeriver(name string, keyDeriver passwordBasedKeyDeriver) {
 	keyDerivers[name] = keyDeriver
 }
 
+// registerAlgorithmIfNeeded registers a KDF algorithm by its name if it matches a known pattern.
+func registerAlgorithmIfNeeded(algorithm string) {
+	// Check if already registered
+	if _, ok := keyDerivers[algorithm]; ok {
+		return
+	}
+
+	// Parse PBKDF2 algorithm: pbkdf2-sha256-{iterations}
+	var pbkdf2Iterations int
+	if _, err := fmt.Sscanf(algorithm, "pbkdf2-sha256-%d", &pbkdf2Iterations); err == nil && pbkdf2Iterations > 0 {
+		keyDerivers[algorithm] = &pbkdf2KeyDeriver{
+			iterations:    pbkdf2Iterations,
+			minSaltLength: pbkdf2Sha256MinSaltLength,
+		}
+		return
+	}
+
+	// Parse scrypt algorithm: scrypt-{N}-8-1
+	var n int
+	if _, err := fmt.Sscanf(algorithm, "scrypt-%d-8-1", &n); err == nil && n > 0 {
+		keyDerivers[algorithm] = &scryptKeyDeriver{
+			n:             n,
+			r:             8,
+			p:             1,
+			minSaltLength: scryptMinSaltLength,
+		}
+		return
+	}
+}
+
 // DeriveKeyFromPassword derives encryption key using the provided password and per-repository unique ID.
 func DeriveKeyFromPassword(password string, salt []byte, keySize int, algorithm string) ([]byte, error) {
+	// Try to register the algorithm if it follows a known pattern
+	registerAlgorithmIfNeeded(algorithm)
+
 	kd, ok := keyDerivers[algorithm]
 	if !ok {
 		return nil, errors.Errorf("unsupported key derivation algorithm: %v, supported algorithms %v", algorithm, supportedPBKeyDerivationAlgorithms())

--- a/repo/format/format_change_password.go
+++ b/repo/format/format_change_password.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/crypto"
 	"github.com/kopia/kopia/repo/blob"
 )
 
 // ChangePassword changes the repository password and rewrites
 // `kopia.repository` & `kopia.blobcfg`.
-func (m *Manager) ChangePassword(ctx context.Context, newPassword string) error {
+// If kdf is empty, the existing KDF algorithm is preserved.
+// If kdf is "pbkdf2" or "scrypt", the corresponding algorithm is used with the provided parameters.
+func (m *Manager) ChangePassword(ctx context.Context, newPassword string, kdf string, kdfIterations, kdfMemoryMB int) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -18,13 +21,37 @@ func (m *Manager) ChangePassword(ctx context.Context, newPassword string) error 
 		return errors.New("password changes are not supported for repositories created using Kopia v0.8 or older")
 	}
 
-	newFormatEncryptionKey, err := m.j.DeriveFormatEncryptionKeyFromPassword(newPassword)
+	// Determine the KDF algorithm to use
+	algorithm := m.j.KeyDerivationAlgorithm
+	if kdf != "" {
+		// Build algorithm from parameters
+		if kdf == crypto.PBKDF2 {
+			if kdfIterations > 0 {
+				algorithm = crypto.NewPBKDF2KeyDeriverWithIterations(kdfIterations)
+			} else {
+				algorithm = crypto.Pbkdf2Algorithm
+			}
+		} else if kdf == crypto.Scrypt {
+			if kdfMemoryMB > 0 {
+				algorithm = crypto.NewScryptKeyDeriverWithMemory(kdfMemoryMB)
+			} else {
+				algorithm = crypto.ScryptAlgorithm
+			}
+		}
+	}
+
+	newFormatEncryptionKey, err := crypto.DeriveKeyFromPassword(newPassword, m.j.UniqueID, 32, algorithm)
 	if err != nil {
 		return errors.Wrap(err, "unable to derive master key")
 	}
 
 	m.formatEncryptionKey = newFormatEncryptionKey
 	m.password = newPassword
+
+	// Update the key derivation algorithm in the format blob if it changed
+	if kdf != "" {
+		m.j.KeyDerivationAlgorithm = algorithm
+	}
 
 	if err := m.j.EncryptRepositoryConfig(m.repoConfig, newFormatEncryptionKey); err != nil {
 		return errors.Wrap(err, "unable to encrypt format bytes")

--- a/repo/format/format_manager_test.go
+++ b/repo/format/format_manager_test.go
@@ -352,7 +352,7 @@ func TestChangePassword(t *testing.T) {
 	mgr2, err := format.NewManagerWithCache(ctx, fst, cacheDuration, "some-password", nowFunc, blobCache)
 	require.NoError(t, err)
 
-	require.NoError(t, mgr2.ChangePassword(ctx, "new-password"))
+	require.NoError(t, mgr2.ChangePassword(ctx, "new-password", "", 0, 0))
 
 	// immediately after changing the password, both managers can still read the repo
 	mustGetMutableParameters(t, mgr)

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -411,7 +411,7 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 
 	// verify that the blobcfg retention blob is created
 	require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, format.KopiaBlobCfgBlobID, 0, -1, &d))
-	require.NoError(t, env.RepositoryWriter.FormatManager().ChangePassword(ctx, "new-password"))
+	require.NoError(t, env.RepositoryWriter.FormatManager().ChangePassword(ctx, "new-password", "", 0, 0))
 	// verify that the blobcfg retention blob is created and is different after
 	// password-change
 	require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, format.KopiaBlobCfgBlobID, 0, -1, &d))
@@ -760,9 +760,9 @@ func (s *formatSpecificTestSuite) TestWriteSessionFlushOnFailure(t *testing.T) {
 func (s *formatSpecificTestSuite) TestChangePassword(t *testing.T) {
 	ctx, env := repotesting.NewEnvironment(t, s.formatVersion)
 	if s.formatVersion == format.FormatVersion1 {
-		require.Error(t, env.RepositoryWriter.FormatManager().ChangePassword(ctx, "new-password"))
+		require.Error(t, env.RepositoryWriter.FormatManager().ChangePassword(ctx, "new-password", "", 0, 0))
 	} else {
-		require.NoError(t, env.RepositoryWriter.FormatManager().ChangePassword(ctx, "new-password"))
+		require.NoError(t, env.RepositoryWriter.FormatManager().ChangePassword(ctx, "new-password", "", 0, 0))
 
 		r, err := repo.Open(ctx, env.RepositoryWriter.ConfigFilename(), "new-password", nil)
 		require.NoError(t, err)


### PR DESCRIPTION
  This commit allows users to set custom key derivation function (KDF)
  parameters when creating or changing a repository password.

  New CLI flags:
    --pbkdf         Password-based key derivation algorithm (pbkdf2 or scrypt)
    --pbkdf-iter    Number of iterations for PBKDF2 (default: 600000)
    --pbkdf-memory  Memory cost in MB for scrypt (default: 64MB)

  Examples:
    kopia repo create filesystem --path /repo --pbkdf=pbkdf2 --pbkdf-iter=1000000
    kopia repo create filesystem --path /repo --pbkdf=scrypt --pbkdf-memory=128
    kopia repo change-password --new-password=newpass --pbkdf=scrypt --pbkdf-memory=256