### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.4
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.13.2
-	github.com/kopia/htmluibuild v0.0.1-0.20260204055701-cfa4cf572030
+	github.com/kopia/htmluibuild v0.0.1-0.20260220043103-12827e348d58
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.13.2 h1:9qtQy2tKEVpVB8Pfq87ZljHZb60/LbeTQ1OxV8EGzdE=
 github.com/klauspost/reedsolomon v1.13.2/go.mod h1:ggJT9lc71Vu+cSOPBlxGvBN6TfAS77qB4fp8vJ05NSA=
-github.com/kopia/htmluibuild v0.0.1-0.20260204055701-cfa4cf572030 h1:dib7t4FiGe+HSuq9AweSiVjrXn/d7p6eoIZ2gmtM5BI=
-github.com/kopia/htmluibuild v0.0.1-0.20260204055701-cfa4cf572030/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260220043103-12827e348d58 h1:dUURSXpQySMEkxEt+9ZBCngOfFeHB93rLxYYdCbuSD8=
+github.com/kopia/htmluibuild v0.0.1-0.20260220043103-12827e348d58/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/88c4d30f57ad3e79d28ca49e774cb4c80a239fe0...0a5894456f16e99b12b071ff2254322eca98e9fc

* Thu 20:25 -0800 https://github.com/kopia/htmlui/commit/0a58944 dependabot[bot] build(deps-dev): bump axios from 1.12.1 to 1.13.5

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Fri Feb 20 04:31:24 UTC 2026*
