### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.4
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.13.2
-	github.com/kopia/htmluibuild v0.0.1-0.20260220043103-12827e348d58
+	github.com/kopia/htmluibuild v0.0.1-0.20260223225928-affc284183d9
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.13.2 h1:9qtQy2tKEVpVB8Pfq87ZljHZb60/LbeTQ1OxV8EGzdE=
 github.com/klauspost/reedsolomon v1.13.2/go.mod h1:ggJT9lc71Vu+cSOPBlxGvBN6TfAS77qB4fp8vJ05NSA=
-github.com/kopia/htmluibuild v0.0.1-0.20260220043103-12827e348d58 h1:dUURSXpQySMEkxEt+9ZBCngOfFeHB93rLxYYdCbuSD8=
-github.com/kopia/htmluibuild v0.0.1-0.20260220043103-12827e348d58/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260223225928-affc284183d9 h1:yxrtNk9N0FoteomfltTc8PRkMqVzv3kLQut78hk2iBY=
+github.com/kopia/htmluibuild v0.0.1-0.20260223225928-affc284183d9/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/0a5894456f16e99b12b071ff2254322eca98e9fc...bbbfcf37747b59b5872d1ae321fdf645ce525423

* 2 minutes ago https://github.com/kopia/htmlui/commit/bbbfcf3 dependabot[bot] build(deps-dev): bump ajv from 6.12.6 to 6.14.0

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Mon Feb 23 22:59:48 UTC 2026*
