### PR TITLE
feat(snapshots): parallel chunk restore for large single files

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -117,6 +117,7 @@ type commandRestore struct {
 	restoreConsistentAttributes   bool
 	restoreMode                   string
 	restoreParallel               int
+	restoreParallelChunkWorkers   int
 	restoreIgnorePermissionErrors bool
 	restoreWriteFilesAtomically   bool
 	restoreSkipTimes              bool
@@ -148,6 +149,7 @@ func (c *commandRestore) setup(svc appServices, parent commandParent) {
 	cmd.Flag("consistent-attributes", "When multiple snapshots match, fail if they have inconsistent attributes").Envar(svc.EnvName("KOPIA_RESTORE_CONSISTENT_ATTRIBUTES")).BoolVar(&c.restoreConsistentAttributes)
 	cmd.Flag("mode", "Override restore mode").Default(restoreModeAuto).EnumVar(&c.restoreMode, restoreModeAuto, restoreModeLocal, restoreModeZip, restoreModeZipNoCompress, restoreModeTar, restoreModeTgz)
 	cmd.Flag("parallel", "Restore parallelism (1=disable)").Default("8").IntVar(&c.restoreParallel)
+	cmd.Flag("parallel-chunks", "Number of parallel chunk fetchers per file for large file restore (0=default 8, 1=disable)").Default("0").IntVar(&c.restoreParallelChunkWorkers)
 	cmd.Flag("skip-owners", "Skip owners during restore").BoolVar(&c.restoreSkipOwners)
 	cmd.Flag("skip-permissions", "Skip permissions during restore").BoolVar(&c.restoreSkipPermissions)
 	cmd.Flag("skip-times", "Skip times during restore").BoolVar(&c.restoreSkipTimes)
@@ -272,6 +274,7 @@ func (c *commandRestore) restoreOutput(ctx context.Context, rep repo.Repository)
 			SkipTimes:              c.restoreSkipTimes,
 			WriteSparseFiles:       c.restoreWriteSparseFiles,
 			FlushFiles:             c.flushFiles,
+			ParallelChunkWorkers:   c.restoreParallelChunkWorkers,
 		}
 
 		if err := o.Init(ctx); err != nil {

--- a/repo/object/parallel_reader.go
+++ b/repo/object/parallel_reader.go
@@ -1,0 +1,100 @@
+package object
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+// ErrNotParallelizable is returned when an object is not a multi-chunk indirect
+// object and thus cannot be fetched in parallel.
+var ErrNotParallelizable = errors.New("object does not support parallel chunk reading")
+
+// DefaultParallelChunkWorkers is the default number of concurrent chunk fetchers
+// used when parallel chunk restore is enabled.
+const DefaultParallelChunkWorkers = 8
+
+// objectOpener can open objects by ID; satisfied by repo.Repository.
+type objectOpener interface {
+	OpenObject(ctx context.Context, id ID) (Reader, error)
+}
+
+// ReadIndirectObjectParallel reads the chunks of an indirect object in parallel,
+// calling callback(startOffset, data) for each chunk (possibly out of order).
+// Returns ErrNotParallelizable if oid is not a multi-chunk indirect object.
+func ReadIndirectObjectParallel(ctx context.Context, opener objectOpener, oid ID, workers int, callback func(offset int64, data []byte) error) error {
+	indexObjectID, ok := oid.IndexObjectID()
+	if !ok {
+		return ErrNotParallelizable
+	}
+
+	seekTable, err := loadSeekTableViaOpener(ctx, opener, indexObjectID)
+	if err != nil {
+		return err
+	}
+
+	if len(seekTable) <= 1 {
+		return ErrNotParallelizable
+	}
+
+	if workers <= 0 {
+		workers = DefaultParallelChunkWorkers
+	}
+
+	jobs := make(chan int, len(seekTable))
+	for i := range seekTable {
+		jobs <- i
+	}
+
+	close(jobs)
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	for range workers {
+		g.Go(func() error {
+			for idx := range jobs {
+				entry := seekTable[idx]
+
+				r, err := opener.OpenObject(gctx, entry.Object)
+				if err != nil {
+					return errors.Wrapf(err, "opening chunk %d", idx)
+				}
+
+				b := make([]byte, entry.Length)
+				_, err = io.ReadFull(r, b)
+				r.Close() //nolint:errcheck
+
+				if err != nil {
+					return errors.Wrapf(err, "reading chunk %d", idx)
+				}
+
+				if err := callback(entry.Start, b); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	}
+
+	return g.Wait()
+}
+
+func loadSeekTableViaOpener(ctx context.Context, opener objectOpener, indexID ID) ([]IndirectObjectEntry, error) {
+	r, err := opener.OpenObject(ctx, indexID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "opening index object %v", indexID)
+	}
+
+	defer r.Close() //nolint:errcheck
+
+	var ind indirectObject
+	if err := json.NewDecoder(r).Decode(&ind); err != nil {
+		return nil, errors.Wrap(err, "invalid indirect object")
+	}
+
+	return ind.Entries, nil
+}

--- a/repo/object/parallel_reader_test.go
+++ b/repo/object/parallel_reader_test.go
@@ -1,0 +1,129 @@
+package object
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/testlogging"
+)
+
+// parallelOpener wraps a Manager's contentMgr to satisfy objectOpener.
+type parallelOpener struct {
+	om *Manager
+}
+
+func (p *parallelOpener) OpenObject(ctx context.Context, id ID) (Reader, error) {
+	return Open(ctx, p.om.contentMgr, id)
+}
+
+func TestReadIndirectObjectParallel_NotIndirect(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	_, _, mgr := setupTest(t, nil)
+
+	w := mgr.NewWriter(ctx, WriterOptions{})
+	_, err := w.Write([]byte("hello world"))
+	require.NoError(t, err)
+
+	oid, err := w.Result()
+	require.NoError(t, err)
+
+	// A small object will be stored as a single non-indirect object.
+	if _, isIndirect := oid.IndexObjectID(); isIndirect {
+		t.Skip("unexpectedly got an indirect object for tiny data")
+	}
+
+	opener := &parallelOpener{om: mgr}
+	err = ReadIndirectObjectParallel(ctx, opener, oid, 4, func(int64, []byte) error { return nil })
+	require.ErrorIs(t, err, ErrNotParallelizable)
+}
+
+func TestReadIndirectObjectParallel_MultiChunk(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	// setupTest uses FIXED-1M splitter; write >2MB to guarantee at least 2 chunks.
+	_, _, mgr := setupTest(t, nil)
+
+	fileData := make([]byte, 3_000_000)
+	for i := range fileData {
+		fileData[i] = byte(i % 251)
+	}
+
+	w := mgr.NewWriter(ctx, WriterOptions{})
+	_, err := w.Write(fileData)
+	require.NoError(t, err)
+
+	oid, err := w.Result()
+	require.NoError(t, err)
+
+	if _, isIndirect := oid.IndexObjectID(); !isIndirect {
+		t.Fatal("expected an indirect object for large data")
+	}
+
+	opener := &parallelOpener{om: mgr}
+
+	var mu sync.Mutex
+	collected := map[int64][]byte{}
+
+	var callCount atomic.Int32
+
+	err = ReadIndirectObjectParallel(ctx, opener, oid, 4, func(offset int64, chunk []byte) error {
+		callCount.Add(1)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		collected[offset] = append([]byte(nil), chunk...)
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Greater(t, int(callCount.Load()), 1, "expected multiple chunks")
+
+	// Reassemble and compare with original.
+	var total int64
+	for _, b := range collected {
+		total += int64(len(b))
+	}
+
+	require.Equal(t, int64(len(fileData)), total)
+
+	assembled := make([]byte, len(fileData))
+	for off, b := range collected {
+		copy(assembled[off:], b)
+	}
+
+	require.Equal(t, fileData, assembled)
+}
+
+func TestReadIndirectObjectParallel_CallbackError(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	_, _, mgr := setupTest(t, nil)
+
+	fileData := make([]byte, 3_000_000)
+
+	w := mgr.NewWriter(ctx, WriterOptions{})
+	_, err := w.Write(fileData)
+	require.NoError(t, err)
+
+	oid, err := w.Result()
+	require.NoError(t, err)
+
+	if _, isIndirect := oid.IndexObjectID(); !isIndirect {
+		t.Fatal("expected an indirect object for large data")
+	}
+
+	opener := &parallelOpener{om: mgr}
+	errBoom := fmt.Errorf("boom")
+
+	err = ReadIndirectObjectParallel(ctx, opener, oid, 4, func(int64, []byte) error {
+		return errBoom
+	})
+	require.ErrorIs(t, err, errBoom)
+}

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -217,6 +217,13 @@ func (rf *repositoryFile) Open(ctx context.Context) (fs.Reader, error) {
 	return withFileInfo(r, rf), nil
 }
 
+// ReadChunksParallel reads the chunks of this file in parallel, calling
+// callback(startOffset, data) for each chunk (possibly out of order).
+// Returns object.ErrNotParallelizable for single-chunk or non-indirect objects.
+func (rf *repositoryFile) ReadChunksParallel(ctx context.Context, workers int, callback func(offset int64, data []byte) error) error {
+	return object.ReadIndirectObjectParallel(ctx, rf.repo, rf.metadata.ObjectID, workers, callback)
+}
+
 func (rsl *repositorySymlink) Readlink(ctx context.Context) (string, error) {
 	r, err := rsl.repo.OpenObject(ctx, rsl.metadata.ObjectID)
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes #5113

Large files stored as indirect (multi-chunk) objects were restored sequentially — one HTTP request per chunk. With ~50ms S3 latency and ~100k chunks for a 400GB VM disk, this created ~5000s of pure latency overhead, limiting restore throughput to ~5–6 MB/s regardless of available bandwidth.

This PR implements parallel chunk fetching during restore:

- **`repo/object/parallel_reader.go`** — `ReadIndirectObjectParallel()`: loads the seek table from the indirect object index, dispatches N goroutines to fetch chunks concurrently via the `objectOpener` interface (satisfied by `repo.Repository`)
- **`snapshot/snapshotfs/repofs.go`** — `repositoryFile.ReadChunksParallel()`: exposes parallel chunk access for snapshot files (duck-typed, no interface change to `fs.File`)
- **`snapshot/restore/local_fs_output.go`** — `FilesystemOutput` detects multi-chunk files and writes chunks out-of-order via `WriteAt()`; automatically falls back to sequential for atomic/sparse writes or single-chunk objects (`ErrNotParallelizable`)
- **`cli/command_restore.go`** — `--parallel-chunks` flag (default `0` = 8 workers, `1` = disable)

## Test plan

- [x] `TestReadIndirectObjectParallel_NotIndirect` — single-chunk object returns `ErrNotParallelizable`
- [x] `TestReadIndirectObjectParallel_MultiChunk` — parallel fetch reassembles data correctly
- [x] `TestReadIndirectObjectParallel_CallbackError` — callback error is propagated
- [x] Full test suite with `-race`: `./repo/object/...`, `./snapshot/...`, `./fs/...`, `./internal/...`, `./cli/...` — all pass
