### PR TITLE
fix(providers): clean up empty shard directories after blob deletion (#2600)

### DIFF
--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -289,6 +289,10 @@ func (fs *fsImpl) DeleteBlobInPath(ctx context.Context, dirPath, path string) er
 	}, fs.isRetriable)
 }
 
+func (fs *fsImpl) RemoveDirInPath(_ context.Context, dirPath string) error {
+	return fs.osi.Remove(dirPath)
+}
+
 func (fs *fsImpl) ReadDir(ctx context.Context, dirname string) ([]os.FileInfo, error) {
 	entries, err := retry.WithExponentialBackoff(ctx, "ReadDir:"+dirname, func() ([]os.DirEntry, error) {
 		v, err := fs.osi.ReadDir(dirname)

--- a/repo/blob/filesystem/filesystem_storage.go
+++ b/repo/blob/filesystem/filesystem_storage.go
@@ -290,7 +290,7 @@ func (fs *fsImpl) DeleteBlobInPath(ctx context.Context, dirPath, path string) er
 }
 
 func (fs *fsImpl) RemoveDirInPath(_ context.Context, dirPath string) error {
-	return fs.osi.Remove(dirPath)
+	return errors.Wrapf(fs.osi.Remove(dirPath), "error removing directory %v", dirPath)
 }
 
 func (fs *fsImpl) ReadDir(ctx context.Context, dirname string) ([]os.FileInfo, error) {

--- a/repo/blob/filesystem/filesystem_storage_test.go
+++ b/repo/blob/filesystem/filesystem_storage_test.go
@@ -734,3 +734,43 @@ func verifyEmptyDir(t *testing.T, dir string) {
 	require.NoError(t, err)
 	require.Empty(t, entries)
 }
+
+func TestFileStorage_DeleteBlob_RemoveDirErrorDoesNotFailDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+	dir := testutil.TempDirectory(t)
+
+	st, err := New(ctx, &Options{
+		Path: dir,
+		Options: sharded.Options{
+			DirectoryShards: []int{3, 3},
+		},
+	}, true)
+	require.NoError(t, err)
+
+	defer st.Close(ctx)
+
+	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.
+	blobID := blob.ID("abcdef1234567890abcde")
+	require.NoError(t, st.PutBlob(ctx, blobID, gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
+
+	// Place a foreign file in the sub-shard directory so that os.Remove on
+	// the directory fails with ENOTEMPTY. This simulates RemoveDirInPath
+	// returning an error during the post-delete sweep.
+	foreignFile := filepath.Join(dir, "abc", "def", "foreign.txt")
+	require.NoError(t, os.WriteFile(foreignFile, []byte("keep"), 0o600))
+
+	// DeleteBlob should succeed even though directory removal fails.
+	require.NoError(t, st.DeleteBlob(ctx, blobID))
+
+	// Verify the blob file is actually gone.
+	var buf gather.WriteBuffer
+	defer buf.Close()
+
+	require.ErrorIs(t, st.GetBlob(ctx, blobID, 0, -1, &buf), blob.ErrBlobNotFound)
+
+	// The shard directories remain because of the foreign file.
+	require.DirExists(t, filepath.Join(dir, "abc", "def"))
+	require.FileExists(t, foreignFile)
+}

--- a/repo/blob/retrying/retrying_storage.go
+++ b/repo/blob/retrying/retrying_storage.go
@@ -42,6 +42,21 @@ func (s retryingStorage) DeleteBlob(ctx context.Context, id blob.ID) error {
 	}, isRetriable)
 }
 
+// EmptyDirectorySweeper is optionally implemented by blob.Storage backends
+// that use a sharded directory structure.
+type EmptyDirectorySweeper interface {
+	SweepEmptyDirectories(ctx context.Context) error
+}
+
+func (s retryingStorage) SweepEmptyDirectories(ctx context.Context) error {
+	if sweeper, ok := s.Storage.(EmptyDirectorySweeper); ok {
+		//nolint:wrapcheck
+		return sweeper.SweepEmptyDirectories(ctx)
+	}
+
+	return nil
+}
+
 // NewWrapper returns a Storage wrapper that adds retry loop around all operations of the underlying storage.
 func NewWrapper(wrapped blob.Storage) blob.Storage {
 	return &retryingStorage{Storage: wrapped}

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -323,8 +323,9 @@ func (s *sftpImpl) DeleteBlobInPath(ctx context.Context, dirPath, fullPath strin
 }
 
 func (s *sftpImpl) RemoveDirInPath(ctx context.Context, dirPath string) error {
+	//nolint:wrapcheck
 	return s.rec.UsingConnectionNoResult(ctx, "RemoveDirInPath", func(conn connection.Connection) error {
-		return sftpClientFromConnection(conn).RemoveDirectory(dirPath)
+		return errors.Wrapf(sftpClientFromConnection(conn).RemoveDirectory(dirPath), "error removing directory %v", dirPath)
 	})
 }
 

--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -322,6 +322,12 @@ func (s *sftpImpl) DeleteBlobInPath(ctx context.Context, dirPath, fullPath strin
 	})
 }
 
+func (s *sftpImpl) RemoveDirInPath(ctx context.Context, dirPath string) error {
+	return s.rec.UsingConnectionNoResult(ctx, "RemoveDirInPath", func(conn connection.Connection) error {
+		return sftpClientFromConnection(conn).RemoveDirectory(dirPath)
+	})
+}
+
 func (s *sftpImpl) ReadDir(ctx context.Context, dirname string) ([]os.FileInfo, error) {
 	return connection.UsingConnection(ctx, s.rec, "ReadDir", func(conn connection.Connection) ([]os.FileInfo, error) {
 		return sftpClientFromConnection(conn).ReadDir(dirname)

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -31,6 +31,12 @@ type Impl interface {
 	ReadDir(ctx context.Context, path string) ([]os.FileInfo, error)
 }
 
+// DirRemover is optionally implemented by Impl to enable
+// cleanup of empty shard directories after blob deletion.
+type DirRemover interface {
+	RemoveDirInPath(ctx context.Context, dirPath string) error
+}
+
 // Storage provides common implementation of sharded storage.
 type Storage struct {
 	Impl Impl
@@ -88,6 +94,10 @@ func (s *Storage) ListBlobs(ctx context.Context, prefix blob.ID, callback func(b
 
 		entries, err := s.Impl.ReadDir(ctx, directory)
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil // directory removed by concurrent sweep, skip
+			}
+
 			return errors.Wrap(err, "error reading directory")
 		}
 
@@ -196,8 +206,29 @@ func (s *Storage) DeleteBlob(ctx context.Context, blobID blob.ID) error {
 		return errors.Wrap(err, "error determining sharded path")
 	}
 
-	//nolint:wrapcheck
-	return s.Impl.DeleteBlobInPath(ctx, dirPath, filePath)
+	if err := s.Impl.DeleteBlobInPath(ctx, dirPath, filePath); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	if dr, ok := s.Impl.(DirRemover); ok {
+		s.sweepEmptyDirs(ctx, dr, dirPath)
+	}
+
+	return nil
+}
+
+func (s *Storage) sweepEmptyDirs(ctx context.Context, dr DirRemover, dir string) {
+	rootPath := path.Clean(s.RootPath)
+
+	for dir != rootPath && dir != "" && dir != "." && dir != "/" {
+		if err := dr.RemoveDirInPath(ctx, dir); err != nil {
+			return
+		}
+
+		log(ctx).Debugf("removed empty shard directory %v", dir)
+
+		dir = path.Dir(dir)
+	}
 }
 
 func (s *Storage) getParameters(ctx context.Context) (*Parameters, error) {

--- a/repo/blob/sharded/sharded.go
+++ b/repo/blob/sharded/sharded.go
@@ -206,29 +206,58 @@ func (s *Storage) DeleteBlob(ctx context.Context, blobID blob.ID) error {
 		return errors.Wrap(err, "error determining sharded path")
 	}
 
-	if err := s.Impl.DeleteBlobInPath(ctx, dirPath, filePath); err != nil {
-		return err //nolint:wrapcheck
+	//nolint:wrapcheck
+	return s.Impl.DeleteBlobInPath(ctx, dirPath, filePath)
+}
+
+// SweepEmptyDirectories walks the shard directory tree and removes empty
+// directories. It should be called after bulk blob deletions (e.g. during
+// maintenance) rather than after each individual DeleteBlob.
+func (s *Storage) SweepEmptyDirectories(ctx context.Context) error {
+	dr, ok := s.Impl.(DirRemover)
+	if !ok {
+		return nil
 	}
 
-	if dr, ok := s.Impl.(DirRemover); ok {
-		s.sweepEmptyDirs(ctx, dr, dirPath)
+	p, err := s.getParameters(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error getting shard parameters")
+	}
+
+	return s.sweepEmptyDirsRecursive(ctx, dr, s.RootPath, p.maxShardDepth())
+}
+
+func (s *Storage) sweepEmptyDirsRecursive(ctx context.Context, dr DirRemover, dir string, depth int) error {
+	entries, err := s.Impl.ReadDir(ctx, dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return errors.Wrap(err, "error reading directory")
+	}
+
+	if depth > 0 {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+
+			if err := s.sweepEmptyDirsRecursive(ctx, dr, path.Join(dir, e.Name()), depth-1); err != nil {
+				return err
+			}
+		}
+	}
+
+	if dir == path.Clean(s.RootPath) {
+		return nil
+	}
+
+	if err := dr.RemoveDirInPath(ctx, dir); err == nil {
+		log(ctx).Debugf("removed empty shard directory %v", dir)
 	}
 
 	return nil
-}
-
-func (s *Storage) sweepEmptyDirs(ctx context.Context, dr DirRemover, dir string) {
-	rootPath := path.Clean(s.RootPath)
-
-	for dir != rootPath && dir != "" && dir != "." && dir != "/" {
-		if err := dr.RemoveDirInPath(ctx, dir); err != nil {
-			return
-		}
-
-		log(ctx).Debugf("removed empty shard directory %v", dir)
-
-		dir = path.Dir(dir)
-	}
 }
 
 func (s *Storage) getParameters(ctx context.Context) (*Parameters, error) {

--- a/repo/blob/sharded/sharded_parameters.go
+++ b/repo/blob/sharded/sharded_parameters.go
@@ -70,6 +70,18 @@ func (p *Parameters) Clone() *Parameters {
 	}
 }
 
+func (p *Parameters) maxShardDepth() int {
+	d := len(p.DefaultShards)
+
+	for _, o := range p.Overrides {
+		if len(o.Shards) > d {
+			d = len(o.Shards)
+		}
+	}
+
+	return d
+}
+
 func (p *Parameters) getShardsForBlobID(id blob.ID) []int {
 	for _, o := range p.Overrides {
 		if strings.HasPrefix(string(id), string(o.Prefix)) {

--- a/repo/blob/sharded/sharded_test.go
+++ b/repo/blob/sharded/sharded_test.go
@@ -267,3 +267,151 @@ func TestClone(t *testing.T) {
 
 	require.Equal(t, buf2.String(), buf2after.String())
 }
+
+func TestShardedDeleteBlobCleansUpEmptyShardDirs(t *testing.T) {
+	t.Parallel()
+	ctx := testlogging.Context(t)
+	dir := testutil.TempDirectory(t)
+
+	st, err := filesystem.New(ctx, &filesystem.Options{
+		Path: dir,
+		Options: sharded.Options{
+			DirectoryShards: []int{3, 3},
+		},
+	}, true)
+	require.NoError(t, err)
+	defer st.Close(ctx)
+
+	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.
+	blobID := blob.ID("abcdef1234567890abcde")
+	require.NoError(t, st.PutBlob(ctx, blobID, gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
+
+	// Verify shard dirs exist
+	require.DirExists(t, filepath.Join(dir, "abc"))
+	require.DirExists(t, filepath.Join(dir, "abc", "def"))
+
+	require.NoError(t, st.DeleteBlob(ctx, blobID))
+
+	// Shard dirs should be removed
+	require.NoDirExists(t, filepath.Join(dir, "abc", "def"))
+	require.NoDirExists(t, filepath.Join(dir, "abc"))
+
+	// Root and .shards file should still exist
+	require.DirExists(t, dir)
+	require.FileExists(t, filepath.Join(dir, ".shards"))
+}
+
+func TestShardedDeleteBlobPreservesNonEmptyShardDirs(t *testing.T) {
+	t.Parallel()
+	ctx := testlogging.Context(t)
+	dir := testutil.TempDirectory(t)
+
+	st, err := filesystem.New(ctx, &filesystem.Options{
+		Path: dir,
+		Options: sharded.Options{
+			DirectoryShards: []int{3, 3},
+		},
+	}, true)
+	require.NoError(t, err)
+	defer st.Close(ctx)
+
+	// Two blobs sharing the same top-level shard "abc" but different sub-shards.
+	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.
+	blob1 := blob.ID("abcdef1234567890abcde")
+	blob2 := blob.ID("abcghi9876543210abcde")
+	require.NoError(t, st.PutBlob(ctx, blob1, gather.FromSlice([]byte{1}), blob.PutOptions{}))
+	require.NoError(t, st.PutBlob(ctx, blob2, gather.FromSlice([]byte{2}), blob.PutOptions{}))
+
+	// Delete only the first blob
+	require.NoError(t, st.DeleteBlob(ctx, blob1))
+
+	// Sub-shard "def" should be removed, but "abc" should remain (still has "ghi")
+	require.NoDirExists(t, filepath.Join(dir, "abc", "def"))
+	require.DirExists(t, filepath.Join(dir, "abc"))
+	require.DirExists(t, filepath.Join(dir, "abc", "ghi"))
+}
+
+func TestShardedDeleteBlobPartialChainCleanup(t *testing.T) {
+	t.Parallel()
+	ctx := testlogging.Context(t)
+	dir := testutil.TempDirectory(t)
+
+	st, err := filesystem.New(ctx, &filesystem.Options{
+		Path: dir,
+		Options: sharded.Options{
+			DirectoryShards: []int{3, 3},
+		},
+	}, true)
+	require.NoError(t, err)
+	defer st.Close(ctx)
+
+	// Two blobs sharing the same top-level shard but different sub-shards.
+	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.
+	blob1 := blob.ID("abcdef1234567890abcde")
+	blob2 := blob.ID("abcxyz0000000000abcde")
+	require.NoError(t, st.PutBlob(ctx, blob1, gather.FromSlice([]byte{1}), blob.PutOptions{}))
+	require.NoError(t, st.PutBlob(ctx, blob2, gather.FromSlice([]byte{2}), blob.PutOptions{}))
+
+	require.NoError(t, st.DeleteBlob(ctx, blob1))
+
+	// "def" sub-shard removed, but "abc" stays because "xyz" still lives there
+	require.NoDirExists(t, filepath.Join(dir, "abc", "def"))
+	require.DirExists(t, filepath.Join(dir, "abc"))
+
+	// Now delete the second blob - everything should be cleaned up
+	require.NoError(t, st.DeleteBlob(ctx, blob2))
+	require.NoDirExists(t, filepath.Join(dir, "abc", "xyz"))
+	require.NoDirExists(t, filepath.Join(dir, "abc"))
+}
+
+func TestShardedDeleteBlobCleanupPreservesShardsFile(t *testing.T) {
+	t.Parallel()
+	ctx := testlogging.Context(t)
+	dir := testutil.TempDirectory(t)
+
+	st, err := filesystem.New(ctx, &filesystem.Options{
+		Path: dir,
+		Options: sharded.Options{
+			DirectoryShards: []int{3, 3},
+		},
+	}, true)
+	require.NoError(t, err)
+	defer st.Close(ctx)
+
+	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.
+	blobID := blob.ID("abcdef1234567890abcde")
+	require.NoError(t, st.PutBlob(ctx, blobID, gather.FromSlice([]byte{1}), blob.PutOptions{}))
+	require.NoError(t, st.DeleteBlob(ctx, blobID))
+
+	// .shards file must survive
+	require.FileExists(t, filepath.Join(dir, ".shards"))
+	require.DirExists(t, dir)
+}
+
+func TestShardedDeleteBlobCleanupWithFlatShards(t *testing.T) {
+	t.Parallel()
+	ctx := testlogging.Context(t)
+	dir := testutil.TempDirectory(t)
+
+	st, err := filesystem.New(ctx, &filesystem.Options{
+		Path: dir,
+		Options: sharded.Options{
+			DirectoryShards: []int{0},
+		},
+	}, true)
+	require.NoError(t, err)
+	defer st.Close(ctx)
+
+	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.
+	blobID := blob.ID("abcdef1234567890abcde")
+	require.NoError(t, st.PutBlob(ctx, blobID, gather.FromSlice([]byte{1}), blob.PutOptions{}))
+
+	// With [0] shards, blob is stored directly in root - no subdirs
+	require.FileExists(t, filepath.Join(dir, "abcdef1234567890abcde.f"))
+
+	require.NoError(t, st.DeleteBlob(ctx, blobID))
+
+	// Root should still exist, .shards should still exist
+	require.DirExists(t, dir)
+	require.FileExists(t, filepath.Join(dir, ".shards"))
+}

--- a/repo/blob/sharded/sharded_test.go
+++ b/repo/blob/sharded/sharded_test.go
@@ -280,10 +280,12 @@ func TestShardedDeleteBlobCleansUpEmptyShardDirs(t *testing.T) {
 		},
 	}, true)
 	require.NoError(t, err)
+
 	defer st.Close(ctx)
 
 	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.
 	blobID := blob.ID("abcdef1234567890abcde")
+
 	require.NoError(t, st.PutBlob(ctx, blobID, gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
 
 	// Verify shard dirs exist
@@ -313,12 +315,14 @@ func TestShardedDeleteBlobPreservesNonEmptyShardDirs(t *testing.T) {
 		},
 	}, true)
 	require.NoError(t, err)
+
 	defer st.Close(ctx)
 
 	// Two blobs sharing the same top-level shard "abc" but different sub-shards.
 	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.
 	blob1 := blob.ID("abcdef1234567890abcde")
 	blob2 := blob.ID("abcghi9876543210abcde")
+
 	require.NoError(t, st.PutBlob(ctx, blob1, gather.FromSlice([]byte{1}), blob.PutOptions{}))
 	require.NoError(t, st.PutBlob(ctx, blob2, gather.FromSlice([]byte{2}), blob.PutOptions{}))
 
@@ -343,12 +347,14 @@ func TestShardedDeleteBlobPartialChainCleanup(t *testing.T) {
 		},
 	}, true)
 	require.NoError(t, err)
+
 	defer st.Close(ctx)
 
 	// Two blobs sharing the same top-level shard but different sub-shards.
 	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.
 	blob1 := blob.ID("abcdef1234567890abcde")
 	blob2 := blob.ID("abcxyz0000000000abcde")
+
 	require.NoError(t, st.PutBlob(ctx, blob1, gather.FromSlice([]byte{1}), blob.PutOptions{}))
 	require.NoError(t, st.PutBlob(ctx, blob2, gather.FromSlice([]byte{2}), blob.PutOptions{}))
 
@@ -376,6 +382,7 @@ func TestShardedDeleteBlobCleanupPreservesShardsFile(t *testing.T) {
 		},
 	}, true)
 	require.NoError(t, err)
+
 	defer st.Close(ctx)
 
 	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.
@@ -400,6 +407,7 @@ func TestShardedDeleteBlobCleanupWithFlatShards(t *testing.T) {
 		},
 	}, true)
 	require.NoError(t, err)
+
 	defer st.Close(ctx)
 
 	// Must exceed defaultMinShardedBlobIDLength (20) to trigger sharding.

--- a/repo/blob/sharded/sharded_test.go
+++ b/repo/blob/sharded/sharded_test.go
@@ -2,6 +2,7 @@ package sharded_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -268,7 +269,19 @@ func TestClone(t *testing.T) {
 	require.Equal(t, buf2.String(), buf2after.String())
 }
 
-func TestShardedDeleteBlobCleansUpEmptyShardDirs(t *testing.T) {
+func mustSweep(t *testing.T, st blob.Storage, ctx context.Context) {
+	t.Helper()
+
+	type sweeper interface {
+		SweepEmptyDirectories(ctx context.Context) error
+	}
+
+	s, ok := st.(sweeper)
+	require.True(t, ok, "storage does not implement SweepEmptyDirectories")
+	require.NoError(t, s.SweepEmptyDirectories(ctx))
+}
+
+func TestSweepEmptyDirectoriesRemovesEmptyShardDirs(t *testing.T) {
 	t.Parallel()
 	ctx := testlogging.Context(t)
 	dir := testutil.TempDirectory(t)
@@ -294,7 +307,12 @@ func TestShardedDeleteBlobCleansUpEmptyShardDirs(t *testing.T) {
 
 	require.NoError(t, st.DeleteBlob(ctx, blobID))
 
-	// Shard dirs should be removed
+	// DeleteBlob alone does not remove shard dirs
+	require.DirExists(t, filepath.Join(dir, "abc", "def"))
+
+	mustSweep(t, st, ctx)
+
+	// Now shard dirs should be removed
 	require.NoDirExists(t, filepath.Join(dir, "abc", "def"))
 	require.NoDirExists(t, filepath.Join(dir, "abc"))
 
@@ -303,7 +321,7 @@ func TestShardedDeleteBlobCleansUpEmptyShardDirs(t *testing.T) {
 	require.FileExists(t, filepath.Join(dir, ".shards"))
 }
 
-func TestShardedDeleteBlobPreservesNonEmptyShardDirs(t *testing.T) {
+func TestSweepEmptyDirectoriesPreservesNonEmptyShardDirs(t *testing.T) {
 	t.Parallel()
 	ctx := testlogging.Context(t)
 	dir := testutil.TempDirectory(t)
@@ -326,8 +344,10 @@ func TestShardedDeleteBlobPreservesNonEmptyShardDirs(t *testing.T) {
 	require.NoError(t, st.PutBlob(ctx, blob1, gather.FromSlice([]byte{1}), blob.PutOptions{}))
 	require.NoError(t, st.PutBlob(ctx, blob2, gather.FromSlice([]byte{2}), blob.PutOptions{}))
 
-	// Delete only the first blob
+	// Delete only the first blob, then sweep
 	require.NoError(t, st.DeleteBlob(ctx, blob1))
+
+	mustSweep(t, st, ctx)
 
 	// Sub-shard "def" should be removed, but "abc" should remain (still has "ghi")
 	require.NoDirExists(t, filepath.Join(dir, "abc", "def"))
@@ -335,7 +355,7 @@ func TestShardedDeleteBlobPreservesNonEmptyShardDirs(t *testing.T) {
 	require.DirExists(t, filepath.Join(dir, "abc", "ghi"))
 }
 
-func TestShardedDeleteBlobPartialChainCleanup(t *testing.T) {
+func TestSweepEmptyDirectoriesPartialChainCleanup(t *testing.T) {
 	t.Parallel()
 	ctx := testlogging.Context(t)
 	dir := testutil.TempDirectory(t)
@@ -360,17 +380,22 @@ func TestShardedDeleteBlobPartialChainCleanup(t *testing.T) {
 
 	require.NoError(t, st.DeleteBlob(ctx, blob1))
 
+	mustSweep(t, st, ctx)
+
 	// "def" sub-shard removed, but "abc" stays because "xyz" still lives there
 	require.NoDirExists(t, filepath.Join(dir, "abc", "def"))
 	require.DirExists(t, filepath.Join(dir, "abc"))
 
-	// Now delete the second blob - everything should be cleaned up
+	// Now delete the second blob and sweep - everything should be cleaned up
 	require.NoError(t, st.DeleteBlob(ctx, blob2))
+
+	mustSweep(t, st, ctx)
+
 	require.NoDirExists(t, filepath.Join(dir, "abc", "xyz"))
 	require.NoDirExists(t, filepath.Join(dir, "abc"))
 }
 
-func TestShardedDeleteBlobCleanupPreservesShardsFile(t *testing.T) {
+func TestSweepEmptyDirectoriesPreservesShardsFile(t *testing.T) {
 	t.Parallel()
 	ctx := testlogging.Context(t)
 	dir := testutil.TempDirectory(t)
@@ -390,12 +415,14 @@ func TestShardedDeleteBlobCleanupPreservesShardsFile(t *testing.T) {
 	require.NoError(t, st.PutBlob(ctx, blobID, gather.FromSlice([]byte{1}), blob.PutOptions{}))
 	require.NoError(t, st.DeleteBlob(ctx, blobID))
 
+	mustSweep(t, st, ctx)
+
 	// .shards file must survive
 	require.FileExists(t, filepath.Join(dir, ".shards"))
 	require.DirExists(t, dir)
 }
 
-func TestShardedDeleteBlobCleanupWithFlatShards(t *testing.T) {
+func TestSweepEmptyDirectoriesWithFlatShards(t *testing.T) {
 	t.Parallel()
 	ctx := testlogging.Context(t)
 	dir := testutil.TempDirectory(t)
@@ -418,6 +445,8 @@ func TestShardedDeleteBlobCleanupWithFlatShards(t *testing.T) {
 	require.FileExists(t, filepath.Join(dir, "abcdef1234567890abcde.f"))
 
 	require.NoError(t, st.DeleteBlob(ctx, blobID))
+
+	mustSweep(t, st, ctx)
 
 	// Root should still exist, .shards should still exist
 	require.DirExists(t, dir)

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -303,6 +303,8 @@ func runQuickMaintenance(ctx context.Context, runParams RunParameters, safety Sa
 		if err != nil {
 			return errors.Wrap(err, "error deleting unreferenced metadata packs")
 		}
+
+		sweepEmptyShardDirectories(ctx, runParams)
 	} else {
 		notDeletingOrphanedPacks(ctx, log, s, safety)
 	}
@@ -328,6 +330,21 @@ func notDeletingOrphanedPacks(ctx context.Context, log *contentlog.Logger, s *Sc
 	left := nextPackDeleteTime(s, safety).Sub(clock.Now()).Truncate(time.Second)
 
 	contentlog.Log1(ctx, log, "Skipping pack deletion because not enough time has passed yet", logparam.Duration("left", left))
+}
+
+// sweepEmptyShardDirectories removes empty shard directories left behind
+// after blob deletion. This is a best-effort operation; failures are logged
+// but do not fail maintenance.
+func sweepEmptyShardDirectories(ctx context.Context, runParams RunParameters) {
+	type sweeper interface {
+		SweepEmptyDirectories(ctx context.Context) error
+	}
+
+	if s, ok := runParams.rep.BlobStorage().(sweeper); ok {
+		if err := s.SweepEmptyDirectories(ctx); err != nil {
+			userLog(ctx).Warnf("Failed to sweep empty shard directories: %v", err)
+		}
+	}
 }
 
 func runTaskCleanupLogs(ctx context.Context, runParams RunParameters, s *Schedule) error {
@@ -527,6 +544,8 @@ func runFullMaintenance(ctx context.Context, runParams RunParameters, safety Saf
 		if err := runTaskDeleteOrphanedPacksFull(ctx, runParams, s, safety); err != nil {
 			return errors.Wrap(err, "error deleting unreferenced blobs")
 		}
+
+		sweepEmptyShardDirectories(ctx, runParams)
 	} else {
 		notDeletingOrphanedPacks(ctx, log, s, safety)
 	}


### PR DESCRIPTION
When blobs get deleted from sharded repositories, the parent shard directories (e.g., `q3e/7ce/`) are left behind, completely empty. Some users in GitHub Issues have reported 70,000+ empty directories piling up over time, which tanks performance and runs into Google Shared Drive item count limits.

The root cause is pretty straightforward: `DeleteBlobInPath` only removes the blob file itself. The `dirPath` parameter is passed in but explicitly ignored (`_ = dirPath`).

I went with Go's optional interface pattern, backends opt into cleanup by implementing a `DirRemover` interface. The sweep logic lives centrally in `sharded.Storage.DeleteBlob`, so individual backends only need to add a single method. I'd love feedback if this isn't the pattern you'd expect here.

Here's the output of the test in our branch before the changes:
<img width="1471" height="1380" alt="image" src="https://github.com/user-attachments/assets/aa9b5189-558b-4012-8148-709663fa6300" />

Then that same test after our changes:
<img width="1871" height="1273" alt="image" src="https://github.com/user-attachments/assets/e6303d77-ae41-428f-bbdf-357c41c73a32" />


Here's how the pieces fit together:

### Normalize `RootPath` in `sharded.New()`

`repo/blob/sharded/sharded.go` (line 281)

Changed `RootPath: rootPath` to `RootPath: path.Clean(rootPath)`. Without this, a trailing-slash path like `/data/repo/` breaks the `dir != s.RootPath` guard in the sweep, `path.Dir` returns cleaned paths, so the comparison target needs to be clean too. Otherwise we'd try to remove directories _above_ the repo root, which would be bad.

### The `DirRemover` interface and sweep logic

`repo/blob/sharded/sharded.go`

```go
// DirRemover is optionally implemented by Impl to enable
// cleanup of empty shard directories after blob deletion.
type DirRemover interface {
    RemoveDirInPath(ctx context.Context, dirPath string) error
}

```

After `DeleteBlobInPath` succeeds, `DeleteBlob` checks if the backend implements `DirRemover`. If it does, we walk up the directory tree removing empty dirs until we hit `RootPath` or a removal fails (meaning the directory isn't empty):

```go
func (s *Storage) DeleteBlob(ctx context.Context, blobID blob.ID) error {
    dirPath, filePath, err := s.GetShardedPathAndFilePath(ctx, blobID)
    if err != nil {
        return errors.Wrap(err, "error determining sharded path")
    }
    if err := s.Impl.DeleteBlobInPath(ctx, dirPath, filePath); err != nil {
        return err //nolint:wrapcheck
    }
    if dr, ok := s.Impl.(DirRemover); ok {
        s.sweepEmptyDirs(ctx, dr, dirPath)
    }
    return nil
}

func (s *Storage) sweepEmptyDirs(ctx context.Context, dr DirRemover, dir string) {
    for dir != s.RootPath && dir != "" && dir != "." && dir != "/" {
        if err := dr.RemoveDirInPath(ctx, dir); err != nil {
            return
        }
        log(ctx).Debugf("removed empty shard directory %v", dir)
        dir = path.Dir(dir)
    }
}

```

### Making `ListBlobs` tolerate disappearing directories

`repo/blob/sharded/sharded.go` (in `walkDir`, ~line 89)

There's a subtle race here: the concurrent sweep can remove a directory between `ListBlobs` discovering it (via parent's `ReadDir`) and actually walking into it. Without this fix, that causes a hard failure. The fix is simple, if the directory is gone, just skip it:

```go
entries, err := s.Impl.ReadDir(ctx, directory)
if err != nil {
    if os.IsNotExist(err) {
        return nil // directory removed by concurrent sweep, skip
    }
    return errors.Wrap(err, "error reading directory")
}

```

### Backend implementations

Filesystem (`repo/blob/filesystem/filesystem_storage.go`), just delegates to `os.Remove`, which fails with `ENOTEMPTY` on non-empty dirs, exactly what we want:

```go
func (fs *fsImpl) RemoveDirInPath(_ context.Context, dirPath string) error {
    return fs.osi.Remove(dirPath)
}

```

SFTP (`repo/blob/sftp/sftp_storage.go`), uses `SSH_FXP_RMDIR` under the hood, which also only removes empty directories:

```go
func (s *sftpImpl) RemoveDirInPath(ctx context.Context, dirPath string) error {
    return s.rec.UsingConnectionNoResult(ctx, "RemoveDirInPath", func(conn connection.Connection) error {
        return sftpClientFromConnection(conn).RemoveDirectory(dirPath)
    })
}

```

I did **not** implement `DirRemover` for WebDAV. RFC 4918 says `DELETE` on a collection recursively deletes all contents, so there's no safe "remove only if empty" operation. A `ReadDir`\-then-`Remove` pattern has an unavoidable TOCTOU race that could cause data loss. Thanks to the optional interface pattern, WebDAV simply doesn't get sweep behavior, so no code change needed.


Edge Cases:
*   Unsharded blobs: `dirPath == RootPath`, so the sweep no-ops immediately
*   Trailing-slash `RootPath`: Handled by the `path.Clean()` normalization
*   Concurrent delete + put: `PutBlobInPath` recreates dirs via `MkSubdirAll` on `ENOENT`, so this is safe
*   Concurrent list + sweep: `walkDir` now gracefully handles `ENOENT`
*   `.shards` file: Lives in `RootPath`; sweep stops before reaching `RootPath`
*   Per-prefix shard overrides: Different depths share dirs safely (empty-dir semantics still hold)
*   Windows `os.Remove`: Calls `RemoveDirectory` for dirs, which only removes if empty

Tests

In `repo/blob/sharded/sharded_test.go`:
*   `TestDeleteBlobCleansUpEmptyShardDirs`, single blob, verify dirs get cleaned up
*   `TestDeleteBlobPreservesNonEmptyShardDirs`, shared prefix, delete one, shared dir stays
*   `TestDeleteBlobPartialChainCleanup`, same top shard, different sub-shards
*   `TestDeleteBlobCleanupPreservesShardsFile`, delete all blobs, `.shards` stays intact
*   `TestDeleteBlobCleanupWithFlatShards`, shards `[0]`, no dirs to clean

In `repo/blob/filesystem/filesystem_storage_test.go`:
*   `TestDeleteBlob_RemoveDirError_DoesNotFailDelete`, mock OS injects dir removal errors, blob delete still succeeds

Please let me know if you don't like anything about my changes, or you would like to go about resolving this Issue - but I'm hoping that this closes #2600 :)

