### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.4
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.13.3
-	github.com/kopia/htmluibuild v0.0.1-0.20260302044405-39cf4ae42011
+	github.com/kopia/htmluibuild v0.0.1-0.20260317050713-8dc0184502e8
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.13.3 h1:01GwnO2xoCSaM0ShP4qwl+FsHg3csFShC6Tu/RS1ji0=
 github.com/klauspost/reedsolomon v1.13.3/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
-github.com/kopia/htmluibuild v0.0.1-0.20260302044405-39cf4ae42011 h1:zLII9D9ueGu4gEaIla82qEghSJA1ZeUsIjZqHxoem04=
-github.com/kopia/htmluibuild v0.0.1-0.20260302044405-39cf4ae42011/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260317050713-8dc0184502e8 h1:M1Ew+mmcjmFemLrlInIhrrSqoUNBzuwPPI2Z8zMxWdY=
+github.com/kopia/htmluibuild v0.0.1-0.20260317050713-8dc0184502e8/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/522a7f3d7d1ae8e3a6df56f362443c3df015b35f...a20fbbf8bc1d9a6c38e768ec54ddc72a8a6ae78a

* Mon 22:06 -0700 https://github.com/kopia/htmlui/commit/a20fbbf dependabot[bot] build(deps-dev): bump flatted from 3.3.3 to 3.4.1

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Tue Mar 17 05:07:34 UTC 2026*
