### PR TITLE
fix(general): do not included concatenated entries in log

### DIFF
--- a/repo/object/object_manager.go
+++ b/repo/object/object_manager.go
@@ -129,7 +129,7 @@ func (om *Manager) Concatenate(ctx context.Context, objectIDs []ID, metadataComp
 		}
 	}
 
-	log(ctx).Debugf("concatenated %d entries, total: %v", len(concatenatedEntries), totalLength)
+	log(ctx).Debugf("concatenated %d entries, total object length: %d", len(concatenatedEntries), totalLength)
 
 	w := om.NewWriter(ctx, WriterOptions{
 		Prefix:             indirectContentPrefix,


### PR DESCRIPTION
- Fixes #3093

## Changes

The debug log at `object_manager.go:132` was using `%v` to format the entire `concatenatedEntries` slice, which for large files with many indirect entries could produce 1M+ character log lines.

Changed `log(ctx).Debugf("concatenated: %v total: %v", concatenatedEntries, totalLength)` to `log(ctx).Debugf("concatenated %d entries, total: %v", len(concatenatedEntries), totalLength)`.

This logs just the entry count instead of dumping the full slice contents. `totalLength` is already a simple `int64` so it stays as-is.

## Test Plan

- `go build ./repo/object/...` — compiles cleanly
- `go vet ./repo/object/...` — no issues
- `go test ./repo/object/...` — all tests pass

Log-only change, no behavioral impact.