### PR TITLE
fix(snapshots): use entry-specific policy for ErrorEntry handling

### DIFF
--- a/snapshot/upload/upload.go
+++ b/snapshot/upload/upload.go
@@ -928,8 +928,10 @@ func (u *Uploader) processSingle(
 			prefix         string
 		)
 
+		entryPolicy := policyTree.Child(entry.Name()).EffectivePolicy()
+
 		if errors.Is(entry.ErrorInfo(), fs.ErrUnknown) {
-			isIgnoredError = policyTree.EffectivePolicy().ErrorHandlingPolicy.IgnoreUnknownTypes.OrDefault(true)
+			isIgnoredError = entryPolicy.ErrorHandlingPolicy.IgnoreUnknownTypes.OrDefault(true)
 
 			// If unknown types are configured to be ignored, skip them completely without any error reporting
 			if isIgnoredError {
@@ -938,13 +940,13 @@ func (u *Uploader) processSingle(
 
 			prefix = "unknown entry"
 		} else {
-			isIgnoredError = policyTree.EffectivePolicy().ErrorHandlingPolicy.IgnoreFileErrors.OrDefault(false)
+			isIgnoredError = entryPolicy.ErrorHandlingPolicy.IgnoreFileErrors.OrDefault(false)
 			prefix = "error"
 		}
 
 		return u.processEntryUploadResult(ctx, nil, entry.ErrorInfo(), entryRelativePath, parentDirBuilder,
 			isIgnoredError,
-			u.OverrideEntryLogDetail.OrDefault(policyTree.EffectivePolicy().LoggingPolicy.Entries.Snapshotted.OrDefault(policy.LogDetailNone)),
+			u.OverrideEntryLogDetail.OrDefault(entryPolicy.LoggingPolicy.Entries.Snapshotted.OrDefault(policy.LogDetailNone)),
 			prefix, t0)
 
 	case fs.StreamingFile:


### PR DESCRIPTION
## Summary

The `fs.ErrorEntry` case in `processSingle` resolves policy using `policyTree.EffectivePolicy()`, which returns the parent directory's policy rather than the entry-specific policy. This makes per-entry policy rules ineffective for permission-denied ErrorEntry items.

## Changes

- Extract `entryPolicy := policyTree.Child(entry.Name()).EffectivePolicy()` in the ErrorEntry case
- Use entry-specific policy for `IgnoreUnknownTypes`, `IgnoreFileErrors`, and `LoggingPolicy` decisions
- Consistent with how `fs.File` (line 918) and `fs.StreamingFile` (line 953) already resolve their policies

## Context

Implements the review suggestion from #5217 (comment r2957889891): using `policyTree.Child(entry.Name())` for error handling decisions so that per-entry policies are respected.

Fixes #5232

This contribution was developed with AI assistance (Claude Code).