### PR TITLE
test(kopiaui): skip htmlui tests that are timing out

### DIFF
--- a/tests/htmlui_e2e_test/htmlui_e2e_test.go
+++ b/tests/htmlui_e2e_test/htmlui_e2e_test.go
@@ -207,6 +207,12 @@ func TestEndToEndTest(t *testing.T) {
 			chromedp.Click("a[data-testid='tab-repo']"),
 			tc.captureScreenshot("repository"),
 
+			chromedp.ActionFunc(func(context.Context) error {
+				t.Skip("Disconnect times out, skipping for now to unblock CI")
+
+				return nil
+			}),
+
 			tc.log("disconnecting"),
 			chromedp.Click("button[data-testid='disconnect']"),
 			tc.captureScreenshot("disconnected"),
@@ -254,6 +260,12 @@ func TestConnectDisconnectReconnect(t *testing.T) {
 			tc.log("navigating to repository page"),
 			chromedp.Click("a[data-testid='tab-repo']"),
 			tc.captureScreenshot("repository"),
+
+			chromedp.ActionFunc(func(context.Context) error {
+				t.Skip("Disconnect times out, skipping for now to unblock CI")
+
+				return nil
+			}),
 
 			tc.log("disconnecting"),
 			chromedp.Click("button[data-testid='disconnect']"),


### PR DESCRIPTION
Skip htmlui tests that are timing out.

This appears to be caused by changes in the Chrome version that is included in the test [runner image](https://github.com/actions/runner-images/blob/macos-15-arm64/20260325.0234/images/macos/macos-15-arm64-Readme.md).