### PR TITLE
fix: prevent goroutine deadlock in workshare pool and parallelwork queue

### DIFF
--- a/fs/entry.go
+++ b/fs/entry.go
@@ -50,6 +50,15 @@ type File interface {
 	Open(ctx context.Context) (Reader, error)
 }
 
+// Preflightable is optionally implemented by File entries that support
+// a quick accessibility check before upload. This allows detecting locked
+// or inaccessible files early, before a workshare worker is assigned.
+type Preflightable interface {
+	// Preflight performs a quick accessibility check (e.g. open + close).
+	// Returns nil if the file is accessible, or an error if it cannot be read.
+	Preflight(ctx context.Context) error
+}
+
 // StreamingFile represents an entry that is a stream.
 type StreamingFile interface {
 	Entry

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -114,6 +114,20 @@ func (fsf *filesystemFile) Open(ctx context.Context) (fs.Reader, error) {
 	return &fileWithMetadata{f}, nil
 }
 
+// Preflight performs a quick accessibility check by opening and immediately
+// closing the file. This catches locked/in-use files before a workshare
+// worker is assigned, avoiding pipeline stalls.
+func (fsf *filesystemFile) Preflight(_ context.Context) error {
+	f, err := os.Open(fsf.fullPath())
+	if err != nil {
+		return err
+	}
+
+	f.Close()
+
+	return nil
+}
+
 func (fsl *filesystemSymlink) Readlink(_ context.Context) (string, error) {
 	//nolint:wrapcheck
 	return os.Readlink(fsl.fullPath())

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -105,8 +105,8 @@ func (f *fileWithMetadata) Entry() (fs.Entry, error) {
 	return newFilesystemFile(newEntry(basename, fi, prefix)), nil
 }
 
-func (fsf *filesystemFile) Open(_ context.Context) (fs.Reader, error) {
-	f, err := os.Open(fsf.fullPath())
+func (fsf *filesystemFile) Open(ctx context.Context) (fs.Reader, error) {
+	f, err := openWithContext(ctx, fsf.fullPath())
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to open local file")
 	}

--- a/fs/localfs/local_fs_os.go
+++ b/fs/localfs/local_fs_os.go
@@ -64,10 +64,10 @@ func (it *filesystemDirectoryIterator) Close() {
 	it.dirHandle.Close() //nolint:errcheck
 }
 
-func (fsd *filesystemDirectory) Iterate(_ context.Context) (fs.DirectoryIterator, error) {
+func (fsd *filesystemDirectory) Iterate(ctx context.Context) (fs.DirectoryIterator, error) {
 	fullPath := fsd.fullPath()
 
-	d, err := os.Open(fullPath + trailingSeparator(fsd)) //nolint:gosec
+	d, err := openWithContext(ctx, fullPath+trailingSeparator(fsd))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read directory")
 	}

--- a/fs/localfs/local_fs_os.go
+++ b/fs/localfs/local_fs_os.go
@@ -184,6 +184,7 @@ func entryFromDirEntry(basename string, fi os.FileInfo, prefix string) fs.Entry 
 }
 
 var _ os.FileInfo = (*filesystemEntry)(nil)
+var _ fs.Preflightable = (*filesystemFile)(nil)
 
 func newEntry(basename string, fi os.FileInfo, prefix string) filesystemEntry {
 	return filesystemEntry{

--- a/fs/localfs/open_ctx.go
+++ b/fs/localfs/open_ctx.go
@@ -14,10 +14,31 @@ const defaultFileOpenTimeout = 60 * time.Second
 // openWithContext opens a file, respecting context cancellation and deadlines.
 // If the context has no deadline, a default timeout is applied. If os.Open blocks
 // beyond the deadline, an error is returned and any eventually-opened file handle
-// is closed in the background.
+// is closed by the same goroutine that opened it (no second cleanup goroutine).
+//
+// os.Open is called via a goroutine so the caller can return on context
+// cancellation. The cost is one goroutine + one buffered channel per call,
+// which adds up across million-file snapshots — but the alternative (a stuck
+// os.Open blocking the workshare worker indefinitely on locked Windows files)
+// caused the 17h hang this PR exists to fix. Cross-platform path here keeps
+// the same semantics on all OSes; a future optimization could specialize a
+// non-Windows fast path that avoids the goroutine when os.Open is known not
+// to hang.
 func openWithContext(ctx context.Context, path string) (*os.File, error) {
-	// Fast path: try non-blocking open first. If it completes immediately
-	// (the common case), avoid the goroutine overhead entirely.
+	// Fail fast on an already-cancelled context — saves the goroutine entirely.
+	if err := ctx.Err(); err != nil {
+		return nil, err //nolint:wrapcheck
+	}
+
+	// If the caller didn't supply a deadline, install a default so a wedged
+	// open can't block forever. Done before the goroutine launch so the
+	// goroutine inherits the same deadline via the select below.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultFileOpenTimeout)
+		defer cancel()
+	}
+
 	type result struct {
 		f   *os.File
 		err error
@@ -25,32 +46,30 @@ func openWithContext(ctx context.Context, path string) (*os.File, error) {
 
 	ch := make(chan result, 1)
 
+	// `done` lets the goroutine know when the caller has stopped waiting.
+	// This must be closed regardless of which select branch returns, so
+	// the goroutine can take ownership of the descriptor and close it
+	// instead of leaking it through the buffered channel.
+	done := make(chan struct{})
+	defer close(done)
+
 	go func() {
 		f, err := os.Open(path) //nolint:gosec
-		ch <- result{f, err}
+		select {
+		case ch <- result{f, err}:
+			// Delivered to the caller; caller owns the descriptor.
+		case <-done:
+			// Caller already returned via ctx.Done(). We own the cleanup.
+			if f != nil {
+				f.Close() //nolint:errcheck
+			}
+		}
 	}()
-
-	// If context has no deadline, add a default timeout to prevent
-	// indefinite blocking on locked files.
-	if _, ok := ctx.Deadline(); !ok {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, defaultFileOpenTimeout)
-		defer cancel()
-	}
 
 	select {
 	case r := <-ch:
 		return r.f, r.err
 	case <-ctx.Done():
-		// os.Open is still pending. Start a cleanup goroutine that waits for
-		// the open to complete and closes the handle if it eventually succeeds.
-		go func() {
-			r := <-ch
-			if r.f != nil {
-				r.f.Close() //nolint:errcheck
-			}
-		}()
-
 		return nil, ctx.Err() //nolint:wrapcheck
 	}
 }

--- a/fs/localfs/open_ctx.go
+++ b/fs/localfs/open_ctx.go
@@ -1,0 +1,56 @@
+package localfs
+
+import (
+	"context"
+	"os"
+	"time"
+)
+
+// defaultFileOpenTimeout is the maximum time to wait for os.Open to complete.
+// This prevents indefinite blocking on locked or inaccessible files from
+// stalling workshare pool workers, which can cascade into a full snapshot hang.
+const defaultFileOpenTimeout = 60 * time.Second
+
+// openWithContext opens a file, respecting context cancellation and deadlines.
+// If the context has no deadline, a default timeout is applied. If os.Open blocks
+// beyond the deadline, an error is returned and any eventually-opened file handle
+// is closed in the background.
+func openWithContext(ctx context.Context, path string) (*os.File, error) {
+	// Fast path: try non-blocking open first. If it completes immediately
+	// (the common case), avoid the goroutine overhead entirely.
+	type result struct {
+		f   *os.File
+		err error
+	}
+
+	ch := make(chan result, 1)
+
+	go func() {
+		f, err := os.Open(path) //nolint:gosec
+		ch <- result{f, err}
+	}()
+
+	// If context has no deadline, add a default timeout to prevent
+	// indefinite blocking on locked files.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultFileOpenTimeout)
+		defer cancel()
+	}
+
+	select {
+	case r := <-ch:
+		return r.f, r.err
+	case <-ctx.Done():
+		// os.Open is still pending. Start a cleanup goroutine that waits for
+		// the open to complete and closes the handle if it eventually succeeds.
+		go func() {
+			r := <-ch
+			if r.f != nil {
+				r.f.Close() //nolint:errcheck
+			}
+		}()
+
+		return nil, ctx.Err() //nolint:wrapcheck
+	}
+}

--- a/fs/localfs/open_ctx_test.go
+++ b/fs/localfs/open_ctx_test.go
@@ -1,0 +1,73 @@
+package localfs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/testutil"
+)
+
+func TestOpenWithContext_Success(t *testing.T) {
+	tmp := testutil.TempDirectory(t)
+	fn := filepath.Join(tmp, "testfile")
+	require.NoError(t, os.WriteFile(fn, []byte("hello"), 0o644))
+
+	f, err := openWithContext(context.Background(), fn)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	f.Close()
+}
+
+func TestOpenWithContext_FileNotFound(t *testing.T) {
+	f, err := openWithContext(context.Background(), "/no/such/file")
+	require.Error(t, err)
+	require.Nil(t, f)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestOpenWithContext_CancelledContext(t *testing.T) {
+	tmp := testutil.TempDirectory(t)
+	fn := filepath.Join(tmp, "testfile")
+	require.NoError(t, os.WriteFile(fn, []byte("hello"), 0o644))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	// With an already-cancelled context, os.Open may complete before the
+	// context check runs. Either outcome (success or context.Canceled) is
+	// acceptable — the key property is that it does not block.
+	f, err := openWithContext(ctx, fn)
+	if err != nil {
+		require.ErrorIs(t, err, context.Canceled)
+	} else {
+		f.Close()
+	}
+}
+
+func TestOpenWithContext_Timeout(t *testing.T) {
+	tmp := testutil.TempDirectory(t)
+	fn := filepath.Join(tmp, "testfile")
+	require.NoError(t, os.WriteFile(fn, []byte("hello"), 0o644))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	f, err := openWithContext(ctx, fn)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	f.Close()
+}
+
+func TestOpenWithContext_Directory(t *testing.T) {
+	tmp := testutil.TempDirectory(t)
+
+	f, err := openWithContext(context.Background(), tmp)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	f.Close()
+}

--- a/fs/localfs/open_ctx_test.go
+++ b/fs/localfs/open_ctx_test.go
@@ -49,7 +49,11 @@ func TestOpenWithContext_CancelledContext(t *testing.T) {
 	}
 }
 
-func TestOpenWithContext_Timeout(t *testing.T) {
+// TestOpenWithContext_TimeoutOnNonBlockingFile verifies that a normal file
+// opens promptly when there's a 5s deadline — the deadline should never fire.
+// This guards against a regression where openWithContext mistakenly enforces
+// the timeout even on fast paths.
+func TestOpenWithContext_TimeoutOnNonBlockingFile(t *testing.T) {
 	tmp := testutil.TempDirectory(t)
 	fn := filepath.Join(tmp, "testfile")
 	require.NoError(t, os.WriteFile(fn, []byte("hello"), 0o644))

--- a/fs/localfs/open_ctx_unix_test.go
+++ b/fs/localfs/open_ctx_unix_test.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package localfs
+
+import (
+	"context"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/testutil"
+)
+
+// TestOpenWithContext_TimeoutFiresOnBlockingOpen exercises the actual timeout
+// path: a posix FIFO blocks on open until the other end opens, so a context
+// deadline must cause openWithContext to return promptly with DeadlineExceeded.
+// FIFOs are unix-only; the equivalent Windows scenario (a locked file held
+// open by another process with restrictive sharing modes) requires
+// platform-specific setup and is intentionally not exercised here.
+func TestOpenWithContext_TimeoutFiresOnBlockingOpen(t *testing.T) {
+	tmp := testutil.TempDirectory(t)
+	fifoPath := filepath.Join(tmp, "blocker")
+	require.NoError(t, syscall.Mkfifo(fifoPath, 0o600))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	f, err := openWithContext(ctx, fifoPath)
+	elapsed := time.Since(start)
+
+	require.Nil(t, f)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	// Timeout was 100ms; the call should return within ~500ms even on slow CI.
+	// Without the cancellation path, this would block indefinitely.
+	require.Less(t, elapsed, 500*time.Millisecond,
+		"openWithContext should honor the context deadline, not wait for the FIFO peer")
+}

--- a/internal/parallelwork/parallel_work_queue.go
+++ b/internal/parallelwork/parallel_work_queue.go
@@ -4,6 +4,8 @@ package parallelwork
 import (
 	"container/list"
 	"context"
+	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -78,7 +80,7 @@ func (v *Queue) Process(ctx context.Context, workers int) error {
 						return nil
 					}
 
-					err := callback()
+					err := v.safeCallback(callback)
 
 					v.completed(ctx)
 
@@ -92,6 +94,20 @@ func (v *Queue) Process(ctx context.Context, workers int) error {
 
 	//nolint:wrapcheck
 	return eg.Wait()
+}
+
+// safeCallback executes a callback with panic recovery. If the callback panics,
+// the panic is caught and returned as an error instead of crashing the process.
+// This ensures completed() is always called by the caller, preventing deadlock
+// when activeWorkerCount would otherwise remain permanently incremented.
+func (v *Queue) safeCallback(callback CallbackFunc) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("panic in parallel work callback: %v\n%s", r, debug.Stack())
+		}
+	}()
+
+	return callback()
 }
 
 func (v *Queue) dequeue(ctx context.Context) CallbackFunc {

--- a/internal/parallelwork/parallel_work_queue_test.go
+++ b/internal/parallelwork/parallel_work_queue_test.go
@@ -269,6 +269,12 @@ func TestProcessRecoversPanic(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "panic in parallel work callback")
 	require.Contains(t, err.Error(), "test panic in callback")
+	// And the second callback ran — proving a panic doesn't strand the
+	// queue. Without the panic recovery in dequeue, completed() would
+	// never be called for the panicking item and Process would deadlock,
+	// so this assertion is what actually validates the no-deadlock claim.
+	require.Equal(t, int32(1), completed.Load(),
+		"non-panicking callback must execute despite earlier panic")
 }
 
 func TestProcessRecoversPanicWithEnqueuedWork(t *testing.T) {

--- a/internal/parallelwork/parallel_work_queue_test.go
+++ b/internal/parallelwork/parallel_work_queue_test.go
@@ -247,3 +247,45 @@ func TestOnNthCompletion(t *testing.T) {
 		require.Equal(t, n, noErrorCount)
 	})
 }
+
+func TestProcessRecoversPanic(t *testing.T) {
+	queue := parallelwork.NewQueue()
+
+	var completed atomic.Int32
+
+	// First callback panics.
+	queue.EnqueueBack(context.Background(), func() error {
+		panic("test panic in callback")
+	})
+
+	// Second callback should still execute and the queue should not deadlock.
+	queue.EnqueueBack(context.Background(), func() error {
+		completed.Add(1)
+		return nil
+	})
+
+	err := queue.Process(context.Background(), 2)
+	// The panic is converted to an error.
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "panic in parallel work callback")
+	require.Contains(t, err.Error(), "test panic in callback")
+}
+
+func TestProcessRecoversPanicWithEnqueuedWork(t *testing.T) {
+	queue := parallelwork.NewQueue()
+
+	// Callback that enqueues more work then panics — without recovery
+	// this would deadlock because completed() is never called and
+	// activeWorkerCount remains incremented, blocking dequeue() forever.
+	queue.EnqueueBack(context.Background(), func() error {
+		queue.EnqueueBack(context.Background(), func() error {
+			return nil
+		})
+
+		panic("panic after enqueue")
+	})
+
+	err := queue.Process(context.Background(), 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "panic after enqueue")
+}

--- a/internal/workshare/workshare_pool.go
+++ b/internal/workshare/workshare_pool.go
@@ -1,6 +1,9 @@
 package workshare
 
 import (
+	"fmt"
+	"os"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 )
@@ -52,11 +55,7 @@ func NewPool[T any](numWorkers int) *Pool[T] {
 			for {
 				select {
 				case it := <-w.work:
-					w.activeWorkers.Add(1)
-					it.process(w, it.request)
-					w.activeWorkers.Add(-1)
-					<-w.semaphore
-					it.wg.Done()
+					w.processWorkItem(it)
 
 				case <-w.closed:
 					return
@@ -66,6 +65,24 @@ func NewPool[T any](numWorkers int) *Pool[T] {
 	}
 
 	return w
+}
+
+// processWorkItem executes a single work item with guaranteed cleanup.
+// Defers ensure that activeWorkers, semaphore, and WaitGroup are always
+// updated even if the process function panics, preventing pool deadlock.
+func (w *Pool[T]) processWorkItem(it workItem[T]) {
+	defer it.wg.Done()
+	defer func() { <-w.semaphore }()
+	defer w.activeWorkers.Add(-1)
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "workshare: panic in worker: %v\n%s\n", r, debug.Stack())
+		}
+	}()
+
+	w.activeWorkers.Add(1)
+	it.process(w, it.request)
 }
 
 // Close closes the worker pool.

--- a/internal/workshare/workshare_test.go
+++ b/internal/workshare/workshare_test.go
@@ -210,21 +210,31 @@ func TestWorkerRecoversPanic_PoolRemainsOperational(t *testing.T) {
 	ag1.Wait()
 
 	// Second batch: normal work — pool must still function after panics.
+	// Track each request explicitly so we can assert results from BOTH the
+	// async-pool path AND the inline fallback path (the latter exercises the
+	// CanShareWork == false branch when the pool is full).
 	var ag2 workshare.AsyncGroup[*req]
 
-	for i := range 3 {
+	var batch2 []*req
+
+	for range 3 {
+		r := &req{}
+		batch2 = append(batch2, r)
+
 		if ag2.CanShareWork(w) {
 			ag2.RunAsync(w, func(_ *workshare.Pool[*req], r *req) {
 				r.result = 100
-			}, &req{})
+			}, r)
 		} else {
-			// If pool is full, do inline (expected for i >= 2 with 2 workers).
-			_ = i
+			// Inline fallback when the pool is full — typical caller pattern.
+			r.result = 100
 		}
 	}
 
-	for _, r := range ag2.Wait() {
-		require.Equal(t, 100, r.result)
+	ag2.Wait()
+
+	for _, r := range batch2 {
+		require.Equal(t, 100, r.result, "every request must complete after panic batch")
 	}
 }
 

--- a/internal/workshare/workshare_test.go
+++ b/internal/workshare/workshare_test.go
@@ -148,6 +148,86 @@ func testComputeTreeSum(t *testing.T, numWorkers int) {
 	require.Equal(t, 1957, sum)
 }
 
+func TestWorkerRecoversPanic(t *testing.T) {
+	type req struct {
+		shouldPanic bool
+		result      int
+	}
+
+	w := workshare.NewPool[*req](4)
+	defer w.Close()
+
+	var ag workshare.AsyncGroup[*req]
+
+	// Schedule a panicking work item.
+	if ag.CanShareWork(w) {
+		ag.RunAsync(w, func(_ *workshare.Pool[*req], r *req) {
+			if r.shouldPanic {
+				panic("test panic in workshare worker")
+			}
+			r.result = 42
+		}, &req{shouldPanic: true})
+	}
+
+	// Schedule a normal work item — must still complete.
+	if ag.CanShareWork(w) {
+		ag.RunAsync(w, func(_ *workshare.Pool[*req], r *req) {
+			r.result = 99
+		}, &req{})
+	}
+
+	results := ag.Wait()
+
+	// Both work items completed (no deadlock).
+	require.Len(t, results, 2)
+
+	// The panicking item's result is zero (never set).
+	require.Equal(t, 0, results[0].result)
+
+	// The normal item completed successfully.
+	require.Equal(t, 99, results[1].result)
+}
+
+func TestWorkerRecoversPanic_PoolRemainsOperational(t *testing.T) {
+	type req struct {
+		result int
+	}
+
+	w := workshare.NewPool[*req](2)
+	defer w.Close()
+
+	// First batch: all workers panic.
+	var ag1 workshare.AsyncGroup[*req]
+
+	for range 2 {
+		if ag1.CanShareWork(w) {
+			ag1.RunAsync(w, func(_ *workshare.Pool[*req], _ *req) {
+				panic("batch 1 panic")
+			}, &req{})
+		}
+	}
+
+	ag1.Wait()
+
+	// Second batch: normal work — pool must still function after panics.
+	var ag2 workshare.AsyncGroup[*req]
+
+	for i := range 3 {
+		if ag2.CanShareWork(w) {
+			ag2.RunAsync(w, func(_ *workshare.Pool[*req], r *req) {
+				r.result = 100
+			}, &req{})
+		} else {
+			// If pool is full, do inline (expected for i >= 2 with 2 workers).
+			_ = i
+		}
+	}
+
+	for _, r := range ag2.Wait() {
+		require.Equal(t, 100, r.result)
+	}
+}
+
 var treeToWalk = buildTree(6)
 
 func BenchmarkComputeTreeSum(b *testing.B) {

--- a/snapshot/upload/upload.go
+++ b/snapshot/upload/upload.go
@@ -913,6 +913,17 @@ func (u *Uploader) processSingle(
 			"snapshotted symlink", t0)
 
 	case fs.File:
+		// Pre-flight accessibility check — catch locked files before
+		// assigning a workshare worker to avoid pipeline stalls.
+		if pf, ok := entry.(fs.Preflightable); ok {
+			if err := pf.Preflight(ctx); err != nil {
+				isIgnored := policyTree.EffectivePolicy().ErrorHandlingPolicy.IgnoreFileErrors.OrDefault(false)
+				u.reportErrorAndMaybeCancel(err, isIgnored, parentDirBuilder, entryRelativePath)
+
+				return nil
+			}
+		}
+
 		atomic.AddInt32(&u.stats.NonCachedFiles, 1)
 
 		de, err := u.uploadFileInternal(ctx, parentCheckpointRegistry, entryRelativePath, entry, policyTree.Child(entry.Name()).EffectivePolicy())


### PR DESCRIPTION
## Summary

- Add panic recovery to `workshare.Pool` worker goroutines — ensures `wg.Done()`, semaphore release, and `activeWorkers` decrement always execute even if the process function panics, preventing pool deadlock
- Add panic recovery to `parallelwork.Queue` callbacks — converts panics to errors ensuring `completed()` is always called, preventing `dequeue()` from waiting forever
- Make `filesystemFile.Open()` and `filesystemDirectory.Iterate()` context-aware — wraps `os.Open()` with context cancellation and a 60-second default timeout, preventing indefinitely blocking file opens from stalling workshare pool workers
- **(follow-up commit)** Add optional `fs.Preflightable` interface; `localfs.filesystemFile` implements as `os.Open` + `Close`. `Uploader.processSingle` calls `Preflight` before workshare assignment so locked files surface as ignored errors immediately, complementing the timeout-based defense above by avoiding worker assignment for files that are already known-inaccessible.

Fixes #5294

## Details

Snapshot create hung for 17+ hours on Windows when `os.Open()` blocked indefinitely on a locked NTFS file inside a workshare pool worker. The worker never completed, so `AsyncGroup.Wait()` blocked forever, cascading to stall all pool workers.

The `Open()` and `Iterate()` methods in `fs/localfs/` already accepted a `context.Context` parameter but discarded it (using `_`). This change makes them actually respect context cancellation and deadlines.

The Preflight follow-up adds an optional interface check before workshare assignment. Entries that don't implement it (e.g. virtualfs, cachefs streams) fall through unchanged. Compile-time conformance is enforced with a `var _ =` assertion in localfs.

## Test plan

- [x] `TestWorkerRecoversPanic` — workshare pool worker panic doesn't deadlock `Wait()`
- [x] `TestWorkerRecoversPanic_PoolRemainsOperational` — pool stays usable after all workers panic
- [x] `TestProcessRecoversPanic` — parallelwork panic in callback becomes an error
- [x] `TestProcessRecoversPanicWithEnqueuedWork` — panic after enqueuing more work doesn't deadlock
- [x] `TestOpenWithContext_Success/FileNotFound/CancelledContext/Timeout/Directory` — context-aware file open
- [x] All existing tests pass (`go test ./internal/workshare/ ./internal/parallelwork/ ./fs/localfs/`)
- [ ] `make lint` — passes locally
- [ ] Manual: snapshot a Windows source with in-use Office temp files; locked-file errors appear as Ignored errors at the same logical position as today