### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.5
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.13.3
-	github.com/kopia/htmluibuild v0.0.1-0.20260414002305-a859d43ee893
+	github.com/kopia/htmluibuild v0.0.1-0.20260416161538-83b24c27eef7
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/minio/minio-go/v7 v7.0.100

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.13.3 h1:01GwnO2xoCSaM0ShP4qwl+FsHg3csFShC6Tu/RS1ji0=
 github.com/klauspost/reedsolomon v1.13.3/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
-github.com/kopia/htmluibuild v0.0.1-0.20260414002305-a859d43ee893 h1:J9g3qLDJAIebtq9ojSPov12B5V2G3WEQ8s96Y/e/4pk=
-github.com/kopia/htmluibuild v0.0.1-0.20260414002305-a859d43ee893/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260416161538-83b24c27eef7 h1:tMcr+W8OCaLHen5nxHDrchOKLNigCqslt2X9/kdPfkA=
+github.com/kopia/htmluibuild v0.0.1-0.20260416161538-83b24c27eef7/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/32a943e218e4a4d5a050b35f517c711f473b1cde...9e816755d4098bf717853872e418d44a99e44d76

* 2 minutes ago https://github.com/kopia/htmlui/commit/9e81675 dependabot[bot] build(deps): bump follow-redirects from 1.15.11 to 1.16.0

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Thu Apr 16 16:16:09 UTC 2026*
