### PR TITLE
fix(maintenance): x/exp removal, lz4 v4, listBlobWorker, context, timeZone global

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -49,6 +49,14 @@ func (o *textOutput) setup(svc appServices) {
 	o.svc = svc
 }
 
+func (o *textOutput) timeZone() string {
+	if o.svc == nil {
+		return "local"
+	}
+
+	return o.svc.getTimeZone()
+}
+
 func (o *textOutput) stdout() io.Writer {
 	if o.svc == nil {
 		return os.Stdout
@@ -92,6 +100,7 @@ type appServices interface {
 	getRestoreProgress() RestoreProgress
 	notificationTemplateOptions() notifytemplate.Options
 
+	getTimeZone() string
 	stdout() io.Writer
 	Stderr() io.Writer
 	stdin() io.Reader
@@ -121,6 +130,7 @@ type advancedAppServices interface {
 // App contains per-invocation flags and state of Kopia CLI.
 type App struct {
 	// global flags
+	timeZone                      string
 	enableAutomaticMaintenance    bool
 	progress                      *cliProgress
 	restoreProgress               RestoreProgress
@@ -185,6 +195,10 @@ type App struct {
 
 func (c *App) enableTestOnlyFlags() bool {
 	return c.isInProcessTest || os.Getenv("KOPIA_TESTONLY_FLAGS") != ""
+}
+
+func (c *App) getTimeZone() string {
+	return c.timeZone
 }
 
 func (c *App) getProgress() *cliProgress {
@@ -273,7 +287,7 @@ func (c *App) setup(app *kingpin.Application) {
 	app.Flag("update-available-notify-interval", "Interval between update notifications").Default("1h").Hidden().Envar(c.EnvName("KOPIA_UPDATE_NOTIFY_INTERVAL")).DurationVar(&c.updateAvailableNotifyInterval)
 	app.Flag("config-file", "Specify the config file to use").Default("repository.config").Envar(c.EnvName("KOPIA_CONFIG_PATH")).StringVar(&c.configPath)
 	app.Flag("trace-storage", "Enables tracing of storage operations.").Default("true").Hidden().BoolVar(&c.traceStorage)
-	app.Flag("timezone", "Format time according to specified time zone (local, utc, original or time zone name)").Hidden().StringVar(&timeZone)
+	app.Flag("timezone", "Format time according to specified time zone (local, utc, original or time zone name)").Hidden().StringVar(&c.timeZone)
 	app.Flag("password", "Repository password.").Envar(c.EnvName("KOPIA_PASSWORD")).Short('p').StringVar(&c.password)
 	app.Flag("persist-credentials", "Persist credentials").Default("true").Envar(c.EnvName("KOPIA_PERSIST_CREDENTIALS_ON_CONNECT")).BoolVar(&c.persistCredentials)
 	app.Flag("disable-repository-log", "Disable repository log").Hidden().Envar(c.EnvName("KOPIA_DISABLE_REPOSITORY_LOG")).BoolVar(&c.disableRepositoryLog)
@@ -325,6 +339,7 @@ type commandParent interface {
 // NewApp creates a new instance of App.
 func NewApp() *App {
 	return &App{
+		timeZone: "local",
 		progress: &cliProgress{},
 		cliStorageProviders: []StorageProvider{
 			{"from-config", "the provided configuration file", func() StorageFlags { return &storageFromConfigFlags{} }},

--- a/cli/command_blob_list.go
+++ b/cli/command_blob_list.go
@@ -49,7 +49,7 @@ func (c *commandBlobList) run(ctx context.Context, rep repo.DirectRepository) er
 		if c.jo.jsonOutput {
 			jl.emit(b)
 		} else {
-			c.out.printStdout("%-70v %10v %v\n", b.BlobID, b.Length, formatTimestamp(b.Timestamp))
+			c.out.printStdout("%-70v %10v %v\n", b.BlobID, b.Length, formatTimestamp(b.Timestamp, c.out.timeZone()))
 		}
 
 		return nil

--- a/cli/command_content_list.go
+++ b/cli/command_content_list.go
@@ -91,7 +91,7 @@ func (c *commandContentList) outputLong(b content.Info) {
 	c.out.printStdout("%v %v %v %v %v+%v%v %v\n",
 		b.ContentID,
 		b.OriginalLength,
-		formatTimestamp(b.Timestamp()),
+		formatTimestamp(b.Timestamp(), c.out.timeZone()),
 		b.PackBlobID,
 		b.PackOffset,
 		maybeHumanReadableBytes(c.human, int64(b.PackedLength)),

--- a/cli/command_content_verify.go
+++ b/cli/command_content_verify.go
@@ -21,6 +21,8 @@ type commandContentVerify struct {
 	progressInterval            time.Duration
 
 	contentRange contentRangeFlags
+
+	svc appServices
 }
 
 func (c *commandContentVerify) setup(svc appServices, parent commandParent) {
@@ -33,6 +35,8 @@ func (c *commandContentVerify) setup(svc appServices, parent commandParent) {
 	cmd.Flag("progress-interval", "Progress output interval").Default("3s").DurationVar(&c.progressInterval)
 	c.contentRange.setup(cmd)
 	cmd.Action(svc.directRepositoryReadAction(c.run))
+
+	c.svc = svc
 }
 
 func (c *commandContentVerify) run(ctx context.Context, rep repo.DirectRepository) error {
@@ -88,7 +92,7 @@ func (c *commandContentVerify) run(ctx context.Context, rep repo.DirectRepositor
 					timings.PercentComplete,
 					vps.ErrorCount,
 					timings.Remaining,
-					formatTimestamp(timings.EstimatedEndTime),
+					formatTimestamp(timings.EstimatedEndTime, c.svc.getTimeZone()),
 				)
 			} else {
 				log(ctx).Infof("  Verified %v contents, %v errors, estimating...", verifiedCount, vps.ErrorCount)

--- a/cli/command_index_epoch_list.go
+++ b/cli/command_index_epoch_list.go
@@ -40,7 +40,7 @@ func (c *commandIndexEpochList) run(ctx context.Context, rep repo.DirectReposito
 	c.out.printStdout("Current Epoch: %v\n", snap.WriteEpoch)
 
 	if est := snap.EpochStartTime[snap.WriteEpoch]; !est.IsZero() {
-		c.out.printStdout("Epoch Started  %v\n", formatTimestamp(est))
+		c.out.printStdout("Epoch Started  %v\n", formatTimestamp(est, c.out.timeZone()))
 	}
 
 	firstNonRangeCompacted := 0
@@ -55,8 +55,8 @@ func (c *commandIndexEpochList) run(ctx context.Context, rep repo.DirectReposito
 
 			c.out.printStdout("%v %v ... %v, %v blobs, %v, span %v\n",
 				e,
-				formatTimestamp(minTime),
-				formatTimestamp(maxTime),
+				formatTimestamp(minTime, c.out.timeZone()),
+				formatTimestamp(maxTime, c.out.timeZone()),
 				len(uces),
 				units.BytesString(blob.TotalLength(uces)),
 				maxTime.Sub(minTime).Round(time.Second),
@@ -66,7 +66,7 @@ func (c *commandIndexEpochList) run(ctx context.Context, rep repo.DirectReposito
 		if secs := snap.SingleEpochCompactionSets[e]; secs != nil {
 			c.out.printStdout("%v: %v single-epoch %v blobs, %v\n",
 				e,
-				formatTimestamp(secs[0].Timestamp),
+				formatTimestamp(secs[0].Timestamp, c.out.timeZone()),
 				len(secs),
 				units.BytesString(blob.TotalLength(secs)),
 			)

--- a/cli/command_index_inspect.go
+++ b/cli/command_index_inspect.go
@@ -119,8 +119,8 @@ func (c *commandIndexInspect) dumpIndexBlobEntries(entries chan indexBlobPlusCon
 		}
 
 		c.out.printStdout("%v %v %v %v %v %v %v %v\n",
-			formatTimestampPrecise(bm.Timestamp), bm.BlobID,
-			ci.ContentID, state, formatTimestampPrecise(ci.Timestamp()), ci.PackBlobID, ci.PackOffset, ci.PackedLength)
+			formatTimestampPrecise(bm.Timestamp, c.out.timeZone()), bm.BlobID,
+			ci.ContentID, state, formatTimestampPrecise(ci.Timestamp(), c.out.timeZone()), ci.PackBlobID, ci.PackOffset, ci.PackedLength)
 	}
 }
 

--- a/cli/command_index_list.go
+++ b/cli/command_index_list.go
@@ -58,7 +58,7 @@ func (c *commandIndexList) run(ctx context.Context, rep repo.DirectRepository) e
 		if c.jo.jsonOutput {
 			jl.emit(b)
 		} else {
-			c.out.printStdout("%-60v %10v %v %v\n", b.BlobID, b.Length, formatTimestampPrecise(b.Timestamp), b.Superseded)
+			c.out.printStdout("%-60v %10v %v %v\n", b.BlobID, b.Length, formatTimestampPrecise(b.Timestamp, c.out.timeZone()), b.Superseded)
 		}
 	}
 

--- a/cli/command_index_recover.go
+++ b/cli/command_index_recover.go
@@ -162,7 +162,7 @@ func (c *commandIndexRecover) recoverIndexesFromAllPacks(ctx context.Context, re
 								disc,
 								e.PercentComplete,
 								e.Remaining,
-								formatTimestamp(e.EstimatedEndTime))
+								formatTimestamp(e.EstimatedEndTime, c.svc.getTimeZone()))
 						}
 					} else {
 						log(ctx).Infof("Recovered %v index entries from %v blobs, estimating time remaining... (found %v blobs)",

--- a/cli/command_logs_list.go
+++ b/cli/command_logs_list.go
@@ -40,7 +40,7 @@ func (c *commandLogsList) run(ctx context.Context, rep repo.DirectRepository) er
 	for _, s := range allSessions {
 		c.out.printStdout(
 			"%v %v %v %v %v\n", s.id,
-			formatTimestamp(s.startTime),
+			formatTimestamp(s.startTime, c.out.timeZone()),
 			s.endTime.Sub(s.startTime),
 			units.BytesString(s.totalSize),
 			len(s.segments),

--- a/cli/command_logs_show.go
+++ b/cli/command_logs_show.go
@@ -50,7 +50,7 @@ func (c *commandLogsShow) run(ctx context.Context, rep repo.DirectRepository) er
 	// by default show latest one
 	if !c.crit.any() {
 		sessions = sessions[len(sessions)-1:]
-		log(ctx).Infof("Showing the latest log (%v)", formatTimestamp(sessions[0].startTime))
+		log(ctx).Infof("Showing the latest log (%v)", formatTimestamp(sessions[0].startTime, c.out.timeZone()))
 	}
 
 	var data gather.WriteBuffer

--- a/cli/command_ls.go
+++ b/cli/command_ls.go
@@ -116,7 +116,7 @@ func (c *commandList) printDirectoryEntry(ctx context.Context, e fs.Entry, prefi
 			"%v %12s %v %-34v %v%v",
 			e.Mode(),
 			maybeHumanReadableBytes(c.humanReadable, e.Size()),
-			formatTimestamp(e.ModTime().Local()),
+			formatTimestamp(e.ModTime().Local(), c.out.timeZone()),
 			oid,
 			c.nameToDisplay(prefix, e),
 			errorSummary,

--- a/cli/command_maintenance_info.go
+++ b/cli/command_maintenance_info.go
@@ -94,7 +94,7 @@ func (c *commandMaintenanceInfo) run(ctx context.Context, rep repo.DirectReposit
 
 			c.out.printStdout(
 				"    %v (%v) %v\n",
-				formatTimestamp(t.Start),
+				formatTimestamp(t.Start, c.out.timeZone()),
 				t.End.Sub(t.Start).Truncate(time.Second),
 				message)
 		}
@@ -110,7 +110,7 @@ func (c *commandMaintenanceInfo) displayCycleInfo(cp *maintenance.CycleParams, t
 		c.out.printStdout("  interval: %v\n", cp.Interval)
 
 		if rep.Time().Before(t) {
-			c.out.printStdout("  next run: %v (in %v)\n", formatTimestamp(t), t.Sub(clock.Now()).Truncate(time.Second))
+			c.out.printStdout("  next run: %v (in %v)\n", formatTimestamp(t, c.out.timeZone()), t.Sub(clock.Now()).Truncate(time.Second))
 		} else {
 			c.out.printStdout("  next run: now\n")
 		}

--- a/cli/command_maintenance_set.go
+++ b/cli/command_maintenance_set.go
@@ -27,6 +27,8 @@ type commandMaintenanceSet struct {
 	extendObjectLocks []bool // optional boolean
 
 	listParallelism int
+
+	svc appServices
 }
 
 func (c *commandMaintenanceSet) setup(svc appServices, parent commandParent) {
@@ -62,6 +64,8 @@ func (c *commandMaintenanceSet) setup(svc appServices, parent commandParent) {
 	cmd.Flag("list-parallelism", "Override list parallelism.").IntVar(&c.listParallelism)
 
 	cmd.Action(svc.directRepositoryWriteAction(c.run))
+
+	c.svc = svc
 }
 
 func (c *commandMaintenanceSet) setLogCleanupParametersFromFlags(ctx context.Context, p *maintenance.Params, changed *bool) {
@@ -179,14 +183,14 @@ func (c *commandMaintenanceSet) run(ctx context.Context, rep repo.DirectReposito
 		s.NextQuickMaintenanceTime = rep.Time().Add(pauseDuration)
 		changedSchedule = true
 
-		log(ctx).Infof("Quick maintenance paused until %v", formatTimestamp(s.NextQuickMaintenanceTime))
+		log(ctx).Infof("Quick maintenance paused until %v", formatTimestamp(s.NextQuickMaintenanceTime, c.svc.getTimeZone()))
 	}
 
 	if pauseDuration := c.maintenanceSetPauseFull; pauseDuration != -1 {
 		s.NextFullMaintenanceTime = rep.Time().Add(pauseDuration)
 		changedSchedule = true
 
-		log(ctx).Infof("Full maintenance paused until %v", formatTimestamp(s.NextFullMaintenanceTime))
+		log(ctx).Infof("Full maintenance paused until %v", formatTimestamp(s.NextFullMaintenanceTime, c.svc.getTimeZone()))
 	}
 
 	if !changedParams && !changedSchedule {

--- a/cli/command_manifest_ls.go
+++ b/cli/command_manifest_ls.go
@@ -65,7 +65,7 @@ func (c *commandManifestList) listManifestItems(ctx context.Context, rep repo.Re
 			jl.emit(it)
 		} else {
 			t := it.Labels["type"]
-			c.out.printStdout("%v %10v %v type:%v %v\n", it.ID, it.Length, formatTimestamp(it.ModTime.Local()), t, sortedMapValues(it.Labels))
+			c.out.printStdout("%v %10v %v type:%v %v\n", it.ID, it.Length, formatTimestamp(it.ModTime.Local(), c.out.timeZone()), t, sortedMapValues(it.Labels))
 		}
 	}
 

--- a/cli/command_manifest_show.go
+++ b/cli/command_manifest_show.go
@@ -45,7 +45,7 @@ func (c *commandManifestShow) showManifestItems(ctx context.Context, rep repo.Re
 
 		c.out.printStdout("// id: %v\n", it)
 		c.out.printStdout("// length: %v\n", md.Length)
-		c.out.printStdout("// modified: %v\n", formatTimestamp(md.ModTime))
+		c.out.printStdout("// modified: %v\n", formatTimestamp(md.ModTime, c.out.timeZone()))
 
 		for k, v := range md.Labels {
 			c.out.printStdout("// label %v:%v\n", k, v)

--- a/cli/command_notification_template_list.go
+++ b/cli/command_notification_template_list.go
@@ -55,7 +55,7 @@ func (c *commandNotificationTemplateList) run(ctx context.Context, rep repo.Repo
 			lastModString = ""
 		} else {
 			typeString = "<customized>"
-			lastModString = formatTimestamp(*i.LastModified)
+			lastModString = formatTimestamp(*i.LastModified, c.out.timeZone())
 		}
 
 		c.out.printStdout("%-30v %-15v %v\n", i.Name, typeString, lastModString)

--- a/cli/command_repository_sync.go
+++ b/cli/command_repository_sync.go
@@ -255,7 +255,7 @@ func (c *commandRepositorySyncTo) runSyncBlobs(ctx context.Context, src blob.Rea
 				progressMutex.Lock()
 
 				if est, ok := tt.Estimate(float64(bytesCopied), float64(totalBytes)); ok {
-					eta = fmt.Sprintf("%v (%v)", est.Remaining, formatTimestamp(est.EstimatedEndTime))
+					eta = fmt.Sprintf("%v (%v)", est.Remaining, formatTimestamp(est.EstimatedEndTime, c.out.timeZone()))
 					speed = units.BytesPerSecondsString(est.SpeedPerSecond)
 				}
 

--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -517,7 +517,7 @@ func (c *commandRestore) tryToConvertPathToID(ctx context.Context, rep repo.Repo
 		"   Snapshot source: %v\n"+
 		"   Snapshot time: %v\n"+
 		"   Relative path: %v\n"+
-		"   Object ID: %v", m.Source, formatTimestamp(m.StartTime.ToTime()), relPath, ohid)
+		"   Object ID: %v", m.Source, formatTimestamp(m.StartTime.ToTime(), c.svc.getTimeZone()), relPath, ohid)
 
 	return ohid.String(), nil
 }

--- a/cli/command_session_list.go
+++ b/cli/command_session_list.go
@@ -25,7 +25,7 @@ func (c *commandSessionList) run(ctx context.Context, rep repo.DirectRepository)
 	}
 
 	for _, s := range sessions {
-		c.out.printStdout("%v %v@%v %v %v\n", s.ID, s.User, s.Host, formatTimestamp(s.StartTime), formatTimestamp(s.CheckpointTime))
+		c.out.printStdout("%v %v@%v %v %v\n", s.ID, s.User, s.Host, formatTimestamp(s.StartTime, c.out.timeZone()), formatTimestamp(s.CheckpointTime, c.out.timeZone()))
 	}
 
 	return nil

--- a/cli/command_snapshot_copy_move_history.go
+++ b/cli/command_snapshot_copy_move_history.go
@@ -15,6 +15,8 @@ type commandSnapshotCopyMoveHistory struct {
 	snapshotCopyOrMoveDryRun      bool
 	snapshotCopyOrMoveSource      string
 	snapshotCopyOrMoveDestination string
+
+	svc appServices
 }
 
 func (c *commandSnapshotCopyMoveHistory) setup(svc appServices, parent commandParent, isMove bool) {
@@ -32,6 +34,8 @@ func (c *commandSnapshotCopyMoveHistory) setup(svc appServices, parent commandPa
 	cmd.Action(svc.repositoryWriterAction(func(ctx context.Context, rep repo.RepositoryWriter) error {
 		return c.run(ctx, rep, isMove)
 	}))
+
+	c.svc = svc
 }
 
 func snapshotCopyMoveHelp(verb string) string {
@@ -108,13 +112,13 @@ func (c *commandSnapshotCopyMoveHistory) run(ctx context.Context, rep repo.Repos
 
 		if snapshotExists(dstSnapshots, dstSource, manifest) {
 			if isMoveCommand && !c.snapshotCopyOrMoveDryRun {
-				log(ctx).Infof("%v (%v) already exists - deleting source", dstSource, formatTimestamp(manifest.StartTime.ToTime()))
+				log(ctx).Infof("%v (%v) already exists - deleting source", dstSource, formatTimestamp(manifest.StartTime.ToTime(), c.svc.getTimeZone()))
 
 				if err := rep.DeleteManifest(ctx, manifest.ID); err != nil {
 					return errors.Wrap(err, "unable to delete source manifest")
 				}
 			} else {
-				log(ctx).Infof("%v (%v) already exists", dstSource, formatTimestamp(manifest.StartTime.ToTime()))
+				log(ctx).Infof("%v (%v) already exists", dstSource, formatTimestamp(manifest.StartTime.ToTime(), c.svc.getTimeZone()))
 			}
 
 			continue
@@ -122,7 +126,7 @@ func (c *commandSnapshotCopyMoveHistory) run(ctx context.Context, rep repo.Repos
 
 		srcID := manifest.ID
 
-		log(ctx).Infof("%v %v (%v) => %v", c.getCopySnapshotAction(isMoveCommand), manifest.Source, formatTimestamp(manifest.StartTime.ToTime()), dstSource)
+		log(ctx).Infof("%v %v (%v) => %v", c.getCopySnapshotAction(isMoveCommand), manifest.Source, formatTimestamp(manifest.StartTime.ToTime(), c.svc.getTimeZone()), dstSource)
 
 		if c.snapshotCopyOrMoveDryRun {
 			continue

--- a/cli/command_snapshot_delete.go
+++ b/cli/command_snapshot_delete.go
@@ -16,6 +16,8 @@ type commandSnapshotDelete struct {
 	snapshotDeleteIDs                   []string
 	snapshotDeleteConfirm               bool
 	snapshotDeleteAllSnapshotsForSource bool
+
+	svc appServices
 }
 
 func (c *commandSnapshotDelete) setup(svc appServices, parent commandParent) {
@@ -26,6 +28,8 @@ func (c *commandSnapshotDelete) setup(svc appServices, parent commandParent) {
 	// hidden flag for backwards compatibility
 	cmd.Flag("unsafe-ignore-source", "Alias for --delete").Hidden().BoolVar(&c.snapshotDeleteConfirm)
 	cmd.Action(svc.repositoryWriterAction(c.run))
+
+	c.svc = svc
 }
 
 func (c *commandSnapshotDelete) run(ctx context.Context, rep repo.RepositoryWriter) error {
@@ -82,7 +86,7 @@ func (c *commandSnapshotDelete) snapshotDeleteSources(ctx context.Context, rep r
 }
 
 func (c *commandSnapshotDelete) deleteSnapshot(ctx context.Context, rep repo.RepositoryWriter, m *snapshot.Manifest) error {
-	desc := fmt.Sprintf("snapshot %v of %v at %v", m.ID, m.Source, formatTimestamp(m.StartTime.ToTime()))
+	desc := fmt.Sprintf("snapshot %v of %v at %v", m.ID, m.Source, formatTimestamp(m.StartTime.ToTime(), c.svc.getTimeZone()))
 
 	if !c.snapshotDeleteConfirm {
 		log(ctx).Infof("Would delete %v (pass --delete to confirm)", desc)

--- a/cli/command_snapshot_fix.go
+++ b/cli/command_snapshot_fix.go
@@ -32,6 +32,8 @@ type commonRewriteSnapshots struct {
 	commit             bool
 	parallel           int
 	invalidDirHandling string
+
+	svc appServices
 }
 
 const (
@@ -42,7 +44,7 @@ const (
 )
 
 func (c *commonRewriteSnapshots) setup(svc appServices, cmd *kingpin.CmdClause) {
-	_ = svc
+	c.svc = svc
 
 	cmd.Flag("manifest-id", "Manifest IDs").StringsVar(&c.manifestIDs)
 	cmd.Flag("source", "Source to target (username@hostname:/path)").StringsVar(&c.sources)
@@ -99,7 +101,7 @@ func (c *commonRewriteSnapshots) rewriteMatchingSnapshots(ctx context.Context, r
 		metadataComp := policyTree.EffectivePolicy().MetadataCompressionPolicy.MetadataCompressor()
 
 		for _, man := range snapshot.SortByTime(mg, false) {
-			log(ctx).Debugf("  %v (%v)", formatTimestamp(man.StartTime.ToTime()), man.ID)
+			log(ctx).Debugf("  %v (%v)", formatTimestamp(man.StartTime.ToTime(), c.svc.getTimeZone()), man.ID)
 
 			old := man.Clone()
 
@@ -109,7 +111,7 @@ func (c *commonRewriteSnapshots) rewriteMatchingSnapshots(ctx context.Context, r
 			}
 
 			if !changed {
-				log(ctx).Infof("  %v unchanged (%v)", formatTimestamp(man.StartTime.ToTime()), man.ID)
+				log(ctx).Infof("  %v unchanged (%v)", formatTimestamp(man.StartTime.ToTime(), c.svc.getTimeZone()), man.ID)
 
 				continue
 			}
@@ -120,7 +122,7 @@ func (c *commonRewriteSnapshots) rewriteMatchingSnapshots(ctx context.Context, r
 				}
 			}
 
-			log(ctx).Infof("  %v replaced manifest from %v to %v", formatTimestamp(man.StartTime.ToTime()), old.ID, man.ID)
+			log(ctx).Infof("  %v replaced manifest from %v to %v", formatTimestamp(man.StartTime.ToTime(), c.svc.getTimeZone()), old.ID, man.ID)
 			log(ctx).Infof("    diff %v %v", old.RootEntry.ObjectID, man.RootEntry.ObjectID)
 
 			if d := snapshotSizeDelta(old, man); d != "" {

--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -278,13 +278,13 @@ func (c *commandSnapshotList) outputManifestFromSingleSource(ctx context.Context
 	if err := c.iterateSnapshotsMaybeWithStorageStats(ctx, rep, manifests, func(m *snapshot.Manifest) error {
 		root, err := snapshotfs.SnapshotRoot(rep, m)
 		if err != nil {
-			c.out.printStdout("  %v <ERROR> %v\n", formatTimestamp(m.StartTime.ToTime()), err)
+			c.out.printStdout("  %v <ERROR> %v\n", formatTimestamp(m.StartTime.ToTime(), c.out.timeZone()), err)
 			return nil
 		}
 
 		ent, err := snapshotfs.GetNestedEntry(ctx, root, parts)
 		if err != nil {
-			c.out.printStdout("  %v <ERROR> %v\n", formatTimestamp(m.StartTime.ToTime()), err)
+			c.out.printStdout("  %v <ERROR> %v\n", formatTimestamp(m.StartTime.ToTime(), c.out.timeZone()), err)
 			return nil
 		}
 
@@ -372,13 +372,13 @@ func (c *commandSnapshotList) outputSnapshotRows(rows []*snapshotListRow) {
 			bits = append(bits, "pins:"+strings.Join(row.pins, ","))
 		}
 
-		row.color.Fprint(c.out.stdout(), fmt.Sprintf("  %v %v %v\n", formatTimestamp(row.firstStartTime), row.oid, strings.Join(bits, " "))) //nolint:errcheck
+		row.color.Fprint(c.out.stdout(), fmt.Sprintf("  %v %v %v\n", formatTimestamp(row.firstStartTime, c.out.timeZone()), row.oid, strings.Join(bits, " "))) //nolint:errcheck
 
 		if row.count > 1 {
 			c.out.printStdout(
 				"  + %v identical snapshots until %v\n",
 				row.count-1,
-				formatTimestamp(row.lastStartTime),
+				formatTimestamp(row.lastStartTime, c.out.timeZone()),
 			)
 		}
 	}
@@ -417,7 +417,7 @@ func (c *commandSnapshotList) entryBits(ctx context.Context, m *snapshot.Manifes
 	}
 
 	if c.snapshotListShowModTime {
-		bits = append(bits, fmt.Sprintf("modified:%v", formatTimestamp(ent.ModTime())))
+		bits = append(bits, fmt.Sprintf("modified:%v", formatTimestamp(ent.ModTime(), c.out.timeZone())))
 	}
 
 	if c.snapshotListShowItemID {

--- a/cli/command_snapshot_migrate.go
+++ b/cli/command_snapshot_migrate.go
@@ -254,7 +254,7 @@ func (c *commandSnapshotMigrate) migrateSingleSource(ctx context.Context, upload
 
 func (c *commandSnapshotMigrate) migrateSingleSourceSnapshot(ctx context.Context, uploader *upload.Uploader, sourceRepo repo.Repository, destRepo repo.RepositoryWriter, s snapshot.SourceInfo, m *snapshot.Manifest) error {
 	if m.IncompleteReason != "" {
-		log(ctx).Debugf("ignoring incomplete %v at %v", s, formatTimestamp(m.StartTime.ToTime()))
+		log(ctx).Debugf("ignoring incomplete %v at %v", s, formatTimestamp(m.StartTime.ToTime(), c.out.timeZone()))
 		return nil
 	}
 
@@ -269,11 +269,11 @@ func (c *commandSnapshotMigrate) migrateSingleSourceSnapshot(ctx context.Context
 	}
 
 	if existing != nil {
-		log(ctx).Infof("already migrated %v at %v", s, formatTimestamp(m.StartTime.ToTime()))
+		log(ctx).Infof("already migrated %v at %v", s, formatTimestamp(m.StartTime.ToTime(), c.out.timeZone()))
 		return nil
 	}
 
-	log(ctx).Infof("migrating snapshot of %v at %v", s, formatTimestamp(m.StartTime.ToTime()))
+	log(ctx).Infof("migrating snapshot of %v at %v", s, formatTimestamp(m.StartTime.ToTime(), c.out.timeZone()))
 
 	previous, err := snapshot.FindPreviousManifests(ctx, destRepo, m.Source, &m.StartTime)
 	if err != nil {

--- a/cli/command_snapshot_pin.go
+++ b/cli/command_snapshot_pin.go
@@ -15,6 +15,8 @@ type commandSnapshotPin struct {
 	addPins     []string
 	removePins  []string
 	snapshotIDs []string
+
+	svc appServices
 }
 
 func (c *commandSnapshotPin) setup(svc appServices, parent commandParent) {
@@ -23,6 +25,8 @@ func (c *commandSnapshotPin) setup(svc appServices, parent commandParent) {
 	cmd.Flag("remove", "Remove pins").StringsVar(&c.removePins)
 	cmd.Arg("id", "Snapshot ID or root object ID").Required().StringsVar(&c.snapshotIDs)
 	cmd.Action(svc.repositoryWriterAction(c.run))
+
+	c.svc = svc
 }
 
 func (c *commandSnapshotPin) run(ctx context.Context, rep repo.RepositoryWriter) error {
@@ -72,12 +76,12 @@ func (c *commandSnapshotPin) pinSnapshotsByRootObjectID(ctx context.Context, rep
 
 func (c *commandSnapshotPin) pinSnapshot(ctx context.Context, rep repo.RepositoryWriter, m *snapshot.Manifest) error {
 	if !m.UpdatePins(c.addPins, c.removePins) {
-		log(ctx).Infof("No change for snapshot at %v of %v", formatTimestamp(m.StartTime.ToTime()), m.Source)
+		log(ctx).Infof("No change for snapshot at %v of %v", formatTimestamp(m.StartTime.ToTime(), c.svc.getTimeZone()), m.Source)
 
 		return nil
 	}
 
-	log(ctx).Infof("Updating snapshot at %v of %v", formatTimestamp(m.StartTime.ToTime()), m.Source)
+	log(ctx).Infof("Updating snapshot at %v of %v", formatTimestamp(m.StartTime.ToTime(), c.svc.getTimeZone()), m.Source)
 
 	return errors.Wrap(snapshot.UpdateSnapshot(ctx, rep, m), "error updating snapshot")
 }

--- a/cli/command_snapshot_verify.go
+++ b/cli/command_snapshot_verify.go
@@ -120,7 +120,7 @@ func (c *commandSnapshotVerify) makeVerifyWalkerFunc(ctx context.Context, rep re
 		var treeWalkerEntries []twEntry
 
 		for _, man := range manifests {
-			rootPath := fmt.Sprintf("%v@%v", man.Source, formatTimestamp(man.StartTime.ToTime()))
+			rootPath := fmt.Sprintf("%v@%v", man.Source, formatTimestamp(man.StartTime.ToTime(), c.out.timeZone()))
 
 			if man.RootEntry == nil {
 				continue

--- a/cli/show_utils.go
+++ b/cli/show_utils.go
@@ -12,16 +12,16 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"golang.org/x/exp/constraints"
 
 	"github.com/kopia/kopia/internal/iocopy"
 	"github.com/kopia/kopia/internal/units"
 )
 
-const oneHundredPercent = 100.0
+type integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
 
-// TODO - remove this global.
-var timeZone = "local" //nolint:gochecknoglobals
+const oneHundredPercent = 100.0
 
 func showContentWithFlags(w io.Writer, rd io.Reader, unzip, indentJSON bool) error {
 	if unzip {
@@ -54,7 +54,7 @@ func showContentWithFlags(w io.Writer, rd io.Reader, unzip, indentJSON bool) err
 	return nil
 }
 
-func maybeHumanReadableBytes[I constraints.Integer](enable bool, value I) string {
+func maybeHumanReadableBytes[I integer](enable bool, value I) string {
 	if enable {
 		return units.BytesString(value)
 	}
@@ -62,7 +62,7 @@ func maybeHumanReadableBytes[I constraints.Integer](enable bool, value I) string
 	return strconv.FormatInt(int64(value), 10)
 }
 
-func maybeHumanReadableCount[I constraints.Integer](enable bool, value I) string {
+func maybeHumanReadableCount[I integer](enable bool, value I) string {
 	if enable {
 		return units.Count(value)
 	}
@@ -70,16 +70,16 @@ func maybeHumanReadableCount[I constraints.Integer](enable bool, value I) string
 	return strconv.FormatInt(int64(value), 10)
 }
 
-func formatTimestamp(ts time.Time) string {
-	return convertTimezone(ts).Format("2006-01-02 15:04:05 MST")
+func formatTimestamp(ts time.Time, tz string) string {
+	return convertTimezone(ts, tz).Format("2006-01-02 15:04:05 MST")
 }
 
-func formatTimestampPrecise(ts time.Time) string {
-	return convertTimezone(ts).Format("2006-01-02 15:04:05.000 MST")
+func formatTimestampPrecise(ts time.Time, tz string) string {
+	return convertTimezone(ts, tz).Format("2006-01-02 15:04:05.000 MST")
 }
 
-func convertTimezone(ts time.Time) time.Time {
-	switch timeZone {
+func convertTimezone(ts time.Time, tz string) time.Time {
+	switch tz {
 	case "local":
 		return ts.Local()
 	case "utc":
@@ -87,7 +87,7 @@ func convertTimezone(ts time.Time) time.Time {
 	case "original":
 		return ts
 	default:
-		loc, err := time.LoadLocation(timeZone)
+		loc, err := time.LoadLocation(tz)
 		if err == nil {
 			return ts.In(loc)
 		}

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/mxk/go-vss v1.2.1
 	github.com/natefinch/atomic v1.0.1
 	github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9
-	github.com/pierrec/lz4 v2.6.1+incompatible
+	github.com/pierrec/lz4/v4 v4.1.26
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/profile v1.7.0
 	github.com/pkg/sftp v1.13.10
@@ -59,7 +59,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.49.0
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/mod v0.34.0
 	golang.org/x/net v0.52.0
 	golang.org/x/oauth2 v0.36.0
@@ -99,7 +98,6 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/felixge/fgprof v0.9.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/frankban/quicktest v1.13.1 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-json-experiment/json v0.0.0-20250725192818-e39067aee2d2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,7 +72,6 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/T
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -102,8 +101,6 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/foomo/htpasswd v0.0.0-20200116085101-e3a90e78da9c h1:DBGU7zCwrrPPDsD6+gqKG8UfMxenWg9BOJE/Nmfph+4=
 github.com/foomo/htpasswd v0.0.0-20200116085101-e3a90e78da9c/go.mod h1:SHawtolbB0ZOFoRWgDwakX5WpwuIWAK88bUXVZqK0Ss=
-github.com/frankban/quicktest v1.13.1 h1:xVm/f9seEhZFL9+n5kv5XLrGwy6elc4V9v/XFY2vmd8=
-github.com/frankban/quicktest v1.13.1/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
@@ -137,7 +134,6 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/fswalker v0.3.3 h1:K2+d6cb3vNFjquVPRObIY+QaXJ6cbleVV6yZWLzkkQ8=
 github.com/google/fswalker v0.3.3/go.mod h1:9upMSscEE8oRi0WJ0rXZZYya1DmgUtJFhXAw7KNS3c4=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
@@ -181,12 +177,8 @@ github.com/kopia/htmluibuild v0.0.1-0.20260402222501-e7bd71989749 h1:suKuaahbCpZ
 github.com/kopia/htmluibuild v0.0.1-0.20260402222501-e7bd71989749/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
-github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
@@ -219,8 +211,8 @@ github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 h1:1/WtZae0yGtPq+TI6+
 github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9/go.mod h1:x3N5drFsm2uilKKuuYo6LdyD8vZAW55sH/9w+pbo1sw=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
 github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
-github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
-github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
+github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -245,7 +237,6 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
@@ -324,8 +315,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -349,7 +338,6 @@ golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/api v0.274.0 h1:aYhycS5QQCwxHLwfEHRRLf9yNsfvp1JadKKWBE54RFA=
@@ -365,10 +353,8 @@ google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/kothar/go-backblaze.v0 v0.0.0-20210124194846-35409b867216 h1:2TSTkQ8PMvGOD5eeqqRVv6Z9+BYI+bowK97RCr3W+9M=
 gopkg.in/kothar/go-backblaze.v0 v0.0.0-20210124194846-35409b867216/go.mod h1:zJ2QpyDCYo1KvLXlmdnFlQAyF/Qfth0fB8239Qg7BIE=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/logfile/logfile.go
+++ b/internal/logfile/logfile.go
@@ -230,7 +230,7 @@ func (c *loggingFlags) setupLogFileBasedLogger(now time.Time, subdir, suffix, lo
 	// do not scrub directory if custom log file has been provided.
 	if logFileOverride == "" && shouldSweepLog(maxFiles, maxAge) {
 		doSweep = func() {
-			sweepLogDir(context.TODO(), logDir, maxFiles, maxSizeMB, maxAge)
+			sweepLogDir(context.Background(), logDir, maxFiles, maxSizeMB, maxAge)
 		}
 	}
 

--- a/internal/metrics/metrics_distribution.go
+++ b/internal/metrics/metrics_distribution.go
@@ -6,11 +6,18 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/exp/constraints"
 )
 
+type integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+type float interface {
+	~float32 | ~float64
+}
+
 type realNumber interface {
-	constraints.Float | constraints.Integer
+	float | integer
 }
 
 // DistributionState captures momentary state of a Distribution.

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -446,11 +446,24 @@ func (c *concurrencyTest) getMetadataWorker(ctx context.Context, worker int) fun
 	}
 }
 
-func (c *concurrencyTest) listBlobWorker(_ context.Context, worker int) func() error {
-	// TODO: implement me
-	_ = worker
-
+func (c *concurrencyTest) listBlobWorker(ctx context.Context, worker int) func() error {
 	return func() error {
+		for clock.Now().Before(c.deadline) {
+			c.randomSleep()
+
+			var count int
+
+			err := c.st.pickOne().ListBlobs(ctx, c.prefix, func(bm blob.Metadata) error {
+				count++
+				return nil
+			})
+			if err != nil {
+				return errors.Wrapf(err, "list worker %d", worker)
+			}
+
+			log(ctx).Debugf("ListBlobs worker %v listed %v blobs", worker, count)
+		}
+
 		return nil
 	}
 }

--- a/internal/providervalidation/providervalidation.go
+++ b/internal/providervalidation/providervalidation.go
@@ -453,7 +453,7 @@ func (c *concurrencyTest) listBlobWorker(ctx context.Context, worker int) func()
 
 			var count int
 
-			err := c.st.pickOne().ListBlobs(ctx, c.prefix, func(bm blob.Metadata) error {
+			err := c.st.pickOne().ListBlobs(ctx, c.prefix, func(_ blob.Metadata) error {
 				count++
 				return nil
 			})

--- a/internal/units/units.go
+++ b/internal/units/units.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/constraints"
 )
 
 //nolint:gochecknoglobals
@@ -24,8 +22,16 @@ func niceNumber(f float64) string {
 	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.1f", f), "0"), ".")
 }
 
+type integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+type float interface {
+	~float32 | ~float64
+}
+
 type realNumber interface {
-	constraints.Integer | constraints.Float
+	integer | float
 }
 
 func toDecimalUnitString[T realNumber](f T, thousand float64, prefixes []string, suffix string) string {
@@ -72,7 +78,7 @@ func BytesPerSecondsString[T realNumber](bps T) string {
 }
 
 // Count returns the given number with the appropriate base-10 suffix (K, M, G, ...)
-func Count[T constraints.Integer](v T) string {
+func Count[T integer](v T) string {
 	//nolint:mnd
 	return toDecimalUnitString(v, 1000, base10UnitPrefixes, "")
 }

--- a/repo/compression/compressor_lz4.go
+++ b/repo/compression/compressor_lz4.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/pierrec/lz4"
+	"github.com/pierrec/lz4/v4"
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/freepool"

--- a/tests/tools/kopiarunner/kopia_snapshotter.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter.go
@@ -390,7 +390,12 @@ func (ks *KopiaSnapshotter) ConnectOrCreateRepoWithServer(serverAddr string, arg
 
 	serverArgs := []string{"--tls-generate-cert", "--tls-cert-file", tlsCertFile, "--tls-key-file", tlsKeyFile}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	// Cover the full retry window of certKeyExist / waitUntilServerStarted
+	// (retryCount × retryInterval = 15 min today) plus a small slack for
+	// command startup. A shorter timeout would silently truncate the retry
+	// loop on slow CI and surface as flaky timeouts that look unrelated to
+	// the actual cause.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(retryCount)*retryInterval+30*time.Second)
 	defer cancel()
 
 	var cmd *exec.Cmd

--- a/tests/tools/kopiarunner/kopia_snapshotter.go
+++ b/tests/tools/kopiarunner/kopia_snapshotter.go
@@ -390,6 +390,9 @@ func (ks *KopiaSnapshotter) ConnectOrCreateRepoWithServer(serverAddr string, arg
 
 	serverArgs := []string{"--tls-generate-cert", "--tls-cert-file", tlsCertFile, "--tls-key-file", tlsKeyFile}
 
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	var cmd *exec.Cmd
 
 	var cmdErr error
@@ -398,7 +401,7 @@ func (ks *KopiaSnapshotter) ConnectOrCreateRepoWithServer(serverAddr string, arg
 		return nil, "", errors.Wrap(cmdErr, "CreateServer failed")
 	}
 
-	if err := certKeyExist(context.TODO(), tlsCertFile, tlsKeyFile); err != nil {
+	if err := certKeyExist(ctx, tlsCertFile, tlsKeyFile); err != nil {
 		if buf, ok := cmd.Stderr.(*bytes.Buffer); ok {
 			// If the STDERR buffer does not contain any obvious error output,
 			// it is possible the async server creation above is taking a long time
@@ -418,7 +421,7 @@ func (ks *KopiaSnapshotter) ConnectOrCreateRepoWithServer(serverAddr string, arg
 	}
 
 	serverAddr = fmt.Sprintf("https://%v", serverAddr)
-	if err := ks.waitUntilServerStarted(context.TODO(), serverAddr, fingerprint); err != nil {
+	if err := ks.waitUntilServerStarted(ctx, serverAddr, fingerprint); err != nil {
 		return cmd, "", err
 	}
 


### PR DESCRIPTION
## Summary

Six small maintenance fixes from a comprehensive review pass:

- Replace `golang.org/x/exp/constraints` with stdlib inline constraints
- Migrate `pierrec/lz4` v2+incompatible → v4
- Implement `listBlobWorker` in provider validation (was a TODO)
- Replace `context.TODO()` with `context.Background()` in log sweep
- Add timeout context in test server startup
- Move package-level `timeZone` global into `App` struct

## Test plan

- [ ] `make test` — no behavior changes, all existing tests should pass
- [ ] `make lint` — passes