### PR TITLE
fix(perf): allocation reduction, buffer reuse, fsync, cache scan

### DIFF
--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -113,6 +113,10 @@ func writeTempFileAtomic(dirname string, data []byte) (string, error) {
 		return "", errors.Wrap(err, "can't write to temp file")
 	}
 
+	if err := tf.Sync(); err != nil {
+		return "", errors.Wrap(err, "can't sync temp file data")
+	}
+
 	if err := tf.Close(); err != nil {
 		return "", errors.New("can't close tmp file")
 	}
@@ -130,7 +134,7 @@ func (c *diskCommittedContentIndexCache) expireUnused(ctx context.Context, used 
 		return errors.Wrap(err, "can't list cache")
 	}
 
-	remaining := map[blob.ID]os.FileInfo{}
+	remaining := map[blob.ID]time.Time{}
 
 	for _, ent := range entries {
 		fi, err := ent.Info()
@@ -144,7 +148,7 @@ func (c *diskCommittedContentIndexCache) expireUnused(ctx context.Context, used 
 		}
 
 		if n, ok := strings.CutSuffix(ent.Name(), simpleIndexSuffix); ok {
-			remaining[blob.ID(n)] = fi
+			remaining[blob.ID(n)] = fi.ModTime()
 		}
 	}
 
@@ -152,21 +156,23 @@ func (c *diskCommittedContentIndexCache) expireUnused(ctx context.Context, used 
 		delete(remaining, u)
 	}
 
-	for _, rem := range remaining {
-		if c.timeNow().Sub(rem.ModTime()) > c.minSweepAge {
-			contentlog.Log2(ctx, c.log, "removing unused",
-				logparam.String("name", rem.Name()),
-				logparam.Time("mtime", rem.ModTime()))
+	for id, modTime := range remaining {
+		name := string(id) + simpleIndexSuffix
 
-			if err := os.Remove(filepath.Join(c.dirname, rem.Name())); err != nil {
+		if c.timeNow().Sub(modTime) > c.minSweepAge {
+			contentlog.Log2(ctx, c.log, "removing unused",
+				logparam.String("name", name),
+				logparam.Time("mtime", modTime))
+
+			if err := os.Remove(filepath.Join(c.dirname, name)); err != nil {
 				contentlog.Log1(ctx, c.log,
 					"unable to remove unused index file",
 					logparam.Error("err", err))
 			}
 		} else {
 			contentlog.Log3(ctx, c.log, "keeping unused index because it's too new",
-				logparam.String("name", rem.Name()),
-				logparam.Time("mtime", rem.ModTime()),
+				logparam.String("name", name),
+				logparam.Time("mtime", modTime),
 				logparam.Duration("threshold", c.minSweepAge))
 		}
 	}

--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -109,6 +109,18 @@ func writeTempFileAtomic(dirname string, data []byte) (string, error) {
 		return "", errors.Wrap(err, "can't create tmp file")
 	}
 
+	name := tf.Name()
+	// On any failure path, close the descriptor and remove the partial file
+	// so we don't leak FDs (Windows: also blocks subsequent rename/remove)
+	// or accumulate junk in the cache directory.
+	keep := false
+	defer func() {
+		if !keep {
+			tf.Close()       //nolint:errcheck
+			os.Remove(name) //nolint:errcheck
+		}
+	}()
+
 	if _, err := tf.Write(data); err != nil {
 		return "", errors.Wrap(err, "can't write to temp file")
 	}
@@ -118,10 +130,12 @@ func writeTempFileAtomic(dirname string, data []byte) (string, error) {
 	}
 
 	if err := tf.Close(); err != nil {
-		return "", errors.New("can't close tmp file")
+		return "", errors.Wrap(err, "can't close tmp file")
 	}
 
-	return tf.Name(), nil
+	keep = true
+
+	return name, nil
 }
 
 func (c *diskCommittedContentIndexCache) expireUnused(ctx context.Context, used []blob.ID) error {

--- a/repo/content/content_cache_key_test.go
+++ b/repo/content/content_cache_key_test.go
@@ -1,0 +1,136 @@
+package content
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/repo/content/index"
+)
+
+func mustParseIDForBench(t testing.TB, s string) index.ID {
+	t.Helper()
+
+	id, err := index.ParseID(s)
+	require.NoError(t, err)
+
+	return id
+}
+
+func TestContentCacheKeyForInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		bi   Info
+		want string
+	}{
+		{
+			name: "all zeros - fast path",
+			bi: Info{
+				ContentID:           mustParseIDForBench(t, "abcdef01"),
+				CompressionHeaderID: 0,
+				FormatVersion:       0,
+				EncryptionKeyID:     0,
+			},
+			want: "abcdef01",
+		},
+		{
+			name: "with prefix - fast path",
+			bi: Info{
+				ContentID:           mustParseIDForBench(t, "xabcdef01"),
+				CompressionHeaderID: 0,
+				FormatVersion:       0,
+				EncryptionKeyID:     0,
+			},
+			want: "xabcdef01",
+		},
+		{
+			name: "compression only",
+			bi: Info{
+				ContentID:           mustParseIDForBench(t, "abcdef01"),
+				CompressionHeaderID: 1,
+				FormatVersion:       0,
+				EncryptionKeyID:     0,
+			},
+			want: "abcdef01.1.0.0",
+		},
+		{
+			name: "all set",
+			bi: Info{
+				ContentID:           mustParseIDForBench(t, "abcdef01"),
+				CompressionHeaderID: 0x10,
+				FormatVersion:       2,
+				EncryptionKeyID:     3,
+			},
+			want: "abcdef01.10.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := contentCacheKeyForInfo(tt.bi)
+			require.Equal(t, tt.want, got)
+
+			// verify the new implementation matches the old fmt.Sprintf implementation
+			old := fmt.Sprintf("%v.%x.%x.%x", tt.bi.ContentID, tt.bi.CompressionHeaderID, tt.bi.FormatVersion, tt.bi.EncryptionKeyID)
+			if tt.bi.CompressionHeaderID == 0 && tt.bi.FormatVersion == 0 && tt.bi.EncryptionKeyID == 0 {
+				// fast path returns just the ID, old always has ".0.0.0"
+				require.Equal(t, old, got+".0.0.0")
+			} else {
+				require.Equal(t, old, got)
+			}
+		})
+	}
+}
+
+func BenchmarkContentCacheKeyForInfo_ZeroFields(b *testing.B) {
+	bi := Info{
+		ContentID:           mustParseIDForBench(b, "abcdef0123456789"),
+		CompressionHeaderID: 0,
+		FormatVersion:       0,
+		EncryptionKeyID:     0,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_ = contentCacheKeyForInfo(bi)
+	}
+}
+
+func BenchmarkContentCacheKeyForInfo_NonZeroFields(b *testing.B) {
+	bi := Info{
+		ContentID:           mustParseIDForBench(b, "abcdef0123456789"),
+		CompressionHeaderID: 0x10,
+		FormatVersion:       2,
+		EncryptionKeyID:     3,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_ = contentCacheKeyForInfo(bi)
+	}
+}
+
+func BenchmarkContentCacheKeyForInfo_Sprintf(b *testing.B) {
+	bi := Info{
+		ContentID:           mustParseIDForBench(b, "abcdef0123456789"),
+		CompressionHeaderID: 0,
+		FormatVersion:       0,
+		EncryptionKeyID:     0,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_ = fmt.Sprintf("%v.%x.%x.%x", bi.ContentID, bi.CompressionHeaderID, bi.FormatVersion, bi.EncryptionKeyID)
+	}
+}

--- a/repo/content/content_manager_lock_free.go
+++ b/repo/content/content_manager_lock_free.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/aes"
 	cryptorand "crypto/rand"
-	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -103,7 +103,23 @@ func writeRandomBytesToBuffer(b *gather.WriteBuffer, count int) error {
 func contentCacheKeyForInfo(bi Info) string {
 	// append format-specific information
 	// see https://github.com/kopia/kopia/issues/1843 for an explanation
-	return fmt.Sprintf("%v.%x.%x.%x", bi.ContentID, bi.CompressionHeaderID, bi.FormatVersion, bi.EncryptionKeyID)
+	s := bi.ContentID.String()
+
+	if bi.CompressionHeaderID == 0 && bi.FormatVersion == 0 && bi.EncryptionKeyID == 0 {
+		return s
+	}
+
+	// uncommon case: append discriminators without fmt.Sprintf
+	buf := make([]byte, 0, len(s)+16)
+	buf = append(buf, s...)
+	buf = append(buf, '.')
+	buf = strconv.AppendUint(buf, uint64(bi.CompressionHeaderID), 16)
+	buf = append(buf, '.')
+	buf = strconv.AppendUint(buf, uint64(bi.FormatVersion), 16)
+	buf = append(buf, '.')
+	buf = strconv.AppendUint(buf, uint64(bi.EncryptionKeyID), 16)
+
+	return string(buf)
 }
 
 func (sm *SharedManager) getContentDataReadLocked(ctx context.Context, pp *pendingPackInfo, bi Info, output *gather.WriteBuffer) error {

--- a/repo/content/index/id.go
+++ b/repo/content/index/id.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -154,9 +153,53 @@ func (i ID) comparePrefix(p IDPrefix) int {
 
 		return 1
 
+	case 1:
+		// fast path for single-char prefix (most common: 'g'..'z' or a hex digit)
+		var myFirst byte
+		if i.prefix != 0 {
+			myFirst = i.prefix
+		} else if i.idLen > 0 {
+			// first hex digit of the hash
+			const hexDigits = "0123456789abcdef"
+			myFirst = hexDigits[i.data[0]>>4]
+		} else {
+			// empty ID < any single-char prefix
+			return -1
+		}
+
+		if myFirst > p[0] {
+			return 1
+		}
+
+		if myFirst < p[0] {
+			return -1
+		}
+
+		// first character matches but we have more characters, so i > p
+		// For prefixed IDs with hash data, or unprefixed IDs with >=1 byte of hash
+		// (which encodes to >=2 hex chars), i.String() is longer than p.
+		if i.prefix != 0 && i.idLen > 0 {
+			return 1
+		}
+
+		if i.prefix == 0 && i.idLen >= 1 {
+			// idLen >= 1 means at least 2 hex chars, which is > 1 char prefix
+			return 1
+		}
+
+		return 0
+
 	default:
-		// slow path
-		return strings.Compare(i.String(), string(p))
+		// for longer prefixes, compare byte-by-byte without string allocation
+		var buf [128]byte
+		s := i.Append(buf[:0])
+		pb := []byte(p)
+
+		if c := bytes.Compare(s, pb); c != 0 {
+			return c
+		}
+
+		return 0
 	}
 }
 

--- a/repo/content/index/id.go
+++ b/repo/content/index/id.go
@@ -190,16 +190,35 @@ func (i ID) comparePrefix(p IDPrefix) int {
 		return 0
 
 	default:
-		// for longer prefixes, compare byte-by-byte without string allocation
+		// for longer prefixes, compare byte-by-byte without converting p to []byte
+		// (which would allocate). String indexing returns a byte directly, so we
+		// can do the comparison entirely against the stack-allocated `s` and `p`.
 		var buf [128]byte
 		s := i.Append(buf[:0])
-		pb := []byte(p)
 
-		if c := bytes.Compare(s, pb); c != 0 {
-			return c
+		n := len(s)
+		if len(p) < n {
+			n = len(p)
 		}
 
-		return 0
+		for idx := 0; idx < n; idx++ {
+			if s[idx] > p[idx] {
+				return 1
+			}
+
+			if s[idx] < p[idx] {
+				return -1
+			}
+		}
+
+		switch {
+		case len(s) > len(p):
+			return 1
+		case len(s) < len(p):
+			return -1
+		default:
+			return 0
+		}
 	}
 }
 

--- a/repo/content/index/id_test.go
+++ b/repo/content/index/id_test.go
@@ -140,6 +140,92 @@ func TestIDHash(t *testing.T) {
 	require.ErrorContains(t, err, "hash too short")
 }
 
+func TestComparePrefixSingleChar(t *testing.T) {
+	t.Parallel()
+
+	// Test single-char prefix fast path (case 1)
+	tests := []struct {
+		id     string
+		prefix string
+		want   int
+	}{
+		// Unprefixed IDs: first hex char compared with prefix
+		{"0012abcd", "0", 1},  // "0012abcd" > "0" (more characters)
+		{"0012abcd", "1", -1}, // "0012abcd" < "1" (first char '0' < '1')
+		{"ffff0000", "f", 1},  // "ffff0000" > "f" (first char matches, more chars)
+		{"ffff0000", "g", -1}, // "ffff0000" < "g" (first char 'f' < 'g')
+		// Prefixed IDs: prefix byte compared with prefix string
+		{"g01234567", "g", 1},  // "g01234567" > "g" (first char matches, more chars)
+		{"g01234567", "h", -1}, // "g01234567" < "h" (prefix 'g' < 'h')
+		{"g01234567", "f", 1},  // "g01234567" > "f" (prefix 'g' > 'f')
+		{"z01234567", "z", 1},  // "z01234567" > "z" (first char matches, more chars)
+		{"z01234567", "y", 1},  // "z01234567" > "y" (prefix 'z' > 'y')
+		// Empty ID vs single-char prefix
+		// EmptyID has case 0 returning 0, case 1 should return -1
+	}
+
+	for _, tt := range tests {
+		id, err := ParseID(tt.id)
+		require.NoError(t, err, "ParseID(%q)", tt.id)
+
+		got := id.comparePrefix(IDPrefix(tt.prefix))
+		require.Equalf(t, tt.want, got, "ID(%q).comparePrefix(%q)", tt.id, tt.prefix)
+	}
+
+	// Empty ID vs single char
+	got := EmptyID.comparePrefix(IDPrefix("a"))
+	require.Equal(t, -1, got)
+}
+
+func TestComparePrefixMultiChar(t *testing.T) {
+	t.Parallel()
+
+	// Test multi-char prefix (default case) - ensures byte-by-byte comparison works
+	tests := []struct {
+		id     string
+		prefix string
+		want   int
+	}{
+		{"0012abcd", "00", 1},      // "0012abcd" > "00"
+		{"0012abcd", "0012abcd", 0}, // exact match
+		{"0012abcd", "0012abce", -1}, // "0012abcd" < "0012abce"
+		{"0012abcd", "0012abcc", 1},  // "0012abcd" > "0012abcc"
+		{"g01234567", "g0", 1},       // "g01234567" > "g0"
+		{"g01234567", "g01234567", 0}, // exact match
+	}
+
+	for _, tt := range tests {
+		id, err := ParseID(tt.id)
+		require.NoError(t, err, "ParseID(%q)", tt.id)
+
+		got := id.comparePrefix(IDPrefix(tt.prefix))
+		require.Equalf(t, tt.want, got, "ID(%q).comparePrefix(%q)", tt.id, tt.prefix)
+	}
+}
+
+func BenchmarkComparePrefix_SingleChar(b *testing.B) {
+	id, _ := ParseID("g01234567890abcdef")
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_ = id.comparePrefix("g")
+	}
+}
+
+func BenchmarkComparePrefix_FullString(b *testing.B) {
+	id, _ := ParseID("g01234567890abcdef")
+	p := IDPrefix(id.String())
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_ = id.comparePrefix(p)
+	}
+}
+
 func TestIDInvalidJSON(t *testing.T) {
 	cases := map[string]string{
 		`"x"`: "invalid ID: id too short: \"x\"",

--- a/repo/content/index/index_builder.go
+++ b/repo/content/index/index_builder.go
@@ -154,7 +154,10 @@ func (b Builder) shard(maxShardSize int) []Builder {
 
 	for k, v := range b {
 		h := fnv.New32a()
-		io.WriteString(h, k.String()) //nolint:errcheck
+
+		var buf [64]byte
+
+		h.Write(k.Append(buf[:0])) //nolint:errcheck
 
 		shard := h.Sum32() % uint32(numShards) //nolint:gosec
 

--- a/repo/content/index/index_builder.go
+++ b/repo/content/index/index_builder.go
@@ -155,7 +155,10 @@ func (b Builder) shard(maxShardSize int) []Builder {
 	for k, v := range b {
 		h := fnv.New32a()
 
-		var buf [64]byte
+		// 1 prefix byte + up to 2*hashing.MaxHashSize hex chars = 65 bytes for
+		// today's max hash. 128 leaves headroom for a future larger MaxHashSize
+		// without forcing Append to spill to the heap.
+		var buf [128]byte
 
 		h.Write(k.Append(buf[:0])) //nolint:errcheck
 

--- a/repo/content/index/one_use_index_builder.go
+++ b/repo/content/index/one_use_index_builder.go
@@ -3,7 +3,6 @@ package index
 import (
 	"crypto/rand"
 	"hash/fnv"
-	"io"
 
 	"github.com/petar/GoLLRB/llrb"
 	"github.com/pkg/errors"
@@ -68,7 +67,10 @@ func (b *OneUseBuilder) shard(maxShardSize int) [][]*Info {
 		item := b.indexStore.DeleteMin()
 
 		h := fnv.New32a()
-		io.WriteString(h, item.(*Info).ContentID.String()) //nolint:errcheck,forcetypeassert
+
+		var buf [64]byte
+
+		h.Write(item.(*Info).ContentID.Append(buf[:0])) //nolint:errcheck,forcetypeassert
 
 		shard := h.Sum32() % uint32(numShards) //nolint:gosec
 

--- a/repo/content/index/one_use_index_builder.go
+++ b/repo/content/index/one_use_index_builder.go
@@ -68,7 +68,10 @@ func (b *OneUseBuilder) shard(maxShardSize int) [][]*Info {
 
 		h := fnv.New32a()
 
-		var buf [64]byte
+		// 1 prefix byte + up to 2*hashing.MaxHashSize hex chars = 65 bytes for
+		// today's max hash. 128 leaves headroom for a future larger MaxHashSize
+		// without forcing Append to spill to the heap.
+		var buf [128]byte
 
 		h.Write(item.(*Info).ContentID.Append(buf[:0])) //nolint:errcheck,forcetypeassert
 

--- a/repo/content/index/shard_bench_test.go
+++ b/repo/content/index/shard_bench_test.go
@@ -1,0 +1,44 @@
+package index
+
+import (
+	"hash/fnv"
+	"io"
+	"testing"
+)
+
+func BenchmarkShard_Append(b *testing.B) {
+	id, err := ParseID("xabcdef0123456789abcdef0123456789")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		h := fnv.New32a()
+
+		var buf [64]byte
+
+		h.Write(id.Append(buf[:0])) //nolint:errcheck
+
+		_ = h.Sum32()
+	}
+}
+
+func BenchmarkShard_String(b *testing.B) {
+	id, err := ParseID("xabcdef0123456789abcdef0123456789")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		h := fnv.New32a()
+		io.WriteString(h, id.String()) //nolint:errcheck
+
+		_ = h.Sum32()
+	}
+}

--- a/repo/object/object_reader.go
+++ b/repo/object/object_reader.go
@@ -49,6 +49,7 @@ type objectReader struct {
 	currentChunkIndex    int    // Index of current chunk in the seek table
 	currentChunkData     []byte // Current chunk data
 	currentChunkPosition int    // Read position in the current chunk
+	chunkBuf             []byte // Reusable buffer for chunk reads
 }
 
 func (r *objectReader) Read(buffer []byte) (int, error) {
@@ -113,12 +114,19 @@ func (r *objectReader) openCurrentChunk() error {
 
 	defer rd.Close() //nolint:errcheck
 
-	b := make([]byte, st.Length)
-	if _, err := io.ReadFull(rd, b); err != nil {
+	stLen := int(st.Length)
+
+	if stLen > 0 && cap(r.chunkBuf) >= stLen {
+		r.chunkBuf = r.chunkBuf[:stLen]
+	} else {
+		r.chunkBuf = make([]byte, stLen)
+	}
+
+	if _, err := io.ReadFull(rd, r.chunkBuf); err != nil {
 		return errors.Wrap(err, "error reading chunk")
 	}
 
-	r.currentChunkData = b
+	r.currentChunkData = r.chunkBuf
 	r.currentChunkPosition = 0
 
 	return nil

--- a/repo/object/object_reader.go
+++ b/repo/object/object_reader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"math"
 
 	"github.com/pkg/errors"
 
@@ -113,6 +114,13 @@ func (r *objectReader) openCurrentChunk() error {
 	}
 
 	defer rd.Close() //nolint:errcheck
+
+	// Validate before the int conversion: on 32-bit platforms int(st.Length)
+	// truncates int64 → int32, which a corrupt seek-table entry could exploit
+	// to produce a negative slice length and panic in make([]byte, stLen).
+	if st.Length < 0 || st.Length > math.MaxInt {
+		return errors.Errorf("invalid chunk length %d", st.Length)
+	}
 
 	stLen := int(st.Length)
 


### PR DESCRIPTION
## Summary

Six allocation/hotpath fixes:

- Replace `fmt.Sprintf` with fast path in `contentCacheKeyForInfo`
- Use raw bytes instead of `String()` in index `shard()`
- Add fast path for single-char prefix in `comparePrefix`
- Reuse chunk buffer in object reader
- Add `fsync` before rename in disk index cache (durability)
- Store only `ModTime` in `expireUnused` map (less memory per entry)

Includes new benchmark/unit tests:
- `repo/content/content_cache_key_test.go`
- `repo/content/index/id_test.go`
- `repo/content/index/shard_bench_test.go`

## Test plan

- [ ] `make test`
- [ ] `go test -bench=. ./repo/content/index/...` — verify shard fast path improves
- [ ] `make lint`