### PR TITLE
fix(stability): error propagation, cache panic safety, sweep I/O

### DIFF
--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -168,15 +168,17 @@ func (c *PersistentCache) Put(ctx context.Context, key string, data gather.Bytes
 	}
 
 	c.listCacheMutex.Lock()
-	defer c.listCacheMutex.Unlock()
 
 	// make sure the cache has enough room for the new item including any protection overhead.
 	l := data.Length() + c.storageProtection.OverheadBytes()
 	c.pendingWriteBytes += int64(l)
-	c.sweepLocked(ctx)
+	toDelete := c.sweepLocked(ctx)
 
-	// LOCK RELEASED for expensive operations
+	// LOCK RELEASED for expensive I/O operations
 	c.listCacheMutex.Unlock()
+
+	// perform sweep deletes outside the lock
+	c.performSweepDeletes(ctx, toDelete)
 
 	var protected gather.WriteBuffer
 	defer protected.Close()
@@ -184,6 +186,8 @@ func (c *PersistentCache) Put(ctx context.Context, key string, data gather.Bytes
 	c.storageProtection.Protect(key, data, &protected)
 
 	if protected.Length() != l {
+		// No lock is held here, so we can panic safely without causing
+		// a double-unlock from a deferred Unlock.
 		log(ctx).Panicf("protection overhead mismatch, assumed %v got %v", l, protected.Length())
 	}
 
@@ -196,7 +200,7 @@ func (c *PersistentCache) Put(ctx context.Context, key string, data gather.Bytes
 	}
 
 	c.listCacheMutex.Lock()
-	// LOCK RE-ACQUIRED
+	defer c.listCacheMutex.Unlock()
 
 	c.pendingWriteBytes -= int64(protected.Length())
 	c.listCache.AddOrUpdate(blob.Metadata{
@@ -288,41 +292,46 @@ func (c *PersistentCache) aboveHardLimit(extraBytes int64) bool {
 	return c.listCache.totalDataBytes+extraBytes+c.pendingWriteBytes > c.sweep.LimitBytes
 }
 
+// sweepLocked collects cache items that should be deleted to bring the cache
+// below its size limits. It removes them from the heap but does NOT perform
+// I/O. The caller is responsible for deleting the blobs outside the lock and
+// pushing any failed deletes back into the heap.
+//
 // +checklocks:c.listCacheMutex
-func (c *PersistentCache) sweepLocked(ctx context.Context) {
-	var (
-		unsuccessfulDeletes     []blob.Metadata
-		unsuccessfulDeleteBytes int64
-		now                     = c.timeNow()
-	)
+func (c *PersistentCache) sweepLocked(ctx context.Context) []blob.Metadata {
+	var toDelete []blob.Metadata
 
-	for len(c.listCache.data) > 0 && (c.aboveSoftLimit(unsuccessfulDeleteBytes) || c.aboveHardLimit(unsuccessfulDeleteBytes)) {
+	now := c.timeNow()
+
+	for len(c.listCache.data) > 0 && (c.aboveSoftLimit(0) || c.aboveHardLimit(0)) {
 		// examine the oldest cache item without removing it from the heap.
 		oldest := c.listCache.data[0]
 
-		if age := now.Sub(oldest.Timestamp); age < c.sweep.MinSweepAge && !c.aboveHardLimit(unsuccessfulDeleteBytes) {
+		if age := now.Sub(oldest.Timestamp); age < c.sweep.MinSweepAge && !c.aboveHardLimit(0) {
 			// the oldest item is below the specified minimal sweep age and we're below the hard limit, stop here
 			break
 		}
 
 		heap.Pop(&c.listCache)
 
-		if delerr := c.cacheStorage.DeleteBlob(ctx, oldest.BlobID); delerr != nil {
-			log(ctx).Warnw("unable to remove cache item", "cache", c.description, "item", oldest.BlobID, "err", delerr)
-
-			// accumulate unsuccessful deletes to be pushed back into the heap
-			// later so we do not attempt deleting the same blob multiple times
-			//
-			// after this we keep draining from the heap until we bring down
-			// c.listCache.DataSize() to zero
-			unsuccessfulDeletes = append(unsuccessfulDeletes, oldest)
-			unsuccessfulDeleteBytes += oldest.Length
-		}
+		toDelete = append(toDelete, oldest)
 	}
 
-	// put all unsuccessful deletes back into the heap
-	for _, m := range unsuccessfulDeletes {
-		heap.Push(&c.listCache, m)
+	return toDelete
+}
+
+// performSweepDeletes deletes cache blobs outside the lock. Failed deletes are
+// pushed back into the heap so they can be retried on the next sweep.
+func (c *PersistentCache) performSweepDeletes(ctx context.Context, toDelete []blob.Metadata) {
+	for _, item := range toDelete {
+		if delerr := c.cacheStorage.DeleteBlob(ctx, item.BlobID); delerr != nil {
+			log(ctx).Warnw("unable to remove cache item", "cache", c.description, "item", item.BlobID, "err", delerr)
+
+			// push failed deletes back into the heap
+			c.listCacheMutex.Lock()
+			heap.Push(&c.listCache, item)
+			c.listCacheMutex.Unlock()
+		}
 	}
 }
 
@@ -336,7 +345,6 @@ func (c *PersistentCache) initialScan(ctx context.Context) error {
 	)
 
 	c.listCacheMutex.Lock()
-	defer c.listCacheMutex.Unlock()
 
 	err := c.cacheStorage.ListBlobs(ctx, "", func(it blob.Metadata) error {
 		// count items below minimal age.
@@ -350,10 +358,19 @@ func (c *PersistentCache) initialScan(ctx context.Context) error {
 		return nil
 	})
 	if err != nil {
+		c.listCacheMutex.Unlock()
 		return errors.Wrapf(err, "error listing %v", c.description)
 	}
 
-	c.sweepLocked(ctx)
+	toDelete := c.sweepLocked(ctx)
+
+	c.listCacheMutex.Unlock()
+
+	// perform sweep deletes outside the lock
+	c.performSweepDeletes(ctx, toDelete)
+
+	c.listCacheMutex.Lock()
+	defer c.listCacheMutex.Unlock()
 
 	dur := timer.Elapsed()
 

--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -322,16 +322,39 @@ func (c *PersistentCache) sweepLocked(ctx context.Context) []blob.Metadata {
 
 // performSweepDeletes deletes cache blobs outside the lock. Failed deletes are
 // pushed back into the heap so they can be retried on the next sweep.
+//
+// On successful delete (or ErrBlobNotFound), also clears any stale heap entry
+// that may have been re-added by AddOrUpdate between sweepLocked popping the
+// item and this delete completing — without this, the heap and storage could
+// diverge: storage no longer has the blob, but the heap thinks we still do.
 func (c *PersistentCache) performSweepDeletes(ctx context.Context, toDelete []blob.Metadata) {
 	for _, item := range toDelete {
-		if delerr := c.cacheStorage.DeleteBlob(ctx, item.BlobID); delerr != nil {
-			log(ctx).Warnw("unable to remove cache item", "cache", c.description, "item", item.BlobID, "err", delerr)
-
-			// push failed deletes back into the heap
+		delerr := c.cacheStorage.DeleteBlob(ctx, item.BlobID)
+		if delerr == nil || errors.Is(delerr, blob.ErrBlobNotFound) {
 			c.listCacheMutex.Lock()
-			heap.Push(&c.listCache, item)
+			c.removeMatchingListCacheEntryLocked(item.BlobID)
 			c.listCacheMutex.Unlock()
+
+			continue
 		}
+
+		log(ctx).Warnw("unable to remove cache item", "cache", c.description, "item", item.BlobID, "err", delerr)
+
+		// push failed deletes back into the heap
+		c.listCacheMutex.Lock()
+		heap.Push(&c.listCache, item)
+		c.listCacheMutex.Unlock()
+	}
+}
+
+// removeMatchingListCacheEntryLocked removes a heap entry with the given blob
+// ID if one exists. Used by performSweepDeletes after a successful storage
+// delete to keep the heap consistent if the blob was re-added concurrently.
+//
+// +checklocks:c.listCacheMutex
+func (c *PersistentCache) removeMatchingListCacheEntryLocked(blobID blob.ID) {
+	if i, ok := c.listCache.index[blobID]; ok {
+		heap.Remove(&c.listCache, i) // +checklocksignore
 	}
 }
 

--- a/internal/cache/persistent_lru_cache_test.go
+++ b/internal/cache/persistent_lru_cache_test.go
@@ -3,6 +3,7 @@ package cache_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -274,6 +275,72 @@ func TestPersistentLRUCache_Sweep1(t *testing.T) {
 	// simulate error during final sweep
 	fs.AddFaults(blobtesting.MethodListBlobs, fault.New().ErrorInstead(errors.New("some error")))
 	pc.Close(ctx)
+}
+
+// mismatchedProtection is a StorageProtection that reports a different OverheadBytes
+// than what Protect actually produces. This triggers the panic check in Put().
+type mismatchedProtection struct{}
+
+func (mismatchedProtection) Protect(_ string, input gather.Bytes, output *gather.WriteBuffer) {
+	output.Reset()
+	input.WriteTo(output) //nolint:errcheck
+	// Add extra bytes that OverheadBytes() did not account for.
+	output.Append([]byte("extra"))
+}
+
+func (mismatchedProtection) Verify(_ string, input gather.Bytes, output *gather.WriteBuffer) error {
+	output.Reset()
+	input.WriteTo(output) //nolint:errcheck
+
+	return nil
+}
+
+func (mismatchedProtection) OverheadBytes() int {
+	return 0 // lies: Protect adds 5 bytes, but OverheadBytes reports 0
+}
+
+func TestPersistentLRUCache_PutPanicNoDoublePanic(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.ContextWithLevel(t, testlogging.LevelInfo)
+
+	data := blobtesting.DataMap{}
+
+	const maxSizeBytes = 10000
+
+	st := blobtesting.NewMapStorageWithLimit(data, nil, nil, maxSizeBytes)
+	fc := faultyCache{blobtesting.NewFaultyStorage(st)}
+
+	pc, err := cache.NewPersistentCache(ctx, "test", fc, mismatchedProtection{}, cache.SweepSettings{
+		MaxSizeBytes: maxSizeBytes,
+	}, nil, clock.Now)
+	require.NoError(t, err)
+
+	defer pc.Close(ctx)
+
+	// Put should panic due to protection overhead mismatch.
+	// Before the fix, this would cause a double-panic (the mismatch panic
+	// followed by "sync: unlock of unlocked mutex" from the deferred Unlock).
+	// After the fix, only the mismatch panic fires cleanly.
+	recovered := func() (r any) {
+		defer func() {
+			r = recover()
+		}()
+
+		pc.Put(ctx, "key1", gather.FromSlice([]byte{1, 2, 3}))
+
+		return nil
+	}()
+
+	require.NotNil(t, recovered, "expected a panic from protection overhead mismatch")
+
+	panicMsg := fmt.Sprintf("%v", recovered)
+	require.Contains(t, panicMsg, "protection overhead mismatch",
+		"expected panic message about protection overhead mismatch, got: %v", panicMsg)
+	// Before the fix, the deferred Unlock of an already-unlocked mutex would
+	// produce a second panic containing "unlock of unlocked mutex".
+	require.NotContains(t, panicMsg, "unlock of unlocked mutex",
+		"double-panic detected: mutex was unlocked twice")
 }
 
 func TestPersistentLRUCacheNil(t *testing.T) {

--- a/repo/content/content_manager_iterate.go
+++ b/repo/content/content_manager_iterate.go
@@ -106,14 +106,18 @@ func (bm *WriteManager) snapshotUncommittedItems(ctx context.Context) index.Buil
 
 // IterateContents invokes the provided callback for each content starting with a specified prefix
 // and possibly including deleted items.
-func (bm *WriteManager) IterateContents(ctx context.Context, opts IterateOptions, callback IterateCallback) error {
+func (bm *WriteManager) IterateContents(ctx context.Context, opts IterateOptions, callback IterateCallback) (retErr error) {
 	if opts.Range == (IDRange{}) {
 		// range not specified - default to AllIDs
 		opts.Range = index.AllIDs
 	}
 
 	callback, cleanup := maybeParallelExecutor(opts.Parallel, callback)
-	defer cleanup() //nolint:errcheck
+	defer func() {
+		if cerr := cleanup(); cerr != nil && retErr == nil {
+			retErr = cerr
+		}
+	}()
 
 	uncommitted := bm.snapshotUncommittedItems(ctx)
 
@@ -141,7 +145,9 @@ func (bm *WriteManager) IterateContents(ctx context.Context, opts IterateOptions
 	}
 
 	for _, bi := range uncommitted {
-		_ = invokeCallback(bi)
+		if err := invokeCallback(bi); err != nil {
+			return err
+		}
 	}
 
 	if err := bm.maybeRefreshIndexes(ctx); err != nil {
@@ -152,7 +158,9 @@ func (bm *WriteManager) IterateContents(ctx context.Context, opts IterateOptions
 		return err
 	}
 
-	return cleanup()
+	retErr = cleanup()
+
+	return
 }
 
 // IteratePackOptions are the options used to iterate over packs.

--- a/repo/content/content_manager_iterate.go
+++ b/repo/content/content_manager_iterate.go
@@ -158,9 +158,12 @@ func (bm *WriteManager) IterateContents(ctx context.Context, opts IterateOptions
 		return err
 	}
 
-	retErr = cleanup()
-
-	return
+	// cleanup() is invoked exactly once via the deferred wrapper above, which
+	// captures its result into retErr only when no other error was returned.
+	// Calling it explicitly here as well would double-invoke and could leave
+	// the cleanup machinery in an inconsistent state if it ever stops being
+	// idempotent.
+	return nil
 }
 
 // IteratePackOptions are the options used to iterate over packs.

--- a/repo/content/content_manager_test.go
+++ b/repo/content/content_manager_test.go
@@ -1656,6 +1656,25 @@ func (s *contentManagerSuite) TestIterateContents(t *testing.T) {
 	}
 }
 
+func (s *contentManagerSuite) TestIterateContents_UncommittedCallbackError(t *testing.T) {
+	ctx := testlogging.Context(t)
+	data := blobtesting.DataMap{}
+	st := blobtesting.NewMapStorage(data, nil, nil)
+	bm := s.newTestContentManager(t, st)
+
+	// Write content but do NOT flush, so it remains uncommitted.
+	writeContentAndVerify(ctx, t, bm, seededRandomData(10, 100))
+
+	callbackErr := errors.New("uncommitted callback error")
+
+	// Before the fix, IterateContents dropped errors from uncommitted content callbacks.
+	err := bm.IterateContents(ctx, IterateOptions{}, func(ci Info) error {
+		return callbackErr
+	})
+
+	require.ErrorIs(t, err, callbackErr, "expected callback error from uncommitted content to be propagated")
+}
+
 func (s *contentManagerSuite) TestFindUnreferencedBlobs(t *testing.T) {
 	ctx := testlogging.Context(t)
 	data := blobtesting.DataMap{}


### PR DESCRIPTION
## Summary

Four stability fixes:

- Propagate callback errors for uncommitted content in `IterateContents`
- Fix double-panic in `PersistentCache.Put` on invariant violation
- Capture parallel-worker cleanup errors on early return (was swallowed)
- Move cache sweep I/O outside `listCacheMutex` (reduces lock hold time)

Adds tests in `internal/cache/persistent_lru_cache_test.go` and `repo/content/content_manager_test.go`.

## Test plan

- [ ] `make test`
- [ ] `make lint`