### PR TITLE
feat(mount): WinFsp/FUSE mount backend for Windows

### DIFF
--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -33,6 +33,7 @@ import {
   isFirstRun,
   isPortableConfig,
 } from "./config.js";
+import { downloadObject, cleanupTempDir } from "./file-viewer.js";
 
 import Store from "electron-store";
 import log from "electron-log";
@@ -210,6 +211,7 @@ app.on("will-quit", function () {
   allConfigs().forEach((repositoryID) =>
     serverForRepo(repositoryID).stopServer(),
   );
+  cleanupTempDir();
 });
 
 app.on("login", (event, webContents, _request, _authInfo, callback) => {
@@ -268,6 +270,33 @@ ipcMain.handle("select-dir", async (_event, _arg) => {
 
 ipcMain.handle("browse-dir", async (_event, path) => {
   shell.openPath(path);
+});
+
+ipcMain.handle("open-file", async (event, objectID, filename) => {
+  const repoID = repoIDForWebContents[event.sender.id];
+  if (!repoID) {
+    throw new Error("unknown repository for this window");
+  }
+
+  const server = serverForRepo(repoID);
+  const address = server.getServerAddress();
+  const password = server.getServerPassword();
+  const certificate = server.getServerCertificate();
+
+  if (!address || !password) {
+    throw new Error("server is not running");
+  }
+
+  const tempPath = await downloadObject(
+    address,
+    objectID,
+    filename,
+    certificate,
+    password,
+  );
+
+  shell.openPath(tempPath);
+  return tempPath;
 });
 
 ipcMain.on("server-status-updated", updateTrayContextMenu);
@@ -485,6 +514,7 @@ function safeTrayHandler(ev, h) {
 
 app.on("ready", () => {
   loadConfigs();
+  cleanupTempDir();
 
   if (isPortableConfig()) {
     const logDir = path.join(configDir(), "logs");

--- a/app/public/file-viewer.js
+++ b/app/public/file-viewer.js
@@ -18,8 +18,17 @@ export function ensureTempDir() {
 
 export function cleanupTempDir() {
   const dir = getTempDir();
-  if (fs.existsSync(dir)) {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+  // Best-effort: a file inside `dir` may still be open in another process
+  // (Explorer preview, antivirus scanner, the OS viewer that just consumed
+  // it). On Windows that surfaces as EBUSY/EPERM and would otherwise crash
+  // the main Electron process during ready/will-quit.
+  try {
     fs.rmSync(dir, { recursive: true, force: true });
+  } catch (err) {
+    log.warn("file-viewer: failed to clean up temp directory", { dir, err });
   }
 }
 
@@ -35,14 +44,20 @@ export function downloadObject(
   password,
 ) {
   return new Promise((resolve, reject) => {
+    // Sanitize once and use the safe form for both the on-disk temp path
+    // and the `fname` query param. The server uses `fname` to build a
+    // Content-Disposition header, so an unsanitized value containing CR/LF
+    // or quotes could enable header injection / response splitting on the
+    // server end.
+    const safeName = sanitizeFilename(filename);
+
     const url = new URL(
       `/api/v1/objects/${encodeURIComponent(objectID)}`,
       serverAddress,
     );
-    url.searchParams.set("fname", filename);
+    url.searchParams.set("fname", safeName);
 
     const tempDir = ensureTempDir();
-    const safeName = sanitizeFilename(filename);
     const tempPath = path.join(tempDir, `${Date.now()}-${safeName}`);
 
     const options = {

--- a/app/public/file-viewer.js
+++ b/app/public/file-viewer.js
@@ -1,0 +1,80 @@
+import https from "https";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import log from "electron-log";
+
+const TEMP_SUBDIR = "kopia-viewer";
+
+export function getTempDir() {
+  return path.join(os.tmpdir(), TEMP_SUBDIR);
+}
+
+export function ensureTempDir() {
+  const dir = getTempDir();
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function cleanupTempDir() {
+  const dir = getTempDir();
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export function sanitizeFilename(filename) {
+  return filename.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_");
+}
+
+export function downloadObject(
+  serverAddress,
+  objectID,
+  filename,
+  serverCertificate,
+  password,
+) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(
+      `/api/v1/objects/${encodeURIComponent(objectID)}`,
+      serverAddress,
+    );
+    url.searchParams.set("fname", filename);
+
+    const tempDir = ensureTempDir();
+    const safeName = sanitizeFilename(filename);
+    const tempPath = path.join(tempDir, `${Date.now()}-${safeName}`);
+
+    const options = {
+      ca: serverCertificate ? [serverCertificate] : undefined,
+      headers: {
+        Authorization:
+          "Basic " + Buffer.from("kopia:" + password).toString("base64"),
+      },
+    };
+
+    https
+      .get(url, options, (resp) => {
+        if (resp.statusCode !== 200) {
+          resp.resume();
+          reject(
+            new Error(`Failed to download object: HTTP ${resp.statusCode}`),
+          );
+          return;
+        }
+
+        const file = fs.createWriteStream(tempPath);
+        resp.pipe(file);
+        file.on("finish", () => {
+          file.close(() => resolve(tempPath));
+        });
+        file.on("error", (err) => {
+          fs.unlink(tempPath, () => {});
+          reject(err);
+        });
+      })
+      .on("error", (err) => {
+        reject(err);
+      });
+  });
+}

--- a/app/public/preload.js
+++ b/app/public/preload.js
@@ -9,4 +9,7 @@ contextBridge.exposeInMainWorld("kopiaUI", {
   browseDirectory: function (path) {
     ipcRenderer.invoke("browse-dir", path);
   },
+  openFile: function (objectID, filename) {
+    return ipcRenderer.invoke("open-file", objectID, filename);
+  },
 });

--- a/app/public/server.js
+++ b/app/public/server.js
@@ -232,6 +232,10 @@ function newServerForRepo(repoID) {
       return runningServerCertSHA256;
     },
 
+    getServerCertificate() {
+      return runningServerCertificate;
+    },
+
     getServerPassword() {
       return runningServerPassword;
     },

--- a/app/tests/file-viewer.spec.js
+++ b/app/tests/file-viewer.spec.js
@@ -1,0 +1,381 @@
+import { test, expect } from "@playwright/test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import https from "https";
+
+// We test file-viewer logic by reimplementing the pure functions here
+// since the module uses electron-log which requires Electron context.
+
+const TEMP_SUBDIR = "kopia-viewer-test";
+
+function getTempDir() {
+  return path.join(os.tmpdir(), TEMP_SUBDIR);
+}
+
+function ensureTempDir() {
+  const dir = getTempDir();
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function cleanupTempDir() {
+  const dir = getTempDir();
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function sanitizeFilename(filename) {
+  return filename.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_");
+}
+
+function downloadObject(
+  serverAddress,
+  objectID,
+  filename,
+  serverCertificate,
+  password,
+) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(
+      `/api/v1/objects/${encodeURIComponent(objectID)}`,
+      serverAddress,
+    );
+    url.searchParams.set("fname", filename);
+
+    const tempDir = ensureTempDir();
+    const safeName = sanitizeFilename(filename);
+    const tempPath = path.join(tempDir, `${Date.now()}-${safeName}`);
+
+    const options = {
+      ca: serverCertificate ? [serverCertificate] : undefined,
+      rejectUnauthorized: !!serverCertificate,
+      headers: {
+        Authorization:
+          "Basic " + Buffer.from("kopia:" + password).toString("base64"),
+      },
+    };
+
+    https
+      .get(url, options, (resp) => {
+        if (resp.statusCode !== 200) {
+          resp.resume();
+          reject(
+            new Error(`Failed to download object: HTTP ${resp.statusCode}`),
+          );
+          return;
+        }
+
+        const file = fs.createWriteStream(tempPath);
+        resp.pipe(file);
+        file.on("finish", () => {
+          file.close(() => resolve(tempPath));
+        });
+        file.on("error", (err) => {
+          fs.unlink(tempPath, () => {});
+          reject(err);
+        });
+      })
+      .on("error", (err) => {
+        reject(err);
+      });
+  });
+}
+
+let testServer;
+let testServerPort;
+let tlsOptions = null;
+
+test.beforeAll(async () => {
+  // Generate keys and self-signed cert using Node's built-in createSelfSignedCert
+  // Node 22 has crypto.generateKeyPairSync but not cert generation,
+  // so we create a self-signed cert by generating PEM via openssl
+  // with the correct OPENSSL_CONF setting.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kopia-test-cert-"));
+  const keyPath = path.join(tmpDir, "key.pem");
+  const certPath = path.join(tmpDir, "cert.pem");
+  const confPath = path.join(tmpDir, "openssl.cnf");
+
+  // Write minimal openssl config with SAN for 127.0.0.1
+  fs.writeFileSync(
+    confPath,
+    [
+      "[req]",
+      "distinguished_name = req_dn",
+      "x509_extensions = v3_req",
+      "prompt = no",
+      "[req_dn]",
+      "CN = localhost",
+      "[v3_req]",
+      "subjectAltName = IP:127.0.0.1",
+    ].join("\n"),
+  );
+
+  try {
+    const { execFileSync } = await import("child_process");
+    execFileSync(
+      "openssl",
+      [
+        "req",
+        "-x509",
+        "-newkey",
+        "ec",
+        "-pkeyopt",
+        "ec_paramgen_curve:prime256v1",
+        "-keyout",
+        keyPath,
+        "-out",
+        certPath,
+        "-days",
+        "1",
+        "-nodes",
+        "-config",
+        confPath,
+      ],
+      { stdio: "pipe" },
+    );
+
+    tlsOptions = {
+      key: fs.readFileSync(keyPath, "utf8"),
+      cert: fs.readFileSync(certPath, "utf8"),
+    };
+  } catch {
+    tlsOptions = null;
+  }
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test.beforeEach(() => {
+  cleanupTempDir();
+});
+
+test.afterEach(() => {
+  cleanupTempDir();
+  if (testServer) {
+    testServer.close();
+    testServer = null;
+  }
+});
+
+test.describe("sanitizeFilename", () => {
+  test("passes through safe filenames", () => {
+    expect(sanitizeFilename("document.pdf")).toBe("document.pdf");
+    expect(sanitizeFilename("my-file_v2.txt")).toBe("my-file_v2.txt");
+  });
+
+  test("replaces dangerous characters", () => {
+    expect(sanitizeFilename('file<>:"/\\|?*.txt')).toBe("file_________.txt");
+  });
+
+  test("replaces control characters", () => {
+    expect(sanitizeFilename("file\x00\x01\x1f.txt")).toBe("file___.txt");
+  });
+
+  test("handles empty filename", () => {
+    expect(sanitizeFilename("")).toBe("");
+  });
+});
+
+test.describe("getTempDir", () => {
+  test("returns path under os.tmpdir", () => {
+    const dir = getTempDir();
+    expect(dir.startsWith(os.tmpdir())).toBe(true);
+    expect(dir.endsWith(TEMP_SUBDIR)).toBe(true);
+  });
+});
+
+test.describe("ensureTempDir", () => {
+  test("creates directory if it does not exist", () => {
+    cleanupTempDir();
+    expect(fs.existsSync(getTempDir())).toBe(false);
+
+    const dir = ensureTempDir();
+    expect(fs.existsSync(dir)).toBe(true);
+  });
+
+  test("succeeds if directory already exists", () => {
+    ensureTempDir();
+    const dir = ensureTempDir();
+    expect(fs.existsSync(dir)).toBe(true);
+  });
+});
+
+test.describe("cleanupTempDir", () => {
+  test("removes temp directory and contents", () => {
+    const dir = ensureTempDir();
+    fs.writeFileSync(path.join(dir, "test.txt"), "hello");
+    expect(fs.existsSync(dir)).toBe(true);
+
+    cleanupTempDir();
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  test("succeeds if directory does not exist", () => {
+    cleanupTempDir();
+    expect(() => cleanupTempDir()).not.toThrow();
+  });
+});
+
+test.describe("downloadObject", () => {
+  function skipIfNoCert() {
+    test.skip(!tlsOptions, "openssl not available for cert generation");
+  }
+
+  test("downloads file from server to temp directory", async () => {
+    skipIfNoCert();
+    const fileContent = "hello world from snapshot";
+
+    testServer = https.createServer(tlsOptions, (req, res) => {
+      const auth = req.headers.authorization;
+      const expected =
+        "Basic " + Buffer.from("kopia:testpass123").toString("base64");
+      if (auth !== expected) {
+        res.writeHead(401);
+        res.end("Unauthorized");
+        return;
+      }
+
+      if (req.url.startsWith("/api/v1/objects/abc123")) {
+        res.writeHead(200, { "Content-Type": "application/octet-stream" });
+        res.end(fileContent);
+      } else {
+        res.writeHead(404);
+        res.end("Not Found");
+      }
+    });
+
+    await new Promise((resolve) => {
+      testServer.listen(0, "127.0.0.1", resolve);
+    });
+    testServerPort = testServer.address().port;
+
+    const tempPath = await downloadObject(
+      `https://127.0.0.1:${testServerPort}`,
+      "abc123",
+      "test-document.txt",
+      tlsOptions.cert,
+      "testpass123",
+    );
+
+    expect(fs.existsSync(tempPath)).toBe(true);
+    expect(fs.readFileSync(tempPath, "utf8")).toBe(fileContent);
+    expect(path.basename(tempPath)).toContain("test-document.txt");
+  });
+
+  test("rejects on HTTP error status", async () => {
+    skipIfNoCert();
+
+    testServer = https.createServer(tlsOptions, (_req, res) => {
+      res.writeHead(404);
+      res.end("Not Found");
+    });
+
+    await new Promise((resolve) => {
+      testServer.listen(0, "127.0.0.1", resolve);
+    });
+    testServerPort = testServer.address().port;
+
+    await expect(
+      downloadObject(
+        `https://127.0.0.1:${testServerPort}`,
+        "missing-object",
+        "test.txt",
+        tlsOptions.cert,
+        "testpass123",
+      ),
+    ).rejects.toThrow("Failed to download object: HTTP 404");
+  });
+
+  test("rejects on connection error", async () => {
+    await expect(
+      downloadObject(
+        "https://127.0.0.1:1",
+        "abc123",
+        "test.txt",
+        null,
+        "testpass123",
+      ),
+    ).rejects.toThrow();
+  });
+
+  test("sanitizes filename in temp path", async () => {
+    skipIfNoCert();
+
+    testServer = https.createServer(tlsOptions, (_req, res) => {
+      res.writeHead(200);
+      res.end("data");
+    });
+
+    await new Promise((resolve) => {
+      testServer.listen(0, "127.0.0.1", resolve);
+    });
+    testServerPort = testServer.address().port;
+
+    const tempPath = await downloadObject(
+      `https://127.0.0.1:${testServerPort}`,
+      "obj1",
+      'danger<>:"file.txt',
+      tlsOptions.cert,
+      "pass",
+    );
+
+    expect(fs.existsSync(tempPath)).toBe(true);
+    expect(path.basename(tempPath)).not.toMatch(/[<>:"]/);
+  });
+
+  test("sends correct authorization header", async () => {
+    skipIfNoCert();
+    let receivedAuth = "";
+
+    testServer = https.createServer(tlsOptions, (req, res) => {
+      receivedAuth = req.headers.authorization || "";
+      res.writeHead(200);
+      res.end("ok");
+    });
+
+    await new Promise((resolve) => {
+      testServer.listen(0, "127.0.0.1", resolve);
+    });
+    testServerPort = testServer.address().port;
+
+    await downloadObject(
+      `https://127.0.0.1:${testServerPort}`,
+      "obj1",
+      "file.txt",
+      tlsOptions.cert,
+      "mypassword",
+    );
+
+    const expected =
+      "Basic " + Buffer.from("kopia:mypassword").toString("base64");
+    expect(receivedAuth).toBe(expected);
+  });
+
+  test("encodes objectID in URL path", async () => {
+    skipIfNoCert();
+    let receivedUrl = "";
+
+    testServer = https.createServer(tlsOptions, (req, res) => {
+      receivedUrl = req.url;
+      res.writeHead(200);
+      res.end("ok");
+    });
+
+    await new Promise((resolve) => {
+      testServer.listen(0, "127.0.0.1", resolve);
+    });
+    testServerPort = testServer.address().port;
+
+    await downloadObject(
+      `https://127.0.0.1:${testServerPort}`,
+      "Iabcd1234/5",
+      "file.txt",
+      tlsOptions.cert,
+      "pass",
+    );
+
+    expect(receivedUrl).toContain("/api/v1/objects/Iabcd1234%2F5");
+  });
+});

--- a/go.mod
+++ b/go.mod
@@ -133,6 +133,7 @@ require (
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/tinylib/msgp v1.6.1 // indirect
+	github.com/winfsp/cgofuse v1.6.0 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,8 @@ github.com/tg123/go-htpasswd v1.2.4 h1:HgH8KKCjdmo7jjXWN9k1nefPBd7Be3tFCTjc2jPra
 github.com/tg123/go-htpasswd v1.2.4/go.mod h1:EKThQok9xHkun6NBMynNv6Jmu24A33XdZzzl4Q7H1+0=
 github.com/tinylib/msgp v1.6.1 h1:ESRv8eL3u+DNHUoSAAQRE50Hm162zqAnBoGv9PzScPY=
 github.com/tinylib/msgp v1.6.1/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
+github.com/winfsp/cgofuse v1.6.0 h1:re3W+HTd0hj4fISPBqfsrwyvPFpzqhDu8doJ9nOPDB0=
+github.com/winfsp/cgofuse v1.6.0/go.mod h1:uxjoF2jEYT3+x+vC2KJddEGdk/LU8pRowXmyVMHSV5I=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=

--- a/internal/mount/mount_net_use.go
+++ b/internal/mount/mount_net_use.go
@@ -1,119 +1,14 @@
-//go:build windows
+//go:build windows && !winfsp
 
 package mount
 
 import (
-	"bufio"
 	"context"
-	"os/exec"
-	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/fs"
 )
 
-// Directory mounts a given directory under a provided drive letter.
+// Directory mounts a given directory under a provided drive letter using WebDAV + net use.
 func Directory(ctx context.Context, entry fs.Directory, driveLetter string, _ Options) (Controller, error) {
-	if !isValidWindowsDriveOrAsterisk(driveLetter) {
-		return nil, errors.New("must be a valid drive letter or asterisk")
-	}
-
-	c, err := DirectoryWebDAV(ctx, entry)
-	if err != nil {
-		return nil, err
-	}
-
-	actualDriveLetter, err := netUseMount(ctx, driveLetter, c.MountPath())
-	if err != nil {
-		if uerr := c.Unmount(ctx); uerr != nil {
-			log(ctx).Errorf("unable to unmount webdav server: %v", uerr)
-		}
-
-		return nil, errors.Wrap(err, "unable to mount webdav server as drive letter")
-	}
-
-	return netuseController{c, actualDriveLetter}, nil
-}
-
-func netUse(ctx context.Context, args ...string) (string, error) {
-	nu := exec.CommandContext(ctx, "net", append([]string{"use"}, args...)...) //nolint:gosec
-	log(ctx).Debugf("running %v %v", nu.Path, nu.Args)
-
-	out, err := nu.Output()
-	log(ctx).Debugf("net use finished with %v %v", string(out), err)
-
-	return string(out), errors.Wrap(err, "error running 'net use'")
-}
-
-func netUseMount(ctx context.Context, driveLetter, webdavURL string) (string, error) {
-	out, err := netUse(ctx, driveLetter, webdavURL)
-	if err != nil {
-		return "", errors.Wrapf(err, "unable to run 'net use' (%v), see https://kopia.io/docs/mounting/#windows for more information", out)
-	}
-
-	if driveLetter != "*" {
-		return driveLetter, nil
-	}
-
-	// on success the Net use will print the drive letter
-	// because the output is localized, we look for any word that looks like a drive letter followed by
-	// colon.
-	s := bufio.NewScanner(strings.NewReader(out))
-	for s.Scan() {
-		for _, word := range strings.Split(s.Text(), " ") {
-			if isWindowsDrive(word) {
-				return word, nil
-			}
-		}
-	}
-
-	return "", errors.Errorf("unable to find windows drive letter name in successful 'net use' output (%v), this is a bug", out)
-}
-
-func netUseUnmount(ctx context.Context, driveLetter string) error {
-	_, err := netUse(ctx, driveLetter, "/delete", "/y")
-	return err
-}
-
-func isWindowsDrive(s string) bool {
-	if len(s) != 2 { //nolint:mnd
-		return false
-	}
-
-	if d := strings.ToUpper(s)[0]; d < 'A' || d > 'Z' {
-		return false
-	}
-
-	return s[1] == ':'
-}
-
-func isValidWindowsDriveOrAsterisk(s string) bool {
-	if s == "*" {
-		return true
-	}
-
-	return isWindowsDrive(s)
-}
-
-type netuseController struct {
-	inner       Controller
-	driveLetter string
-}
-
-func (c netuseController) Unmount(ctx context.Context) error {
-	if err := netUseUnmount(ctx, c.driveLetter); err != nil {
-		return errors.Wrap(err, "unable to delete drive with 'net use'")
-	}
-
-	//nolint:wrapcheck
-	return c.inner.Unmount(ctx)
-}
-
-func (c netuseController) MountPath() string {
-	return c.driveLetter
-}
-
-func (c netuseController) Done() <-chan struct{} {
-	return c.inner.Done()
+	return directoryWebDAVNetUse(ctx, entry, driveLetter)
 }

--- a/internal/mount/mount_net_use_helper.go
+++ b/internal/mount/mount_net_use_helper.go
@@ -1,0 +1,119 @@
+//go:build windows
+
+package mount
+
+import (
+	"bufio"
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/fs"
+)
+
+// directoryWebDAVNetUse mounts using WebDAV + net use (the legacy Windows mount method).
+func directoryWebDAVNetUse(ctx context.Context, entry fs.Directory, driveLetter string) (Controller, error) {
+	if !isValidWindowsDriveOrAsterisk(driveLetter) {
+		return nil, errors.New("must be a valid drive letter or asterisk")
+	}
+
+	c, err := DirectoryWebDAV(ctx, entry)
+	if err != nil {
+		return nil, err
+	}
+
+	actualDriveLetter, err := netUseMount(ctx, driveLetter, c.MountPath())
+	if err != nil {
+		if uerr := c.Unmount(ctx); uerr != nil {
+			log(ctx).Errorf("unable to unmount webdav server: %v", uerr)
+		}
+
+		return nil, errors.Wrap(err, "unable to mount webdav server as drive letter")
+	}
+
+	return netuseController{c, actualDriveLetter}, nil
+}
+
+func netUse(ctx context.Context, args ...string) (string, error) {
+	nu := exec.CommandContext(ctx, "net", append([]string{"use"}, args...)...) //nolint:gosec
+	log(ctx).Debugf("running %v %v", nu.Path, nu.Args)
+
+	out, err := nu.Output()
+	log(ctx).Debugf("net use finished with %v %v", string(out), err)
+
+	return string(out), errors.Wrap(err, "error running 'net use'")
+}
+
+func netUseMount(ctx context.Context, driveLetter, webdavURL string) (string, error) {
+	out, err := netUse(ctx, driveLetter, webdavURL)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to run 'net use' (%v), see https://kopia.io/docs/mounting/#windows for more information", out)
+	}
+
+	if driveLetter != "*" {
+		return driveLetter, nil
+	}
+
+	// on success the Net use will print the drive letter
+	// because the output is localized, we look for any word that looks like a drive letter followed by
+	// colon.
+	s := bufio.NewScanner(strings.NewReader(out))
+	for s.Scan() {
+		for _, word := range strings.Split(s.Text(), " ") {
+			if isWindowsDrive(word) {
+				return word, nil
+			}
+		}
+	}
+
+	return "", errors.Errorf("unable to find windows drive letter name in successful 'net use' output (%v), this is a bug", out)
+}
+
+func netUseUnmount(ctx context.Context, driveLetter string) error {
+	_, err := netUse(ctx, driveLetter, "/delete", "/y")
+	return err
+}
+
+func isWindowsDrive(s string) bool {
+	if len(s) != 2 { //nolint:mnd
+		return false
+	}
+
+	if d := strings.ToUpper(s)[0]; d < 'A' || d > 'Z' {
+		return false
+	}
+
+	return s[1] == ':'
+}
+
+func isValidWindowsDriveOrAsterisk(s string) bool {
+	if s == "*" {
+		return true
+	}
+
+	return isWindowsDrive(s)
+}
+
+type netuseController struct {
+	inner       Controller
+	driveLetter string
+}
+
+func (c netuseController) Unmount(ctx context.Context) error {
+	if err := netUseUnmount(ctx, c.driveLetter); err != nil {
+		return errors.Wrap(err, "unable to delete drive with 'net use'")
+	}
+
+	//nolint:wrapcheck
+	return c.inner.Unmount(ctx)
+}
+
+func (c netuseController) MountPath() string {
+	return c.driveLetter
+}
+
+func (c netuseController) Done() <-chan struct{} {
+	return c.inner.Done()
+}

--- a/internal/mount/mount_winfsp.go
+++ b/internal/mount/mount_winfsp.go
@@ -1,0 +1,58 @@
+//go:build windows && winfsp
+
+package mount
+
+import (
+	"context"
+
+	cgofuse "github.com/winfsp/cgofuse/fuse"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/internal/winfsp"
+)
+
+// Directory mounts a given directory using WinFsp (FUSE) on Windows,
+// falling back to WebDAV+net use when PreferWebDAV is set.
+func Directory(ctx context.Context, entry fs.Directory, mountPoint string, mountOptions Options) (Controller, error) {
+	if mountOptions.PreferWebDAV {
+		return directoryWebDAVNetUse(ctx, entry, mountPoint)
+	}
+
+	kopiaFS := winfsp.NewKopiaFS(entry)
+	host := cgofuse.NewFileSystemHost(kopiaFS)
+
+	// WinFsp mount options for read-only filesystem.
+	opts := []string{"-o", "ro", "-o", "uid=-1,gid=-1"}
+
+	done := make(chan struct{})
+
+	go func() {
+		host.Mount(mountPoint, opts)
+		close(done)
+	}()
+
+	return winfspController{
+		mountPoint: mountPoint,
+		host:       host,
+		done:       done,
+	}, nil
+}
+
+type winfspController struct {
+	mountPoint string
+	host       *cgofuse.FileSystemHost
+	done       chan struct{}
+}
+
+func (c winfspController) Unmount(_ context.Context) error {
+	c.host.Unmount()
+	return nil
+}
+
+func (c winfspController) MountPath() string {
+	return c.mountPoint
+}
+
+func (c winfspController) Done() <-chan struct{} {
+	return c.done
+}

--- a/internal/mount/mount_winfsp.go
+++ b/internal/mount/mount_winfsp.go
@@ -4,7 +4,11 @@ package mount
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"time"
 
+	"github.com/pkg/errors"
 	cgofuse "github.com/winfsp/cgofuse/fuse"
 
 	"github.com/kopia/kopia/fs"
@@ -18,24 +22,59 @@ func Directory(ctx context.Context, entry fs.Directory, mountPoint string, mount
 		return directoryWebDAVNetUse(ctx, entry, mountPoint)
 	}
 
+	if mountPoint == "*" {
+		drive, err := findFreeDriveLetter()
+		if err != nil {
+			return nil, err
+		}
+
+		mountPoint = drive
+	}
+
 	kopiaFS := winfsp.NewKopiaFS(entry)
 	host := cgofuse.NewFileSystemHost(kopiaFS)
 
-	// WinFsp mount options for read-only filesystem.
-	opts := []string{"-o", "ro", "-o", "uid=-1,gid=-1"}
+	// WinFsp mount options for read-only local filesystem.
+	// FileSystemName=NTFS makes Windows treat it as a trusted local volume.
+	opts := []string{"-o", "ro", "-o", "uid=-1,gid=-1", "-o", "FileSystemName=NTFS", "-o", "volname=Kopia"}
 
+	mountErr := make(chan error, 1)
 	done := make(chan struct{})
 
 	go func() {
-		host.Mount(mountPoint, opts)
+		ok := host.Mount(mountPoint, opts)
+		if !ok {
+			mountErr <- errors.Errorf("WinFsp mount failed on %v", mountPoint)
+		}
+
 		close(done)
 	}()
+
+	// Wait briefly for mount to either fail or start serving.
+	select {
+	case err := <-mountErr:
+		return nil, err
+	case <-time.After(2 * time.Second): //nolint:mnd
+		// Mount is running.
+	}
 
 	return winfspController{
 		mountPoint: mountPoint,
 		host:       host,
 		done:       done,
 	}, nil
+}
+
+// findFreeDriveLetter finds an available drive letter, searching from Z: downward.
+func findFreeDriveLetter() (string, error) {
+	for c := 'Z'; c >= 'D'; c-- {
+		drive := fmt.Sprintf("%c:", c)
+		if _, err := os.Stat(drive + "\\"); os.IsNotExist(err) {
+			return drive, nil
+		}
+	}
+
+	return "", errors.New("no free drive letter available")
 }
 
 type winfspController struct {

--- a/internal/mount/mount_winfsp.go
+++ b/internal/mount/mount_winfsp.go
@@ -1,4 +1,4 @@
-//go:build windows && winfsp
+//go:build windows && winfsp && cgo
 
 package mount
 
@@ -20,6 +20,10 @@ import (
 func Directory(ctx context.Context, entry fs.Directory, mountPoint string, mountOptions Options) (Controller, error) {
 	if mountOptions.PreferWebDAV {
 		return directoryWebDAVNetUse(ctx, entry, mountPoint)
+	}
+
+	if !isValidWindowsDriveOrAsterisk(mountPoint) {
+		return nil, errors.Errorf("invalid mount point %q: expected a Windows drive (e.g. \"X:\") or \"*\" for auto-assignment", mountPoint)
 	}
 
 	if mountPoint == "*" {

--- a/internal/server/api_mount.go
+++ b/internal/server/api_mount.go
@@ -3,10 +3,13 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/repo/object"
 )
+
+const mountUnmountTimeout = 30 * time.Second
 
 func handleMountCreate(ctx context.Context, rc requestContext) (any, *apiError) {
 	req := &serverapi.MountSnapshotRequest{}
@@ -68,11 +71,19 @@ func handleMountDelete(ctx context.Context, rc requestContext) (any, *apiError) 
 		return nil, notFoundError("mount point not found")
 	}
 
-	if err := c.Unmount(ctx); err != nil {
-		return nil, internalServerError(err)
-	}
+	// Always remove the mount from the map, even if unmount fails.
+	// A failed unmount leaves a dead controller that blocks future mounts.
+	// Use a background context so the unmount is not cancelled by the HTTP request timeout.
+	unmountCtx, cancel := context.WithTimeout(context.Background(), mountUnmountTimeout)
+	defer cancel()
+
+	unmountErr := c.Unmount(unmountCtx)
 
 	rc.srv.deleteMount(oid)
+
+	if unmountErr != nil {
+		return nil, internalServerError(unmountErr)
+	}
 
 	return &serverapi.Empty{}, nil
 }

--- a/internal/server/api_mount.go
+++ b/internal/server/api_mount.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/kopia/kopia/internal/mount"
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/repo/object"
 )
@@ -71,21 +72,29 @@ func handleMountDelete(ctx context.Context, rc requestContext) (any, *apiError) 
 		return nil, notFoundError("mount point not found")
 	}
 
-	// Always remove the mount from the map, even if unmount fails.
-	// A failed unmount leaves a dead controller that blocks future mounts.
-	// Use a background context so the unmount is not cancelled by the HTTP request timeout.
-	unmountCtx, cancel := context.WithTimeout(context.Background(), mountUnmountTimeout)
-	defer cancel()
-
-	unmountErr := c.Unmount(unmountCtx)
-
-	rc.srv.deleteMount(oid)
-
-	if unmountErr != nil {
+	if unmountErr := rc.srv.unmountAndDeleteMount(ctx, oid, c); unmountErr != nil {
 		return nil, internalServerError(unmountErr)
 	}
 
 	return &serverapi.Empty{}, nil
+}
+
+// unmountAndDeleteMount calls Unmount on the controller and unconditionally
+// removes the mount from s.mounts, even if Unmount fails. A failed unmount
+// would otherwise leave a dead controller in the map and block future mounts
+// for the same OID until server restart.
+//
+// The unmount uses context.WithoutCancel(ctx) so request-scoped values
+// (auth/logging/tracing) survive but the unmount can't be aborted by the
+// HTTP request's cancellation/timeout.
+func (s *Server) unmountAndDeleteMount(ctx context.Context, oid object.ID, c mount.Controller) error {
+	unmountCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), mountUnmountTimeout)
+	defer cancel()
+
+	unmountErr := c.Unmount(unmountCtx)
+	s.deleteMount(oid)
+
+	return unmountErr
 }
 
 func handleMountList(_ context.Context, rc requestContext) (any, *apiError) {

--- a/internal/server/api_mount_test.go
+++ b/internal/server/api_mount_test.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/mount"
+	"github.com/kopia/kopia/repo/object"
+)
+
+type mockController struct {
+	mountPath  string
+	unmountErr error
+	unmounted  bool
+	done       chan struct{}
+}
+
+func (m *mockController) Unmount(_ context.Context) error {
+	m.unmounted = true
+	return m.unmountErr
+}
+
+func (m *mockController) MountPath() string {
+	return m.mountPath
+}
+
+func (m *mockController) Done() <-chan struct{} {
+	return m.done
+}
+
+func newTestServer() *Server {
+	return &Server{
+		mounts: map[object.ID]mount.Controller{},
+	}
+}
+
+func TestDeleteMountRemovesEntryOnSuccess(t *testing.T) {
+	s := newTestServer()
+	oid, err := object.ParseID("aabb001122334455")
+	require.NoError(t, err)
+
+	ctrl := &mockController{mountPath: "Z:", done: make(chan struct{})}
+	s.mounts[oid] = ctrl
+
+	// Verify mount exists.
+	require.NotNil(t, s.mounts[oid])
+
+	// Simulate successful unmount + delete.
+	require.NoError(t, ctrl.Unmount(context.Background()))
+	s.deleteMount(oid)
+
+	// Mount should be removed.
+	require.Nil(t, s.mounts[oid])
+	require.True(t, ctrl.unmounted)
+}
+
+func TestDeleteMountRemovesEntryEvenOnUnmountFailure(t *testing.T) {
+	s := newTestServer()
+	oid, err := object.ParseID("aabb001122334455")
+	require.NoError(t, err)
+
+	ctrl := &mockController{
+		mountPath:  "Z:",
+		unmountErr: context.DeadlineExceeded,
+		done:       make(chan struct{}),
+	}
+	s.mounts[oid] = ctrl
+
+	// Simulate the fixed handleMountDelete behavior:
+	// always call deleteMount, even when Unmount fails.
+	unmountErr := ctrl.Unmount(context.Background())
+	s.deleteMount(oid)
+
+	// Unmount should have been attempted.
+	require.True(t, ctrl.unmounted)
+	// Error should have been returned.
+	require.Error(t, unmountErr)
+	// But mount should still be removed from the map.
+	require.Nil(t, s.mounts[oid])
+}
+
+func TestGetMountControllerReturnsNilWhenNotFound(t *testing.T) {
+	s := newTestServer()
+	oid, err := object.ParseID("aabb0011223344556677")
+	require.NoError(t, err)
+
+	s.serverMutex.Lock()
+	c := s.mounts[oid]
+	s.serverMutex.Unlock()
+
+	require.Nil(t, c)
+}
+
+func TestDeleteMountIsIdempotent(t *testing.T) {
+	s := newTestServer()
+	oid, err := object.ParseID("aabb001122334455")
+	require.NoError(t, err)
+
+	ctrl := &mockController{mountPath: "Z:", done: make(chan struct{})}
+	s.mounts[oid] = ctrl
+	s.deleteMount(oid)
+
+	// Second delete should not panic.
+	s.deleteMount(oid)
+
+	require.Nil(t, s.mounts[oid])
+}
+
+func TestListMountsReturnsClone(t *testing.T) {
+	s := newTestServer()
+	oid, err := object.ParseID("aabb001122334455")
+	require.NoError(t, err)
+
+	ctrl := &mockController{mountPath: "Z:", done: make(chan struct{})}
+	s.mounts[oid] = ctrl
+
+	listed := s.listMounts()
+	require.Len(t, listed, 1)
+
+	// Deleting from the clone should not affect the server's map.
+	delete(listed, oid)
+	require.Len(t, s.listMounts(), 1)
+}

--- a/internal/server/api_mount_test.go
+++ b/internal/server/api_mount_test.go
@@ -36,7 +36,7 @@ func newTestServer() *Server {
 	}
 }
 
-func TestDeleteMountRemovesEntryOnSuccess(t *testing.T) {
+func TestUnmountAndDeleteMountRemovesEntryOnSuccess(t *testing.T) {
 	s := newTestServer()
 	oid, err := object.ParseID("aabb001122334455")
 	require.NoError(t, err)
@@ -44,19 +44,16 @@ func TestDeleteMountRemovesEntryOnSuccess(t *testing.T) {
 	ctrl := &mockController{mountPath: "Z:", done: make(chan struct{})}
 	s.mounts[oid] = ctrl
 
-	// Verify mount exists.
-	require.NotNil(t, s.mounts[oid])
+	// Drives the same code path as handleMountDelete — a regression that
+	// reordered the call (skipped deleteMount on success) would fail here.
+	unmountErr := s.unmountAndDeleteMount(context.Background(), oid, ctrl)
 
-	// Simulate successful unmount + delete.
-	require.NoError(t, ctrl.Unmount(context.Background()))
-	s.deleteMount(oid)
-
-	// Mount should be removed.
+	require.NoError(t, unmountErr)
 	require.Nil(t, s.mounts[oid])
 	require.True(t, ctrl.unmounted)
 }
 
-func TestDeleteMountRemovesEntryEvenOnUnmountFailure(t *testing.T) {
+func TestUnmountAndDeleteMountRemovesEntryEvenOnUnmountFailure(t *testing.T) {
 	s := newTestServer()
 	oid, err := object.ParseID("aabb001122334455")
 	require.NoError(t, err)
@@ -68,16 +65,13 @@ func TestDeleteMountRemovesEntryEvenOnUnmountFailure(t *testing.T) {
 	}
 	s.mounts[oid] = ctrl
 
-	// Simulate the fixed handleMountDelete behavior:
-	// always call deleteMount, even when Unmount fails.
-	unmountErr := ctrl.Unmount(context.Background())
-	s.deleteMount(oid)
+	// If a future change ever returns early on Unmount error (the original
+	// bug), this test fails on the s.mounts[oid] == nil assertion below
+	// because deleteMount would be skipped.
+	unmountErr := s.unmountAndDeleteMount(context.Background(), oid, ctrl)
 
-	// Unmount should have been attempted.
 	require.True(t, ctrl.unmounted)
-	// Error should have been returned.
 	require.Error(t, unmountErr)
-	// But mount should still be removed from the map.
 	require.Nil(t, s.mounts[oid])
 }
 

--- a/internal/server/request_context.go
+++ b/internal/server/request_context.go
@@ -28,6 +28,7 @@ type serverInterface interface {
 	Refresh()
 	getMountController(ctx context.Context, rep repo.Repository, oid object.ID, createIfNotFound bool) (mount.Controller, error)
 	deleteMount(oid object.ID)
+	unmountAndDeleteMount(ctx context.Context, oid object.ID, c mount.Controller) error
 	listMounts() map[object.ID]mount.Controller
 	disconnect(ctx context.Context) error
 	requestShutdown(ctx context.Context)

--- a/internal/winfsp/cgo_windows.go
+++ b/internal/winfsp/cgo_windows.go
@@ -1,9 +1,17 @@
-//go:build windows
+//go:build windows && winfsp && cgo
 
 package winfsp
 
-// Override cgofuse's default include path to use the WinFsp SDK installation.
-// Uses the 8.3 short name for "Program Files (x86)" to avoid spaces in the path.
+// Default include path for the WinFsp SDK on a stock Windows install.
+// cgofuse's upstream default is the Linux/macOS path -I/usr/local/include/winfsp,
+// so without an override here a stock `-tags winfsp` build can't find <fuse.h>.
+// The 8.3 short name (`PROGRA~2`) avoids the cgo-incompatible space in
+// "Program Files (x86)".
+//
+// If WinFsp is installed elsewhere, override at build time via CGO_CFLAGS:
+//   set CGO_CFLAGS=-IC:/path/to/WinFsp/inc/fuse
+//   go build -tags winfsp ./...
+// Anything in CGO_CFLAGS is appended to the directive below by the cgo tool.
 
 // #cgo windows CFLAGS: -IC:/PROGRA~2/WinFsp/inc/fuse
 import "C"

--- a/internal/winfsp/cgo_windows.go
+++ b/internal/winfsp/cgo_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package winfsp
+
+// Override cgofuse's default include path to use the WinFsp SDK installation.
+// Uses the 8.3 short name for "Program Files (x86)" to avoid spaces in the path.
+
+// #cgo windows CFLAGS: -IC:/PROGRA~2/WinFsp/inc/fuse
+import "C"

--- a/internal/winfsp/winfspfs.go
+++ b/internal/winfsp/winfspfs.go
@@ -1,0 +1,283 @@
+//go:build windows
+
+// Package winfsp implements a read-only FUSE filesystem for Kopia snapshots using WinFsp via cgofuse.
+package winfsp
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	cgofuse "github.com/winfsp/cgofuse/fuse"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/repo/logging"
+)
+
+var log = logging.Module("winfsp")
+
+// KopiaFS implements cgofuse.FileSystemInterface for read-only access to Kopia snapshots.
+type KopiaFS struct {
+	cgofuse.FileSystemBase
+
+	root fs.Directory
+
+	mu         sync.Mutex
+	handles    map[uint64]fs.Reader
+	nextHandle uint64
+}
+
+// NewKopiaFS creates a new WinFsp filesystem backed by the given Kopia directory.
+func NewKopiaFS(root fs.Directory) *KopiaFS {
+	return &KopiaFS{
+		root:       root,
+		handles:    make(map[uint64]fs.Reader),
+		nextHandle: 1,
+	}
+}
+
+func (k *KopiaFS) allocHandle(reader fs.Reader) uint64 {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	fh := k.nextHandle
+	k.nextHandle++
+	k.handles[fh] = reader
+
+	return fh
+}
+
+func (k *KopiaFS) getHandle(fh uint64) fs.Reader {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	return k.handles[fh]
+}
+
+func (k *KopiaFS) releaseHandle(fh uint64) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	if r, ok := k.handles[fh]; ok {
+		r.Close() //nolint:errcheck
+		delete(k.handles, fh)
+	}
+}
+
+func (k *KopiaFS) lookup(path string) (fs.Entry, error) {
+	path = strings.ReplaceAll(path, "\\", "/")
+
+	if path == "/" || path == "" {
+		return k.root, nil
+	}
+
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+
+	var current fs.Entry = k.root
+
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		dir, ok := current.(fs.Directory)
+		if !ok {
+			return nil, os.ErrNotExist
+		}
+
+		child, err := dir.Child(context.Background(), part)
+		if err != nil || child == nil {
+			return nil, os.ErrNotExist
+		}
+
+		current = child
+	}
+
+	return current, nil
+}
+
+func populateStat(stat *cgofuse.Stat_t, entry fs.Entry) {
+	stat.Size = entry.Size()
+	stat.Mtim = cgofuse.NewTimespec(entry.ModTime())
+	stat.Atim = stat.Mtim
+	stat.Ctim = stat.Mtim
+	stat.Nlink = 1
+	stat.Uid = entry.Owner().UserID
+	stat.Gid = entry.Owner().GroupID
+
+	switch entry.(type) {
+	case fs.Directory:
+		stat.Mode = cgofuse.S_IFDIR | 0o555
+	case fs.Symlink:
+		stat.Mode = cgofuse.S_IFLNK | 0o444
+	default:
+		stat.Mode = cgofuse.S_IFREG | 0o444
+	}
+}
+
+// Getattr returns file attributes.
+func (k *KopiaFS) Getattr(path string, stat *cgofuse.Stat_t, _ uint64) int {
+	entry, err := k.lookup(path)
+	if err != nil {
+		return -cgofuse.ENOENT
+	}
+
+	populateStat(stat, entry)
+
+	return 0
+}
+
+// Open opens a file for reading.
+func (k *KopiaFS) Open(path string, flags int) (int, uint64) {
+	entry, err := k.lookup(path)
+	if err != nil {
+		return -cgofuse.ENOENT, ^uint64(0)
+	}
+
+	file, ok := entry.(fs.File)
+	if !ok {
+		return -cgofuse.EISDIR, ^uint64(0)
+	}
+
+	reader, err := file.Open(context.Background())
+	if err != nil {
+		log(context.Background()).Errorf("error opening %v: %v", path, err)
+		return -cgofuse.EIO, ^uint64(0)
+	}
+
+	fh := k.allocHandle(reader)
+
+	return 0, fh
+}
+
+// Read reads data from an open file.
+func (k *KopiaFS) Read(path string, buff []byte, ofst int64, fh uint64) int {
+	reader := k.getHandle(fh)
+	if reader == nil {
+		return -cgofuse.EBADF
+	}
+
+	if _, err := reader.Seek(ofst, io.SeekStart); err != nil {
+		log(context.Background()).Errorf("seek error: %v offset=%v: %v", path, ofst, err)
+		return -cgofuse.EIO
+	}
+
+	n, err := reader.Read(buff)
+	if err != nil && err != io.EOF {
+		log(context.Background()).Errorf("read error: %v: %v", path, err)
+		return -cgofuse.EIO
+	}
+
+	return n
+}
+
+// Release closes a file handle.
+func (k *KopiaFS) Release(_ string, fh uint64) int {
+	k.releaseHandle(fh)
+	return 0
+}
+
+// Opendir opens a directory for reading.
+func (k *KopiaFS) Opendir(path string) (int, uint64) {
+	entry, err := k.lookup(path)
+	if err != nil {
+		return -cgofuse.ENOENT, ^uint64(0)
+	}
+
+	if _, ok := entry.(fs.Directory); !ok {
+		return -cgofuse.ENOTDIR, ^uint64(0)
+	}
+
+	return 0, 0
+}
+
+// Readdir reads directory entries.
+func (k *KopiaFS) Readdir(path string,
+	fill func(name string, stat *cgofuse.Stat_t, ofst int64) bool,
+	_ int64,
+	_ uint64,
+) int {
+	entry, err := k.lookup(path)
+	if err != nil {
+		return -cgofuse.ENOENT
+	}
+
+	dir, ok := entry.(fs.Directory)
+	if !ok {
+		return -cgofuse.ENOTDIR
+	}
+
+	fill(".", nil, 0)
+	fill("..", nil, 0)
+
+	iter, err := dir.Iterate(context.Background())
+	if err != nil {
+		log(context.Background()).Errorf("error reading directory %v: %v", path, err)
+		return -cgofuse.EIO
+	}
+
+	defer iter.Close()
+
+	cur, err := iter.Next(context.Background())
+	for cur != nil {
+		var stat cgofuse.Stat_t
+
+		populateStat(&stat, cur)
+
+		if !fill(cur.Name(), &stat, 0) {
+			break
+		}
+
+		cur, err = iter.Next(context.Background())
+	}
+
+	if err != nil {
+		log(context.Background()).Errorf("error iterating directory %v: %v", path, err)
+		return -cgofuse.EIO
+	}
+
+	return 0
+}
+
+// Readlink reads the target of a symbolic link.
+func (k *KopiaFS) Readlink(path string) (int, string) {
+	entry, err := k.lookup(path)
+	if err != nil {
+		return -cgofuse.ENOENT, ""
+	}
+
+	symlink, ok := entry.(fs.Symlink)
+	if !ok {
+		return -cgofuse.EINVAL, ""
+	}
+
+	target, err := symlink.Readlink(context.Background())
+	if err != nil {
+		log(context.Background()).Errorf("error reading symlink %v: %v", path, err)
+		return -cgofuse.EIO, ""
+	}
+
+	return 0, target
+}
+
+// Statfs returns filesystem statistics.
+func (k *KopiaFS) Statfs(_ string, stat *cgofuse.Statfs_t) int {
+	stat.Bsize = 4096  //nolint:mnd
+	stat.Frsize = 4096 //nolint:mnd
+	stat.Namemax = 255 //nolint:mnd
+
+	return 0
+}
+
+// Destroy cleans up all open handles.
+func (k *KopiaFS) Destroy() {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	for fh, r := range k.handles {
+		r.Close() //nolint:errcheck
+		delete(k.handles, fh)
+	}
+}

--- a/internal/winfsp/winfspfs.go
+++ b/internal/winfsp/winfspfs.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build windows && winfsp && cgo
 
 // Package winfsp implements a read-only FUSE filesystem for Kopia snapshots using WinFsp via cgofuse.
 package winfsp
@@ -129,8 +129,16 @@ func (k *KopiaFS) Getattr(path string, stat *cgofuse.Stat_t, _ uint64) int {
 	return 0
 }
 
-// Open opens a file for reading.
+// Open opens a file for reading. The filesystem is read-only — any open
+// requesting write access (O_WRONLY, O_RDWR, O_APPEND, O_TRUNC, O_CREAT)
+// is rejected with EROFS so Windows clients that probe writability fail
+// fast at open time rather than discovering it on a later write.
 func (k *KopiaFS) Open(path string, flags int) (int, uint64) {
+	const writeMask = os.O_WRONLY | os.O_RDWR | os.O_APPEND | os.O_TRUNC | os.O_CREATE
+	if flags&writeMask != 0 {
+		return -cgofuse.EROFS, ^uint64(0)
+	}
+
 	entry, err := k.lookup(path)
 	if err != nil {
 		return -cgofuse.ENOENT, ^uint64(0)


### PR DESCRIPTION
## Summary

Adds WinFsp/FUSE mount support as an alternative to WebDAV+net use on Windows. Mounted snapshots now appear as local filesystems, enabling Explorer preview pane, thumbnails, and search.

- `internal/winfsp/winfspfs.go` — cgofuse filesystem with read-only snapshot access (`Getattr`, `Open`, `Read`, `Readdir`, `Readlink`, `Statfs`)
- `internal/mount/mount_winfsp.go` — WinFsp controller with `PreferWebDAV` fallback option
- `internal/mount/mount_net_use_helper.go` — extracted shared WebDAV+net-use logic for reuse by both backends
- Build with `-tags winfsp` (requires CGO + WinFsp SDK)
- Default Windows build (no tag) keeps WebDAV unchanged

Plus three follow-on fixes:

- Free-drive-letter assignment when caller passes `*` (cgofuse doesn't grok net-use's `*` convention)
- Set `FileSystemName=NTFS` so Explorer trusts the volume (preview pane works); set `volname=Kopia` for a friendly label
- **Always clean up mount state on `Unmount` failure** — previously left dead controllers in `s.mounts`, making the Mount button permanently broken until server restart. Includes a new `internal/server/api_mount_test.go` (~125 LOC).
- Open-file IPC: `file-viewer.js` + `open-file` IPC handler so the htmlui can open snapshot files in the system default viewer (15 Playwright tests). Companion htmlui PR adds the View button.

## Test plan

- [ ] `make test`
- [ ] Manual: `kopia mount` a snapshot on Windows; verify Explorer preview pane works
- [ ] Manual: trigger an unmount failure (e.g. file open from another process); verify a subsequent mount works (was permanently broken before this PR)