### PR TITLE
fix(tools): drop incompatible linter flags for golangci-lint v2 on Windows

### DIFF
--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -150,9 +150,6 @@ linter_dir=$(TOOLS_DIR)$(slash)golangci-lint-$(GOLANGCI_LINT_VERSION)
 linter=$(linter_dir)$(slash)golangci-lint$(exe_suffix)
 
 linter_flags=
-ifeq ($(GOOS),windows)
-linter_flags=-D gofmt -D goimports
-endif
 
 $(linter):
 	go run github.com/kopia/kopia/tools/gettool --tool linter:$(GOLANGCI_LINT_VERSION) --output-dir $(linter_dir)


### PR DESCRIPTION
## Summary

`golangci-lint` v2 reclassified `gofmt` and `goimports` as formatters, so the `-D` flag (which disables linters) no longer accepts them. Since `.golangci.yml` controls formatter configuration, these flags are unnecessary.

## Test plan

- [ ] `make lint` succeeds on Windows with golangci-lint v2.x