### PR TITLE
feat(cli): restrict insecure unauthenticated server to loopback binds

### DIFF
--- a/cli/command_server_start.go
+++ b/cli/command_server_start.go
@@ -20,6 +20,7 @@ import (
 	htpasswd "github.com/tg123/go-htpasswd"
 
 	"github.com/kopia/kopia/internal/auth"
+	"github.com/kopia/kopia/internal/insecureserverbind"
 	"github.com/kopia/kopia/internal/server"
 	"github.com/kopia/kopia/notification"
 	"github.com/kopia/kopia/notification/sender/jsonsender"
@@ -75,6 +76,8 @@ type commandServerStart struct {
 
 	logServerRequests bool
 
+	serverStartAllowDangerousUnauthenticatedNetwork bool
+
 	disableCSRFTokenChecks bool // disable CSRF token checks - used for development/debugging only
 
 	sf  serverFlags
@@ -93,6 +96,10 @@ func (c *commandServerStart) setup(svc advancedAppServices, parent commandParent
 	cmd.Flag("refresh-interval", "Frequency for refreshing repository status").Default("4h").DurationVar(&c.serverStartRefreshInterval)
 	cmd.Flag("insecure", "Allow insecure configurations (do not use in production)").Hidden().BoolVar(&c.serverStartInsecure)
 	cmd.Flag("max-concurrency", "Maximum number of server goroutines").Default("0").IntVar(&c.serverStartMaxConcurrency)
+
+	cmd.Flag(insecureserverbind.AllowDangerousUnauthenticatedNetworkFlag, insecureserverbind.AllowDangerousUnauthenticatedNetworkFlagHelp).
+		Hidden().
+		BoolVar(&c.serverStartAllowDangerousUnauthenticatedNetwork)
 
 	cmd.Flag("without-password", "Start the server without a password").Hidden().BoolVar(&c.serverStartWithoutPassword)
 	cmd.Flag("random-password", "Generate random password and print to stderr").Hidden().BoolVar(&c.serverStartRandomPassword)
@@ -190,6 +197,15 @@ func (c *commandServerStart) initRepositoryPossiblyAsync(ctx context.Context, sr
 }
 
 func (c *commandServerStart) run(ctx context.Context) (reterr error) {
+	if err := insecureserverbind.ValidateListenAddressIfRestricted(
+		c.serverStartInsecure,
+		c.serverStartWithoutPassword,
+		c.serverStartAllowDangerousUnauthenticatedNetwork,
+		c.sf.serverAddress,
+	); err != nil {
+		return errors.Wrap(err, "listen address not allowed for insecure server without password")
+	}
+
 	opts, err := c.serverStartOptions(ctx)
 	if err != nil {
 		return err

--- a/cli/command_server_tls.go
+++ b/cli/command_server_tls.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/insecureserverbind"
 	"github.com/kopia/kopia/internal/tlsutil"
 )
 
@@ -60,6 +61,17 @@ func (c *commandServerStart) startServerWithOptionalTLS(ctx context.Context, htt
 		l = listeners[0]
 	default:
 		return errors.Errorf("Too many activated sockets found.  Expected 1, got %v", len(listeners))
+	}
+
+	if err := insecureserverbind.ValidateListenerAddrIfRestricted(
+		c.serverStartInsecure,
+		c.serverStartWithoutPassword,
+		c.serverStartAllowDangerousUnauthenticatedNetwork,
+		l.Addr(),
+	); err != nil {
+		l.Close() //nolint:errcheck
+
+		return errors.Wrap(err, "insecure server bind validation")
 	}
 
 	defer l.Close() //nolint:errcheck

--- a/internal/insecureserverbind/insecureserverbind.go
+++ b/internal/insecureserverbind/insecureserverbind.go
@@ -47,7 +47,13 @@ func stripProtocol(addr string) string {
 }
 
 // ParseListenHost extracts the host part of a server listen address flag value.
-// If isUnix is true, host is empty and the address refers to a unix domain socket.
+// If isUnix is true, host is empty and the address refers to a Unix domain socket.
+//
+// Unix detection runs after stripping a leading http:// or https:// (same as the server’s
+// stripProtocol). Any form that becomes unix:… is treated as a Unix socket, including:
+//   - unix:/path/to/socket
+//   - http://unix:/path/to/socket
+//   - https://unix:/path/to/socket
 func ParseListenHost(address string) (host string, isUnix bool, err error) {
 	stripped := stripProtocol(address)
 	if strings.HasPrefix(stripped, "unix:") {

--- a/internal/insecureserverbind/insecureserverbind.go
+++ b/internal/insecureserverbind/insecureserverbind.go
@@ -1,0 +1,123 @@
+// Package insecureserverbind validates listen addresses for insecure, unauthenticated Kopia servers.
+package insecureserverbind
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// AllowDangerousUnauthenticatedNetworkFlag is the CLI flag that disables bind restrictions.
+const AllowDangerousUnauthenticatedNetworkFlag = "allow-extremely-dangerous-unauthenticated-server-on-the-network"
+
+// AllowDangerousUnauthenticatedNetworkFlagHelp is the kingpin description for that flag.
+const AllowDangerousUnauthenticatedNetworkFlagHelp = "Allow unauthenticated server to listen on non-loopback addresses; " +
+	"exposes full repository and control API to the network without authentication (extremely dangerous)"
+
+// ErrDisallowedPublicBind is returned when the address would expose an unauthenticated server beyond loopback.
+var ErrDisallowedPublicBind = errors.New("refusing to expose unauthenticated server on non-loopback network bind")
+
+// RestrictionApplies reports whether insecure unauthenticated bind checks must run.
+func RestrictionApplies(insecure, withoutPassword, allowDangerousNetwork bool) bool {
+	return insecure && withoutPassword && !allowDangerousNetwork
+}
+
+// ValidateListenAddressIfRestricted runs [ValidateListenAddressFlag] only when [RestrictionApplies] is true.
+func ValidateListenAddressIfRestricted(insecure, withoutPassword, allowDangerousNetwork bool, address string) error {
+	if !RestrictionApplies(insecure, withoutPassword, allowDangerousNetwork) {
+		return nil
+	}
+
+	return ValidateListenAddressFlag(address)
+}
+
+// ValidateListenerAddrIfRestricted runs [ValidateListenerAddr] only when [RestrictionApplies] is true.
+func ValidateListenerAddrIfRestricted(insecure, withoutPassword, allowDangerousNetwork bool, addr net.Addr) error {
+	if !RestrictionApplies(insecure, withoutPassword, allowDangerousNetwork) {
+		return nil
+	}
+
+	return ValidateListenerAddr(addr)
+}
+
+func stripProtocol(addr string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(addr, "https://"), "http://")
+}
+
+// ParseListenHost extracts the host part of a server listen address flag value.
+// If isUnix is true, host is empty and the address refers to a unix domain socket.
+func ParseListenHost(address string) (host string, isUnix bool, err error) {
+	stripped := stripProtocol(address)
+	if strings.HasPrefix(stripped, "unix:") {
+		return "", true, nil
+	}
+
+	s := stripped
+	if !strings.Contains(s, "://") {
+		s = "http://" + s
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", false, fmt.Errorf("parsing listen address: %w", err)
+	}
+
+	return u.Hostname(), false, nil
+}
+
+// ValidateListenAddressFlag checks that --address is safe for an insecure server without a UI password.
+func ValidateListenAddressFlag(address string) error {
+	host, isUnix, err := ParseListenHost(address)
+	if err != nil {
+		return err
+	}
+
+	if isUnix {
+		return nil
+	}
+
+	if host == "" {
+		return fmt.Errorf("%w: missing host in listen address %q binds all interfaces; use loopback, a unix socket, or pass --%s (extremely dangerous)",
+			ErrDisallowedPublicBind, address, AllowDangerousUnauthenticatedNetworkFlag)
+	}
+
+	if strings.EqualFold(host, "localhost") {
+		return nil
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() {
+			return nil
+		}
+
+		return fmt.Errorf("%w: %q is not a loopback address; pass --%s only in isolated lab environments (extremely dangerous)",
+			ErrDisallowedPublicBind, host, AllowDangerousUnauthenticatedNetworkFlag)
+	}
+
+	return fmt.Errorf("%w: hostname %q is not localhost; pass --%s only in isolated lab environments (extremely dangerous)",
+		ErrDisallowedPublicBind, host, AllowDangerousUnauthenticatedNetworkFlag)
+}
+
+// ValidateListenerAddr checks the bound listener address after Listen (covers socket activation).
+func ValidateListenerAddr(addr net.Addr) error {
+	switch a := addr.(type) {
+	case *net.UnixAddr:
+		return nil
+	case *net.TCPAddr:
+		if a.IP != nil && a.IP.IsLoopback() {
+			return nil
+		}
+
+		return fmt.Errorf("%w: listener %v is not loopback; pass --%s only in isolated lab environments (extremely dangerous)",
+			ErrDisallowedPublicBind, addr, AllowDangerousUnauthenticatedNetworkFlag)
+	default:
+		if addr.Network() == "unix" {
+			return nil
+		}
+
+		return fmt.Errorf("%w: cannot validate listener type %T %v; pass --%s only if you accept the risk",
+			ErrDisallowedPublicBind, addr, addr, AllowDangerousUnauthenticatedNetworkFlag)
+	}
+}

--- a/internal/insecureserverbind/insecureserverbind.go
+++ b/internal/insecureserverbind/insecureserverbind.go
@@ -14,7 +14,7 @@ const AllowDangerousUnauthenticatedNetworkFlag = "allow-extremely-dangerous-unau
 
 // AllowDangerousUnauthenticatedNetworkFlagHelp is the kingpin description for that flag.
 const AllowDangerousUnauthenticatedNetworkFlagHelp = "Allow unauthenticated server to listen on non-loopback addresses; " +
-	"exposes full repository and control API to the network without authentication (extremely dangerous)"
+	"exposes full repository and control API to the network without authentication which allows any external attacker to take full control of the server host (extremely dangerous)"
 
 // ErrDisallowedPublicBind is returned when the address would expose an unauthenticated server beyond loopback.
 var ErrDisallowedPublicBind = errors.New("refusing to expose unauthenticated server on non-loopback network bind")

--- a/internal/insecureserverbind/insecureserverbind_test.go
+++ b/internal/insecureserverbind/insecureserverbind_test.go
@@ -1,0 +1,210 @@
+package insecureserverbind
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestrictionApplies(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		insecure, withoutPassword, allowDangerous bool
+		want                                      bool
+		name                                      string
+	}{
+		{true, true, false, true, "all_restriction_flags"},
+		{true, true, true, false, "escape_hatch"},
+		{true, false, false, false, "no_without_password"},
+		{false, true, false, false, "no_insecure"},
+		{false, false, false, false, "neither"},
+		{false, false, true, false, "neither_plus_escape"},
+		{true, false, true, false, "insecure_escape_no_nopass"},
+		{false, true, true, false, "nopass_escape_no_insecure"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := RestrictionApplies(tc.insecure, tc.withoutPassword, tc.allowDangerous)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestValidateListenAddressIfRestricted(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateListenAddressIfRestricted(
+		false, true, false, "http://0.0.0.0:0",
+	), "when restriction does not apply, bad address is ignored")
+
+	require.NoError(t, ValidateListenAddressIfRestricted(
+		true, true, true, "http://0.0.0.0:0",
+	), "escape hatch skips validation")
+
+	err := ValidateListenAddressIfRestricted(true, true, false, "http://0.0.0.0:0")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrDisallowedPublicBind)
+
+	require.NoError(t, ValidateListenAddressIfRestricted(
+		true, true, false, "http://127.0.0.1:0",
+	))
+}
+
+func TestValidateListenerAddrIfRestricted(t *testing.T) {
+	t.Parallel()
+
+	pub := &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 80}
+
+	require.NoError(t, ValidateListenerAddrIfRestricted(false, true, false, pub))
+
+	require.NoError(t, ValidateListenerAddrIfRestricted(true, true, true, pub))
+
+	err := ValidateListenerAddrIfRestricted(true, true, false, pub)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrDisallowedPublicBind)
+
+	require.NoError(t, ValidateListenerAddrIfRestricted(
+		true, true, false,
+		&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1},
+	))
+}
+
+func TestParseListenHost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in        string
+		wantHost  string
+		wantUnix  bool
+		wantError bool
+	}{
+		{"http://127.0.0.1:51515", "127.0.0.1", false, false},
+		{"https://127.0.0.1:51515", "127.0.0.1", false, false},
+		{"127.0.0.1:51515", "127.0.0.1", false, false},
+		{"http://LOCALHOST:0", "LOCALHOST", false, false},
+		{"http://[::1]:123", "::1", false, false},
+		{"unix:/tmp/kopia.sock", "", true, false},
+		{"http://unix:/wrong", "", true, false},
+		{"http://:51515", "", false, false},
+		{"http://0.0.0.0:0", "0.0.0.0", false, false},
+		{"http://192.0.2.1:1", "192.0.2.1", false, false},
+		{"http://example.com:80", "example.com", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+
+			host, isUnix, err := ParseListenHost(tc.in)
+			if tc.wantError {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantHost, host)
+			require.Equal(t, tc.wantUnix, isUnix)
+		})
+	}
+}
+
+func TestValidateListenAddressFlag(t *testing.T) {
+	t.Parallel()
+
+	ok := []string{
+		"http://127.0.0.1:51515",
+		"http://localhost:0",
+		"http://LOCALHOST:9999",
+		"http://[::1]:123",
+		"http://127.0.0.2:1",
+		"unix:/tmp/foo.sock",
+		"https://127.0.0.1:1",
+	}
+
+	for _, addr := range ok {
+		t.Run(addr, func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, ValidateListenAddressFlag(addr))
+		})
+	}
+
+	bad := []string{
+		"http://0.0.0.0:0",
+		"http://:51515",
+		"http://192.0.2.1:80",
+		"http://example.com:80",
+	}
+
+	for _, addr := range bad {
+		t.Run(addr, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateListenAddressFlag(addr)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrDisallowedPublicBind)
+			require.ErrorContains(t, err, AllowDangerousUnauthenticatedNetworkFlag)
+		})
+	}
+}
+
+func TestValidateListenerAddr(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateListenerAddr(&net.UnixAddr{Name: "/tmp/x", Net: "unix"}))
+
+	require.NoError(t, ValidateListenerAddr(&net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 51515,
+	}))
+
+	require.NoError(t, ValidateListenerAddr(&net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.2"),
+		Port: 1,
+	}))
+
+	require.NoError(t, ValidateListenerAddr(&net.TCPAddr{
+		IP:   net.ParseIP("::1"),
+		Port: 1,
+	}))
+
+	err := ValidateListenerAddr(&net.TCPAddr{
+		IP:   net.ParseIP("192.0.2.1"),
+		Port: 80,
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrDisallowedPublicBind)
+	require.ErrorContains(t, err, AllowDangerousUnauthenticatedNetworkFlag)
+
+	err = ValidateListenerAddr(&net.TCPAddr{
+		IP:   net.ParseIP("0.0.0.0"),
+		Port: 51515,
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrDisallowedPublicBind)
+
+	err = ValidateListenerAddr(&net.TCPAddr{
+		Port: 51515,
+	})
+	require.Error(t, err)
+}
+
+type stubAddr struct {
+	network, s string
+}
+
+func (a stubAddr) Network() string { return a.network }
+func (a stubAddr) String() string  { return a.s }
+
+func TestValidateListenerAddr_unknownType(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateListenerAddr(stubAddr{network: "tcp", s: "192.0.2.1:80"})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrDisallowedPublicBind)
+}

--- a/internal/insecureserverbind/insecureserverbind_test.go
+++ b/internal/insecureserverbind/insecureserverbind_test.go
@@ -38,40 +38,103 @@ func TestRestrictionApplies(t *testing.T) {
 func TestValidateListenAddressIfRestricted(t *testing.T) {
 	t.Parallel()
 
-	require.NoError(t, ValidateListenAddressIfRestricted(
-		false, true, false, "http://0.0.0.0:0",
-	), "when restriction does not apply, bad address is ignored")
+	cases := []struct {
+		name                                      string
+		insecure, withoutPassword, allowDangerous bool
+		address                                   string
+		wantErr                                   bool
+	}{
+		{
+			name: "when_restriction_does_not_apply_bad_address_ignored",
+			// not insecure+without-password: bad address is not validated
+			insecure: false, withoutPassword: true, allowDangerous: false,
+			address: "http://0.0.0.0:0", wantErr: false,
+		},
+		{
+			name:     "escape_hatch_skips_validation",
+			insecure: true, withoutPassword: true, allowDangerous: true,
+			address: "http://0.0.0.0:0", wantErr: false,
+		},
+		{
+			name:     "restricted_non_loopback_rejected",
+			insecure: true, withoutPassword: true, allowDangerous: false,
+			address: "http://0.0.0.0:0", wantErr: true,
+		},
+		{
+			name:     "restricted_loopback_ok",
+			insecure: true, withoutPassword: true, allowDangerous: false,
+			address: "http://127.0.0.1:0", wantErr: false,
+		},
+	}
 
-	require.NoError(t, ValidateListenAddressIfRestricted(
-		true, true, true, "http://0.0.0.0:0",
-	), "escape hatch skips validation")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	err := ValidateListenAddressIfRestricted(true, true, false, "http://0.0.0.0:0")
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrDisallowedPublicBind)
+			err := ValidateListenAddressIfRestricted(
+				tc.insecure, tc.withoutPassword, tc.allowDangerous, tc.address)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrDisallowedPublicBind)
 
-	require.NoError(t, ValidateListenAddressIfRestricted(
-		true, true, false, "http://127.0.0.1:0",
-	))
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestValidateListenerAddrIfRestricted(t *testing.T) {
 	t.Parallel()
 
 	pub := &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 80}
+	loopback := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1}
 
-	require.NoError(t, ValidateListenerAddrIfRestricted(false, true, false, pub))
+	cases := []struct {
+		name                                      string
+		insecure, withoutPassword, allowDangerous bool
+		addr                                      net.Addr
+		wantErr                                   bool
+	}{
+		{
+			name:     "when_restriction_does_not_apply_public_listener_ignored",
+			insecure: false, withoutPassword: true, allowDangerous: false,
+			addr: pub, wantErr: false,
+		},
+		{
+			name:     "escape_hatch_skips_validation",
+			insecure: true, withoutPassword: true, allowDangerous: true,
+			addr: pub, wantErr: false,
+		},
+		{
+			name:     "restricted_public_listener_rejected",
+			insecure: true, withoutPassword: true, allowDangerous: false,
+			addr: pub, wantErr: true,
+		},
+		{
+			name:     "restricted_loopback_ok",
+			insecure: true, withoutPassword: true, allowDangerous: false,
+			addr: loopback, wantErr: false,
+		},
+	}
 
-	require.NoError(t, ValidateListenerAddrIfRestricted(true, true, true, pub))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	err := ValidateListenerAddrIfRestricted(true, true, false, pub)
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrDisallowedPublicBind)
+			err := ValidateListenerAddrIfRestricted(
+				tc.insecure, tc.withoutPassword, tc.allowDangerous, tc.addr)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrDisallowedPublicBind)
 
-	require.NoError(t, ValidateListenerAddrIfRestricted(
-		true, true, false,
-		&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1},
-	))
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestParseListenHost(t *testing.T) {
@@ -120,6 +183,7 @@ func TestValidateListenAddressFlag(t *testing.T) {
 	ok := []string{
 		"http://127.0.0.1:51515",
 		"http://localhost:0",
+		"http://LoCaLhOsT:51515",
 		"http://LOCALHOST:9999",
 		"http://[::1]:123",
 		"http://127.0.0.2:1",
@@ -207,4 +271,10 @@ func TestValidateListenerAddr_unknownType(t *testing.T) {
 	err := ValidateListenerAddr(stubAddr{network: "tcp", s: "192.0.2.1:80"})
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrDisallowedPublicBind)
+}
+
+func TestValidateListenerAddr_stubUnixNetwork(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateListenerAddr(stubAddr{network: "unix", s: "/tmp/kopia.sock"}))
 }

--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -583,7 +583,8 @@ func TestServerStartInsecureUnauthenticatedEscapeHatchNonLoopback(t *testing.T) 
 		"--"+insecureserverbind.AllowDangerousUnauthenticatedNetworkFlag,
 	)
 
-	time.Sleep(300 * time.Millisecond)
+	require.Eventually(t, func() bool { return sp.BaseURL != "" }, 15*time.Second, 50*time.Millisecond)
+
 	kill()
 	wait()
 

--- a/tests/end_to_end_test/server_start_test.go
+++ b/tests/end_to_end_test/server_start_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kopia/kopia/internal/apiclient"
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/insecureserverbind"
 	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/internal/testlogging"
@@ -543,6 +544,50 @@ func TestServerStartInsecure(t *testing.T) {
 
 	// server fails to start when TLS is not configured and `--insecure` is not specified
 	e.RunAndExpectFailure(t, "server", "start", "--ui", "--address=localhost:0")
+}
+
+func TestServerStartInsecureUnauthenticatedNonLoopbackRejected(t *testing.T) {
+	t.Parallel()
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-hostname=fake-hostname", "--override-username=fake-username")
+
+	e.RunAndExpectFailure(t, "server", "start", "--ui",
+		"--address=http://0.0.0.0:0",
+		"--without-password",
+		"--insecure",
+	)
+}
+
+func TestServerStartInsecureUnauthenticatedEscapeHatchNonLoopback(t *testing.T) {
+	t.Parallel()
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--override-hostname=fake-hostname", "--override-username=fake-username")
+
+	var sp testutil.ServerParameters
+
+	wait, kill := e.RunAndProcessStderr(t, sp.ProcessOutput,
+		"server", "start",
+		"--address=http://0.0.0.0:0",
+		"--without-password",
+		"--insecure",
+		"--"+insecureserverbind.AllowDangerousUnauthenticatedNetworkFlag,
+	)
+
+	time.Sleep(300 * time.Millisecond)
+	kill()
+	wait()
+
+	require.NotEmpty(t, sp.BaseURL)
 }
 
 func verifyServerConnected(t *testing.T, cli *apiclient.KopiaAPIClient, want bool) *serverapi.StatusResponse {


### PR DESCRIPTION
Reject starting the server with --insecure and --without-password when --address would bind outside loopback (including empty host / all interfaces). Validate the actual listener after Listen so systemd socket activation cannot bypass the check.

Add hidden --allow-extremely-dangerous-unauthenticated-server-on-the-network to opt into the previous behavior for isolated environments.

Extract validation into internal/insecureserverbind with table-driven tests. Add end-to-end smoke tests for rejection and escape hatch.