### PR TITLE
Make a Distinction between Quick Maintenance and Full Maintenance

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -996,7 +996,21 @@ func (s *Server) runSnapshotTask(ctx context.Context, src snapshot.SourceInfo, i
 }
 
 func (s *Server) runMaintenanceTask(ctx context.Context, dr repo.DirectRepository) error {
-	return errors.Wrap(s.taskmgr.Run(ctx, "Maintenance", "Periodic maintenance", func(ctx context.Context, _ uitask.Controller) error {
+	p, err := maintenance.GetParams(ctx, dr)
+	if err != nil {
+		return errors.Wrap(err, "unable to get maintenance params")
+	}
+	mode, err := maintenance.DetermineMode(ctx, dr, p)
+	if err != nil {
+		return errors.Wrap(err, "unable to determine maintenance mode")
+	}
+	kind := "Maintenance"
+	if mode == maintenance.ModeFull {
+		kind = "Maintenance - Full"
+	} else if mode == maintenance.ModeQuick {
+		kind = "Maintenance - Quick"
+	}
+	return errors.Wrap(s.taskmgr.Run(ctx, kind, "Periodic maintenance", func(ctx context.Context, _ uitask.Controller) error {
 		return repo.DirectWriteSession(ctx, dr, repo.WriteSessionOptions{
 			Purpose: "periodicMaintenance",
 		}, func(ctx context.Context, w repo.DirectRepositoryWriter) error {

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -57,6 +57,10 @@ const (
 	TaskEpochCompactSingle           = "compact-single-epoch"
 )
 
+func DetermineMode(ctx context.Context, rep repo.DirectRepository, p *Params) (Mode, error) {
+	return shouldRun(ctx, rep, p)
+}
+
 // shouldRun returns Mode if repository is due for periodic maintenance.
 func shouldRun(ctx context.Context, rep repo.DirectRepository, p *Params) (Mode, error) {
 	if myUsername := rep.ClientOptions().UsernameAtHost(); p.Owner != myUsername {


### PR DESCRIPTION
Long-time fan of Kopia.
Very simple change here, but it shows up in KopiaUI which is my desired effect. This change simply makes a distinction between Quick and Full Maintenance instead of stuffing them all under the umbrella category of kind=Maintenance.

I didn't intend on this being two commits, but in haste I ran `git add .` and `git commit` in the wrong directory the first time around, so alas, here we are. Two commits for ~20 lines of code added.

Note, I consider myself to be a junior Go developer, I only learned Go properly in early 2025 and have been playing with it ever since. If anything looks weird or fishy, I'm likely to blame for not knowing what kind of impact a change might have. As far as I know, this shouldn't break anything. I have only tested this on my own macbook Air by swapping in this build into the KopiaUI package. It is working well so far. See screenshot below for the UI change that this affects:



<img width="1354" height="747" alt="2026-05-21_17-53" src="https://github.com/user-attachments/assets/6437861b-ed29-4964-aa1c-e066d2291ff9" />
