### PR TITLE
chore(ci): test new windows runners

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest, ubuntu-24.04-arm ]
+        os: [windows-2025-vs2026, ubuntu-latest, macos-latest, ubuntu-24.04-arm ]
     name: Make
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest, ubuntu-24.04-arm ]
+        os: [windows-2025-vs2026, ubuntu-latest, macos-latest, ubuntu-24.04-arm ]
     name: Tests
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/volume-shadow-copy-test.yml
+++ b/.github/workflows/volume-shadow-copy-test.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   vss-test:
     name: Volume Shadow Copy Test
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     steps:
     - name: Check out repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
GitHub Change: The "windows-latest" and “windows-2025” labels in GitHub Actions will be migrated to use Visual Studio 2026 by default.

This change will be rolled out over a week beginning June 8, 2026 and will complete by June 15, 2026.

- https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners