### PR TITLE
Add Cloudflare R2 storage provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Pick the Cloud Storage Provider You Want
 Kopia supports saving your [encrypted](https://kopia.io/docs/features/#user-controlled-end-to-end-encryption) and [compressed](https://kopia.io/docs/features/#compression) snapshots to all of the following [storage locations](https://kopia.io/docs/features/#save-snapshots-to-cloud-network-or-local-storage):
 
 * **Amazon S3** and any **cloud storage that is compatible with S3**
+* **Cloudflare R2**
 * **Azure Blob Storage**
 * **Backblaze B2**
 * **Google Cloud Storage**

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/r2"
 	"github.com/kopia/kopia/repo/ecc"
 	"github.com/kopia/kopia/repo/encryption"
 	"github.com/kopia/kopia/repo/format"
@@ -22,6 +23,8 @@ const runValidationNote = `NOTE: To validate that your provider is compatible wi
 $ kopia repository validate-provider
 
 `
+
+const r2UnsupportedRetentionMessage = "Cloudflare R2 does not support S3 Object Lock headers; --retention-mode and --retention-period are unsupported"
 
 type commandRepositoryCreate struct {
 	createBlockHashFormat             string
@@ -120,6 +123,9 @@ func (c *commandRepositoryCreate) runCreateCommandWithStorage(ctx context.Contex
 	}
 
 	options := c.newRepositoryOptionsFromFlags()
+	if st.ConnectionInfo().Type == r2.StorageType && (options.RetentionMode != "" || options.RetentionPeriod != 0) {
+		return errors.New(r2UnsupportedRetentionMessage)
+	}
 
 	pass, err := c.svc.getPasswordFromFlags(ctx, true, false)
 	if err != nil {

--- a/cli/command_repository_set_parameters.go
+++ b/cli/command_repository_set_parameters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/r2"
 	"github.com/kopia/kopia/repo/format"
 	"github.com/kopia/kopia/repo/maintenance"
 )
@@ -202,6 +203,10 @@ func (c *commandRepositorySetParameters) run(ctx context.Context, rep repo.Direc
 			disableBlobRetention(ctx, &blobcfg, &anyChange)
 		}
 	} else {
+		if rep.BlobStorage().ConnectionInfo().Type == r2.StorageType && (c.retentionMode != "" || c.retentionPeriod != 0) {
+			return errors.New(r2UnsupportedRetentionMessage)
+		}
+
 		setRetentionModeParameter(ctx, blob.RetentionMode(c.retentionMode), "storage backend blob retention mode", &blobcfg.RetentionMode, &anyChange)
 		setDurationParameter(ctx, c.retentionPeriod, "storage backend blob retention period", &blobcfg.RetentionPeriod, &anyChange)
 	}

--- a/cli/storage_r2.go
+++ b/cli/storage_r2.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/r2"
+)
+
+type storageR2Flags struct {
+	r2options       r2.Options
+	rootCaPemBase64 string
+	rootCaPemPath   string
+}
+
+func (c *storageR2Flags) Setup(svc StorageProviderServices, cmd *kingpin.CmdClause) {
+	cmd.Flag("account-id", "Cloudflare account ID used to derive the R2 endpoint").Required().Envar(svc.EnvName("R2_ACCOUNT_ID")).StringVar(&c.r2options.AccountID)
+	cmd.Flag("bucket", "Name of the Cloudflare R2 bucket").Required().StringVar(&c.r2options.BucketName)
+	cmd.Flag("endpoint", "Endpoint to use instead of deriving one from the account ID").StringVar(&c.r2options.Endpoint)
+	cmd.Flag("jurisdiction", "Cloudflare R2 jurisdiction for derived endpoints").Default("default").EnumVar(&c.r2options.Jurisdiction, "default", "eu", "fedramp")
+	cmd.Flag("access-key", "Access key ID (overrides R2_ACCESS_KEY_ID environment variable)").Required().Envar(svc.EnvName("R2_ACCESS_KEY_ID")).StringVar(&c.r2options.AccessKeyID)
+	cmd.Flag("secret-access-key", "Secret access key (overrides R2_SECRET_ACCESS_KEY environment variable)").Required().Envar(svc.EnvName("R2_SECRET_ACCESS_KEY")).StringVar(&c.r2options.SecretAccessKey)
+	cmd.Flag("session-token", "Session token (overrides R2_SESSION_TOKEN environment variable)").Envar(svc.EnvName("R2_SESSION_TOKEN")).StringVar(&c.r2options.SessionToken)
+	cmd.Flag("prefix", "Prefix to use for objects in the bucket. Put trailing slash (/) if you want to use prefix as directory. e.g my-backup-dir/ would put repository contents inside my-backup-dir directory").StringVar(&c.r2options.Prefix)
+	cmd.Flag("disable-tls", "Disable TLS security (HTTPS)").BoolVar(&c.r2options.DoNotUseTLS)
+	cmd.Flag("disable-tls-verification", "Disable TLS (HTTPS) certificate verification").BoolVar(&c.r2options.DoNotVerifyTLS)
+
+	commonThrottlingFlags(cmd, &c.r2options.Limits)
+
+	cmd.Flag("root-ca-pem-base64", "Certificate authority in-line (base64 enc.)").Envar(svc.EnvName("ROOT_CA_PEM_BASE64")).PreAction(c.preActionLoadPEMBase64).StringVar(&c.rootCaPemBase64)
+	cmd.Flag("root-ca-pem-path", "Certificate authority file path").PreAction(c.preActionLoadPEMPath).StringVar(&c.rootCaPemPath)
+}
+
+func (c *storageR2Flags) preActionLoadPEMPath(_ *kingpin.ParseContext) error {
+	if len(c.r2options.RootCA) > 0 {
+		return errors.New("root-ca-pem-base64 and root-ca-pem-path are mutually exclusive")
+	}
+
+	data, err := os.ReadFile(c.rootCaPemPath) //#nosec
+	if err != nil {
+		return errors.Wrapf(err, "error opening root-ca-pem-path %v", c.rootCaPemPath)
+	}
+
+	c.r2options.RootCA = data
+
+	return nil
+}
+
+func (c *storageR2Flags) preActionLoadPEMBase64(_ *kingpin.ParseContext) error {
+	caContent, err := base64.StdEncoding.DecodeString(c.rootCaPemBase64)
+	if err != nil {
+		return errors.Wrap(err, "unable to decode CA")
+	}
+
+	c.r2options.RootCA = caContent
+
+	return nil
+}
+
+func (c *storageR2Flags) Connect(ctx context.Context, isCreate bool, formatVersion int) (blob.Storage, error) {
+	_ = formatVersion
+
+	//nolint:wrapcheck
+	return r2.New(ctx, &c.r2options, isCreate)
+}
+
+func init() {
+	mustRegisterStorageProvider(
+		"r2",
+		"a Cloudflare R2 bucket",
+		func() StorageFlags { return &storageR2Flags{} },
+	)
+}

--- a/cli/storage_r2_test.go
+++ b/cli/storage_r2_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/testutil"
+)
+
+func TestR2LoadPEMBase64(t *testing.T) {
+	var r2flags storageR2Flags
+
+	r2flags = storageR2Flags{rootCaPemBase64: ""}
+	require.NoError(t, r2flags.preActionLoadPEMBase64(nil))
+
+	r2flags = storageR2Flags{rootCaPemBase64: "AA=="}
+	require.NoError(t, r2flags.preActionLoadPEMBase64(nil))
+
+	r2flags = storageR2Flags{rootCaPemBase64: fakeCertContentAsBase64}
+	require.NoError(t, r2flags.preActionLoadPEMBase64(nil))
+	require.Equal(t, fakeCertContent, r2flags.r2options.RootCA, "content of RootCA should be %v", fakeCertContent)
+
+	r2flags = storageR2Flags{rootCaPemBase64: "!"}
+	err := r2flags.preActionLoadPEMBase64(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "illegal base64 data")
+}
+
+func TestR2LoadPEMPath(t *testing.T) {
+	var r2flags storageR2Flags
+
+	tempdir := testutil.TempDirectory(t)
+	certpath := filepath.Join(tempdir, "certificate-filename")
+
+	require.NoError(t, os.WriteFile(certpath, fakeCertContent, 0o644))
+
+	r2flags = storageR2Flags{rootCaPemPath: certpath}
+	require.NoError(t, r2flags.preActionLoadPEMPath(nil))
+	require.Equal(t, fakeCertContent, r2flags.r2options.RootCA, "content of RootCA should be %v", fakeCertContent)
+
+	r2flags = storageR2Flags{rootCaPemPath: "/does-not-exists"}
+	err := r2flags.preActionLoadPEMPath(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error opening root-ca-pem-path")
+}
+
+func TestR2LoadPEMBoth(t *testing.T) {
+	r2flags := storageR2Flags{rootCaPemBase64: "AA==", rootCaPemPath: "/tmp/blah"}
+	require.NoError(t, r2flags.preActionLoadPEMBase64(nil))
+	err := r2flags.preActionLoadPEMPath(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+}

--- a/internal/server/api_repo.go
+++ b/internal/server/api_repo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kopia/kopia/internal/serverapi"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/r2"
 	"github.com/kopia/kopia/repo/blob/throttling"
 	"github.com/kopia/kopia/repo/compression"
 	"github.com/kopia/kopia/repo/ecc"
@@ -111,6 +112,10 @@ func handleRepoCreate(ctx context.Context, rc requestContext) (any, *apiError) {
 		return nil, requestError(serverapi.ErrorStorageConnection, "unable to connect to storage: "+err.Error())
 	}
 	defer st.Close(ctx) //nolint:errcheck
+
+	if st.ConnectionInfo().Type == r2.StorageType && (req.NewRepositoryOptions.RetentionMode != "" || req.NewRepositoryOptions.RetentionPeriod != 0) {
+		return nil, requestError(serverapi.ErrorMalformedRequest, "Cloudflare R2 does not support S3 Object Lock headers; retention options are unsupported")
+	}
 
 	if err = repo.Initialize(ctx, st, &req.NewRepositoryOptions, req.Password); err != nil {
 		return nil, repoErrorToAPIError(err)

--- a/repo/blob/r2/r2_options.go
+++ b/repo/blob/r2/r2_options.go
@@ -1,0 +1,148 @@
+package r2
+
+import (
+	"net/url"
+	"strings"
+	"unicode"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/blob/s3"
+	"github.com/kopia/kopia/repo/blob/throttling"
+)
+
+const (
+	// StorageType is the blob storage type used for Cloudflare R2 repositories.
+	StorageType = "r2"
+	r2Region    = "auto"
+)
+
+// Options defines options for Cloudflare R2-backed storage.
+type Options struct {
+	// AccountID is the Cloudflare account ID used to derive the R2 endpoint.
+	AccountID string `json:"accountID,omitempty"`
+
+	// Jurisdiction scopes the derived R2 endpoint when set to "eu" or "fedramp".
+	Jurisdiction string `json:"jurisdiction,omitempty"`
+
+	// BucketName is the name of the R2 bucket where data is stored.
+	BucketName string `json:"bucket"`
+
+	// Prefix specifies additional string to prepend to all objects.
+	Prefix string `json:"prefix,omitempty"`
+
+	// Endpoint optionally overrides the endpoint derived from AccountID.
+	Endpoint string `json:"endpoint,omitempty"`
+
+	DoNotUseTLS    bool   `json:"doNotUseTLS,omitempty"`
+	DoNotVerifyTLS bool   `json:"doNotVerifyTLS,omitempty"`
+	RootCA         []byte `json:"rootCA,omitempty"`
+
+	AccessKeyID     string `json:"accessKeyID"`
+	SecretAccessKey string `json:"secretAccessKey" kopia:"sensitive"`
+	SessionToken    string `json:"sessionToken" kopia:"sensitive"`
+
+	throttling.Limits
+}
+
+func (o *Options) toS3Options() (*s3.Options, error) {
+	endpoint, doNotUseTLS, err := o.s3Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	if o.BucketName == "" {
+		return nil, errors.New("bucket name must be specified")
+	}
+
+	return &s3.Options{
+		BucketName:      o.BucketName,
+		Prefix:          o.Prefix,
+		Endpoint:        endpoint,
+		DoNotUseTLS:     doNotUseTLS,
+		DoNotVerifyTLS:  o.DoNotVerifyTLS,
+		RootCA:          o.RootCA,
+		AccessKeyID:     o.AccessKeyID,
+		SecretAccessKey: o.SecretAccessKey,
+		SessionToken:    o.SessionToken,
+		Region:          r2Region,
+		Limits:          o.Limits,
+	}, nil
+}
+
+func (o *Options) s3Endpoint() (endpoint string, doNotUseTLS bool, err error) {
+	if o.Endpoint != "" {
+		return normalizeEndpoint(o.Endpoint, o.DoNotUseTLS)
+	}
+
+	if o.AccountID == "" {
+		return "", false, errors.New("account ID must be specified when endpoint is not provided")
+	}
+	if !isValidAccountID(o.AccountID) {
+		return "", false, errors.New("account ID must contain only letters and digits")
+	}
+
+	switch strings.ToLower(o.Jurisdiction) {
+	case "", "default":
+		return o.AccountID + ".r2.cloudflarestorage.com", o.DoNotUseTLS, nil
+	case "eu":
+		return o.AccountID + ".eu.r2.cloudflarestorage.com", o.DoNotUseTLS, nil
+	case "fedramp":
+		return o.AccountID + ".fedramp.r2.cloudflarestorage.com", o.DoNotUseTLS, nil
+	default:
+		return "", false, errors.Errorf("unsupported R2 jurisdiction: %q", o.Jurisdiction)
+	}
+}
+
+func normalizeEndpoint(endpoint string, doNotUseTLS bool) (string, bool, error) {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "", false, errors.New("endpoint must be specified")
+	}
+
+	if !strings.Contains(endpoint, "://") {
+		if strings.ContainsAny(endpoint, "/?#@") {
+			return "", false, errors.New("endpoint must not include path, query, fragment, or user info")
+		}
+
+		return endpoint, doNotUseTLS, nil
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", false, errors.Wrap(err, "invalid endpoint")
+	}
+
+	if (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" || u.User != nil {
+		return "", false, errors.New("endpoint must not include path, query, fragment, or user info")
+	}
+
+	if u.Host == "" {
+		return "", false, errors.New("endpoint host must be specified")
+	}
+
+	switch u.Scheme {
+	case "https":
+		if doNotUseTLS {
+			return "", false, errors.New("endpoint uses https but TLS is disabled")
+		}
+
+		return u.Host, false, nil
+
+	case "http":
+		return u.Host, true, nil
+
+	default:
+		return "", false, errors.Errorf("unsupported endpoint scheme: %q", u.Scheme)
+	}
+}
+
+func isValidAccountID(accountID string) bool {
+	for _, r := range accountID {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/repo/blob/r2/r2_provider_test.go
+++ b/repo/blob/r2/r2_provider_test.go
@@ -1,0 +1,120 @@
+package r2
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/providervalidation"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
+)
+
+const (
+	testAccountIDEnv       = "KOPIA_R2_TEST_ACCOUNT_ID"
+	testEndpointEnv        = "KOPIA_R2_TEST_ENDPOINT"
+	testAccessKeyIDEnv     = "KOPIA_R2_TEST_ACCESS_KEY_ID"
+	testSecretAccessKeyEnv = "KOPIA_R2_TEST_SECRET_ACCESS_KEY"
+	testSessionTokenEnv    = "KOPIA_R2_TEST_SESSION_TOKEN"
+	testJurisdictionEnv    = "KOPIA_R2_TEST_JURISDICTION"
+)
+
+func TestR2StorageCloudflare(t *testing.T) {
+	t.Parallel()
+	testutil.ProviderTest(t)
+
+	options := &Options{
+		AccountID:       getEnvOrSkip(t, testAccountIDEnv),
+		Endpoint:        os.Getenv(testEndpointEnv),
+		AccessKeyID:     getEnvOrSkip(t, testAccessKeyIDEnv),
+		SecretAccessKey: getEnvOrSkip(t, testSecretAccessKeyEnv),
+		SessionToken:    os.Getenv(testSessionTokenEnv),
+		Jurisdiction:    os.Getenv(testJurisdictionEnv),
+		BucketName:      "kopia-r2-test-" + uuid.NewString(),
+	}
+
+	ctx := testlogging.Context(t)
+	cli := createClient(t, options)
+
+	require.NoError(t, cli.MakeBucket(ctx, options.BucketName, minio.MakeBucketOptions{
+		Region: r2Region,
+	}))
+
+	t.Cleanup(func() {
+		ctx := testlogging.ContextForCleanup(t)
+		removeAllObjects(ctx, t, cli, options.BucketName)
+		require.NoError(t, cli.RemoveBucket(ctx, options.BucketName))
+	})
+
+	st, err := New(ctx, options, false)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		ctx := testlogging.ContextForCleanup(t)
+		blobtesting.CleanupOldData(ctx, t, st, 0)
+		require.NoError(t, st.Close(ctx))
+	})
+
+	require.NoError(t, providervalidation.ValidateProvider(ctx, st, blobtesting.TestValidationOptions))
+	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
+}
+
+func getEnvOrSkip(tb testing.TB, name string) string {
+	tb.Helper()
+
+	value := os.Getenv(name)
+	if value == "" {
+		tb.Skipf("Environment variable '%s' not provided", name)
+	}
+
+	return value
+}
+
+func createClient(tb testing.TB, opt *Options) *minio.Client {
+	tb.Helper()
+
+	s3Options, err := opt.toS3Options()
+	require.NoError(tb, err)
+
+	minioClient, err := minio.New(s3Options.Endpoint,
+		&minio.Options{
+			Creds:     credentials.NewStaticV4(opt.AccessKeyID, opt.SecretAccessKey, opt.SessionToken),
+			Secure:    !s3Options.DoNotUseTLS,
+			Region:    r2Region,
+			Transport: nil,
+		})
+	require.NoError(tb, err)
+
+	return minioClient
+}
+
+func removeAllObjects(ctx context.Context, tb testing.TB, cli *minio.Client, bucketName string) {
+	tb.Helper()
+
+	objectCh := make(chan minio.ObjectInfo)
+
+	go func() {
+		defer close(objectCh)
+
+		for object := range cli.ListObjects(ctx, bucketName, minio.ListObjectsOptions{Recursive: true}) {
+			if object.Err != nil {
+				tb.Logf("unable to list object for cleanup: %v", object.Err)
+				continue
+			}
+
+			objectCh <- object
+		}
+	}()
+
+	for err := range cli.RemoveObjects(ctx, bucketName, objectCh, minio.RemoveObjectsOptions{}) {
+		if err.Err != nil {
+			tb.Logf("unable to remove object %v during cleanup: %v", err.ObjectName, err.Err)
+		}
+	}
+}

--- a/repo/blob/r2/r2_storage.go
+++ b/repo/blob/r2/r2_storage.go
@@ -1,0 +1,74 @@
+// Package r2 implements Storage based on a Cloudflare R2 bucket.
+package r2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/s3"
+)
+
+type r2Storage struct {
+	blob.Storage
+
+	opt Options
+}
+
+func (s *r2Storage) PutBlob(ctx context.Context, b blob.ID, data blob.Bytes, opts blob.PutOptions) error {
+	if opts.HasRetentionOptions() {
+		// R2 does not support S3 Object Lock headers, so fail before the S3
+		// compatibility layer can send retention options to Cloudflare.
+		return errors.Wrap(blob.ErrUnsupportedPutBlobOption, "blob-retention")
+	}
+
+	return s.Storage.PutBlob(ctx, b, data, opts) //nolint:wrapcheck
+}
+
+func (s *r2Storage) ExtendBlobRetention(ctx context.Context, b blob.ID, opts blob.ExtendOptions) error {
+	return blob.ErrUnsupportedObjectLock
+}
+
+func (s *r2Storage) ConnectionInfo() blob.ConnectionInfo {
+	return blob.ConnectionInfo{
+		Type:   StorageType,
+		Config: &s.opt,
+	}
+}
+
+func (s *r2Storage) DisplayName() string {
+	endpoint, _, err := s.opt.s3Endpoint()
+	if err != nil {
+		endpoint = s.opt.Endpoint
+	}
+
+	return fmt.Sprintf("Cloudflare R2: %v %v", endpoint, s.opt.BucketName)
+}
+
+func (s *r2Storage) String() string {
+	return fmt.Sprintf("r2://%v/%v", s.opt.BucketName, s.opt.Prefix)
+}
+
+// New creates new Cloudflare R2-backed storage with specified options.
+func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error) {
+	s3Options, err := opt.toS3Options()
+	if err != nil {
+		return nil, err
+	}
+
+	st, err := s3.New(ctx, s3Options, isCreate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &r2Storage{
+		Storage: st,
+		opt:     *opt,
+	}, nil
+}
+
+func init() {
+	blob.AddSupportedStorage(StorageType, Options{}, New)
+}

--- a/repo/blob/r2/r2_storage_test.go
+++ b/repo/blob/r2/r2_storage_test.go
@@ -1,0 +1,230 @@
+package r2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+func TestToS3Options(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := (&Options{
+			AccountID:       "abc123",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.NoError(t, err)
+		require.Equal(t, "abc123.r2.cloudflarestorage.com", got.Endpoint)
+		require.Equal(t, "auto", got.Region)
+		require.False(t, got.DoNotUseTLS)
+	})
+
+	t.Run("eu jurisdiction", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := (&Options{
+			AccountID:       "abc123",
+			Jurisdiction:    "eu",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.NoError(t, err)
+		require.Equal(t, "abc123.eu.r2.cloudflarestorage.com", got.Endpoint)
+		require.Equal(t, "auto", got.Region)
+	})
+
+	t.Run("fedramp jurisdiction", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := (&Options{
+			AccountID:       "abc123",
+			Jurisdiction:    "fedramp",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.NoError(t, err)
+		require.Equal(t, "abc123.fedramp.r2.cloudflarestorage.com", got.Endpoint)
+		require.Equal(t, "auto", got.Region)
+	})
+
+	t.Run("explicit https endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := (&Options{
+			Endpoint:        "https://custom.example.com",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.NoError(t, err)
+		require.Equal(t, "custom.example.com", got.Endpoint)
+		require.False(t, got.DoNotUseTLS)
+	})
+
+	t.Run("explicit http endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := (&Options{
+			Endpoint:        "http://localhost:9000",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.NoError(t, err)
+		require.Equal(t, "localhost:9000", got.Endpoint)
+		require.True(t, got.DoNotUseTLS)
+	})
+
+	t.Run("host endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := (&Options{
+			Endpoint:        "localhost:9000",
+			BucketName:      "test-bucket",
+			DoNotUseTLS:     true,
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.NoError(t, err)
+		require.Equal(t, "localhost:9000", got.Endpoint)
+		require.True(t, got.DoNotUseTLS)
+	})
+
+	t.Run("unknown jurisdiction", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := (&Options{
+			AccountID:       "abc123",
+			Jurisdiction:    "moon",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.ErrorContains(t, err, `unsupported R2 jurisdiction: "moon"`)
+	})
+
+	t.Run("account required", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := (&Options{
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.ErrorContains(t, err, "account ID must be specified")
+	})
+
+	t.Run("account must be host safe", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := (&Options{
+			AccountID:       "abc123/other",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.ErrorContains(t, err, "account ID must contain only letters and digits")
+	})
+
+	t.Run("bucket required", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := (&Options{
+			AccountID:       "abc123",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.ErrorContains(t, err, "bucket name must be specified")
+	})
+
+	t.Run("path rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := (&Options{
+			Endpoint:        "https://custom.example.com/path",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.ErrorContains(t, err, "endpoint must not include path")
+	})
+
+	t.Run("host endpoint path rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := (&Options{
+			Endpoint:        "custom.example.com/path",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.ErrorContains(t, err, "endpoint must not include path")
+	})
+
+	t.Run("empty host rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := (&Options{
+			Endpoint:        "https://",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		}).toS3Options()
+
+		require.ErrorContains(t, err, "endpoint host must be specified")
+	})
+}
+
+func TestUnsupportedObjectLock(t *testing.T) {
+	t.Parallel()
+
+	st := &r2Storage{
+		Storage: blobtesting.NewMapStorage(nil, nil, nil),
+		opt: Options{
+			AccountID:       "abc123",
+			BucketName:      "test-bucket",
+			AccessKeyID:     "key",
+			SecretAccessKey: "secret",
+		},
+	}
+
+	ctx := context.Background()
+
+	err := st.PutBlob(ctx, "test", gather.FromSlice([]byte("test")), blob.PutOptions{
+		RetentionMode:   blob.Governance,
+		RetentionPeriod: time.Hour,
+	})
+	require.True(t, errors.Is(err, blob.ErrUnsupportedPutBlobOption))
+
+	err = st.ExtendBlobRetention(ctx, "test", blob.ExtendOptions{
+		RetentionMode:   blob.Governance,
+		RetentionPeriod: time.Hour,
+	})
+	require.ErrorIs(t, err, blob.ErrUnsupportedObjectLock)
+}

--- a/site/content/docs/Features/_index.md
+++ b/site/content/docs/Features/_index.md
@@ -56,6 +56,7 @@ Policies can be applied at multiple different levels:
 Kopia performs all its operations locally on your machine, meaning that you do not need to have any dedicated server to run your backups and you can save your snapshots to a variety of storage locations. Kopia supports network and local storage locations, of course, but also many cloud or remote storage locations:
 
 * **Amazon S3** and any **cloud storage that is compatible with S3**
+* **Cloudflare R2**
 * **Azure Blob Storage**
 * **Backblaze B2**
 * **Google Cloud Storage**

--- a/site/content/docs/Reference/Command-Line/_index.md
+++ b/site/content/docs/Reference/Command-Line/_index.md
@@ -40,6 +40,7 @@ Examples:
 
 * [create repository in local filesystem](common/repository-create-filesystem/)
 * [create repository in Google Cloud Storage bucket](common/repository-create-google/)
+* [create repository in Cloudflare R2 bucket](common/repository-create-r2/)
 * [create repository in S3-compatible bucket](common/repository-create-s3/) (e.g. [Amazon S3](https://aws.amazon.com/s3/), [minio.io](https://minio.io/), [Wasabi](https://wasabi.com))
 
 To connect to an existing repository use the same flags but instead of `create` use `connect`:

--- a/site/content/docs/Repositories/_index.md
+++ b/site/content/docs/Repositories/_index.md
@@ -11,6 +11,7 @@ Kopia allows you to save your [encrypted](../features/#user-controlled-end-to-en
 * [Amazon S3 and S3-compatible Cloud Storage](#amazon-s3-and-s3-compatible-cloud-storage)
   * Kopia supports all cloud storage platforms that support the S3 API
   * Kopia supports object locking and [hot, cold, and archive storage classes](../advanced/amazon-s3/) for any cloud storage that supports the features using the S3 API
+* [Cloudflare R2](#cloudflare-r2)
 * [Azure Blob Storage](#azure-blob-storage)
 * [Backblaze B2](#backblaze-b2)
 * [Google Cloud Storage](#google-cloud-storage)
@@ -65,6 +66,44 @@ You will be asked to enter the repository password that you want. Remember, this
 #### Connecting to Repository
 
 After you have created the `repository`, you connect to it using the [`kopia repository connect s3` command](../reference/command-line/common/repository-connect-s3/). Read the [help docs](../reference/command-line/common/repository-connect-s3/) for more information on the options available for this command.
+
+## Cloudflare R2
+
+Creating a Cloudflare R2 `repository` is done differently depending on if you use Kopia GUI or Kopia CLI.
+
+Cloudflare R2 uses an S3-compatible API, but Kopia exposes it as a dedicated `r2` storage type so Kopia can use R2 defaults automatically. Kopia derives the R2 endpoint from your Cloudflare account ID by default, using the form `<account-id>.r2.cloudflarestorage.com`. If your bucket uses a jurisdiction-specific endpoint, pass `--jurisdiction=eu` or `--jurisdiction=fedramp`. You can also pass an explicit `--endpoint` when you need to override endpoint derivation.
+
+> NOTE: Cloudflare R2 does not support S3 Object Lock headers. Kopia therefore does not support repository blob-retention options, such as `--retention-mode` and `--retention-period`, for R2 repositories.
+
+### Kopia GUI
+
+Select the `Cloudflare R2` option in the `Repository` tab in `KopiaUI`. Then, follow on-screen instructions. You will need to enter your `Account ID`, `Bucket` name, `Access Key ID`, and `Secret Access Key`. You can optionally enter an `Endpoint`, `Jurisdiction`, `Prefix`, and `Session Token`.
+
+You will next need to enter the repository password that you want. Remember, this [password is used to encrypt your data](../faqs/#how-do-i-enable-encryption), so make sure it is a secure password! At this same password screen, you have the option to change the `Encryption` algorithm, `Hash` algorithm, `Splitter` algorithm, `Repository Format`, `Username`, and `Hostname`. Click the `Show Advanced Options` button to access these settings. If you do not understand what these settings are, do not change them because the default settings are the best settings.
+
+Once you do all that, your repository should be created and you can start backing up your data!
+
+### Kopia CLI
+
+#### Creating a Repository
+
+You must use the [`kopia repository create r2` command](../reference/command-line/common/repository-create-r2/) to create a `repository`:
+
+```shell
+$ kopia repository create r2 \
+        --account-id=... \
+        --bucket=... \
+        --access-key=... \
+        --secret-access-key=...
+```
+
+You can also provide credentials with the `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and `R2_SESSION_TOKEN` environment variables. If you provide `--account-id` and omit `--endpoint`, Kopia derives the endpoint and signs requests with the R2-required `auto` region.
+
+You will be asked to enter the repository password that you want. Remember, this [password is used to encrypt your data](../faqs/#how-do-i-enable-encryption), so make sure it is a secure password!
+
+#### Connecting to Repository
+
+After you have created the `repository`, you connect to it using the [`kopia repository connect r2` command](../reference/command-line/common/repository-connect-r2/). Read the [help docs](../reference/command-line/common/repository-connect-r2/) for more information on the options available for this command.
 
 ## Azure Blob Storage
 

--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -16,6 +16,7 @@ When ready, head to the [installation](installation/) page to download and insta
 Kopia supports saving your [encrypted](features/#user-controlled-end-to-end-encryption) and [compressed](features/#compression) snapshots to all of the following [storage locations](features/#save-snapshots-to-cloud-network-or-local-storage):
 
 * **Amazon S3** and any **cloud storage that is compatible with S3**
+* **Cloudflare R2**
 * **Azure Blob Storage**
 * **Backblaze B2**
 * **Google Cloud Storage**


### PR DESCRIPTION
## Summary
- add a first-class Cloudflare R2 blob storage provider backed by the existing S3 implementation
- derive R2 endpoints from account ID and jurisdiction, with optional explicit endpoint override
- add CLI create/connect support and R2 environment variables
- reject unsupported S3 Object Lock retention options for R2 in CLI, server API, and provider code
- document R2 setup and limitations

Related UI PR: https://github.com/kopia/htmlui/pull/440

## Validation
- go test ./repo/blob/r2 ./repo/blob/s3 ./internal/server ./cli
- make -C site build
- live R2 repository validate-provider
- live R2 snapshot/restore with nested text files, binary file, empty file, empty directory, and symlink
- restored tree compared with diff -r
- htmlui validation in related PR: npm test -- SetupRepositoryR2, npm test -- SetupRepository, npm run lint, npm run build