### PR TITLE
fix: keep env cache directory from re-enabling disabled cache

### DIFF
--- a/repo/local_config.go
+++ b/repo/local_config.go
@@ -147,8 +147,8 @@ func LoadConfigFromFile(fileName string) (*LocalConfig, error) {
 			lc.Caching.CacheDirectory = filepath.Join(filepath.Dir(fileName), lc.Caching.CacheDirectory)
 		}
 
-		// override cache directory from the environment variable.
-		if cd := os.Getenv("KOPIA_CACHE_DIRECTORY"); cd != "" && ospath.IsAbs(cd) {
+		// override cache directory from the environment variable when caching is enabled.
+		if cd := os.Getenv("KOPIA_CACHE_DIRECTORY"); lc.Caching.ContentCacheSizeBytes > 0 && cd != "" && ospath.IsAbs(cd) {
 			lc.Caching.CacheDirectory = cd
 		}
 	}

--- a/repo/local_config_test.go
+++ b/repo/local_config_test.go
@@ -60,6 +60,46 @@ func TestLocalConfig_noCaching(t *testing.T) {
 	}
 }
 
+func TestLocalConfig_disabledCachingIgnoresEnvCacheDirectory(t *testing.T) {
+	td := testutil.TempDirectory(t)
+	cacheDir := filepath.Join(td, "env-cache")
+	t.Setenv("KOPIA_CACHE_DIRECTORY", cacheDir)
+
+	originalLC := &LocalConfig{
+		Caching: &content.CachingOptions{},
+	}
+
+	cfgFile := filepath.Join(td, "repository.config")
+	require.NoError(t, originalLC.writeToFile(cfgFile))
+
+	loadedLC, err := LoadConfigFromFile(cfgFile)
+	require.NoError(t, err)
+
+	require.NotNil(t, loadedLC.Caching)
+	require.Empty(t, loadedLC.Caching.CacheDirectory)
+}
+
+func TestLocalConfig_enabledCachingUsesEnvCacheDirectory(t *testing.T) {
+	td := testutil.TempDirectory(t)
+	cacheDir := filepath.Join(td, "env-cache")
+	t.Setenv("KOPIA_CACHE_DIRECTORY", cacheDir)
+
+	originalLC := &LocalConfig{
+		Caching: &content.CachingOptions{
+			CacheDirectory:        filepath.Join(td, "cache-dir"),
+			ContentCacheSizeBytes: 1,
+		},
+	}
+
+	cfgFile := filepath.Join(td, "repository.config")
+	require.NoError(t, originalLC.writeToFile(cfgFile))
+
+	loadedLC, err := LoadConfigFromFile(cfgFile)
+	require.NoError(t, err)
+
+	require.Equal(t, cacheDir, loadedLC.Caching.CacheDirectory)
+}
+
 func TestLocalConfig_notFound(t *testing.T) {
 	if _, err := LoadConfigFromFile("nosuchfile.json"); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("unexpected error %v: wanted ErrNotExist", err)


### PR DESCRIPTION
## Summary

Fixes #5406.

When repository caching is disabled, the local config stores `caching: {}`. `LoadConfigFromFile` still applied `KOPIA_CACHE_DIRECTORY` to that empty caching block, which turned a disabled cache into a disk-cache path with zero cache sizes. This keeps the env cache directory override only for configs with caching enabled, while preserving the override for nonzero content cache sizes.

AI assistance was used while preparing this patch. I reviewed the final change and tests.

## Tests

- `go test ./repo -run TestLocalConfig_disabledCachingIgnoresEnvCacheDirectory -count=1` failed before the fix
- `go test ./repo -run 'TestLocalConfig' -count=1`\n- `go test ./repo -count=1`\n- `git diff --check`