### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.6
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.14.0
-	github.com/kopia/htmluibuild v0.0.1-0.20260521013841-3c52622ae393
+	github.com/kopia/htmluibuild v0.0.1-0.20260608231842-7bf9fcc0831d
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/minio/minio-go/v7 v7.2.0

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.14.0 h1:5YSZeclzSYg5nl349+GDG/agDtQ6MZiwUYXvVKN1Jx0=
 github.com/klauspost/reedsolomon v1.14.0/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
-github.com/kopia/htmluibuild v0.0.1-0.20260521013841-3c52622ae393 h1:wJ2Zjf+FVsWHb26/Y1fMsNH9SQTKGPpZg88p7RtzwiA=
-github.com/kopia/htmluibuild v0.0.1-0.20260521013841-3c52622ae393/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260608231842-7bf9fcc0831d h1:2nHZuoDenhCDeIdDnQXLaaMziiHfIjf+INorIIUVNk8=
+github.com/kopia/htmluibuild v0.0.1-0.20260608231842-7bf9fcc0831d/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/0c063c03936efd4433e4f97e1328549cfe35b91b...e9f6ace72ea3a9edd4f8526e133885afa33c42e7

* Wed May 20 18:37 https://github.com/kopia/htmlui/commit/dc22114 dependabot[bot] build(deps-dev): bump axios from 1.15.0 to 1.16.0
* 8 minutes ago https://github.com/kopia/htmlui/commit/e9f6ace dependabot[bot] build(deps): bump react-router and react-router-dom

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Mon Jun  8 23:21:48 UTC 2026*
