### PR TITLE
refactor(repository): prevent using `WriteBuffer` after it is closed

### DIFF
--- a/internal/cache/content_cache_test.go
+++ b/internal/cache/content_cache_test.go
@@ -226,10 +226,10 @@ func verifyContentCache(t *testing.T, cc cache.ContentCache, cacheStorage cache.
 		require.NoError(t, cacheStorage.GetBlob(ctx, cacheKey, 0, -1, &tmp))
 
 		// corrupt the data and write back
-		b := tmp.Bytes()
-		b.Slices[0][0] ^= 1
+		b := tmp.Bytes().ToByteSlice()
+		b[0] ^= 1
 
-		require.NoError(t, cacheStorage.PutBlob(ctx, cacheKey, b, blob.PutOptions{}))
+		require.NoError(t, cacheStorage.PutBlob(ctx, cacheKey, gather.FromSlice(b), blob.PutOptions{}))
 
 		err := cc.GetContent(ctx, "xf0f0f1", "content-1", 1, 5, &tmp)
 		require.NoError(t, err, "error in getContent")

--- a/internal/gather/gather_bytes.go
+++ b/internal/gather/gather_bytes.go
@@ -21,7 +21,7 @@ var (
 //
 //nolint:recvcheck
 type Bytes struct {
-	Slices [][]byte
+	slices [][]byte
 
 	// for common case where there's one slice, store the slice itself here
 	// to avoid allocation
@@ -30,7 +30,7 @@ type Bytes struct {
 
 func (b *Bytes) invalidate() {
 	b.sliceBuf[0] = invalidSliceBuf
-	b.Slices = nil
+	b.slices = nil
 }
 
 func (b *Bytes) assertValid() {
@@ -50,7 +50,7 @@ func (b *Bytes) AppendSectionTo(w io.Writer, offset, size int) error {
 	// find the index of starting slice
 	sliceNdx := -1
 
-	for i, bs := range b.Slices {
+	for i, bs := range b.slices {
 		if offset < len(bs) {
 			sliceNdx = i
 			break
@@ -66,14 +66,14 @@ func (b *Bytes) AppendSectionTo(w io.Writer, offset, size int) error {
 
 	// first slice, possibly with offset zero
 	var firstChunkSize int
-	if offset+size <= len(b.Slices[sliceNdx]) {
+	if offset+size <= len(b.slices[sliceNdx]) {
 		firstChunkSize = size
 	} else {
 		// slice shorter
-		firstChunkSize = len(b.Slices[sliceNdx]) - offset
+		firstChunkSize = len(b.slices[sliceNdx]) - offset
 	}
 
-	if _, err := w.Write(b.Slices[sliceNdx][offset : offset+firstChunkSize]); err != nil {
+	if _, err := w.Write(b.slices[sliceNdx][offset : offset+firstChunkSize]); err != nil {
 		return errors.Wrap(err, "error appending")
 	}
 
@@ -81,8 +81,8 @@ func (b *Bytes) AppendSectionTo(w io.Writer, offset, size int) error {
 	sliceNdx++
 
 	// at this point we're staying at offset 0
-	for size > 0 && sliceNdx < len(b.Slices) {
-		s := b.Slices[sliceNdx]
+	for size > 0 && sliceNdx < len(b.slices) {
+		s := b.slices[sliceNdx]
 
 		// l is how many bytes we consume out of the current slice
 		l := min(size, len(s))
@@ -104,7 +104,7 @@ func (b Bytes) Length() int {
 
 	l := 0
 
-	for _, data := range b.Slices {
+	for _, data := range b.slices {
 		l += len(data)
 	}
 
@@ -127,7 +127,7 @@ func (b *bytesReadSeekCloser) ReadAt(bs []byte, off int64) (int, error) {
 	b.b.assertValid()
 	// cache "b.b.Slices" - slice parameters will stay constant for duration of
 	// function.  Locking is left to the calling function
-	slices := b.b.Slices
+	slices := b.b.slices
 
 	// source data that is read will be written to w, the buffer backed by p.
 	offset := off
@@ -255,7 +255,7 @@ func (b Bytes) Reader() io.ReadSeekCloser {
 func (b Bytes) AppendToSlice(output []byte) []byte {
 	b.assertValid()
 
-	for _, v := range b.Slices {
+	for _, v := range b.slices {
 		output = append(output, v...)
 	}
 
@@ -275,7 +275,7 @@ func (b Bytes) WriteTo(w io.Writer) (int64, error) {
 
 	var totalN int64
 
-	for _, v := range b.Slices {
+	for _, v := range b.slices {
 		n, err := w.Write(v)
 
 		totalN += int64(n)
@@ -294,7 +294,7 @@ func FromSlice(b []byte) Bytes {
 	var r Bytes
 
 	r.sliceBuf[0] = b
-	r.Slices = r.sliceBuf[:]
+	r.slices = r.sliceBuf[:]
 
 	return r
 }

--- a/internal/gather/gather_bytes.go
+++ b/internal/gather/gather_bytes.go
@@ -39,7 +39,7 @@ func (b *Bytes) assertValid() {
 	}
 }
 
-// AppendSectionTo writes the section of the buffer to the provided writer.
+// AppendSectionTo writes the section of the buffer to w.
 func (b *Bytes) AppendSectionTo(w io.Writer, offset, size int) error {
 	b.assertValid()
 

--- a/internal/gather/gather_bytes.go
+++ b/internal/gather/gather_bytes.go
@@ -21,7 +21,7 @@ var (
 //
 //nolint:recvcheck
 type Bytes struct {
-	Slices [][]byte
+	slices [][]byte
 
 	// for common case where there's one slice, store the slice itself here
 	// to avoid allocation
@@ -30,7 +30,7 @@ type Bytes struct {
 
 func (b *Bytes) invalidate() {
 	b.sliceBuf[0] = invalidSliceBuf
-	b.Slices = nil
+	b.slices = nil
 }
 
 func (b *Bytes) assertValid() {
@@ -50,7 +50,7 @@ func (b *Bytes) AppendSectionTo(w io.Writer, offset, size int) error {
 	// find the index of starting slice
 	sliceNdx := -1
 
-	for i, bs := range b.Slices {
+	for i, bs := range b.slices {
 		if offset < len(bs) {
 			sliceNdx = i
 			break
@@ -66,14 +66,14 @@ func (b *Bytes) AppendSectionTo(w io.Writer, offset, size int) error {
 
 	// first slice, possibly with offset zero
 	var firstChunkSize int
-	if offset+size <= len(b.Slices[sliceNdx]) {
+	if offset+size <= len(b.slices[sliceNdx]) {
 		firstChunkSize = size
 	} else {
 		// slice shorter
-		firstChunkSize = len(b.Slices[sliceNdx]) - offset
+		firstChunkSize = len(b.slices[sliceNdx]) - offset
 	}
 
-	if _, err := w.Write(b.Slices[sliceNdx][offset : offset+firstChunkSize]); err != nil {
+	if _, err := w.Write(b.slices[sliceNdx][offset : offset+firstChunkSize]); err != nil {
 		return errors.Wrap(err, "error appending")
 	}
 
@@ -81,8 +81,8 @@ func (b *Bytes) AppendSectionTo(w io.Writer, offset, size int) error {
 	sliceNdx++
 
 	// at this point we're staying at offset 0
-	for size > 0 && sliceNdx < len(b.Slices) {
-		s := b.Slices[sliceNdx]
+	for size > 0 && sliceNdx < len(b.slices) {
+		s := b.slices[sliceNdx]
 
 		// l is how many bytes we consume out of the current slice
 		l := min(size, len(s))
@@ -104,7 +104,7 @@ func (b Bytes) Length() int {
 
 	l := 0
 
-	for _, data := range b.Slices {
+	for _, data := range b.slices {
 		l += len(data)
 	}
 
@@ -125,9 +125,9 @@ type bytesReadSeekCloser struct {
 
 func (b *bytesReadSeekCloser) ReadAt(bs []byte, off int64) (int, error) {
 	b.b.assertValid()
-	// cache "b.b.Slices" - slice parameters will stay constant for duration of
+	// cache "b.b.slices" - slice parameters will stay constant for duration of
 	// function.  Locking is left to the calling function
-	slices := b.b.Slices
+	slices := b.b.slices
 
 	// source data that is read will be written to w, the buffer backed by p.
 	offset := off
@@ -255,7 +255,7 @@ func (b Bytes) Reader() io.ReadSeekCloser {
 func (b Bytes) AppendToSlice(output []byte) []byte {
 	b.assertValid()
 
-	for _, v := range b.Slices {
+	for _, v := range b.slices {
 		output = append(output, v...)
 	}
 
@@ -275,7 +275,7 @@ func (b Bytes) WriteTo(w io.Writer) (int64, error) {
 
 	var totalN int64
 
-	for _, v := range b.Slices {
+	for _, v := range b.slices {
 		n, err := w.Write(v)
 
 		totalN += int64(n)
@@ -294,7 +294,7 @@ func FromSlice(b []byte) Bytes {
 	var r Bytes
 
 	r.sliceBuf[0] = b
-	r.Slices = r.sliceBuf[:]
+	r.slices = r.sliceBuf[:]
 
 	return r
 }

--- a/internal/gather/gather_bytes_test.go
+++ b/internal/gather/gather_bytes_test.go
@@ -36,13 +36,13 @@ func TestGatherBytes(t *testing.T) {
 		},
 		{
 			whole: []byte{},
-			sliced: Bytes{Slices: [][]byte{
+			sliced: Bytes{slices: [][]byte{
 				nil,
 			}},
 		},
 		{
 			whole: []byte{},
-			sliced: Bytes{Slices: [][]byte{
+			sliced: Bytes{slices: [][]byte{
 				nil,
 				{},
 				nil,
@@ -54,7 +54,7 @@ func TestGatherBytes(t *testing.T) {
 		},
 		{
 			whole: sample1,
-			sliced: Bytes{Slices: [][]byte{
+			sliced: Bytes{slices: [][]byte{
 				nil,
 				sample1,
 				nil,
@@ -62,14 +62,14 @@ func TestGatherBytes(t *testing.T) {
 		},
 		{
 			whole: sample1,
-			sliced: Bytes{Slices: [][]byte{
+			sliced: Bytes{slices: [][]byte{
 				sample1[0:20],
 				sample1[20:],
 			}},
 		},
 		{
 			whole: sample1,
-			sliced: Bytes{Slices: [][]byte{
+			sliced: Bytes{slices: [][]byte{
 				sample1[0:20],
 				nil, // zero-length
 				{},  // zero-length
@@ -78,7 +78,7 @@ func TestGatherBytes(t *testing.T) {
 		},
 		{
 			whole: sample1,
-			sliced: Bytes{Slices: [][]byte{
+			sliced: Bytes{slices: [][]byte{
 				sample1[0:10],
 				sample1[10:25],
 				sample1[25:30],

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -12,9 +12,10 @@ var log = logging.Module("gather") // +checklocksignore
 // WriteBuffer is a write buffer for content of unknown size that manages
 // data in a series of byte slices of uniform size.
 type WriteBuffer struct {
-	alloc *chunkAllocator
-	mu    sync.Mutex
-	inner Bytes
+	alloc  *chunkAllocator
+	mu     sync.Mutex
+	inner  Bytes
+	closed bool
 }
 
 // Close releases all memory allocated by this buffer.
@@ -22,8 +23,11 @@ func (b *WriteBuffer) Close() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.checkNotClosedLocked()
 	b.releaseChunksLocked()
 	b.inner.invalidate()
+
+	b.closed = true
 }
 
 // MakeContiguous ensures the write buffer consists of exactly one contiguous single slice of the provided length
@@ -32,6 +36,7 @@ func (b *WriteBuffer) MakeContiguous(length int) []byte {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.checkNotClosedLocked()
 	b.releaseChunksLocked()
 
 	var v []byte
@@ -60,6 +65,7 @@ func (b *WriteBuffer) Reset() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.checkNotClosedLocked()
 	b.releaseChunksLocked()
 }
 
@@ -87,6 +93,8 @@ func (b *WriteBuffer) AppendSectionTo(w io.Writer, offset, size int) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.checkNotClosedLocked()
+
 	return b.inner.AppendSectionTo(w, offset, size)
 }
 
@@ -95,6 +103,8 @@ func (b *WriteBuffer) Length() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.checkNotClosedLocked()
+
 	return b.inner.Length()
 }
 
@@ -102,6 +112,8 @@ func (b *WriteBuffer) Length() int {
 func (b *WriteBuffer) ToByteSlice() []byte {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	b.checkNotClosedLocked()
 
 	return b.inner.ToByteSlice()
 }
@@ -114,6 +126,8 @@ func (b *WriteBuffer) Bytes() Bytes {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.checkNotClosedLocked()
+
 	return b.inner
 }
 
@@ -122,6 +136,7 @@ func (b *WriteBuffer) Append(data []byte) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.checkNotClosedLocked()
 	b.inner.assertValid()
 
 	if len(b.inner.slices) == 0 {
@@ -143,6 +158,13 @@ func (b *WriteBuffer) Append(data []byte) {
 
 		b.inner.slices[ndx] = append(b.inner.slices[ndx], data[0:chunkSize]...)
 		data = data[chunkSize:]
+	}
+}
+
+func (b *WriteBuffer) checkNotClosedLocked() {
+	if b.closed {
+		// programming error, thus panic
+		panic("WriteBuffer already closed")
 	}
 }
 

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -158,19 +158,6 @@ func (b *WriteBuffer) allocChunk() []byte {
 	return b.alloc.allocChunk()
 }
 
-// Dup creates a clone of the WriteBuffer.
-func (b *WriteBuffer) Dup() *WriteBuffer {
-	dup := &WriteBuffer{}
-
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	dup.alloc = b.alloc
-	dup.inner = FromSlice(b.inner.ToByteSlice())
-
-	return dup
-}
-
 // NewWriteBuffer creates new write buffer.
 func NewWriteBuffer() *WriteBuffer {
 	return &WriteBuffer{}

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -73,10 +73,9 @@ func (b *WriteBuffer) Reset() {
 		}
 	}
 
-	b.inner.invalidate()
-
 	b.alloc = nil
 
+	// calling b.inner.invalidate() is ineffective because it is reset below
 	b.inner = Bytes{}
 }
 

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -22,24 +22,17 @@ func (b *WriteBuffer) Close() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if b.alloc != nil {
-		for _, s := range b.inner.slices {
-			b.alloc.releaseChunk(s)
-		}
-
-		b.alloc = nil
-	}
-
+	b.releaseChunksLocked()
 	b.inner.invalidate()
 }
 
 // MakeContiguous ensures the write buffer consists of exactly one contiguous single slice of the provided length
 // and returns the slice.
 func (b *WriteBuffer) MakeContiguous(length int) []byte {
-	b.Reset()
-
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	b.releaseChunksLocked()
 
 	var v []byte
 
@@ -67,6 +60,10 @@ func (b *WriteBuffer) Reset() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.releaseChunksLocked()
+}
+
+func (b *WriteBuffer) releaseChunksLocked() {
 	if b.alloc != nil {
 		for _, s := range b.inner.slices {
 			b.alloc.releaseChunk(s)

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -73,11 +73,9 @@ func (b *WriteBuffer) Reset() {
 		}
 	}
 
-	b.inner.invalidate()
-
-	b.alloc = nil
-
+	// calling b.inner.invalidate() is innefective because it is reset below
 	b.inner = Bytes{}
+	b.alloc = nil
 }
 
 // Write implements io.Writer for appending to the buffer.

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -86,7 +86,7 @@ func (b *WriteBuffer) Write(data []byte) (n int, err error) {
 	return len(data), nil
 }
 
-// AppendSectionTo appends the section of the buffer to the provided slice and returns it.
+// AppendSectionTo appends the section of the buffer to the provided writer.
 func (b *WriteBuffer) AppendSectionTo(w io.Writer, offset, size int) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -102,7 +102,7 @@ func (b *WriteBuffer) Length() int {
 	return b.inner.Length()
 }
 
-// ToByteSlice appends all bytes to the provided slice and returns it.
+// ToByteSlice returns contents as a newly-allocated byte slice.
 func (b *WriteBuffer) ToByteSlice() []byte {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -111,6 +111,9 @@ func (b *WriteBuffer) ToByteSlice() []byte {
 }
 
 // Bytes returns inner gather.Bytes.
+// Notice: Use with caution, the returned Bytes are not concurrency safe.
+// A routine reading from the returned Bytes may or may not observe a
+// concurrent modification in this WriteBuffer.
 func (b *WriteBuffer) Bytes() Bytes {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -23,7 +23,7 @@ func (b *WriteBuffer) Close() {
 	defer b.mu.Unlock()
 
 	if b.alloc != nil {
-		for _, s := range b.inner.Slices {
+		for _, s := range b.inner.slices {
 			b.alloc.releaseChunk(s)
 		}
 
@@ -57,7 +57,7 @@ func (b *WriteBuffer) MakeContiguous(length int) []byte {
 		v = make([]byte, length)
 	}
 
-	b.inner.Slices = [][]byte{v}
+	b.inner.slices = [][]byte{v}
 
 	return v
 }
@@ -68,7 +68,7 @@ func (b *WriteBuffer) Reset() {
 	defer b.mu.Unlock()
 
 	if b.alloc != nil {
-		for _, s := range b.inner.Slices {
+		for _, s := range b.inner.slices {
 			b.alloc.releaseChunk(s)
 		}
 	}
@@ -128,24 +128,24 @@ func (b *WriteBuffer) Append(data []byte) {
 
 	b.inner.assertValid()
 
-	if len(b.inner.Slices) == 0 {
+	if len(b.inner.slices) == 0 {
 		b.inner.sliceBuf[0] = b.allocChunk()
-		b.inner.Slices = b.inner.sliceBuf[0:1]
+		b.inner.slices = b.inner.sliceBuf[0:1]
 	}
 
 	for len(data) > 0 {
-		ndx := len(b.inner.Slices) - 1
-		remaining := cap(b.inner.Slices[ndx]) - len(b.inner.Slices[ndx])
+		ndx := len(b.inner.slices) - 1
+		remaining := cap(b.inner.slices[ndx]) - len(b.inner.slices[ndx])
 
 		if remaining == 0 {
-			b.inner.Slices = append(b.inner.Slices, b.allocChunk())
-			ndx = len(b.inner.Slices) - 1
-			remaining = cap(b.inner.Slices[ndx]) - len(b.inner.Slices[ndx])
+			b.inner.slices = append(b.inner.slices, b.allocChunk())
+			ndx = len(b.inner.slices) - 1
+			remaining = cap(b.inner.slices[ndx]) - len(b.inner.slices[ndx])
 		}
 
 		chunkSize := min(remaining, len(data))
 
-		b.inner.Slices[ndx] = append(b.inner.Slices[ndx], data[0:chunkSize]...)
+		b.inner.slices[ndx] = append(b.inner.slices[ndx], data[0:chunkSize]...)
 		data = data[chunkSize:]
 	}
 }

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -86,7 +86,7 @@ func (b *WriteBuffer) Write(data []byte) (n int, err error) {
 	return len(data), nil
 }
 
-// AppendSectionTo appends the section of the buffer to the provided slice and returns it.
+// AppendSectionTo appends the section of the buffer to the provided writer.
 func (b *WriteBuffer) AppendSectionTo(w io.Writer, offset, size int) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -102,7 +102,7 @@ func (b *WriteBuffer) Length() int {
 	return b.inner.Length()
 }
 
-// ToByteSlice appends all bytes to the provided slice and returns it.
+// ToByteSlice returns contents as a newly-allocated byte slice.
 func (b *WriteBuffer) ToByteSlice() []byte {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -111,6 +111,9 @@ func (b *WriteBuffer) ToByteSlice() []byte {
 }
 
 // Bytes returns inner gather.Bytes.
+// Note: Use with caution, the returned Bytes are not concurrency safe.
+// A goroutine reading from the returned Bytes may or may not observe a
+// concurrent modification in this WriteBuffer.
 func (b *WriteBuffer) Bytes() Bytes {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -40,11 +40,11 @@ func (b *WriteBuffer) MakeContiguous(length int) []byte {
 	case length <= typicalContiguousAllocator.chunkSize:
 		// most commonly used allocator for default chunk size with max 8MB
 		b.alloc = typicalContiguousAllocator
-		v = b.allocChunk()[0:length]
+		v = b.allocChunkLocked()[0:length]
 
 	case length <= maxContiguousAllocator.chunkSize:
 		b.alloc = maxContiguousAllocator
-		v = b.allocChunk()[0:length]
+		v = b.allocChunkLocked()[0:length]
 
 	default:
 		v = make([]byte, length)
@@ -125,7 +125,7 @@ func (b *WriteBuffer) Append(data []byte) {
 	b.inner.assertValid()
 
 	if len(b.inner.slices) == 0 {
-		b.inner.sliceBuf[0] = b.allocChunk()
+		b.inner.sliceBuf[0] = b.allocChunkLocked()
 		b.inner.slices = b.inner.sliceBuf[0:1]
 	}
 
@@ -134,7 +134,7 @@ func (b *WriteBuffer) Append(data []byte) {
 		remaining := cap(b.inner.slices[ndx]) - len(b.inner.slices[ndx])
 
 		if remaining == 0 {
-			b.inner.slices = append(b.inner.slices, b.allocChunk())
+			b.inner.slices = append(b.inner.slices, b.allocChunkLocked())
 			ndx = len(b.inner.slices) - 1
 			remaining = cap(b.inner.slices[ndx]) - len(b.inner.slices[ndx])
 		}
@@ -146,7 +146,7 @@ func (b *WriteBuffer) Append(data []byte) {
 	}
 }
 
-func (b *WriteBuffer) allocChunk() []byte {
+func (b *WriteBuffer) allocChunkLocked() []byte {
 	if b.alloc == nil {
 		b.alloc = defaultAllocator
 	}

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -22,24 +22,17 @@ func (b *WriteBuffer) Close() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if b.alloc != nil {
-		for _, s := range b.inner.slices {
-			b.alloc.releaseChunk(s)
-		}
-
-		b.alloc = nil
-	}
-
+	b.releaseChunksLocked()
 	b.inner.invalidate()
 }
 
 // MakeContiguous ensures the write buffer consists of exactly one contiguous single slice of the provided length
 // and returns the slice.
 func (b *WriteBuffer) MakeContiguous(length int) []byte {
-	b.Reset()
-
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	b.releaseChunksLocked()
 
 	var v []byte
 
@@ -67,15 +60,20 @@ func (b *WriteBuffer) Reset() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.releaseChunksLocked()
+}
+
+func (b *WriteBuffer) releaseChunksLocked() {
 	if b.alloc != nil {
 		for _, s := range b.inner.slices {
 			b.alloc.releaseChunk(s)
 		}
 	}
 
+	b.alloc = nil
+
 	// calling b.inner.invalidate() is innefective because it is reset below
 	b.inner = Bytes{}
-	b.alloc = nil
 }
 
 // Write implements io.Writer for appending to the buffer.

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -14,6 +14,7 @@ var log = logging.Module("gather") // +checklocksignore
 type WriteBuffer struct {
 	alloc *chunkAllocator
 	mu    sync.Mutex
+	// +checklocks:mu
 	inner Bytes
 }
 
@@ -63,6 +64,7 @@ func (b *WriteBuffer) Reset() {
 	b.releaseChunksLocked()
 }
 
+// +checklocks:b.mu
 func (b *WriteBuffer) releaseChunksLocked() {
 	if b.alloc != nil {
 		for _, s := range b.inner.slices {
@@ -146,6 +148,7 @@ func (b *WriteBuffer) Append(data []byte) {
 	}
 }
 
+// +checklocks:b.mu
 func (b *WriteBuffer) allocChunkLocked() []byte {
 	if b.alloc == nil {
 		b.alloc = defaultAllocator

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -12,8 +12,9 @@ var log = logging.Module("gather") // +checklocksignore
 // WriteBuffer is a write buffer for content of unknown size that manages
 // data in a series of byte slices of uniform size.
 type WriteBuffer struct {
+	mu sync.Mutex
+	// +checklocks:mu
 	alloc *chunkAllocator
-	mu    sync.Mutex
 	// +checklocks:mu
 	inner Bytes
 }

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -125,6 +125,11 @@ func (b *WriteBuffer) Append(data []byte) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.appendLocked(data)
+}
+
+// +checklocks:b.mu
+func (b *WriteBuffer) appendLocked(data []byte) {
 	b.inner.assertValid()
 
 	if len(b.inner.slices) == 0 {

--- a/internal/gather/gather_write_buffer.go
+++ b/internal/gather/gather_write_buffer.go
@@ -75,8 +75,7 @@ func (b *WriteBuffer) releaseChunksLocked() {
 
 	b.alloc = nil
 
-	// calling b.inner.invalidate() is ineffective because it is reset below
-	b.inner = Bytes{}
+	b.inner.invalidate()
 }
 
 // Write implements io.Writer for appending to the buffer.

--- a/internal/gather/gather_write_buffer_test.go
+++ b/internal/gather/gather_write_buffer_test.go
@@ -26,7 +26,7 @@ func TestGatherWriteBuffer(t *testing.T) {
 		t.Errorf("invaldi bytes %v, want %v", string(got), string(want))
 	}
 
-	if got, want := len(w.inner.Slices), 1; got != want {
+	if got, want := len(w.inner.slices), 1; got != want {
 		t.Errorf("invalid number of slices %v, want %v", got, want)
 	}
 
@@ -37,7 +37,7 @@ func TestGatherWriteBuffer(t *testing.T) {
 	}
 
 	// one more slice was allocated
-	if got, want := len(w.inner.Slices), 2; got != want {
+	if got, want := len(w.inner.slices), 2; got != want {
 		t.Errorf("invalid number of slices %v, want %v", got, want)
 	}
 
@@ -45,7 +45,7 @@ func TestGatherWriteBuffer(t *testing.T) {
 	w.Append(bytes.Repeat([]byte("x"), all.chunkSize-12))
 
 	// still 2 slices
-	if got, want := len(w.inner.Slices), 2; got != want {
+	if got, want := len(w.inner.slices), 2; got != want {
 		t.Errorf("invalid number of slices %v, want %v", got, want)
 	}
 
@@ -53,7 +53,7 @@ func TestGatherWriteBuffer(t *testing.T) {
 	w.Append([]byte("x"))
 
 	// still 3 slices
-	if got, want := len(w.inner.Slices), 3; got != want {
+	if got, want := len(w.inner.slices), 3; got != want {
 		t.Errorf("invalid number of slices %v, want %v", got, want)
 	}
 
@@ -72,7 +72,7 @@ func TestGatherDefaultWriteBuffer(t *testing.T) {
 	// one more byte allocates new slice
 	w.Append([]byte("x"))
 
-	if got, want := len(w.inner.Slices), 1; got != want {
+	if got, want := len(w.inner.slices), 1; got != want {
 		t.Errorf("invalid number of slices %v, want %v", got, want)
 	}
 }
@@ -118,7 +118,7 @@ func TestGatherWriteBufferMax(t *testing.T) {
 	}
 
 	// make sure we have 1 contiguous buffer
-	require.Len(t, b.Bytes().Slices, 1)
+	require.Len(t, b.Bytes().slices, 1)
 
 	// write 10Mx5 bytes
 	for range 10000000 {
@@ -126,5 +126,5 @@ func TestGatherWriteBufferMax(t *testing.T) {
 	}
 
 	// 51M requires 4x16MB buffers
-	require.Len(t, b.Bytes().Slices, 4)
+	require.Len(t, b.Bytes().slices, 4)
 }

--- a/internal/gather/gather_write_buffer_test.go
+++ b/internal/gather/gather_write_buffer_test.go
@@ -15,7 +15,7 @@ func TestGatherWriteBuffer(t *testing.T) {
 	}
 
 	w := NewWriteBuffer()
-	w.alloc = all
+	w.alloc = all // +checklocksignore
 
 	defer w.Close()
 
@@ -26,7 +26,7 @@ func TestGatherWriteBuffer(t *testing.T) {
 		t.Errorf("invaldi bytes %v, want %v", string(got), string(want))
 	}
 
-	if got, want := len(w.inner.slices), 1; got != want {
+	if got, want := len(w.Bytes().slices), 1; got != want {
 		t.Errorf("invalid number of slices %v, want %v", got, want)
 	}
 
@@ -37,7 +37,7 @@ func TestGatherWriteBuffer(t *testing.T) {
 	}
 
 	// one more slice was allocated
-	if got, want := len(w.inner.slices), 2; got != want {
+	if got, want := len(w.Bytes().slices), 2; got != want {
 		t.Errorf("invalid number of slices %v, want %v", got, want)
 	}
 
@@ -45,7 +45,7 @@ func TestGatherWriteBuffer(t *testing.T) {
 	w.Append(bytes.Repeat([]byte("x"), all.chunkSize-12))
 
 	// still 2 slices
-	if got, want := len(w.inner.slices), 2; got != want {
+	if got, want := len(w.Bytes().slices), 2; got != want {
 		t.Errorf("invalid number of slices %v, want %v", got, want)
 	}
 
@@ -53,7 +53,7 @@ func TestGatherWriteBuffer(t *testing.T) {
 	w.Append([]byte("x"))
 
 	// still 3 slices
-	if got, want := len(w.inner.slices), 3; got != want {
+	if got, want := len(w.Bytes().slices), 3; got != want {
 		t.Errorf("invalid number of slices %v, want %v", got, want)
 	}
 
@@ -72,7 +72,7 @@ func TestGatherDefaultWriteBuffer(t *testing.T) {
 	// one more byte allocates new slice
 	w.Append([]byte("x"))
 
-	if got, want := len(w.inner.slices), 1; got != want {
+	if got, want := len(w.Bytes().slices), 1; got != want {
 		t.Errorf("invalid number of slices %v, want %v", got, want)
 	}
 }

--- a/repo/encryption/encryption_test.go
+++ b/repo/encryption/encryption_test.go
@@ -86,10 +86,10 @@ func TestRoundTrip(t *testing.T) {
 			require.Error(t, e.Decrypt(cipherText2.Bytes(), contentID1, &plainText2))
 
 			// flip some bits in the cipherText
-			b := cipherText2.Bytes()
-			b.Slices[0][mathrand.Intn(b.Length())] ^= byte(1 + mathrand.Intn(254))
+			b := cipherText2.Bytes().ToByteSlice()
+			b[mathrand.Intn(len(b))] ^= byte(1 + mathrand.Intn(254))
 
-			require.Error(t, e.Decrypt(b, contentID1, &plainText2))
+			require.Error(t, e.Decrypt(gather.FromSlice(b), contentID1, &plainText2))
 		})
 	}
 }

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -421,21 +421,25 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 		"repository already initialized")
 
 	// backup blobcfg blob
-	{
+	func() {
+		var b gather.WriteBuffer
+		defer b.Close()
+
 		// backup & corrupt the blobcfg blob
-		d.Reset()
-		require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, format.KopiaBlobCfgBlobID, 0, -1, &d))
-		corruptedData := d.Dup()
-		corruptedData.Append([]byte("bad bits"))
-		require.NoError(t, env.RepositoryWriter.BlobStorage().PutBlob(ctx, format.KopiaBlobCfgBlobID, corruptedData.Bytes(), blob.PutOptions{}))
+		require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, format.KopiaBlobCfgBlobID, 0, -1, &b))
+
+		originalBlobCfg := b.ToByteSlice()
+
+		b.Append([]byte("bad bits"))
+		require.NoError(t, env.RepositoryWriter.BlobStorage().PutBlob(ctx, format.KopiaBlobCfgBlobID, b.Bytes(), blob.PutOptions{}))
 
 		// verify that we error out on corrupted blobcfg blob
 		_, err := repo.Open(ctx, env.ConfigFile(), env.Password, &repo.Options{})
 		require.ErrorContains(t, err, "invalid repository password")
 
 		// restore the original blob
-		require.NoError(t, env.RepositoryWriter.BlobStorage().PutBlob(ctx, format.KopiaBlobCfgBlobID, d.Bytes(), blob.PutOptions{}))
-	}
+		require.NoError(t, env.RepositoryWriter.BlobStorage().PutBlob(ctx, format.KopiaBlobCfgBlobID, gather.FromSlice(originalBlobCfg), blob.PutOptions{}))
+	}()
 
 	// verify that we'd hard-fail on unexpected errors on blobcfg blob-puts
 	// when creating a new repository

--- a/repo/repository_test.go
+++ b/repo/repository_test.go
@@ -423,21 +423,25 @@ func TestInitializeWithBlobCfgRetentionBlob(t *testing.T) {
 		"repository already initialized")
 
 	// backup blobcfg blob
-	{
+	func() {
+		var b gather.WriteBuffer
+		defer b.Close()
+
 		// backup & corrupt the blobcfg blob
-		d.Reset()
-		require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, format.KopiaBlobCfgBlobID, 0, -1, &d))
-		corruptedData := d.Dup()
-		corruptedData.Append([]byte("bad bits"))
-		require.NoError(t, env.RepositoryWriter.BlobStorage().PutBlob(ctx, format.KopiaBlobCfgBlobID, corruptedData.Bytes(), blob.PutOptions{}))
+		require.NoError(t, env.RepositoryWriter.BlobStorage().GetBlob(ctx, format.KopiaBlobCfgBlobID, 0, -1, &b))
+
+		originalBlobCfg := b.ToByteSlice()
+
+		b.Append([]byte("bad bits"))
+		require.NoError(t, env.RepositoryWriter.BlobStorage().PutBlob(ctx, format.KopiaBlobCfgBlobID, b.Bytes(), blob.PutOptions{}))
 
 		// verify that we error out on corrupted blobcfg blob
 		_, err := repo.Open(ctx, env.ConfigFile(), env.Password, &repo.Options{})
 		require.ErrorContains(t, err, "invalid repository password")
 
 		// restore the original blob
-		require.NoError(t, env.RepositoryWriter.BlobStorage().PutBlob(ctx, format.KopiaBlobCfgBlobID, d.Bytes(), blob.PutOptions{}))
-	}
+		require.NoError(t, env.RepositoryWriter.BlobStorage().PutBlob(ctx, format.KopiaBlobCfgBlobID, gather.FromSlice(originalBlobCfg), blob.PutOptions{}))
+	}()
 
 	// verify that we'd hard-fail on unexpected errors on blobcfg blob-puts
 	// when creating a new repository


### PR DESCRIPTION
- add mechanism for checking whether a `WriteBuffer` was already closed;
- refactor tests to remove reference to `gather.Bytes.Slices`;
- un-export `gather.Bytes.slices`;
- add `WriteBuffer.ReleaseChunksLocked()` helper;
- rename function to `WriteBuffer.allockChunkLocked()`;
- add comment about the safety of `WriteBuffer.Bytes()`.