### PR TITLE
refactor(testing): minor cleanups in epoch manager tests

### DIFF
--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -139,24 +139,33 @@ func makeSeq(base, start, end int) []int {
 
 func makeIndexBlob(
 	ctx context.Context,
+	tb testing.TB,
 	te *epochManagerTestEnv,
 	prefix blob.ID,
 	ndx *fakeIndex,
 ) {
+	tb.Helper()
+
 	blobID := blob.ID(fmt.Sprintf("%v%016x-s0-c1", prefix, rand.Int63()))
-	te.st.PutBlob(ctx, blobID, gather.FromSlice(ndx.Bytes()), blob.PutOptions{})
+	err := te.st.PutBlob(ctx, blobID, gather.FromSlice(ndx.Bytes()), blob.PutOptions{})
+
+	require.NoError(tb, err)
 }
 
 func makeUncompactedIndexBlobsForEpochs(
 	ctx context.Context,
+	tb testing.TB,
 	te *epochManagerTestEnv,
 	startEpoch int,
 	endEpoch int,
 	idxDataOffset int,
 ) {
+	tb.Helper()
+
 	for n := startEpoch; n <= endEpoch; n++ {
 		makeIndexBlob(
 			ctx,
+			tb,
 			te,
 			UncompactedEpochBlobPrefix(n),
 			newFakeIndexWithEntries(idxDataOffset+n),
@@ -166,14 +175,18 @@ func makeUncompactedIndexBlobsForEpochs(
 
 func makeSingleEpochCompactedIndexBlobsForEpochs(
 	ctx context.Context,
+	tb testing.TB,
 	te *epochManagerTestEnv,
 	startEpoch int,
 	endEpoch int,
 	idxDataOffset int, //nolint:unparam
 ) {
+	tb.Helper()
+
 	for n := startEpoch; n <= endEpoch; n++ {
 		makeIndexBlob(
 			ctx,
+			tb,
 			te,
 			compactedEpochBlobPrefix(n),
 			newFakeIndexWithEntries(idxDataOffset+n),
@@ -183,13 +196,17 @@ func makeSingleEpochCompactedIndexBlobsForEpochs(
 
 func makeRangeCheckpointIndexBlob(
 	ctx context.Context,
+	tb testing.TB,
 	te *epochManagerTestEnv,
 	minEpoch int,
 	maxEpoch int,
 	idxDataOffset int,
 ) {
+	tb.Helper()
+
 	makeIndexBlob(
 		ctx,
+		tb,
 		te,
 		rangeCheckpointBlobPrefix(minEpoch, maxEpoch),
 		newFakeIndexWithEntries(makeSeq(idxDataOffset, minEpoch, maxEpoch)...),
@@ -252,8 +269,8 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeRangeCheckpointIndexBlob(ctx, te, 0, 2, 400)
-				makeUncompactedIndexBlobsForEpochs(ctx, te, 3, 4, 300)
+				makeRangeCheckpointIndexBlob(ctx, tb, te, 0, 2, 400)
+				makeUncompactedIndexBlobsForEpochs(ctx, tb, te, 3, 4, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 4)
 			},
 			wantEntries: slices.Concat(
@@ -266,8 +283,8 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 0, 2, 100)
-				makeUncompactedIndexBlobsForEpochs(ctx, te, 3, 4, 300)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, tb, te, 0, 2, 100)
+				makeUncompactedIndexBlobsForEpochs(ctx, tb, te, 3, 4, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 4)
 			},
 			wantEntries: slices.Concat(
@@ -280,11 +297,11 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 0, 0, 100)
-				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 2, 2, 100)
-				makeUncompactedIndexBlobsForEpochs(ctx, te, 1, 1, 200)
-				makeUncompactedIndexBlobsForEpochs(ctx, te, 3, 3, 200)
-				makeUncompactedIndexBlobsForEpochs(ctx, te, 4, 5, 300)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, tb, te, 0, 0, 100)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, tb, te, 2, 2, 100)
+				makeUncompactedIndexBlobsForEpochs(ctx, tb, te, 1, 1, 200)
+				makeUncompactedIndexBlobsForEpochs(ctx, tb, te, 3, 3, 200)
+				makeUncompactedIndexBlobsForEpochs(ctx, tb, te, 4, 5, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 5)
 			},
 			wantEntries: []int{
@@ -298,9 +315,9 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeRangeCheckpointIndexBlob(ctx, te, 0, 2, 400)
-				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 3, 4, 100)
-				makeUncompactedIndexBlobsForEpochs(ctx, te, 5, 6, 300)
+				makeRangeCheckpointIndexBlob(ctx, tb, te, 0, 2, 400)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, tb, te, 3, 4, 100)
+				makeUncompactedIndexBlobsForEpochs(ctx, tb, te, 5, 6, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 6)
 			},
 			wantEntries: slices.Concat(
@@ -314,11 +331,11 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeRangeCheckpointIndexBlob(ctx, te, 0, 2, 400)
-				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 3, 3, 100)
-				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 5, 5, 100)
-				makeUncompactedIndexBlobsForEpochs(ctx, te, 4, 4, 200)
-				makeUncompactedIndexBlobsForEpochs(ctx, te, 6, 7, 300)
+				makeRangeCheckpointIndexBlob(ctx, tb, te, 0, 2, 400)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, tb, te, 3, 3, 100)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, tb, te, 5, 5, 100)
+				makeUncompactedIndexBlobsForEpochs(ctx, tb, te, 4, 4, 200)
+				makeUncompactedIndexBlobsForEpochs(ctx, tb, te, 6, 7, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 7)
 			},
 			wantEntries: []int{
@@ -333,8 +350,8 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeUncompactedIndexBlobsForEpochs(ctx, te, 0, 2, 200)
-				makeUncompactedIndexBlobsForEpochs(ctx, te, 3, 4, 300)
+				makeUncompactedIndexBlobsForEpochs(ctx, tb, te, 0, 2, 200)
+				makeUncompactedIndexBlobsForEpochs(ctx, tb, te, 3, 4, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 4)
 			},
 			wantEntries: slices.Concat(

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -254,7 +254,7 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 
 				makeRangeCheckpointBlob(ctx, te, 0, 2, 400)
 				makeUncompactedBlobsForEpochs(ctx, te, 3, 4, 300)
-				mustMakeWriteEpoch(ctx, t, te, 4)
+				mustMakeWriteEpoch(ctx, tb, te, 4)
 			},
 			wantEntries: slices.Concat(
 				makeSeq(400, 0, 2),
@@ -268,7 +268,7 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 
 				makeSingleEpochCompactedBlobsForEpochs(ctx, te, 0, 2, 100)
 				makeUncompactedBlobsForEpochs(ctx, te, 3, 4, 300)
-				mustMakeWriteEpoch(ctx, t, te, 4)
+				mustMakeWriteEpoch(ctx, tb, te, 4)
 			},
 			wantEntries: slices.Concat(
 				makeSeq(100, 0, 2),
@@ -285,7 +285,7 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 				makeUncompactedBlobsForEpochs(ctx, te, 1, 1, 200)
 				makeUncompactedBlobsForEpochs(ctx, te, 3, 3, 200)
 				makeUncompactedBlobsForEpochs(ctx, te, 4, 5, 300)
-				mustMakeWriteEpoch(ctx, t, te, 5)
+				mustMakeWriteEpoch(ctx, tb, te, 5)
 			},
 			wantEntries: []int{
 				100, 102,
@@ -301,7 +301,7 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 				makeRangeCheckpointBlob(ctx, te, 0, 2, 400)
 				makeSingleEpochCompactedBlobsForEpochs(ctx, te, 3, 4, 100)
 				makeUncompactedBlobsForEpochs(ctx, te, 5, 6, 300)
-				mustMakeWriteEpoch(ctx, t, te, 6)
+				mustMakeWriteEpoch(ctx, tb, te, 6)
 			},
 			wantEntries: slices.Concat(
 				makeSeq(400, 0, 2),
@@ -319,7 +319,7 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 				makeSingleEpochCompactedBlobsForEpochs(ctx, te, 5, 5, 100)
 				makeUncompactedBlobsForEpochs(ctx, te, 4, 4, 200)
 				makeUncompactedBlobsForEpochs(ctx, te, 6, 7, 300)
-				mustMakeWriteEpoch(ctx, t, te, 7)
+				mustMakeWriteEpoch(ctx, tb, te, 7)
 			},
 			wantEntries: []int{
 				400, 401, 402,
@@ -335,7 +335,7 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 
 				makeUncompactedBlobsForEpochs(ctx, te, 0, 2, 200)
 				makeUncompactedBlobsForEpochs(ctx, te, 3, 4, 300)
-				mustMakeWriteEpoch(ctx, t, te, 4)
+				mustMakeWriteEpoch(ctx, tb, te, 4)
 			},
 			wantEntries: slices.Concat(
 				makeSeq(200, 0, 2),

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -147,7 +147,7 @@ func makeIndexBlob(
 	te.st.PutBlob(ctx, blobID, gather.FromSlice(ndx.Bytes()), blob.PutOptions{})
 }
 
-func makeUncompactedBlobsForEpochs(
+func makeUncompactedIndexBlobsForEpochs(
 	ctx context.Context,
 	te *epochManagerTestEnv,
 	startEpoch int,
@@ -164,7 +164,7 @@ func makeUncompactedBlobsForEpochs(
 	}
 }
 
-func makeSingleEpochCompactedBlobsForEpochs(
+func makeSingleEpochCompactedIndexBlobsForEpochs(
 	ctx context.Context,
 	te *epochManagerTestEnv,
 	startEpoch int,
@@ -181,7 +181,7 @@ func makeSingleEpochCompactedBlobsForEpochs(
 	}
 }
 
-func makeRangeCheckpointBlob(
+func makeRangeCheckpointIndexBlob(
 	ctx context.Context,
 	te *epochManagerTestEnv,
 	minEpoch int,
@@ -252,8 +252,8 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeRangeCheckpointBlob(ctx, te, 0, 2, 400)
-				makeUncompactedBlobsForEpochs(ctx, te, 3, 4, 300)
+				makeRangeCheckpointIndexBlob(ctx, te, 0, 2, 400)
+				makeUncompactedIndexBlobsForEpochs(ctx, te, 3, 4, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 4)
 			},
 			wantEntries: slices.Concat(
@@ -266,8 +266,8 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeSingleEpochCompactedBlobsForEpochs(ctx, te, 0, 2, 100)
-				makeUncompactedBlobsForEpochs(ctx, te, 3, 4, 300)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 0, 2, 100)
+				makeUncompactedIndexBlobsForEpochs(ctx, te, 3, 4, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 4)
 			},
 			wantEntries: slices.Concat(
@@ -280,11 +280,11 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeSingleEpochCompactedBlobsForEpochs(ctx, te, 0, 0, 100)
-				makeSingleEpochCompactedBlobsForEpochs(ctx, te, 2, 2, 100)
-				makeUncompactedBlobsForEpochs(ctx, te, 1, 1, 200)
-				makeUncompactedBlobsForEpochs(ctx, te, 3, 3, 200)
-				makeUncompactedBlobsForEpochs(ctx, te, 4, 5, 300)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 0, 0, 100)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 2, 2, 100)
+				makeUncompactedIndexBlobsForEpochs(ctx, te, 1, 1, 200)
+				makeUncompactedIndexBlobsForEpochs(ctx, te, 3, 3, 200)
+				makeUncompactedIndexBlobsForEpochs(ctx, te, 4, 5, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 5)
 			},
 			wantEntries: []int{
@@ -298,9 +298,9 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeRangeCheckpointBlob(ctx, te, 0, 2, 400)
-				makeSingleEpochCompactedBlobsForEpochs(ctx, te, 3, 4, 100)
-				makeUncompactedBlobsForEpochs(ctx, te, 5, 6, 300)
+				makeRangeCheckpointIndexBlob(ctx, te, 0, 2, 400)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 3, 4, 100)
+				makeUncompactedIndexBlobsForEpochs(ctx, te, 5, 6, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 6)
 			},
 			wantEntries: slices.Concat(
@@ -314,11 +314,11 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeRangeCheckpointBlob(ctx, te, 0, 2, 400)
-				makeSingleEpochCompactedBlobsForEpochs(ctx, te, 3, 3, 100)
-				makeSingleEpochCompactedBlobsForEpochs(ctx, te, 5, 5, 100)
-				makeUncompactedBlobsForEpochs(ctx, te, 4, 4, 200)
-				makeUncompactedBlobsForEpochs(ctx, te, 6, 7, 300)
+				makeRangeCheckpointIndexBlob(ctx, te, 0, 2, 400)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 3, 3, 100)
+				makeSingleEpochCompactedIndexBlobsForEpochs(ctx, te, 5, 5, 100)
+				makeUncompactedIndexBlobsForEpochs(ctx, te, 4, 4, 200)
+				makeUncompactedIndexBlobsForEpochs(ctx, te, 6, 7, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 7)
 			},
 			wantEntries: []int{
@@ -333,8 +333,8 @@ func TestGetCompleteIndexSet_CoversAllEpochs(t *testing.T) {
 			initStorage: func(ctx context.Context, tb testing.TB, te *epochManagerTestEnv) {
 				tb.Helper()
 
-				makeUncompactedBlobsForEpochs(ctx, te, 0, 2, 200)
-				makeUncompactedBlobsForEpochs(ctx, te, 3, 4, 300)
+				makeUncompactedIndexBlobsForEpochs(ctx, te, 0, 2, 200)
+				makeUncompactedIndexBlobsForEpochs(ctx, te, 3, 4, 300)
 				mustMakeWriteEpoch(ctx, tb, te, 4)
 			},
 			wantEntries: slices.Concat(


### PR DESCRIPTION
- pass inner `*testing.TB` to helper
- nit: rename test helpers
- check for `PutBlob` error in test helper