### PR TITLE
feat(repository): support inline and file-based web identity tokens for S3 storage

### DIFF
--- a/repo/blob/s3/s3_options.go
+++ b/repo/blob/s3/s3_options.go
@@ -24,6 +24,11 @@ type Options struct {
 	SecretAccessKey string `json:"secretAccessKey" kopia:"sensitive"`
 	SessionToken    string `json:"sessionToken" kopia:"sensitive"`
 
+	// Used for web-identity (OIDC) authentication. When set, the role in RoleARN is
+	// assumed using a refreshing credential provider.
+	WebIdentityToken     string `json:"webIdentityToken,omitempty" kopia:"sensitive"`
+	WebIdentityTokenFile string `json:"webIdentityTokenFile,omitempty"`
+
 	// Used for assume role authentication.
 	RoleARN      string                `json:"roleARN"`
 	SessionName  string                `json:"sessionName"`

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -362,8 +363,24 @@ func newStorage(ctx context.Context, opt *Options) (*s3Storage, error) {
 		},
 	)
 
+	hasWebIdentity := opt.WebIdentityToken != "" || opt.WebIdentityTokenFile != ""
+	if opt.RoleARN != "" && hasWebIdentity {
+		var err error
+
+		creds, err = credentials.NewSTSWebIdentity(
+			opt.RoleEndpoint,
+			webIdentityTokenFetcher(opt),
+			func(i *credentials.STSWebIdentity) {
+				i.RoleARN = opt.RoleARN
+			},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting web identity credentials")
+		}
+	}
+
 	// If a role was specified, use the assume role credential provider
-	if opt.RoleARN != "" {
+	if opt.RoleARN != "" && !hasWebIdentity {
 		assumeRoleOpts := credentials.STSAssumeRoleOptions{
 			AccessKey:       opt.AccessKeyID,
 			SecretKey:       opt.SecretAccessKey,
@@ -386,6 +403,30 @@ func newStorage(ctx context.Context, opt *Options) (*s3Storage, error) {
 	}
 
 	return newStorageWithCredentials(ctx, creds, opt)
+}
+
+// webIdentityTokenFetcher returns a function that supplies the OIDC token used
+// for web-identity authentication. When WebIdentityTokenFile is set it is read
+// on each call (taking precedence over the inline WebIdentityToken) so that the
+// refreshing credential provider always sees the current token.
+func webIdentityTokenFetcher(opt *Options) func() (*credentials.WebIdentityToken, error) {
+	return func() (*credentials.WebIdentityToken, error) {
+		token := opt.WebIdentityToken
+
+		if opt.WebIdentityTokenFile != "" {
+			b, err := os.ReadFile(opt.WebIdentityTokenFile)
+			if err != nil {
+				return nil, errors.Wrap(err, "reading web identity token file")
+			}
+
+			token = string(b)
+		}
+
+		return &credentials.WebIdentityToken{
+			Token:  token,
+			Expiry: int(opt.RoleDuration.Seconds()),
+		}, nil
+	}
 }
 
 func newStorageWithCredentials(ctx context.Context, creds *credentials.Credentials, opt *Options) (*s3Storage, error) {

--- a/repo/blob/s3/s3_storage_test.go
+++ b/repo/blob/s3/s3_storage_test.go
@@ -55,6 +55,8 @@ const (
 	testSTSAccessKeyIDEnv     = "KOPIA_S3_TEST_STS_ACCESS_KEY_ID"
 	testSTSSecretAccessKeyEnv = "KOPIA_S3_TEST_STS_SECRET_ACCESS_KEY"
 	testSessionTokenEnv       = "KOPIA_S3_TEST_SESSION_TOKEN"
+	// path to an OIDC token file, needs to be set to execute TestS3StorageWebIdentity.
+	testWebIdentityTokenFileEnv = "KOPIA_S3_TEST_WEB_IDENTITY_TOKEN_FILE"
 
 	expiredBadSSL       = "https://expired.badssl.com/"
 	selfSignedBadSSL    = "https://self-signed.badssl.com/"
@@ -339,6 +341,113 @@ func TestTokenExpiration(t *testing.T) {
 	creds.Expire()
 	customProvider.forceExpired.Store(false)
 	verifyBlobNotFoundForGetBlob(ctx, t, rst)
+}
+
+func TestWebIdentityTokenFetcher(t *testing.T) {
+	t.Parallel()
+
+	const (
+		inlineToken = "inline-token-value"
+		fileToken   = "file-token-value"
+	)
+
+	dir := testutil.TempDirectory(t)
+	tokenFile := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte(fileToken), 0o600))
+
+	t.Run("inline token", func(t *testing.T) {
+		fetch := webIdentityTokenFetcher(&Options{
+			WebIdentityToken: inlineToken,
+			RoleDuration:     jsonencoding.Duration{Duration: 15 * time.Minute},
+		})
+
+		tok, err := fetch()
+		require.NoError(t, err)
+		require.Equal(t, inlineToken, tok.Token)
+		require.Equal(t, int((15 * time.Minute).Seconds()), tok.Expiry)
+	})
+
+	t.Run("token file is read", func(t *testing.T) {
+		fetch := webIdentityTokenFetcher(&Options{
+			WebIdentityTokenFile: tokenFile,
+		})
+
+		tok, err := fetch()
+		require.NoError(t, err)
+		require.Equal(t, fileToken, tok.Token)
+	})
+
+	t.Run("token file takes precedence over inline token", func(t *testing.T) {
+		fetch := webIdentityTokenFetcher(&Options{
+			WebIdentityToken:     inlineToken,
+			WebIdentityTokenFile: tokenFile,
+		})
+
+		tok, err := fetch()
+		require.NoError(t, err)
+		require.Equal(t, fileToken, tok.Token)
+	})
+
+	t.Run("missing token file returns error", func(t *testing.T) {
+		fetch := webIdentityTokenFetcher(&Options{
+			WebIdentityTokenFile: filepath.Join(dir, "does-not-exist"),
+		})
+
+		_, err := fetch()
+		require.Error(t, err)
+	})
+}
+
+// TestS3StorageWebIdentity exercises the web-identity (OIDC) credential path
+// end-to-end against real AWS STS. It requires a role and a valid OIDC token
+// file; both the WebIdentityTokenFile and the inline WebIdentityToken variants
+// are covered.
+func TestS3StorageWebIdentity(t *testing.T) {
+	t.Parallel()
+
+	tokenFile := getEnvOrSkip(t, testWebIdentityTokenFileEnv)
+	roleARN := getEnvOrSkip(t, testRoleEnv)
+	bucket := getEnvOrSkip(t, testBucketEnv)
+	region := getEnvOrSkip(t, testRegionEnv)
+	endpoint := getEnv(testEndpointEnv, awsEndpoint)
+
+	// Web-identity credentials are temporary and typically lack permission to
+	// create buckets, so provision the bucket up front using static keys, the
+	// same way TestS3StorageAWSSTS does.
+	getOrCreateBucket(t, &Options{
+		Endpoint:        endpoint,
+		AccessKeyID:     getEnv(testAccessKeyIDEnv, ""),
+		SecretAccessKey: getEnv(testSecretAccessKeyEnv, ""),
+		BucketName:      bucket,
+		Region:          region,
+	})
+
+	t.Run("token file", func(t *testing.T) {
+		testStorage(t, &Options{
+			Endpoint:             endpoint,
+			BucketName:           bucket,
+			Region:               region,
+			RoleARN:              roleARN,
+			RoleEndpoint:         awsStsEndpointUSWest2,
+			WebIdentityTokenFile: tokenFile,
+			RoleDuration:         jsonencoding.Duration{Duration: 15 * time.Minute},
+		}, false, blob.PutOptions{})
+	})
+
+	t.Run("inline token", func(t *testing.T) {
+		token, err := os.ReadFile(tokenFile)
+		require.NoError(t, err)
+
+		testStorage(t, &Options{
+			Endpoint:         endpoint,
+			BucketName:       bucket,
+			Region:           region,
+			RoleARN:          roleARN,
+			RoleEndpoint:     awsStsEndpointUSWest2,
+			WebIdentityToken: string(token),
+			RoleDuration:     jsonencoding.Duration{Duration: 15 * time.Minute},
+		}, false, blob.PutOptions{})
+	})
 }
 
 func TestS3StorageMinio(t *testing.T) {


### PR DESCRIPTION
Hi! This PR adds support for web identity tokens for S3-based repositories, along with unit tests and an integration test (I ran it locally, works as expected).

Web identity token files are especially useful because they allow users to refresh tokens before they expire. Web identity tokens are usually short lived (they can't be longer than the underlying AWS policy's max duration, which has a default value of 1 hour), so without being able to refresh them, it's impossible to perform long-running ops such as backup uploads/downloads.