### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.6
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.14.1
-	github.com/kopia/htmluibuild v0.0.1-0.20260616172341-59b7aad2587e
+	github.com/kopia/htmluibuild v0.0.1-0.20260622172320-900e7a05d7cf
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/minio/minio-go/v7 v7.2.0

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.14.1 h1:swE9kzyWXD/wVG+l5Pe8bWnQ0giIY7D1GjCBKk3kG2U=
 github.com/klauspost/reedsolomon v1.14.1/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
-github.com/kopia/htmluibuild v0.0.1-0.20260616172341-59b7aad2587e h1:ZxjcHpsLhSrxgPsBDqJMMfpafFQ+c3Zr5OCdWiTWijI=
-github.com/kopia/htmluibuild v0.0.1-0.20260616172341-59b7aad2587e/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260622172320-900e7a05d7cf h1:szBmQo9RnXSkSFB+YgbT0JZkSfo1fiJqIygyq9/VkhQ=
+github.com/kopia/htmluibuild v0.0.1-0.20260622172320-900e7a05d7cf/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/2876a57dc5d1c9d36db8511e6a15df3fd3b20308...b10bc3178807e8f0189c78f1886530a72c4fedba

* 2 minutes ago https://github.com/kopia/htmlui/commit/b10bc31 dependabot[bot] build(deps): bump http-proxy-middleware from 3.0.5 to 3.0.7

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Mon Jun 22 17:23:49 UTC 2026*
