### PR TITLE
refactor(testing): reduce spurious failures in `TestPickWeighted`

### DIFF
--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -492,9 +492,7 @@ func TestPickActionWeighted(t *testing.T) {
 				exp := p * float64(numTestLoops)
 
 				errPcnt := math.Abs(exp-float64(count)) / exp
-				if errPcnt > 0.1 {
-					t.Errorf("Error in actual counts was above 10%% for %v (exp %v, actual %v)", actionKey, exp, count)
-				}
+				require.LessOrEqualf(t, errPcnt, 0.1, "error in actual counts was above 10%% for '%v' (exp %0.2f, actual %v)", actionKey, exp, count)
 			}
 		})
 	}

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -492,7 +492,7 @@ func TestPickActionWeighted(t *testing.T) {
 				exp := p * float64(numTestLoops)
 
 				errPcnt := math.Abs(exp-float64(count)) / exp
-				require.LessOrEqualf(t, errPcnt, 0.1, "error in actual counts was above 10%% for '%v' (exp %0.2f, actual %v)", actionKey, exp, count)
+				require.LessOrEqualf(t, errPcnt, 0.15, "error in actual counts was above 15%% for '%v' (exp %0.2f, actual %v)", actionKey, exp, count)
 			}
 		})
 	}

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -466,37 +466,37 @@ func TestPickActionWeighted(t *testing.T) {
 			},
 		},
 	} {
-		t.Log(tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			weightsSum := 0.0
+			inputCtrlOpts := make(map[string]string)
 
-		weightsSum := 0.0
-		inputCtrlOpts := make(map[string]string)
+			for k, v := range tc.inputCtrlWeights {
+				// Do not weight actions that are not expected in the results
+				if _, ok := tc.inputActionList[ActionKey(k)]; !ok {
+					continue
+				}
 
-		for k, v := range tc.inputCtrlWeights {
-			// Do not weight actions that are not expected in the results
-			if _, ok := tc.inputActionList[ActionKey(k)]; !ok {
-				continue
+				inputCtrlOpts[k] = strconv.Itoa(int(v))
+				weightsSum += v
 			}
 
-			inputCtrlOpts[k] = strconv.Itoa(int(v))
-			weightsSum += v
-		}
+			numTestLoops := 100000
 
-		numTestLoops := 100000
-
-		results := make(map[ActionKey]int, len(tc.inputCtrlWeights))
-		for range numTestLoops {
-			results[pickActionWeighted(inputCtrlOpts, tc.inputActionList)]++
-		}
-
-		for actionKey, count := range results {
-			p := tc.inputCtrlWeights[string(actionKey)] / weightsSum
-			exp := p * float64(numTestLoops)
-
-			errPcnt := math.Abs(exp-float64(count)) / exp
-			if errPcnt > 0.1 {
-				t.Errorf("Error in actual counts was above 10%% for %v (exp %v, actual %v)", actionKey, exp, count)
+			results := make(map[ActionKey]int, len(tc.inputCtrlWeights))
+			for range numTestLoops {
+				results[pickActionWeighted(inputCtrlOpts, tc.inputActionList)]++
 			}
-		}
+
+			for actionKey, count := range results {
+				p := tc.inputCtrlWeights[string(actionKey)] / weightsSum
+				exp := p * float64(numTestLoops)
+
+				errPcnt := math.Abs(exp-float64(count)) / exp
+				if errPcnt > 0.1 {
+					t.Errorf("Error in actual counts was above 10%% for %v (exp %v, actual %v)", actionKey, exp, count)
+				}
+			}
+		})
 	}
 }
 

--- a/tests/robustness/engine/engine_test.go
+++ b/tests/robustness/engine/engine_test.go
@@ -480,7 +480,7 @@ func TestPickActionWeighted(t *testing.T) {
 				weightsSum += v
 			}
 
-			numTestLoops := 100000
+			numTestLoops := 100_000
 
 			results := make(map[ActionKey]int, len(tc.inputCtrlWeights))
 			for range numTestLoops {


### PR DESCRIPTION
Increase error tolerance for resulting weights in `TestPickWeighted` to reduce spurious failures. The test is non-deterministic by nature.

Additional non-functional changes:
- use sub-tests for test cases
- use `require` helper
- make constant more legible