### PR TITLE
feat(cli): added `kopia snapshot fix remove-files --ignored-files` which removes files that are currently being ignored

### DIFF
--- a/cli/command_snapshot_fix.go
+++ b/cli/command_snapshot_fix.go
@@ -64,18 +64,16 @@ func failedEntryCallback(rep repo.RepositoryWriter, enumVal string) snapshotfs.R
 	}
 }
 
+// RewriteEntryFactory builds a per-source rewrite callback.
+type RewriteEntryFactory func(ctx context.Context, source snapshot.SourceInfo, policyTree *policy.Tree) (snapshotfs.RewriteDirEntryCallback, error)
+
 func (c *commonRewriteSnapshots) rewriteMatchingSnapshots(ctx context.Context, rep repo.RepositoryWriter, rewrite snapshotfs.RewriteDirEntryCallback) error {
-	rw, err := snapshotfs.NewDirRewriter(ctx, rep, snapshotfs.DirRewriterOptions{
-		Parallel:               c.parallel,
-		RewriteEntry:           rewrite,
-		OnDirectoryReadFailure: failedEntryCallback(rep, c.invalidDirHandling),
+	return c.rewriteMatchingSnapshotsWithFactory(ctx, rep, func(ctx context.Context, source snapshot.SourceInfo, policyTree *policy.Tree) (snapshotfs.RewriteDirEntryCallback, error) {
+		return rewrite, nil
 	})
-	if err != nil {
-		return errors.Wrap(err, "unable to create dir rewriter")
-	}
+}
 
-	defer rw.Close(ctx)
-
+func (c *commonRewriteSnapshots) rewriteMatchingSnapshotsWithFactory(ctx context.Context, rep repo.RepositoryWriter, factory RewriteEntryFactory) error {
 	var updatedSnapshots int
 
 	manifestIDs, err := c.listManifestIDs(ctx, rep)
@@ -89,11 +87,27 @@ func (c *commonRewriteSnapshots) rewriteMatchingSnapshots(ctx context.Context, r
 	}
 
 	for _, mg := range snapshot.GroupBySource(manifests) {
-		log(ctx).Infof("Processing snapshot %v", mg[0].Source)
+		source := mg[0].Source
 
-		policyTree, err := policy.TreeForSource(ctx, rep, mg[0].Source)
+		log(ctx).Infof("Processing snapshot %v", source)
+
+		policyTree, err := policy.TreeForSource(ctx, rep, source)
 		if err != nil {
 			return errors.Wrap(err, "unable to get policy tree")
+		}
+
+		rewrite, err := factory(ctx, source, policyTree)
+		if err != nil {
+			return err
+		}
+
+		rw, err := snapshotfs.NewDirRewriter(ctx, rep, snapshotfs.DirRewriterOptions{
+			Parallel:               c.parallel,
+			RewriteEntry:           rewrite,
+			OnDirectoryReadFailure: failedEntryCallback(rep, c.invalidDirHandling),
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to create dir rewriter")
 		}
 
 		metadataComp := policyTree.EffectivePolicy().MetadataCompressionPolicy.MetadataCompressor()
@@ -129,6 +143,8 @@ func (c *commonRewriteSnapshots) rewriteMatchingSnapshots(ctx context.Context, r
 
 			updatedSnapshots++
 		}
+
+		rw.Close(ctx)
 	}
 
 	if updatedSnapshots > 0 {

--- a/cli/command_snapshot_fix_remove_files.go
+++ b/cli/command_snapshot_fix_remove_files.go
@@ -7,8 +7,12 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/fs/ignorefs"
+	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/policy"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
 
 type commandSnapshotFixRemoveFiles struct {
@@ -16,6 +20,7 @@ type commandSnapshotFixRemoveFiles struct {
 
 	removeObjectIDs   []string
 	removeFilesByName []string
+	removeIgnoredFiles bool
 }
 
 func (c *commandSnapshotFixRemoveFiles) setup(svc appServices, parent commandParent) {
@@ -24,37 +29,89 @@ func (c *commandSnapshotFixRemoveFiles) setup(svc appServices, parent commandPar
 
 	cmd.Flag("object-id", "Remove files by their object ID").StringsVar(&c.removeObjectIDs)
 	cmd.Flag("filename", "Remove files by filename (wildcards are supported)").StringsVar(&c.removeFilesByName)
+	cmd.Flag("ignored-files", "Remove files that match current ignore rules (.kopiaignore and policy); requires live access to the snapshot source path on this machine").BoolVar(&c.removeIgnoredFiles)
 
 	cmd.Action(svc.repositoryWriterAction(c.run))
 }
 
-func (c *commandSnapshotFixRemoveFiles) rewriteEntry(ctx context.Context, pathFromRoot string, ent *snapshot.DirEntry) (*snapshot.DirEntry, error) {
+func (c *commandSnapshotFixRemoveFiles) shouldRemoveBySelector(pathFromRoot string, ent *snapshot.DirEntry) (bool, error) {
 	if slices.Contains(c.removeObjectIDs, ent.ObjectID.String()) {
-		log(ctx).Infof("will remove file %v", pathFromRoot)
-
-		return nil, nil
+		return true, nil
 	}
 
 	for _, n := range c.removeFilesByName {
 		matched, err := path.Match(n, ent.Name)
 		if err != nil {
-			return nil, errors.Wrap(err, "invalid wildcard")
+			return false, errors.Wrap(err, "invalid wildcard")
 		}
 
 		if matched {
-			log(ctx).Infof("will remove file %v", pathFromRoot)
-
-			return nil, nil
+			return true, nil
 		}
 	}
 
-	return ent, nil
+	return false, nil
+}
+
+func (c *commandSnapshotFixRemoveFiles) rewriteEntryFactory(rep repo.RepositoryWriter) RewriteEntryFactory {
+	return func(ctx context.Context, source snapshot.SourceInfo, policyTree *policy.Tree) (snapshotfs.RewriteDirEntryCallback, error) {
+		var checker *ignorefs.Checker
+
+		if c.removeIgnoredFiles {
+			if !isLocalSnapshotSource(source, rep) {
+				return nil, errors.Errorf("source %v is not local; --ignored-files requires access to the live source path on this machine", source)
+			}
+
+			dir, err := localfs.Directory(source.Path)
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to open live source directory %v", source.Path)
+			}
+
+			checker = ignorefs.NewChecker(dir, policyTree)
+		}
+
+		return func(ctx context.Context, pathFromRoot string, ent *snapshot.DirEntry) (*snapshot.DirEntry, error) {
+			remove, err := c.shouldRemoveBySelector(pathFromRoot, ent)
+			if err != nil {
+				return nil, err
+			}
+
+			if remove {
+				log(ctx).Infof("will remove file %v", pathFromRoot)
+
+				return nil, nil
+			}
+
+			if checker != nil {
+				isDir := ent.Type == snapshot.EntryTypeDirectory
+
+				ignored, err := checker.IsIgnored(ctx, pathFromRoot, isDir)
+				if err != nil {
+					return nil, errors.Wrapf(err, "unable to evaluate ignore rules for %v", pathFromRoot)
+				}
+
+				if ignored {
+					log(ctx).Infof("will remove ignored file %v", pathFromRoot)
+
+					return nil, nil
+				}
+			}
+
+			return ent, nil
+		}, nil
+	}
+}
+
+func isLocalSnapshotSource(source snapshot.SourceInfo, rep repo.Repository) bool {
+	return source.Host == rep.ClientOptions().Hostname &&
+		source.UserName == rep.ClientOptions().Username &&
+		source.Path != ""
 }
 
 func (c *commandSnapshotFixRemoveFiles) run(ctx context.Context, rep repo.RepositoryWriter) error {
-	if len(c.removeObjectIDs)+len(c.removeFilesByName) == 0 {
+	if len(c.removeObjectIDs)+len(c.removeFilesByName) == 0 && !c.removeIgnoredFiles {
 		return errors.New("must specify files to remove")
 	}
 
-	return c.common.rewriteMatchingSnapshots(ctx, rep, c.rewriteEntry)
+	return c.common.rewriteMatchingSnapshotsWithFactory(ctx, rep, c.rewriteEntryFactory(rep))
 }

--- a/cli/command_snapshot_fix_test.go
+++ b/cli/command_snapshot_fix_test.go
@@ -438,3 +438,65 @@ func mustWriteFileWithRepeatedData(t *testing.T, fname string, repeat int, data 
 		require.NoError(t, err)
 	}
 }
+
+func TestSnapshotFixRemoveIgnoredFiles(t *testing.T) {
+	srcDir := testutil.TempDirectory(t)
+
+	if testutil.ShouldReduceTestComplexity() {
+		return
+	}
+
+	mustWriteFileWithRepeatedData(t, filepath.Join(srcDir, "keep.txt"), 1, []byte("keep"))
+	mustWriteFileWithRepeatedData(t, filepath.Join(srcDir, "secret.txt"), 1, []byte("secret"))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "nested"), 0o700))
+	mustWriteFileWithRepeatedData(t, filepath.Join(srcDir, "nested", "secret.txt"), 1, []byte("nested-secret"))
+
+	runner := testenv.NewInProcRunner(t)
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+
+	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(t, "snapshot", "create", srcDir, "--json"), &snapshot.Manifest{})
+
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, ".kopiaignore"), []byte("secret.txt\n"), 0o600))
+
+	env.RunAndExpectSuccess(t, "snapshot", "fix", "remove-files", "--ignored-files")
+	env.RunAndExpectSuccess(t, "snapshot", "fix", "remove-files", "--ignored-files", "--commit")
+	env.RunAndExpectSuccess(t, "snapshot", "verify")
+
+	var manifests []cli.SnapshotManifest
+
+	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(t, "snapshot", "list", "--json"), &manifests)
+	require.Len(t, manifests, 1)
+
+	var remainingFiles []string
+
+	for f := range mustGetFileMap(t, env, manifests[0].RootObjectID()) {
+		remainingFiles = append(remainingFiles, f)
+	}
+
+	sort.Strings(remainingFiles)
+	require.Equal(t, []string{"keep.txt", "nested"}, remainingFiles)
+}
+
+func TestSnapshotFixRemoveIgnoredFilesRemoteSource(t *testing.T) {
+	srcDir := testutil.TempDirectory(t)
+
+	if testutil.ShouldReduceTestComplexity() {
+		return
+	}
+
+	mustWriteFileWithRepeatedData(t, filepath.Join(srcDir, "file.txt"), 1, []byte("data"))
+
+	runner := testenv.NewInProcRunner(t)
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+	env.RunAndExpectSuccess(t, "snapshot", "create", "--override-source", "other@otherhost:/data", srcDir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, ".kopiaignore"), []byte("*\n"), 0o600))
+
+	env.RunAndExpectFailure(t, "snapshot", "fix", "remove-files", "--ignored-files")
+	env.RunAndExpectFailure(t, "snapshot", "fix", "remove-files", "--ignored-files", "--commit")
+}

--- a/fs/ignorefs/checker.go
+++ b/fs/ignorefs/checker.go
@@ -1,0 +1,212 @@
+package ignorefs
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/snapshot/policy"
+)
+
+// Checker evaluates whether paths would be excluded by current ignore rules
+// (.kopiaignore files and policy IgnoreRules), using the same name-matching
+// logic as ignorefs during snapshot. It does not apply MaxFileSize,
+// OneFileSystem, or cache-directory filters.
+type Checker struct {
+	root       fs.Directory
+	policyTree *policy.Tree
+	rootCtx    *ignoreContext
+
+	mu       sync.Mutex
+	dirCache map[string]*checkerDirContext
+}
+
+type checkerDirContext struct {
+	ctx      *ignoreContext
+	polTree  *policy.Tree
+	fromDisk bool
+}
+
+// NewChecker returns a Checker that reads .kopiaignore files from root on demand.
+func NewChecker(root fs.Directory, policyTree *policy.Tree) *Checker {
+	return &Checker{
+		root:       root,
+		policyTree: policyTree,
+		rootCtx:    &ignoreContext{},
+		dirCache:   map[string]*checkerDirContext{},
+	}
+}
+
+// IsIgnored reports whether relPath would be excluded by current ignore rules.
+// relPath uses snapshot-style paths (e.g. "dir1/file.txt" without a leading "./").
+func (c *Checker) IsIgnored(ctx context.Context, relPath string, isDir bool) (bool, error) {
+	ignorePath := normalizeIgnorePath(relPath)
+
+	components := strings.Split(strings.TrimPrefix(ignorePath, "./"), "/")
+	if components[0] == "" {
+		components = nil
+	}
+
+	for i := 0; i < len(components)-1; i++ {
+		subPath := "./" + strings.Join(components[:i+1], "/")
+
+		parentPath, name := splitParentIgnorePath(subPath)
+
+		ignored, err := c.isIgnoredAtParent(ctx, parentPath, name, subPath, true)
+		if err != nil {
+			return false, err
+		}
+
+		if ignored {
+			return true, nil
+		}
+	}
+
+	parentPath, name := splitParentIgnorePath(ignorePath)
+	if name == "" {
+		return false, nil
+	}
+
+	return c.isIgnoredAtParent(ctx, parentPath, name, ignorePath, isDir)
+}
+
+func (c *Checker) isIgnoredAtParent(ctx context.Context, parentPath, name, ignorePath string, isDir bool) (bool, error) {
+	ic, polTree, err := c.contextForDir(ctx, parentPath)
+	if err != nil {
+		return false, err
+	}
+
+	stub := ignoreEntryStub{name: name, isDir: isDir}
+
+	return !ic.shouldIncludeByName(ctx, ignorePath, stub, polTree), nil
+}
+
+func (c *Checker) contextForDir(ctx context.Context, relativePath string) (*ignoreContext, *policy.Tree, error) {
+	c.mu.Lock()
+	if cached, ok := c.dirCache[relativePath]; ok {
+		c.mu.Unlock()
+
+		return cached.ctx, cached.polTree, nil
+	}
+	c.mu.Unlock()
+
+	ic, polTree, err := c.buildContextForDir(ctx, relativePath)
+
+	c.mu.Lock()
+	c.dirCache[relativePath] = &checkerDirContext{ctx: ic, polTree: polTree, fromDisk: err == nil}
+	c.mu.Unlock()
+
+	return ic, polTree, err
+}
+
+func (c *Checker) buildContextForDir(ctx context.Context, relativePath string) (*ignoreContext, *policy.Tree, error) {
+	if relativePath == "." {
+		ic, err := buildContextForDirectory(ctx, c.root, ".", c.rootCtx, c.policyTree)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return ic, c.policyTree, nil
+	}
+
+	parentPath, name := splitParentIgnorePath(relativePath)
+
+	parentCtx, parentPolTree, err := c.contextForDir(ctx, parentPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	parentDir, err := c.dirAt(ctx, parentPath)
+	if err != nil {
+		return parentCtx, parentPolTree, nil
+	}
+
+	child, err := parentDir.Child(ctx, name)
+	if err != nil {
+		return parentCtx, parentPolTree, nil
+	}
+
+	subDir, ok := child.(fs.Directory)
+	if !ok {
+		return parentCtx, parentPolTree, nil
+	}
+
+	childPolTree := parentPolTree.Child(name)
+
+	ic, err := buildContextForDirectory(ctx, subDir, relativePath, parentCtx, childPolTree)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return ic, childPolTree, nil
+}
+
+func (c *Checker) dirAt(ctx context.Context, relativePath string) (fs.Directory, error) {
+	if relativePath == "." {
+		return c.root, nil
+	}
+
+	dir := c.root
+
+	for _, p := range strings.Split(strings.TrimPrefix(relativePath, "./"), "/") {
+		e, err := dir.Child(ctx, p)
+		if err != nil {
+			return nil, err //nolint:wrapcheck
+		}
+
+		sub, ok := e.(fs.Directory)
+		if !ok {
+			return nil, fs.ErrEntryNotFound
+		}
+
+		dir = sub
+	}
+
+	return dir, nil
+}
+
+func normalizeIgnorePath(relPath string) string {
+	relPath = strings.TrimPrefix(relPath, "/")
+	if relPath == "" || relPath == "." {
+		return "."
+	}
+
+	return "./" + relPath
+}
+
+func splitParentIgnorePath(p string) (parent, name string) {
+	if p == "." {
+		return ".", ""
+	}
+
+	idx := strings.LastIndex(p, "/")
+	if idx < 0 {
+		return ".", strings.TrimPrefix(p, "./")
+	}
+
+	if idx <= 1 {
+		// "./name" -> parent is root "."
+		return ".", p[idx+1:]
+	}
+
+	return p[:idx], p[idx+1:]
+}
+
+type ignoreEntryStub struct {
+	name  string
+	isDir bool
+}
+
+func (e ignoreEntryStub) Name() string               { return e.name }
+func (e ignoreEntryStub) IsDir() bool                { return e.isDir }
+func (e ignoreEntryStub) Mode() os.FileMode              { return 0 }
+func (e ignoreEntryStub) Size() int64                    { return 0 }
+func (e ignoreEntryStub) ModTime() time.Time             { return time.Time{} }
+func (e ignoreEntryStub) Sys() any                     { return nil }
+func (e ignoreEntryStub) Owner() fs.OwnerInfo        { return fs.OwnerInfo{} }
+func (e ignoreEntryStub) Device() fs.DeviceInfo      { return fs.DeviceInfo{} }
+func (e ignoreEntryStub) LocalFilesystemPath() string { return "" }
+func (e ignoreEntryStub) Close()                     {}

--- a/fs/ignorefs/checker_test.go
+++ b/fs/ignorefs/checker_test.go
@@ -1,0 +1,118 @@
+package ignorefs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/fs/ignorefs"
+	"github.com/kopia/kopia/internal/testlogging"
+)
+
+func TestChecker_IsIgnored(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range cases {
+		if tc.policyTree == oneFileSystemPolicy {
+			continue
+		}
+
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			root := setupFilesystem(tc.skipDefaultFiles)
+			if tc.setup != nil {
+				tc.setup(root)
+			}
+
+			checker := ignorefs.NewChecker(root, tc.policyTree)
+			ctx := testlogging.Context(t)
+
+			allPaths := walkTree(t, root)
+			visibleSet := toSet(walkTree(t, ignorefs.New(root, tc.policyTree)))
+
+			for _, p := range allPaths {
+				if p == "./" {
+					continue
+				}
+
+				relPath := p[2:] // strip "./"
+				isDir := p[len(p)-1] == '/'
+
+				if isDir {
+					relPath = relPath[:len(relPath)-1]
+				}
+
+				ignored, err := checker.IsIgnored(ctx, relPath, isDir)
+				require.NoError(t, err)
+
+				wantIgnored := !visibleSet[p]
+
+				if p == "./largefile1" && wantIgnored && !ignored {
+					continue
+				}
+
+				require.Equal(t, wantIgnored, ignored, "path %v", p)
+			}
+		})
+	}
+}
+
+func TestChecker_IsIgnored_NestedDotIgnore(t *testing.T) {
+	t.Parallel()
+
+	root := setupFilesystem(true)
+	root.AddFileLines(".kopiaignore", []string{"*.tmp"}, 0)
+	root.AddFile("keep.txt", dummyFileContents, 0)
+	root.AddFile("drop.tmp", dummyFileContents, 0)
+	root.AddDir("A", 0)
+	root.Subdir("A").AddFileLines(".kopiaignore", []string{"!special.tmp"}, 0)
+	root.Subdir("A").AddFile("normal.tmp", dummyFileContents, 0)
+	root.Subdir("A").AddFile("special.tmp", dummyFileContents, 0)
+
+	checker := ignorefs.NewChecker(root, defaultPolicy)
+	ctx := testlogging.Context(t)
+
+	requireIgnored(t, checker, ctx, "drop.tmp", false, true)
+	requireIgnored(t, checker, ctx, "keep.txt", false, false)
+	requireIgnored(t, checker, ctx, "A/normal.tmp", false, true)
+	requireIgnored(t, checker, ctx, "A/special.tmp", false, false)
+}
+
+func TestChecker_IsIgnored_MissingLiveDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := setupFilesystem(true)
+	root.AddFileLines(".kopiaignore", []string{"**/*.orphan"}, 0)
+	root.AddFile("visible.txt", dummyFileContents, 0)
+
+	checker := ignorefs.NewChecker(root, defaultPolicy)
+	ctx := testlogging.Context(t)
+
+	// Path exists only in snapshot, not on live disk - parent rules still apply.
+	ignored, err := checker.IsIgnored(ctx, "gone/sub/file.orphan", false)
+	require.NoError(t, err)
+	require.True(t, ignored)
+
+	ignored, err = checker.IsIgnored(ctx, "gone/sub/file.txt", false)
+	require.NoError(t, err)
+	require.False(t, ignored)
+}
+
+func requireIgnored(t *testing.T, checker *ignorefs.Checker, ctx context.Context, path string, isDir, want bool) {
+	t.Helper()
+
+	ignored, err := checker.IsIgnored(ctx, path, isDir)
+	require.NoError(t, err)
+	require.Equal(t, want, ignored, "path %v", path)
+}
+
+func toSet(items []string) map[string]bool {
+	m := make(map[string]bool, len(items))
+	for _, it := range items {
+		m[it] = true
+	}
+
+	return m
+}

--- a/fs/ignorefs/ignorefs.go
+++ b/fs/ignorefs/ignorefs.go
@@ -300,9 +300,13 @@ func resolveSymlink(ctx context.Context, entry fs.Symlink) (fs.File, error) {
 }
 
 func (d *ignoreDirectory) buildContext(ctx context.Context) (*ignoreContext, error) {
-	effectiveDotIgnoreFiles := d.parentContext.dotIgnoreFiles
+	return buildContextForDirectory(ctx, d.Directory, d.relativePath, d.parentContext, d.policyTree)
+}
 
-	pol := d.policyTree.DefinedPolicy()
+func buildContextForDirectory(ctx context.Context, dir fs.Directory, relativePath string, parentContext *ignoreContext, policyTree *policy.Tree) (*ignoreContext, error) {
+	effectiveDotIgnoreFiles := parentContext.dotIgnoreFiles
+
+	pol := policyTree.DefinedPolicy()
 	if pol != nil {
 		effectiveDotIgnoreFiles = pol.FilesPolicy.DotIgnoreFiles
 	}
@@ -310,7 +314,7 @@ func (d *ignoreDirectory) buildContext(ctx context.Context) (*ignoreContext, err
 	var dotIgnoreFiles []fs.File
 
 	for _, dotfile := range effectiveDotIgnoreFiles {
-		if e, err := d.Directory.Child(ctx, dotfile); err == nil {
+		if e, err := dir.Child(ctx, dotfile); err == nil {
 			switch entry := e.(type) {
 			case fs.File:
 				dotIgnoreFiles = append(dotIgnoreFiles, entry)
@@ -328,24 +332,24 @@ func (d *ignoreDirectory) buildContext(ctx context.Context) (*ignoreContext, err
 
 	if len(dotIgnoreFiles) == 0 && pol == nil {
 		// no dotfiles and no policy at this level, reuse parent ignore rules
-		return d.parentContext, nil
+		return parentContext, nil
 	}
 
 	newic := &ignoreContext{
-		parent:         d.parentContext,
-		onIgnore:       d.parentContext.onIgnore,
+		parent:         parentContext,
+		onIgnore:       parentContext.onIgnore,
 		dotIgnoreFiles: effectiveDotIgnoreFiles,
-		maxFileSize:    d.parentContext.maxFileSize,
-		oneFileSystem:  d.parentContext.oneFileSystem,
+		maxFileSize:    parentContext.maxFileSize,
+		oneFileSystem:  parentContext.oneFileSystem,
 	}
 
 	if pol != nil {
-		if err := newic.overrideFromPolicy(&pol.FilesPolicy, d.relativePath); err != nil {
+		if err := newic.overrideFromPolicy(&pol.FilesPolicy, relativePath); err != nil {
 			return nil, err
 		}
 	}
 
-	if err := newic.loadDotIgnoreFiles(ctx, d.relativePath, dotIgnoreFiles); err != nil {
+	if err := newic.loadDotIgnoreFiles(ctx, relativePath, dotIgnoreFiles); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This rewrites previously-taken snapshots of a given source and removes files/directories that are CURRENTLY being ignored.

(This came in handy to cleanup the repo after I accidentally snapshotted 5TB of huggingface models).

Usage:

Preview what would be deleted and storage size savings.
```
kopia snapshot fix remove-files --ignored-files --source <path>
```

Actually rewrite snapshot manifests:
```
kopia snapshot fix remove-files --ignored-files --source <path> --commit
```

Note that space is not actually reclaimed until 2 full maintenance cycles laster (can take >48h)