### PR TITLE
fix(repository): filter logs with `_log_` during log cleanup

### DIFF
--- a/repo/maintenance/cleanup_logs.go
+++ b/repo/maintenance/cleanup_logs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/contentlog"
 	"github.com/kopia/kopia/internal/contentlog/logparam"
+	"github.com/kopia/kopia/internal/repodiag"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/maintenancestats"
@@ -54,7 +55,7 @@ func CleanupLogs(ctx context.Context, rep repo.DirectRepositoryWriter, opt LogRe
 		opt.TimeFunc = clock.Now
 	}
 
-	allLogBlobs, err := blob.ListAllBlobs(ctx, rep.BlobStorage(), "_")
+	allLogBlobs, err := blob.ListAllBlobs(ctx, rep.BlobStorage(), repodiag.LogBlobPrefix)
 	if err != nil {
 		return nil, errors.Wrap(err, "error listing logs")
 	}


### PR DESCRIPTION
closes #5448 

e2e tests ran succesfully:

✓  repo/blob/sftp (1m46.079s)
✓  cli (2m26.883s)

✓  tests/end_to_end_test (3m54.533s)
