### PR TITLE
fix(cli): apply --add/--remove together with --clear on policy string lists

### DIFF
--- a/cli/command_policy_set.go
+++ b/cli/command_policy_set.go
@@ -149,19 +149,16 @@ func (c *commandPolicySet) setPolicyFromFlags(ctx context.Context, p *policy.Pol
 }
 
 func applyPolicyStringList(ctx context.Context, desc string, val *[]string, add, remove []string, clearList bool, changeCount *int) {
+	entries := map[string]bool{}
+
 	if clearList {
 		log(ctx).Infof(" - removing all from %q", desc)
 
 		*changeCount++
-
-		*val = nil
-
-		return
-	}
-
-	entries := map[string]bool{}
-	for _, b := range *val {
-		entries[b] = true
+	} else {
+		for _, b := range *val {
+			entries[b] = true
+		}
 	}
 
 	for _, b := range add {

--- a/cli/command_policy_set_stringlist_test.go
+++ b/cli/command_policy_set_stringlist_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyPolicyStringListClearAndAdd is a regression test for
+// https://github.com/kopia/kopia/issues/5323: combining --clear-ignore with
+// --add-ignore in a single "policy set" invocation cleared the list but
+// dropped the added entries, because the clearList branch returned early
+// before applying add/remove.
+func TestApplyPolicyStringListClearAndAdd(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name        string
+		initial     []string
+		add         []string
+		remove      []string
+		clearList   bool
+		want        []string
+		wantChanged bool
+	}{
+		{
+			name:        "clear and add together keeps the added entry",
+			initial:     []string{"old"},
+			add:         []string{"new"},
+			clearList:   true,
+			want:        []string{"new"},
+			wantChanged: true,
+		},
+		{
+			name:        "clear only empties the list",
+			initial:     []string{"a", "b"},
+			clearList:   true,
+			want:        nil,
+			wantChanged: true,
+		},
+		{
+			name:        "add only appends to the existing list",
+			initial:     []string{"a"},
+			add:         []string{"b"},
+			want:        []string{"a", "b"},
+			wantChanged: true,
+		},
+		{
+			name:        "clear, add and remove compose",
+			initial:     []string{"old"},
+			add:         []string{"keep", "drop"},
+			remove:      []string{"drop"},
+			clearList:   true,
+			want:        []string{"keep"},
+			wantChanged: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val := append([]string(nil), tc.initial...)
+			changeCount := 0
+
+			applyPolicyStringList(ctx, "test list", &val, tc.add, tc.remove, tc.clearList, &changeCount)
+
+			require.Equal(t, tc.want, val)
+			require.Equal(t, tc.wantChanged, changeCount > 0)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`kopia policy set <target> --clear-ignore --add-ignore "<pattern>"` clears the
ignore list but silently drops the `--add-ignore` pattern, leaving an empty
list instead of the freshly-added entry. The same happens for the dot-ignore
and `--clear-/-add-` compression-extension lists, which share the same helper.

## Root cause

`applyPolicyStringList` (`cli/command_policy_set.go`) handled `--clear-*` with
an early return, before the add/remove loops:

```go
if clearList {
    log(ctx).Infof(" - removing all from %q", desc)
    *changeCount++
    *val = nil
    return // add/remove never applied
}
```

So when `--clear-*` and `--add-*` are combined in a single invocation, the
adds are never applied.

## Fix

Clear the list in place and keep applying add/remove, so clear + add compose in
one command. Clear-only behaviour is unchanged (the list ends up empty).

## Test

`TestApplyPolicyStringListClearAndAdd` covers clear+add, clear-only, add-only,
and clear+add+remove. It fails before the change (clear+add yields `nil`) and
passes after. `go test ./cli/ ./snapshot/policy/...` stays green.

Fixes #5323
