### PR TITLE
fix(snapshot): compute weekly retention bucket in UTC

### DIFF
--- a/snapshot/policy/retention_policy.go
+++ b/snapshot/policy/retention_policy.go
@@ -133,7 +133,10 @@ func (r *RetentionPolicy) getRetentionReasons(i int, s *snapshot.Manifest, cutof
 
 	var zeroTime time.Time
 
-	yyyy, wk := s.StartTime.ToTime().ISOWeek()
+	// Compute the ISO week in UTC to stay consistent with the other time
+	// periods below, which use s.StartTime.Format() (UTC). Using local time
+	// here would bucket weekly snapshots differently than daily/monthly ones.
+	yyyy, wk := s.StartTime.ToTime().UTC().ISOWeek()
 
 	effectiveKeepLatest := r.EffectiveKeepLatest()
 

--- a/snapshot/policy/retention_policy_test.go
+++ b/snapshot/policy/retention_policy_test.go
@@ -243,3 +243,42 @@ func TestCompactRetentionReasons(t *testing.T) {
 		require.Equal(t, tc.want, CompactRetentionReasons(tc.input))
 	}
 }
+
+// TestRetentionPolicyWeeklyTimezone is a regression test for
+// https://github.com/kopia/kopia/issues/5348: the weekly retention bucket was
+// computed in local time (s.StartTime.ToTime().ISOWeek()) while every other
+// period uses UTC (s.StartTime.Format(...)). In a non-UTC timezone this put
+// snapshots from the same UTC week into different weekly buckets.
+func TestRetentionPolicyWeeklyTimezone(t *testing.T) {
+	origLocal := time.Local
+	t.Cleanup(func() { time.Local = origLocal })
+	// UTC+4: the local week boundary (Mon 2020-01-06 00:00 local) falls at
+	// 2020-01-05T20:00Z, between the two snapshots below.
+	time.Local = time.FixedZone("UTC+4", 4*60*60)
+
+	// Both snapshots are Sunday 2020-01-05 in UTC, i.e. the same ISO week
+	// (UTC week boundary is Mon 2020-01-06T00:00Z). Under the buggy local-time
+	// computation they straddle the local week boundary and end up in two
+	// different weekly buckets.
+	newer, err := time.Parse(time.RFC3339, "2020-01-05T21:00:00Z")
+	require.NoError(t, err)
+	older, err := time.Parse(time.RFC3339, "2020-01-05T19:00:00Z")
+	require.NoError(t, err)
+
+	manifests := []*snapshot.Manifest{
+		{Description: "newer", StartTime: fs.UTCTimestampFromTime(newer)},
+		{Description: "older", StartTime: fs.UTCTimestampFromTime(older)},
+	}
+
+	(&RetentionPolicy{KeepWeekly: newOptionalInt(2)}).ComputeRetentionReasons(manifests)
+
+	got := map[string][]string{}
+	for _, m := range manifests {
+		got[m.Description] = m.RetentionReasons
+	}
+
+	// Same UTC week => only the most recent snapshot is retained as weekly;
+	// the older one shares the bucket and gets no weekly tag.
+	require.Equal(t, []string{"weekly-1"}, got["newer"])
+	require.Empty(t, got["older"])
+}


### PR DESCRIPTION
## Problem

Weekly and daily/monthly/… retention are bucketed in different time zones, so
in a non-UTC environment a snapshot can be assigned to a weekly bucket that
disagrees with its daily/monthly bucket.

## Root cause

In `getRetentionReasons` (`snapshot/policy/retention_policy.go`) the weekly
time-period ID is derived from local time:

```go
yyyy, wk := s.StartTime.ToTime().ISOWeek()
```

`UTCTimestamp.ToTime()` returns `time.Unix(...)`, i.e. local time, while every
other period uses `s.StartTime.Format(...)` which is UTC
(`UTCTimestamp.Format` does `ToTime().UTC().Format(...)`). So weekly is computed
in local time and the rest in UTC.

## Fix

Compute the ISO week in UTC (`s.StartTime.ToTime().UTC().ISOWeek()`) so weekly
is consistent with the other periods.

## Test

`TestRetentionPolicyWeeklyTimezone` sets a non-UTC `time.Local` and uses two
snapshots that fall in the same ISO week in UTC but straddle the local week
boundary; before the fix the older one is given a separate `weekly-2` bucket,
after the fix it shares the week with the newer snapshot. The existing
`TestRetentionPolicyTest` is unaffected.

Fixes #5348
