### PR TITLE
fix(cli): apply the incomplete filter in 'snapshot list --json'

### DIFF
--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -173,6 +173,10 @@ func (c *commandSnapshotList) outputJSON(ctx context.Context, rep repo.Repositor
 		}
 
 		if err := c.iterateSnapshotsMaybeWithStorageStats(ctx, rep, snapshotGroup, func(m *snapshot.Manifest) error {
+			if m.IncompleteReason != "" && !c.snapshotListIncludeIncomplete {
+				return nil
+			}
+
 			wm := SnapshotManifest{Manifest: m, RetentionReasons: m.RetentionReasons}
 			jl.emit(wm)
 			return nil

--- a/cli/command_snapshot_list_test.go
+++ b/cli/command_snapshot_list_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"crypto/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,6 +79,58 @@ func TestSnapshotList(t *testing.T) {
 	// identical snapshot is not coalesced
 	require.Contains(t, lines[4], " 8 B ")
 	require.Contains(t, lines[4], " files:3 dirs:1 ")
+}
+
+// Regression test for #5326: `snapshot list --json` ignored the incomplete
+// filter and always emitted incomplete snapshots, while the text output
+// correctly hid them unless --incomplete/-i was passed.
+func TestSnapshotListIncompleteJSON(t *testing.T) {
+	t.Parallel()
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	srcdir := testutil.TempDirectory(t)
+	require.NoError(t, os.WriteFile(filepath.Join(srcdir, "small.txt"), []byte{1, 2, 3}, 0o600))
+
+	// one complete snapshot
+	e.RunAndExpectSuccess(t, "snapshot", "create", srcdir)
+
+	// force an incomplete (checkpoint) snapshot by capping the upload below the
+	// source size; the data is random so it neither compresses nor dedupes and
+	// reliably exceeds the 1 MB limit.
+	big := make([]byte, 5<<20)
+	_, err := rand.Read(big)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(srcdir, "big.bin"), big, 0o600))
+	e.RunAndExpectSuccess(t, "snapshot", "create", srcdir, "--upload-limit-mb=1")
+
+	// sanity: with --incomplete the incomplete snapshot is present, so the
+	// default-listing assertion below is not vacuously true.
+	var withIncomplete []*cli.SnapshotManifest
+	testutil.MustParseJSONLines(t, e.RunAndExpectSuccess(t, "snapshot", "list", "--json", "--incomplete"), &withIncomplete)
+
+	var incompleteCount int
+
+	for _, s := range withIncomplete {
+		if s.IncompleteReason != "" {
+			incompleteCount++
+		}
+	}
+
+	require.Equal(t, 1, incompleteCount, "expected exactly one incomplete snapshot when --incomplete is set")
+
+	// the bug: without --incomplete, --json must not list incomplete snapshots.
+	var defaultList []*cli.SnapshotManifest
+	testutil.MustParseJSONLines(t, e.RunAndExpectSuccess(t, "snapshot", "list", "--json"), &defaultList)
+
+	for _, s := range defaultList {
+		require.Empty(t, s.IncompleteReason, "snapshot list --json must not include incomplete snapshots unless --incomplete is set")
+	}
 }
 
 func TestSnapshotListWithSameFileInMultipleSnapshots(t *testing.T) {


### PR DESCRIPTION
Fixes #5326.

### Problem

`kopia snapshot list --json` lists incomplete snapshots even without `--incomplete`/`-i` (and `--no-incomplete --json` does too). The text output filters them correctly; only the JSON path is affected.

### Root cause

`snapshot list` has two output paths. The text path filters incomplete snapshots in `outputManifestFromSingleSource`:

```go
if m.IncompleteReason != "" && !c.snapshotListIncludeIncomplete {
    return nil
}
```

The JSON path (`outputJSON`) emits every manifest with no such check, so the `--incomplete` flag has no effect on JSON output:

```go
if err := c.iterateSnapshotsMaybeWithStorageStats(ctx, rep, snapshotGroup, func(m *snapshot.Manifest) error {
    wm := SnapshotManifest{Manifest: m, RetentionReasons: m.RetentionReasons}
    jl.emit(wm)
    return nil
}); err != nil {
```

### Fix

Apply the same `IncompleteReason` filter the text path uses before emitting each manifest in `outputJSON`.

### Test

`TestSnapshotListIncompleteJSON` creates one complete snapshot and one incomplete one (forced via `--upload-limit-mb=1` on random, non-dedupable data), then asserts that `snapshot list --json` excludes the incomplete snapshot while `--json --incomplete` includes it. Fails before the change ("incomplete snapshots listed"), passes after.

Verified end-to-end locally (`go test ./cli/ -run TestSnapshotListIncompleteJSON`, `go vet`, `gofmt`, golangci-lint clean).

---
*Disclosure: prepared with AI assistance (Claude); reproduced, built and tested locally before submitting.*
