### PR TITLE
fix(repository): avoid nil-pointer crash when a cache directory is set but caching is disabled

### DIFF
--- a/internal/cache/content_cache.go
+++ b/internal/cache/content_cache.go
@@ -192,6 +192,13 @@ func NewContentCache(ctx context.Context, st blob.Storage, opt Options, mr *metr
 		return nil, errors.Wrap(err, "unable to create base cache")
 	}
 
+	if pc == nil {
+		// The cache is effectively disabled (zero size) even though a cache
+		// directory was configured, so there is no persistent cache to back the
+		// contentCacheImpl. Fall back to a passthrough to avoid a nil dereference.
+		return passthroughContentCache{st}, nil
+	}
+
 	return &contentCacheImpl{
 		st:             st,
 		pc:             pc,

--- a/internal/cache/content_cache_test.go
+++ b/internal/cache/content_cache_test.go
@@ -172,6 +172,30 @@ func TestDiskContentCache(t *testing.T) {
 	verifyContentCache(t, cc, cacheStorage)
 }
 
+// TestContentCacheZeroSizeWithDirectory is a regression test for #5406: a
+// configured cache directory combined with a zero cache size (cache disabled)
+// must fall back to a passthrough cache instead of building a nil-backed cache
+// that panics with a nil-pointer dereference when a blob is fetched.
+func TestContentCacheZeroSizeWithDirectory(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	cc, err := cache.NewContentCache(ctx, newUnderlyingStorageForContentCacheTesting(t), cache.Options{
+		BaseCacheDirectory: testutil.TempDirectory(t),
+		CacheSubDir:        "contents",
+		Sweep:              cache.SweepSettings{MaxSizeBytes: 0}, // cache disabled
+	}, nil)
+	require.NoError(t, err)
+
+	defer cc.Close(ctx)
+
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	// Previously panicked here with a nil-pointer dereference on the nil persistent cache.
+	require.NoError(t, cc.GetContent(ctx, "content-1", "content-1", 0, -1, &tmp))
+	require.Equal(t, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, tmp.ToByteSlice())
+}
+
 func verifyContentCache(t *testing.T, cc cache.ContentCache, cacheStorage cache.Storage) {
 	t.Helper()
 


### PR DESCRIPTION
Fixes #5406.

`snapshot create` (and any command that reads content) panics with a nil-pointer dereference when the repository has a cache directory configured but the cache size is zero (caching disabled) — e.g. after `cache set --content-cache-size-limit-mb=0 --metadata-cache-size-limit-mb=0` with `KOPIA_CACHE_DIRECTORY` set.

`NewContentCache` (`internal/cache/content_cache.go`) only falls back to a passthrough cache when *no* cache directory is configured. When a directory is set but the size is zero, `NewStorageOrNil` returns a nil storage and `NewPersistentCache` returns a nil cache, yet a `contentCacheImpl` is still built with that nil `pc`. The first blob fetch then dereferences it in `fetchBlobInternal` (`content_cache.go:105`, `c.pc.reportMissBytes`).

Fix: fall back to the passthrough cache when the persistent cache is nil, matching the existing no-directory path.

Added `TestContentCacheZeroSizeWithDirectory` — it panics without the fix and passes with it. The full `internal/cache` package stays green; gofmt and vet are clean.
