### PR TITLE
fix(snapshots): detect symlink target changes when reusing cached entries

### DIFF
--- a/snapshot/upload/issue_symlink_stale_test.go
+++ b/snapshot/upload/issue_symlink_stale_test.go
@@ -1,0 +1,93 @@
+package upload
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/internal/mockfs"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/policy"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
+)
+
+// A symlink whose target changes to a different path of the SAME byte length,
+// with unchanged mtime/mode/owner, must not be treated as unchanged by the
+// incremental cache-reuse check: metadataEquals compares only mtime/mode/owner
+// and Size(), and for a symlink Size() is the target's byte length, never the
+// target itself. Reusing the cached entry would store the OLD target -> silent
+// data corruption on restore.
+func TestSymlinkTargetChangeSameLengthNotStale(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+	th := newUploadTestHarness(ctx, t)
+	t.Cleanup(th.cleanup)
+
+	u := NewUploader(th.repo)
+	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+
+	// First snapshot: link -> "aaaa".
+	root1 := mockfs.NewDirectory()
+	root1.AddSymlink("link", "aaaa", defaultPermissions)
+
+	man1, err := u.Upload(ctx, root1, policyTree, snapshot.SourceInfo{})
+	require.NoError(t, err)
+
+	// Second snapshot: same name/mtime/mode/owner, target changed to "bbbb"
+	// (same 4-byte length as "aaaa").
+	root2 := mockfs.NewDirectory()
+	root2.AddSymlink("link", "bbbb", defaultPermissions)
+
+	man2, err := u.Upload(ctx, root2, policyTree, snapshot.SourceInfo{}, man1)
+	require.NoError(t, err)
+
+	require.Equal(t, "bbbb", readSymlinkTarget(ctx, t, th, man2, "link"),
+		"second snapshot must store the new symlink target, not the stale cached one")
+}
+
+// The fix must stay surgical: an unchanged symlink is still served from the
+// incremental cache (no re-hash), so identical re-uploads report zero hashed
+// files.
+func TestSymlinkUnchangedStillCached(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+	th := newUploadTestHarness(ctx, t)
+	t.Cleanup(th.cleanup)
+
+	u := NewUploader(th.repo)
+	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+
+	root := mockfs.NewDirectory()
+	root.AddSymlink("link", "some/target", defaultPermissions)
+
+	man1, err := u.Upload(ctx, root, policyTree, snapshot.SourceInfo{})
+	require.NoError(t, err)
+
+	man2, err := u.Upload(ctx, root, policyTree, snapshot.SourceInfo{}, man1)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(0), atomic.LoadInt32(&man2.Stats.TotalFileCount),
+		"unchanged symlink must be reused from cache, not re-hashed")
+	require.Equal(t, "some/target", readSymlinkTarget(ctx, t, th, man2, "link"))
+}
+
+func readSymlinkTarget(ctx context.Context, t *testing.T, th *uploadTestHarness, man *snapshot.Manifest, name string) string {
+	t.Helper()
+
+	dir := testutil.EnsureType[fs.Directory](t, snapshotfs.EntryFromDirEntry(th.repo, man.RootEntry))
+
+	child, err := dir.Child(ctx, name)
+	require.NoError(t, err)
+
+	target, err := testutil.EnsureType[fs.Symlink](t, child).Readlink(ctx)
+	require.NoError(t, err)
+
+	return target
+}

--- a/snapshot/upload/upload.go
+++ b/snapshot/upload/upload.go
@@ -719,6 +719,28 @@ func metadataEquals(e1, e2 fs.Entry) bool {
 	return true
 }
 
+// symlinkTargetsEqual reports whether two symlink entries point to the same
+// target. It returns false if either entry is not a symlink or its target
+// cannot be read, so that an unverifiable pair is treated as a cache miss and
+// re-hashed rather than silently reused.
+func symlinkTargetsEqual(ctx context.Context, e1, e2 fs.Entry) bool {
+	s1, ok1 := e1.(fs.Symlink)
+	s2, ok2 := e2.(fs.Symlink)
+
+	if !ok1 || !ok2 {
+		return false
+	}
+
+	t1, err1 := s1.Readlink(ctx)
+	t2, err2 := s2.Readlink(ctx)
+
+	if err1 != nil || err2 != nil {
+		return false
+	}
+
+	return t1 == t2
+}
+
 func findCachedEntry(ctx context.Context, entryRelativePath string, entry fs.Entry, prevDirs []fs.Directory, pol *policy.Tree) fs.Entry {
 	var missedEntry fs.Entry
 
@@ -727,6 +749,15 @@ func findCachedEntry(ctx context.Context, entryRelativePath string, entry fs.Ent
 			switch entry.(type) {
 			case fs.StreamingFile:
 				if commonMetadataEquals(entry, ent) {
+					return ent
+				}
+			case fs.Symlink:
+				// A symlink's content is its target, but Size() only reports the
+				// target's byte length, so metadataEquals cannot distinguish a
+				// same-length target change (with preserved mtime) from an
+				// unchanged symlink. Compare the actual target to avoid reusing a
+				// stale cached entry, which would store the old target.
+				if commonMetadataEquals(entry, ent) && symlinkTargetsEqual(ctx, entry, ent) {
 					return ent
 				}
 			default:


### PR DESCRIPTION
`findCachedEntry` reuses a cached symlink entry using `metadataEquals`, which compares mtime/mode/owner and `Size()`. For a symlink, `Size()` is the byte length of the target, not the target itself — so changing a symlink's target to a different path of the same length while its mtime is preserved (e.g. restored from an archive or synced with `rsync -a`) is treated as unchanged. The snapshot then keeps the previous target, silently storing the wrong link on restore.

This adds a symlink case to `findCachedEntry` that also compares the actual target (via `Readlink`) before reusing the cached entry; a pair whose target cannot be read is treated as a cache miss and re-hashed. Unchanged symlinks are still served from the incremental cache, so identical re-uploads still skip re-hashing.

`TestSymlinkTargetChangeSameLengthNotStale` fails without the change and passes with it; `TestSymlinkUnchangedStillCached` guards the no-regression path. The full `snapshot/upload` package stays green; gofmt and vet are clean.
