### PR TITLE
fix(rclone): make remote control calls resilient to transient failures

### DIFF
--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -22,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/osexec"
+	"github.com/kopia/kopia/internal/retry"
 	"github.com/kopia/kopia/internal/tlsutil"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/blob/webdav"
@@ -35,9 +37,19 @@ const (
 
 	// defaultRcloneStartupTimeout is the time we wait for rclone to print the https address it's serving at.
 	defaultRcloneStartupTimeout = 15 * time.Second
+
+	// remoteControlRequestTimeout is the overall timeout for a single remote control request,
+	// so that a wedged rclone process does not hang storage operations indefinitely.
+	remoteControlRequestTimeout = 1 * time.Minute
+
+	// maxStderrLineLength is the maximum length of a single rclone stderr line the scanner can handle.
+	maxStderrLineLength = 1 << 20
 )
 
 var log = logging.Module("rclone")
+
+// errRCloneExited is returned when the rclone child process is no longer running.
+var errRCloneExited = errors.New("rclone process has exited")
 
 type rcloneStorage struct {
 	blob.Storage // the underlying WebDAV storage used to implement all methods.
@@ -47,10 +59,43 @@ type rcloneStorage struct {
 	cmd          *exec.Cmd // running rclone
 	temporaryDir string
 
+	// exited is closed by the process watchdog when rclone exits; exitErr is set before it is closed.
+	exited  chan struct{}
+	exitErr error
+
 	remoteControlHTTPClient *http.Client
 	remoteControlAddr       string
 	remoteControlUsername   string
 	remoteControlPassword   string
+}
+
+// exitError returns an error if the rclone child process is no longer running, nil otherwise.
+func (r *rcloneStorage) exitError() error {
+	if r.exited == nil {
+		return nil
+	}
+
+	select {
+	case <-r.exited:
+		if r.exitErr != nil {
+			return errors.Wrapf(errRCloneExited, "%v", r.exitErr)
+		}
+
+		return errRCloneExited
+
+	default:
+		return nil
+	}
+}
+
+// waitForExit waits for the rclone process to be reaped after it was killed.
+func (r *rcloneStorage) waitForExit() {
+	if r.exited != nil {
+		<-r.exited
+	} else {
+		// process watchdog not running, e.g. when rclone failed to start.
+		r.cmd.Wait() //nolint:errcheck
+	}
 }
 
 func (r *rcloneStorage) ListBlobs(ctx context.Context, blobIDPrefix blob.ID, cb func(bm blob.Metadata) error) error {
@@ -94,7 +139,7 @@ func (r *rcloneStorage) Kill() {
 	// this will kill rclone process if any
 	if r.cmd != nil && r.cmd.Process != nil {
 		r.cmd.Process.Kill() //nolint:errcheck
-		r.cmd.Wait()         //nolint:errcheck
+		r.waitForExit()
 	}
 }
 
@@ -109,7 +154,7 @@ func (r *rcloneStorage) Close(ctx context.Context) error {
 	if r.cmd != nil && r.cmd.Process != nil {
 		log(ctx).Debug("killing rclone")
 		r.cmd.Process.Kill() //nolint:errcheck
-		r.cmd.Wait()         //nolint:errcheck
+		r.waitForExit()
 	}
 
 	if r.temporaryDir != "" {
@@ -125,7 +170,7 @@ func (r *rcloneStorage) DisplayName() string {
 	return "RClone " + r.RemotePath
 }
 
-func (r *rcloneStorage) processStderrStatus(ctx context.Context, s *bufio.Scanner) {
+func (r *rcloneStorage) processStderrStatus(ctx context.Context, stderr io.Reader, s *bufio.Scanner) {
 	for s.Scan() {
 		l := s.Text()
 
@@ -133,9 +178,54 @@ func (r *rcloneStorage) processStderrStatus(ctx context.Context, s *bufio.Scanne
 			log(ctx).Debugf("[RCLONE] %v", l)
 		}
 	}
+
+	// If scanning stopped because of an error (e.g. a line longer than the scanner buffer),
+	// keep draining the pipe, otherwise rclone would eventually block writing to stderr
+	// and stop responding to all requests.
+	if s.Err() != nil {
+		io.Copy(io.Discard, stderr) //nolint:errcheck
+	}
+}
+
+// remoteControlStatusError is returned when the remote control server responds with a non-200 status.
+type remoteControlStatusError struct {
+	statusCode int
+	status     string
+}
+
+func (e remoteControlStatusError) Error() string {
+	return "RC error: " + e.status
+}
+
+// isRetriableRemoteControlError determines whether a failed remote control call is worth
+// retrying. Connection-level errors (e.g. EOF when rclone closed a pooled connection) and
+// server errors are transient; client errors, cancellations, timeouts and rclone having
+// exited are permanent.
+func isRetriableRemoteControlError(err error) bool {
+	if errors.Is(err, errRCloneExited) {
+		return false
+	}
+
+	// don't retry when the caller's context was canceled or when the request was killed
+	// by the HTTP client timeout: a wedged rclone would fail every attempt the same way,
+	// multiplying the stall by the number of attempts.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var se remoteControlStatusError
+	if errors.As(err, &se) {
+		return se.statusCode >= http.StatusInternalServerError
+	}
+
+	return true
 }
 
 func (r *rcloneStorage) remoteControl(ctx context.Context, path string, input, output any) error {
+	if err := r.exitError(); err != nil {
+		return err
+	}
+
 	var reqBuf bytes.Buffer
 
 	if err := json.NewEncoder(&reqBuf).Encode(input); err != nil {
@@ -149,6 +239,11 @@ func (r *rcloneStorage) remoteControl(ctx context.Context, path string, input, o
 
 	req.SetBasicAuth(r.remoteControlUsername, r.remoteControlPassword)
 
+	// Remote control calls are idempotent, which allows the HTTP transport to transparently
+	// retry the POST on another connection when a pooled keep-alive connection turns out to
+	// have been closed by the server (which otherwise surfaces as immediate EOF).
+	req.Header.Set("Idempotency-Key", uuid.New().String())
+
 	resp, err := r.remoteControlHTTPClient.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "RC error")
@@ -157,7 +252,7 @@ func (r *rcloneStorage) remoteControl(ctx context.Context, path string, input, o
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("RC error: %v", resp.Status)
+		return remoteControlStatusError{statusCode: resp.StatusCode, status: resp.Status}
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
@@ -168,8 +263,10 @@ func (r *rcloneStorage) remoteControl(ctx context.Context, path string, input, o
 }
 
 func (r *rcloneStorage) forgetVFS(ctx context.Context) error {
-	out := map[string]any{}
-	return r.remoteControl(ctx, "vfs/forget", map[string]string{}, &out)
+	return retry.WithExponentialBackoffNoValue(ctx, "ForgetVFS", func() error {
+		out := map[string]any{}
+		return r.remoteControl(ctx, "vfs/forget", map[string]string{}, &out)
+	}, isRetriableRemoteControlError)
 }
 
 type rcloneURLs struct {
@@ -197,6 +294,7 @@ func (r *rcloneStorage) runRCloneAndWaitForServerAddress(ctx context.Context, c 
 
 		go func() {
 			s := bufio.NewScanner(stderr)
+			s.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxStderrLineLength)
 
 			var lastOutput string
 
@@ -221,7 +319,7 @@ func (r *rcloneStorage) runRCloneAndWaitForServerAddress(ctx context.Context, c 
 					// return to caller when we've detected both WebDav and remote control addresses.
 					rcloneAddressChan <- u
 
-					go r.processStderrStatus(ctx, s)
+					go r.processStderrStatus(ctx, stderr, s)
 
 					return
 				}
@@ -361,13 +459,26 @@ func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error)
 
 	log(ctx).Debugf("detected webdav address: %v RC: %v", rcloneUrls.webdavAddr, rcloneUrls.remoteControlAddr)
 
+	// watch the rclone process so that its unexpected death produces clear errors
+	// instead of connection failures on every storage operation.
+	r.exited = make(chan struct{})
+
+	go func() {
+		r.exitErr = r.cmd.Wait()
+
+		// log before closing the channel: the close unblocks Close()/Kill() and the
+		// storage owner may tear down immediately after, invalidating ctx's logger.
+		log(ctx).Debugf("rclone process exited: %v", r.exitErr)
+
+		close(r.exited)
+	}()
+
 	fingerprintBytes := sha256.Sum256(cert.Raw)
 	fingerprintHexString := hex.EncodeToString(fingerprintBytes[:])
 
-	var cli http.Client
-
-	cli.Transport = &http.Transport{
-		TLSClientConfig: tlsutil.TLSConfigTrustingSingleCertificate(fingerprintHexString),
+	cli := http.Client{
+		Timeout:   remoteControlRequestTimeout,
+		Transport: tlsutil.TransportTrustingSingleCertificate(fingerprintHexString),
 	}
 
 	r.remoteControlHTTPClient = &cli

--- a/repo/blob/rclone/rclone_storage_internal_test.go
+++ b/repo/blob/rclone/rclone_storage_internal_test.go
@@ -1,0 +1,35 @@
+//go:build !no_extra_providers
+
+package rclone
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRetriableRemoteControlError(t *testing.T) {
+	cases := []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{desc: "connection-level EOF", err: errors.Wrap(io.EOF, "RC error"), want: true},
+		{desc: "server error", err: remoteControlStatusError{statusCode: http.StatusInternalServerError, status: "500 Internal Server Error"}, want: true},
+		{desc: "service unavailable", err: remoteControlStatusError{statusCode: http.StatusServiceUnavailable, status: "503 Service Unavailable"}, want: true},
+		{desc: "auth failure", err: remoteControlStatusError{statusCode: http.StatusForbidden, status: "403 Forbidden"}, want: false},
+		{desc: "process exited", err: errRCloneExited, want: false},
+		{desc: "process exited wrapped", err: errors.Wrapf(errRCloneExited, "%v", "exit status 1"), want: false},
+		{desc: "context canceled", err: errors.Wrap(context.Canceled, "RC error"), want: false},
+		{desc: "client timeout", err: errors.Wrap(&url.Error{Op: "Post", URL: "https://127.0.0.1:1/vfs/forget", Err: context.DeadlineExceeded}, "RC error"), want: false},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, isRetriableRemoteControlError(tc.err), tc.desc)
+	}
+}

--- a/repo/blob/rclone/rclone_storage_test.go
+++ b/repo/blob/rclone/rclone_storage_test.go
@@ -213,6 +213,47 @@ func TestRCloneStorageInvalidFlags(t *testing.T) {
 	}
 }
 
+func TestRCloneStorageProcessExit(t *testing.T) {
+	t.Parallel()
+	testutil.ProviderTest(t)
+
+	ctx := testlogging.Context(t)
+
+	rcloneExe := mustGetRcloneExeOrSkip(t)
+	dataDir := testutil.TempDirectory(t)
+
+	st, err := rclone.New(ctx, &rclone.Options{
+		// pass local file as remote path.
+		RemotePath: dataDir,
+		RCloneExe:  rcloneExe,
+	}, true)
+	require.NoError(t, err, "unable to connect to rclone backend")
+
+	t.Cleanup(func() {
+		st.Close(testlogging.ContextForCleanup(t))
+	})
+
+	require.NoError(t, st.PutBlob(ctx, "someblob1234567812345678", gather.FromSlice([]byte{1, 2, 3}), blob.PutOptions{}))
+
+	k, ok := st.(Killable)
+	require.True(t, ok, "not killable")
+
+	// kill rclone out from under the storage wrapper.
+	k.Kill()
+
+	// reads must fail quickly with a clear error instead of retrying connection
+	// failures against a dead process.
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	t0 := clock.Now()
+	err = st.GetBlob(ctx, "someblob1234567812345678", 0, -1, &tmp)
+	dur := clock.Now().Sub(t0)
+
+	require.ErrorContains(t, err, "rclone process has exited")
+	require.Less(t, dur, 30*time.Second, "GetBlob against dead rclone took too long: %v", dur)
+}
+
 func TestRCloneProviders(t *testing.T) {
 	testutil.ProviderTest(t)
 


### PR DESCRIPTION
## Problem

With the rclone storage backend, snapshots and maintenance intermittently
fail with errors like:

    error flushing dir cache: RC error: Post "https://127.0.0.1:PORT/vfs/forget": EOF

Reported in #4791 and #5124 across multiple OSes and rclone versions.

(The related state where *every* operation fails until KopiaUI is restarted
turned out to be a separate bug — rclone support files deleted from the OS
temp directory by temp cleaners — addressed in #5485.)

## Root cause

Before every `ListBlobs`, `GetMetadata`, and `GetBlob`, the rclone backend
issues a `vfs/forget` remote-control POST to flush rclone's directory cache
(added in #3284). Unlike all other blob operations — which are wrapped by
`retrying.NewWrapper` — this call had **no retry**, so a single transient
failure failed the whole operation. The most common trigger is an `EOF` when
Go's HTTP transport reuses a keep-alive connection that rclone has already
closed server-side (POSTs are not auto-retried by default).

Two secondary issues could leave rclone unresponsive rather than failing once:

- The RC HTTP client used a zero-value `http.Transport` (idle connections
  pooled indefinitely) with no request timeout, so a wedged rclone could hang
  operations instead of erroring.
- The stderr-scanner goroutine stopped permanently if rclone ever logged a
  line longer than `bufio.Scanner`'s 64 KiB limit; rclone would then block
  writing to stderr and stop responding to all requests.

## Changes

- Retry `vfs/forget` using the existing exponential-backoff helper, treating
  connection errors and 5xx as retriable and client errors, cancellations,
  client timeouts and process death as terminal.
- Mark the RC POST idempotent (`Idempotency-Key`) so the transport
  transparently replays it on a fresh connection when a pooled one was closed
  — fixing the common EOF at zero latency cost. (The body is a `*bytes.Buffer`,
  so `http.NewRequest` populates `GetBody`, which makes the POST replayable.)
- Give the RC HTTP client a request timeout and the shared certificate-pinned
  transport (standard dial/TLS/idle timeouts) used by the WebDAV path.
- Keep draining rclone's stderr after an over-long line so rclone never blocks
  on a full stderr pipe.
- Watch the rclone child process and fail fast with a clear
  `rclone process has exited` error instead of retrying against a dead process.

## Testing

- New unit test for the retry classifier.
- New end-to-end test that kills rclone mid-session and asserts operations
  fail fast with a clear error.
- `go test ./repo/blob/rclone/...` passes with `KOPIA_PROVIDER_TEST=1` against
  rclone v1.69.2, including provider validation.
- `golangci-lint` (repo config) and `gofmt` are clean.

Continues the rclone process-lifecycle hardening from #5040, whose
non-cancelling exec context the process watchdog here builds on.

Relates to #4791 (fixes the transient EOF failures; the persistent
restart-required variant is addressed by #5485)
Relates to #5124

