### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.18.6
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.14.1
-	github.com/kopia/htmluibuild v0.0.1-0.20260622172320-900e7a05d7cf
+	github.com/kopia/htmluibuild v0.0.1-0.20260702020518-e2ab6ef7b573
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/minio/minio-go/v7 v7.2.1

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.14.1 h1:swE9kzyWXD/wVG+l5Pe8bWnQ0giIY7D1GjCBKk3kG2U=
 github.com/klauspost/reedsolomon v1.14.1/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
-github.com/kopia/htmluibuild v0.0.1-0.20260622172320-900e7a05d7cf h1:szBmQo9RnXSkSFB+YgbT0JZkSfo1fiJqIygyq9/VkhQ=
-github.com/kopia/htmluibuild v0.0.1-0.20260622172320-900e7a05d7cf/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260702020518-e2ab6ef7b573 h1:4tOePD7uWMDfM7uubVsLSBYertgqLst17ngGIUNw7ww=
+github.com/kopia/htmluibuild v0.0.1-0.20260702020518-e2ab6ef7b573/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/b10bc3178807e8f0189c78f1886530a72c4fedba...7d46b25a0df806ad134bbbfb008576b89cbcc6ed

* Wed 19:04 -0700 https://github.com/kopia/htmlui/commit/7d46b25 dependabot[bot] build(deps): bump react-router-dom from 7.17.0 to 7.18.1

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Thu Jul  2 02:05:40 UTC 2026*
