### PR TITLE
chore(general): address nits

### DIFF
--- a/internal/servertesting/servertesting.go
+++ b/internal/servertesting/servertesting.go
@@ -106,6 +106,5 @@ func ConnectAndOpenAPIServer(t *testing.T, ctx context.Context, asi *repo.APISer
 		repo.Disconnect(ctx, configFile)
 	})
 
-	//
 	return repo.Open(ctx, configFile, password, opt)
 }

--- a/repo/content/committed_content_index_disk_cache.go
+++ b/repo/content/committed_content_index_disk_cache.go
@@ -44,6 +44,7 @@ func (c *diskCommittedContentIndexCache) openIndex(ctx context.Context, indexBlo
 	ndx, err := index.Open(f, closeMmap, c.v1PerContentOverhead)
 	if err != nil {
 		closeMmap() //nolint:errcheck
+
 		return nil, errors.Wrapf(err, "error opening index from %v", indexBlobID)
 	}
 

--- a/repo/format/format_blob.go
+++ b/repo/format/format_blob.go
@@ -169,11 +169,11 @@ func verifyFormatBlobChecksum(b []byte) ([]byte, bool) {
 
 // WriteKopiaRepositoryBlob writes `kopia.repository` blob to a given storage.
 func (f *KopiaRepositoryJSON) WriteKopiaRepositoryBlob(ctx context.Context, st blob.Storage, blobCfg BlobStorageConfiguration) error {
-	return f.WriteKopiaRepositoryBlobWithID(ctx, st, blobCfg, KopiaRepositoryBlobID)
+	return f.writeKopiaRepositoryBlobWithID(ctx, st, blobCfg, KopiaRepositoryBlobID)
 }
 
-// WriteKopiaRepositoryBlobWithID writes `kopia.repository` blob to a given storage under an alternate blobID.
-func (f *KopiaRepositoryJSON) WriteKopiaRepositoryBlobWithID(ctx context.Context, st blob.Storage, blobCfg BlobStorageConfiguration, id blob.ID) error {
+// writeKopiaRepositoryBlobWithID writes `kopia.repository` blob to a given storage under an alternate blobID.
+func (f *KopiaRepositoryJSON) writeKopiaRepositoryBlobWithID(ctx context.Context, st blob.Storage, blobCfg BlobStorageConfiguration, id blob.ID) error {
 	buf := gather.NewWriteBuffer()
 	e := json.NewEncoder(buf)
 	e.SetIndent("", "  ")

--- a/repo/format/format_provider.go
+++ b/repo/format/format_provider.go
@@ -61,7 +61,6 @@ type Provider interface {
 	GetMutableParameters(ctx context.Context) (MutableParameters, error)
 	GetCachedMutableParameters() MutableParameters
 	SupportsPasswordChange() bool
-	GetMasterKey() []byte
 
 	RepositoryFormatBytes(ctx context.Context) ([]byte, error)
 }

--- a/repo/format/upgrade_lock.go
+++ b/repo/format/upgrade_lock.go
@@ -58,7 +58,7 @@ func (m *Manager) SetUpgradeLockIntent(ctx context.Context, l UpgradeLockIntent)
 
 		// backup the current repository config from local cache to the
 		// repository when we place the lock for the first time
-		if err := m.j.WriteKopiaRepositoryBlobWithID(ctx, m.blobs, m.blobCfgBlob, BackupBlobID(l)); err != nil {
+		if err := m.j.writeKopiaRepositoryBlobWithID(ctx, m.blobs, m.blobCfgBlob, BackupBlobID(l)); err != nil {
 			return nil, errors.Wrap(err, "failed to backup the repo format blob")
 		}
 

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -257,7 +257,7 @@ func (m *committedManifestManager) compactLocked(ctx context.Context) error {
 	}
 
 	// compaction needs to be atomic (deletes and rewrite should show up in one index blob or not show up at all)
-	// that's why we want to prevent index flushes while we're d.
+	// that's why we want to prevent index flushes while we're compacting.
 	m.b.DisableIndexFlush(ctx)
 	defer m.b.EnableIndexFlush(ctx)
 

--- a/site/content/docs/Installation/_index.md
+++ b/site/content/docs/Installation/_index.md
@@ -288,7 +288,7 @@ $ docker run -e KOPIA_PASSWORD \
 
 In addition to creating the docker container with *docker run*, the following docker-compose provides an example for setting up a minimal container in [server mode](../features/#optional-server-mode-with-api-support-to-centrally-manage-backups-of-multiple-machines) including the web interface. You can access the interface via http://localhost:51515 or at the server's IP address after starting the container.  
 
->NOTE Kopia provides a vast of parameters to configure the container. Please check our [docker-compose](https://github.com/kopia/kopia/blob/master/tools/docker/docker-compose.yml) for more details.
+The [sample docker-compose file](https://github.com/kopia/kopia/blob/master/tools/docker/docker-compose.yml) shows various configuration parameters for running Kopia in containers.
 
 ```shell
 version: '3.7'


### PR DESCRIPTION
- unexport `writeKopiaRepositoryBlobWithID`
- fix and reword comments
- remove redundant function declaration in interface