### PR TITLE
chore(general): remove unused `deprecated` field

### DIFF
--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -28,7 +28,7 @@ func (c *commandBenchmarkCrypto) setup(svc appServices, parent commandParent) {
 	cmd := parent.Command("crypto", "Run combined hash and encryption benchmarks")
 	cmd.Flag("block-size", "Size of a block to encrypt").Default("1MB").BytesVar(&c.blockSize)
 	cmd.Flag("repeat", "Number of repetitions").Default("100").UintVar(&c.repeat)
-	cmd.Flag("deprecated", "Include deprecated algorithms [DEPRECATED flag]").Hidden().BoolVar(&c.deprecatedAlgorithms)
+	cmd.Flag("deprecated", "Include deprecated algorithms [DEPRECATED flag, it has no effect]").Hidden().BoolVar(&c.deprecatedAlgorithms)
 	cmd.Flag("parallel", "Number of parallel goroutines").Default("1").UintVar(&c.parallel)
 	cmd.Flag("print-options", "Print out options usable for repository creation").BoolVar(&c.optionPrint)
 	cmd.Action(svc.noRepositoryAction(c.run))

--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -66,7 +66,7 @@ func (c *commandBenchmarkCrypto) runBenchmark(ctx context.Context) []cryptoBench
 	data := make([]byte, c.blockSize)
 
 	for _, ha := range hashing.SupportedAlgorithms() {
-		for _, ea := range encryption.SupportedAlgorithms(c.deprecatedAlgorithms) {
+		for _, ea := range encryption.SupportedAlgorithms() {
 			fo := &format.ContentFormat{
 				Encryption: ea,
 				Hash:       ha,

--- a/cli/command_benchmark_crypto.go
+++ b/cli/command_benchmark_crypto.go
@@ -28,7 +28,7 @@ func (c *commandBenchmarkCrypto) setup(svc appServices, parent commandParent) {
 	cmd := parent.Command("crypto", "Run combined hash and encryption benchmarks")
 	cmd.Flag("block-size", "Size of a block to encrypt").Default("1MB").BytesVar(&c.blockSize)
 	cmd.Flag("repeat", "Number of repetitions").Default("100").UintVar(&c.repeat)
-	cmd.Flag("deprecated", "Include deprecated algorithms").BoolVar(&c.deprecatedAlgorithms)
+	cmd.Flag("deprecated", "Include deprecated algorithms [DEPRECATED flag]").Hidden().BoolVar(&c.deprecatedAlgorithms)
 	cmd.Flag("parallel", "Number of parallel goroutines").Default("1").UintVar(&c.parallel)
 	cmd.Flag("print-options", "Print out options usable for repository creation").BoolVar(&c.optionPrint)
 	cmd.Action(svc.noRepositoryAction(c.run))

--- a/cli/command_benchmark_encryption.go
+++ b/cli/command_benchmark_encryption.go
@@ -65,7 +65,7 @@ func (c *commandBenchmarkEncryption) runBenchmark(ctx context.Context) []cryptoB
 
 	data := make([]byte, c.blockSize)
 
-	for _, ea := range encryption.SupportedAlgorithms(c.deprecatedAlgorithms) {
+	for _, ea := range encryption.SupportedAlgorithms() {
 		enc, err := encryption.CreateEncryptor(&format.ContentFormat{
 			Encryption: ea,
 			Hash:       hashing.DefaultAlgorithm,

--- a/cli/command_benchmark_encryption.go
+++ b/cli/command_benchmark_encryption.go
@@ -28,7 +28,7 @@ func (c *commandBenchmarkEncryption) setup(svc appServices, parent commandParent
 	cmd := parent.Command("encryption", "Run encryption benchmarks")
 	cmd.Flag("block-size", "Size of a block to encrypt").Default("1MB").BytesVar(&c.blockSize)
 	cmd.Flag("repeat", "Number of repetitions").Default("1000").UintVar(&c.repeat)
-	cmd.Flag("deprecated", "Include deprecated algorithms").BoolVar(&c.deprecatedAlgorithms)
+	cmd.Flag("deprecated", "Include deprecated algorithms [DEPRECATED flag]").Hidden().BoolVar(&c.deprecatedAlgorithms)
 	cmd.Flag("parallel", "Number of parallel goroutines").Default("1").UintVar(&c.parallel)
 	cmd.Flag("print-options", "Print out options usable for repository creation").BoolVar(&c.optionPrint)
 	cmd.Action(svc.noRepositoryAction(c.run))

--- a/cli/command_benchmark_encryption.go
+++ b/cli/command_benchmark_encryption.go
@@ -28,7 +28,7 @@ func (c *commandBenchmarkEncryption) setup(svc appServices, parent commandParent
 	cmd := parent.Command("encryption", "Run encryption benchmarks")
 	cmd.Flag("block-size", "Size of a block to encrypt").Default("1MB").BytesVar(&c.blockSize)
 	cmd.Flag("repeat", "Number of repetitions").Default("1000").UintVar(&c.repeat)
-	cmd.Flag("deprecated", "Include deprecated algorithms [DEPRECATED flag]").Hidden().BoolVar(&c.deprecatedAlgorithms)
+	cmd.Flag("deprecated", "Include deprecated algorithms [DEPRECATED flag, it has no effect]").Hidden().BoolVar(&c.deprecatedAlgorithms)
 	cmd.Flag("parallel", "Number of parallel goroutines").Default("1").UintVar(&c.parallel)
 	cmd.Flag("print-options", "Print out options usable for repository creation").BoolVar(&c.optionPrint)
 	cmd.Action(svc.noRepositoryAction(c.run))

--- a/cli/command_repository_create.go
+++ b/cli/command_repository_create.go
@@ -44,7 +44,7 @@ func (c *commandRepositoryCreate) setup(svc advancedAppServices, parent commandP
 	cmd := parent.Command("create", "Create new repository in a specified location.")
 
 	cmd.Flag("block-hash", "Content hash algorithm.").PlaceHolder("ALGO").Default(hashing.DefaultAlgorithm).EnumVar(&c.createBlockHashFormat, hashing.SupportedAlgorithms()...)
-	cmd.Flag("encryption", "Content encryption algorithm.").PlaceHolder("ALGO").Default(encryption.DefaultAlgorithm).EnumVar(&c.createBlockEncryptionFormat, encryption.SupportedAlgorithms(false)...)
+	cmd.Flag("encryption", "Content encryption algorithm.").PlaceHolder("ALGO").Default(encryption.DefaultAlgorithm).EnumVar(&c.createBlockEncryptionFormat, encryption.SupportedAlgorithms()...)
 	cmd.Flag("ecc", "[EXPERIMENTAL] Error correction algorithm.").PlaceHolder("ALGO").Default(ecc.DefaultAlgorithm).EnumVar(&c.createBlockECCFormat, ecc.SupportedAlgorithms()...)
 	cmd.Flag("ecc-overhead-percent", "[EXPERIMENTAL] How much space overhead can be used for error correction, in percentage. Use 0 to disable ECC.").Default("0").IntVar(&c.createBlockECCOverheadPercent)
 	cmd.Flag("object-splitter", "The splitter to use for new objects in the repository").Default(splitter.DefaultAlgorithm).EnumVar(&c.createSplitter, splitter.SupportedAlgorithms()...)

--- a/internal/server/api_repo.go
+++ b/internal/server/api_repo.go
@@ -246,7 +246,7 @@ func handleRepoSupportedAlgorithms(_ context.Context, _ requestContext) (any, *a
 		SupportedHashAlgorithms: toAlgorithmInfo(hashing.SupportedAlgorithms(), neverDeprecated),
 
 		DefaultEncryptionAlgorithm:    encryption.DefaultAlgorithm,
-		SupportedEncryptionAlgorithms: toAlgorithmInfo(encryption.SupportedAlgorithms(false), neverDeprecated),
+		SupportedEncryptionAlgorithms: toAlgorithmInfo(encryption.SupportedAlgorithms(), neverDeprecated),
 
 		DefaultECCAlgorithm:    ecc.DefaultAlgorithm,
 		SupportedECCAlgorithms: toAlgorithmInfo(ecc.SupportedAlgorithms(), neverDeprecated),

--- a/repo/content/content_formatter_test.go
+++ b/repo/content/content_formatter_test.go
@@ -29,7 +29,7 @@ func TestFormatters(t *testing.T) {
 
 	for _, hashAlgo := range hashing.SupportedAlgorithms() {
 		t.Run(hashAlgo, func(t *testing.T) {
-			for _, encryptionAlgo := range encryption.SupportedAlgorithms(true) {
+			for _, encryptionAlgo := range encryption.SupportedAlgorithms() {
 				t.Run(encryptionAlgo, func(t *testing.T) {
 					ctx := testlogging.Context(t)
 

--- a/repo/encryption/aes256_gcm_hmac_sha256_encryptor.go
+++ b/repo/encryption/aes256_gcm_hmac_sha256_encryptor.go
@@ -69,7 +69,7 @@ func (e aes256GCMHmacSha256) Overhead() int {
 }
 
 func init() {
-	Register("AES256-GCM-HMAC-SHA256", "AES-256-GCM using per-content key generated using HMAC-SHA256", false, func(p Parameters) (Encryptor, error) {
+	Register("AES256-GCM-HMAC-SHA256", "AES-256-GCM using per-content key generated using HMAC-SHA256", func(p Parameters) (Encryptor, error) {
 		keyDerivationSecret, err := deriveKey(p, []byte(purposeEncryptionKey), aes256KeyDerivationSecretSize)
 		if err != nil {
 			return nil, err

--- a/repo/encryption/chacha20_poly1305_hmac_sha256_encryptor.go
+++ b/repo/encryption/chacha20_poly1305_hmac_sha256_encryptor.go
@@ -64,7 +64,7 @@ func (e chacha20poly1305hmacSha256Encryptor) Overhead() int {
 }
 
 func init() {
-	Register("CHACHA20-POLY1305-HMAC-SHA256", "CHACHA20-POLY1305 using per-content key generated using HMAC-SHA256", false, func(p Parameters) (Encryptor, error) {
+	Register("CHACHA20-POLY1305-HMAC-SHA256", "CHACHA20-POLY1305 using per-content key generated using HMAC-SHA256", func(p Parameters) (Encryptor, error) {
 		keyDerivationSecret, err := deriveKey(p, []byte(purposeEncryptionKey), chacha20KeyDerivationSecretSize)
 		if err != nil {
 			return nil, err

--- a/repo/encryption/encryption.go
+++ b/repo/encryption/encryption.go
@@ -69,7 +69,7 @@ func SupportedAlgorithms() []string {
 }
 
 // Register registers new encryption algorithm.
-func Register(name, description string, deprecated bool, newEncryptor EncryptorFactory) {
+func Register(name, description string, newEncryptor EncryptorFactory) {
 	encryptors[name] = &encryptorInfo{
 		description,
 		newEncryptor,

--- a/repo/encryption/encryption.go
+++ b/repo/encryption/encryption.go
@@ -59,11 +59,7 @@ const DefaultAlgorithm = "AES256-GCM-HMAC-SHA256"
 func SupportedAlgorithms(includeDeprecated bool) []string {
 	var result []string
 
-	for k, e := range encryptors {
-		if e.deprecated && !includeDeprecated {
-			continue
-		}
-
+	for k := range encryptors {
 		result = append(result, k)
 	}
 
@@ -76,14 +72,12 @@ func SupportedAlgorithms(includeDeprecated bool) []string {
 func Register(name, description string, deprecated bool, newEncryptor EncryptorFactory) {
 	encryptors[name] = &encryptorInfo{
 		description,
-		deprecated,
 		newEncryptor,
 	}
 }
 
 type encryptorInfo struct {
 	description  string
-	deprecated   bool
 	newEncryptor EncryptorFactory
 }
 

--- a/repo/encryption/encryption.go
+++ b/repo/encryption/encryption.go
@@ -4,7 +4,8 @@ package encryption
 import (
 	"crypto/hkdf"
 	"crypto/sha256"
-	"sort"
+	"maps"
+	"slices"
 
 	"github.com/pkg/errors"
 
@@ -57,15 +58,7 @@ const DefaultAlgorithm = "AES256-GCM-HMAC-SHA256"
 // SupportedAlgorithms returns the names of the supported encryption
 // methods.
 func SupportedAlgorithms() []string {
-	var result []string
-
-	for k := range encryptors {
-		result = append(result, k)
-	}
-
-	sort.Strings(result)
-
-	return result
+	return slices.Sorted(maps.Keys(encryptors))
 }
 
 // Register registers new encryption algorithm.

--- a/repo/encryption/encryption.go
+++ b/repo/encryption/encryption.go
@@ -56,7 +56,7 @@ const DefaultAlgorithm = "AES256-GCM-HMAC-SHA256"
 
 // SupportedAlgorithms returns the names of the supported encryption
 // methods.
-func SupportedAlgorithms(includeDeprecated bool) []string {
+func SupportedAlgorithms() []string {
 	var result []string
 
 	for k := range encryptors {

--- a/repo/encryption/encryption_test.go
+++ b/repo/encryption/encryption_test.go
@@ -35,7 +35,7 @@ func TestRoundTrip(t *testing.T) {
 	contentID2 := make([]byte, 16)
 	rand.Read(contentID2)
 
-	for _, encryptionAlgo := range encryption.SupportedAlgorithms(true) {
+	for _, encryptionAlgo := range encryption.SupportedAlgorithms() {
 		t.Run(encryptionAlgo, func(t *testing.T) {
 			e, err := encryption.CreateEncryptor(parameters{encryptionAlgo, masterKey})
 			if err != nil {
@@ -133,7 +133,7 @@ func TestCiphertextSamples(t *testing.T) {
 func verifyCiphertextSamples(t *testing.T, masterKey, contentID, payload []byte, samples map[string]string) {
 	t.Helper()
 
-	for _, encryptionAlgo := range encryption.SupportedAlgorithms(true) {
+	for _, encryptionAlgo := range encryption.SupportedAlgorithms() {
 		enc, err := encryption.CreateEncryptor(parameters{encryptionAlgo, masterKey})
 		if err != nil {
 			t.Fatal(err)

--- a/tests/end_to_end_test/all_formats_test.go
+++ b/tests/end_to_end_test/all_formats_test.go
@@ -24,7 +24,7 @@ func TestAllFormatsSmokeTest(t *testing.T) {
 		MaxFileSize:            100,
 	}, nil)
 
-	for _, encryptionAlgo := range encryption.SupportedAlgorithms(false) {
+	for _, encryptionAlgo := range encryption.SupportedAlgorithms() {
 		t.Run(encryptionAlgo, func(t *testing.T) {
 			for _, hashAlgo := range hashing.SupportedAlgorithms() {
 				t.Run(hashAlgo, func(t *testing.T) {


### PR DESCRIPTION
- remove unused field `encryptorInfo.deprecated`
- simplify implementations and function signatures
- deprecate `--deprecated` CLI flag