### PR TITLE
build(deps): upgrade Go to 1.25.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kopia/kopia
 
 go 1.25.8
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	cloud.google.com/go/storage v1.63.0


### PR DESCRIPTION
- https://github.com/golang/go/issues?q=milestone%3AGo1.25.12+label%3ACherryPickApproved

---

os: Root escape via symlink plus trailing slash

On Unix systems, opening a file in an os.Root improperly
followed symlinks to locations outside of the Root when
the final path component of the a path is a symbolic link
and the path ends in /.

For example, root.Open("symlink/") would open "symlink"
even when "symlink" is a symbolic link pointing outside of the root.

On Unix, openat(fd, path, O_NOFOLLOW) will follow symlinks
in path when path ends in a /. Root failed to account for
this behavior, permitting paths with a trailing / to escape.
It now properly sanitizes the path parameter provided to openat.

Thanks to Mundur (https://github.com/M0nd0R) for reporting this issue.

This is CVE-2026-39822 and Go issue https://go.dev/issue/79005.

crypto/tls: Encrypted Client Hello privacy leak

The Encrypted Client Hello implementation would leak the pre-shared key
identities during the handshake, allowing a passive network observer who can
collect handshakes to de-anonymize the hostname of the server, even when ECH was
being used.

Thanks to Coia Prant ([github.com/rbqvq](http://github.com/rbqvq)) for reporting this issue.

This is CVE-2026-42505 and Go issue https://go.dev/issue/79282.