### PR TITLE
fix(rclone): keep rclone support files out of the OS temp directory

### DIFF
--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -172,6 +172,34 @@ func (r *rcloneStorage) forgetVFS(ctx context.Context) error {
 	return r.remoteControl(ctx, "vfs/forget", map[string]string{}, &out)
 }
 
+// createSupportFilesDir creates a directory for files that must remain available
+// for the lifetime of the rclone child process: the htpasswd file, the TLS key and
+// certificate, and the optional embedded rclone config.
+//
+// These files must NOT live in the OS temp directory: temp cleaners (e.g. Windows
+// Storage Sense) delete them from under long-running processes, after which rclone
+// drops every authenticated connection and all storage operations fail with EOF
+// until the storage is reopened (#4791). The user cache dir is used instead,
+// falling back to the temp dir when no cache dir is available.
+func createSupportFilesDir() (string, error) {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		td, terr := os.MkdirTemp("", "kopia-rclone")
+		return td, errors.Wrap(terr, "unable to create temporary dir")
+	}
+
+	parent := filepath.Join(base, "kopia-rclone")
+
+	//nolint:mnd
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return "", errors.Wrap(err, "unable to create rclone support files dir")
+	}
+
+	td, err := os.MkdirTemp(parent, "s")
+
+	return td, errors.Wrap(err, "unable to create rclone support files dir")
+}
+
 type rcloneURLs struct {
 	webdavAddr        string
 	remoteControlAddr string
@@ -252,10 +280,10 @@ func (r *rcloneStorage) runRCloneAndWaitForServerAddress(ctx context.Context, c 
 func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error) {
 	log(ctx).Warn("The rclone storage provider is not actively tested, it may cause data loss, use at your own risk")
 
-	// generate directory for all temp files.
-	td, err := os.MkdirTemp("", "kopia-rclone")
+	// directory for rclone support files (htpasswd, TLS key+cert, embedded config).
+	td, err := createSupportFilesDir()
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting temporary dir")
+		return nil, errors.Wrap(err, "error creating support files dir")
 	}
 
 	r := &rcloneStorage{

--- a/repo/blob/rclone/rclone_storage_supportdir_test.go
+++ b/repo/blob/rclone/rclone_storage_supportdir_test.go
@@ -1,0 +1,91 @@
+//go:build !no_extra_providers
+
+package rclone
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
+)
+
+func TestCreateSupportFilesDirAvoidsOSTempDir(t *testing.T) {
+	t.Parallel()
+
+	td, err := createSupportFilesDir()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.RemoveAll(td) //nolint:errcheck
+	})
+
+	require.DirExists(t, td)
+
+	if _, err := os.UserCacheDir(); err == nil {
+		require.NotEqual(t, filepath.Clean(os.TempDir()), filepath.Dir(filepath.Clean(td)),
+			"rclone support files must not live in the OS temp directory - temp cleaners delete them from under a running rclone (#4791)")
+	}
+}
+
+func TestRCloneStorageSupportFilesDeleted(t *testing.T) {
+	t.Parallel()
+	testutil.ProviderTest(t)
+
+	ctx := testlogging.Context(t)
+
+	rcloneExe := os.Getenv("RCLONE_EXE")
+	if rcloneExe == "" {
+		rcloneExe = "rclone"
+	}
+
+	if err := exec.CommandContext(ctx, rcloneExe, "version").Run(); err != nil {
+		if os.Getenv("CI") == "" {
+			t.Skipf("rclone not installed: %v", err)
+		} else {
+			// on CI fail hard
+			t.Fatalf("rclone not installed: %v", err)
+		}
+	}
+
+	st, err := New(ctx, &Options{
+		// pass local file as remote path.
+		RemotePath: testutil.TempDirectory(t),
+		RCloneExe:  rcloneExe,
+	}, true)
+	require.NoError(t, err, "unable to connect to rclone backend")
+
+	t.Cleanup(func() {
+		st.Close(testlogging.ContextForCleanup(t))
+	})
+
+	r, ok := st.(*rcloneStorage)
+	require.True(t, ok)
+
+	// simulate a temp cleaner (e.g. Windows Storage Sense) deleting support files
+	// from under the running rclone (#4791). rclone only opens the htpasswd file
+	// while serving an authenticated request, so right after startup nothing holds
+	// it and the deletion succeeds - just like a cleaner sweeping an idle instance.
+	require.NoError(t, os.Remove(filepath.Join(r.temporaryDir, "htpasswd")))
+
+	// once the htpasswd file is gone, rclone drops every connection that carries
+	// an Authorization header; operations must fail with a clear error instead of
+	// appearing to hang.
+	var tmp gather.WriteBuffer
+	defer tmp.Close()
+
+	t0 := clock.Now()
+	err = st.GetBlob(ctx, "someblob1234567812345678", 0, -1, &tmp)
+	dur := clock.Now().Sub(t0)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "error flushing dir cache")
+	require.Less(t, dur, time.Minute, "operation against auth-broken rclone took too long: %v", dur)
+}


### PR DESCRIPTION
## Problem

With the rclone backend, a long-running kopia/KopiaUI instance eventually enters a
state where **every** operation fails with:

    error flushing dir cache: RC error: Post "https://127.0.0.1:PORT/vfs/forget": EOF

and nothing recovers until KopiaUI is restarted, even though the rclone child
process is still running. Reported repeatedly in #4791 ("works again after
restart").

## Root cause

`rclone.New` writes files that must remain available for the lifetime of the
rclone child — the `htpasswd` file, the TLS key/certificate, and the optional
embedded rclone config — into `os.MkdirTemp("", "kopia-rclone")`, i.e. the OS
temp directory.

Temp cleaners delete files from under long-running processes. On a live wedged
instance (Windows 11, KopiaUI up for 8 days) Windows Storage Sense had deleted
these files while kopia and rclone kept running.

rclone re-opens the htpasswd file for every authenticated request. Once the file
is gone, rclone drops every connection that carries an `Authorization` header —
kopia always sends one, so every RC and WebDAV request fails with an instant EOF.
From the outside the process looks healthy: TLS handshakes succeed and
unauthenticated requests get a normal `401` (the auth challenge is issued without
consulting the file), which is what made this hard to pin down. Restarting
KopiaUI recreates the files, hence "restart fixes it".

Verified on the live instance by request bisection: identical requests with an
`Authorization` header → instant EOF; without → `401`; the htpasswd confirmed
missing from the temp dir; both the RC and WebDAV listeners affected (same
`--htpasswd`).

The existing reports in #4791 fit this mechanism closely: the original (macOS)
report fails "after several days" and recovers on restart — macOS's daily
maintenance deletes `$TMPDIR` files unused for ~3 days, which is exactly where
`os.MkdirTemp` places these files on macOS — and another report had three
independent docker instances fail simultaneously (consistent with a host-level
tmp cleanup), all recovering only on restart.

### Forensic timeline from the affected machine (all times local, same day)

| Time | Event | Source |
|---|---|---|
| 15:27 | last healthy storage operation; server then idle | kopia server log |
| 15:45:48 | Storage Sense scheduled task runs | `\Microsoft\Windows\DiskFootprint\StorageSense` `LastRunTime` |
| 15:45:55 | support files inside the `kopia-rclone*` temp dir deleted | NTFS `LastWriteTime` of the surviving (now empty) directory |
| 16:26:11 | first authenticated RC call after the sweep fails with EOF; every subsequent operation fails until restart | kopia server log |

The same temp directory also holds ~140 older, now-empty `kopia-rclone*`
directories accumulated over 14 months of using this backend, essentially all
with the same signature: created, then emptied 7–9 days later (Storage Sense's
~7-day "unused temp files" threshold). Instances restarted within a week
escaped; any instance that lived longer had its credentials swept out from
under it.

## Change

Create the support-files directory under `os.UserCacheDir()` (e.g.
`%LOCALAPPDATA%\kopia-rclone\` on Windows, `~/.cache/kopia-rclone/` on Linux)
instead of the OS temp directory — temp cleaners do not sweep these locations.
Falls back to the temp dir when no user cache dir is available. Lifecycle is
unchanged: the directory is still removed on `Close()`.

## Testing

- New regression test deletes the htpasswd from under a freshly started rclone
  storage and verifies operations fail with a clear error rather than hanging.
  Deleting right after startup is deterministic: rclone only holds the file open
  around authenticated requests, which is the same idle window a temp cleaner
  hits in production.
- New unit test asserts the support dir is not placed in the OS temp directory.
- `go test ./repo/blob/rclone/...` passes with `KOPIA_PROVIDER_TEST=1` against
  rclone v1.69.2.
- `golangci-lint` (repo config) and `gofmt` are clean.

Fixes #4791

(An earlier PR, #5462, hardened the remote-control path based on a
transient stale-connection hypothesis; I withdrew it after concluding the
documented failures all match the root cause fixed here.)


