### PR TITLE
fix(repository): stop cache hits from corrupting LRU size accounting

### DIFF
--- a/internal/cache/persistent_lru_cache.go
+++ b/internal/cache/persistent_lru_cache.go
@@ -95,7 +95,7 @@ func (c *PersistentCache) getFull(ctx context.Context, key string, output *gathe
 	return c.getPartial(ctx, key, 0, -1, output)
 }
 
-func (c *PersistentCache) getPartialCacheHit(ctx context.Context, key string, length int64, output *gather.WriteBuffer) {
+func (c *PersistentCache) getPartialCacheHit(ctx context.Context, key string, output *gather.WriteBuffer) {
 	// cache hit
 	c.reportHitBytes(int64(output.Length()))
 
@@ -105,11 +105,11 @@ func (c *PersistentCache) getPartialCacheHit(ctx context.Context, key string, le
 	defer c.listCacheMutex.Unlock()
 
 	if err == nil {
-		c.listCache.AddOrUpdate(blob.Metadata{
-			BlobID:    blob.ID(key),
-			Length:    length,
-			Timestamp: mtime,
-		})
+		// a read does not change the item's on-disk size, so only refresh its
+		// timestamp. Passing the request length here (-1 for a full read, or a
+		// sub-range length for a partial read) as the tracked size would corrupt
+		// totalDataBytes and defeat the sweep's size limits until the next scan.
+		c.listCache.Touch(blob.ID(key), mtime)
 	}
 }
 
@@ -146,7 +146,7 @@ func (c *PersistentCache) getPartial(ctx context.Context, key string, offset, le
 		}
 
 		if err := sp.Verify(key, tmp.Bytes(), output); err == nil {
-			c.getPartialCacheHit(ctx, key, length, output)
+			c.getPartialCacheHit(ctx, key, output)
 
 			return true
 		}
@@ -260,6 +260,16 @@ func (h *contentMetadataHeap) AddOrUpdate(bm blob.Metadata) {
 		}
 	} else {
 		heap.Push(h, bm)
+	}
+}
+
+// Touch refreshes the timestamp of an already-tracked item without altering its
+// tracked size (a cache hit does not change the blob's on-disk length). Items
+// that are not tracked are ignored, since their size is unknown here.
+func (h *contentMetadataHeap) Touch(blobID blob.ID, ts time.Time) {
+	if i, exists := h.index[blobID]; exists && ts.After(h.data[i].Timestamp) {
+		h.data[i].Timestamp = ts
+		heap.Fix(h, i)
 	}
 }
 

--- a/internal/cache/persistent_lru_cache_accounting_test.go
+++ b/internal/cache/persistent_lru_cache_accounting_test.go
@@ -1,0 +1,116 @@
+package cache_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/cache"
+	"github.com/kopia/kopia/internal/cacheprot"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+// TestPersistentLRUCache_CacheHitsPreserveHardLimit reproduces #5408: a
+// long-running reader (e.g. a `kopia mount` + diff/restore) fills the content
+// cache far beyond its configured hard limit, and only a fresh `kopia cache
+// info` (which re-scans the directory) brings it back down.
+//
+// The mechanism: on every full-blob cache hit, getPartialCacheHit records the
+// *request* length (-1 for a full read) as the item's tracked size. That
+// corrupts the running totalDataBytes downward, so both the soft and the hard
+// sweep limits stop firing and the on-disk cache grows without bound until the
+// next initialScan recomputes the size from the actual blobs.
+func TestPersistentLRUCache_CacheHitsPreserveHardLimit(t *testing.T) {
+	ctx := testlogging.ContextWithLevel(t, testlogging.LevelInfo)
+
+	// monotonically increasing clock so every TouchBlob advances the stored
+	// mtime and the accounting update path is exercised on each cache hit.
+	var (
+		mu   sync.Mutex
+		base = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		tick int64
+	)
+
+	timeNow := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		tick++
+
+		return base.Add(time.Duration(tick) * time.Second)
+	}
+
+	const (
+		limitBytes = 1000
+		blobSize   = 300
+	)
+
+	data := blobtesting.DataMap{}
+	cs := testutil.EnsureType[cache.Storage](t, blobtesting.NewMapStorageWithLimit(data, nil, timeNow, -1))
+
+	pc, err := cache.NewPersistentCache(ctx, "testing", cs, cacheprot.ChecksumProtection([]byte{1, 2, 3}), cache.SweepSettings{
+		MaxSizeBytes:   limitBytes,
+		LimitBytes:     limitBytes,      // hard limit, enforced regardless of item age
+		MinSweepAge:    time.Hour,       // keep every item "young" so ONLY the hard limit can evict
+		TouchThreshold: time.Nanosecond, // refresh mtime on every read (the real default is 10m, which a long mount crosses)
+	}, nil, timeNow)
+	require.NoError(t, err)
+
+	payload := bytes.Repeat([]byte{1}, blobSize)
+
+	// Prime the cache up to its hard limit (3 * ~332 bytes <= 1000).
+	pc.Put(ctx, "key1", gather.FromSlice(payload))
+	pc.Put(ctx, "key2", gather.FromSlice(payload))
+	pc.Put(ctx, "key3", gather.FromSlice(payload))
+
+	// Simulate a sustained read-heavy mount: each cached blob is read back
+	// (a full-blob cache hit) while new content keeps being fetched. Every hit
+	// records -1 (the request length of a full read) as the item's tracked
+	// size, so the running total drifts ever more negative and the sweep never
+	// sees the cache cross its hard limit -- even though the directory keeps
+	// growing on disk.
+	const total = 30
+
+	for i := 1; i <= total; i++ {
+		var tmp gather.WriteBuffer
+		pc.TestingGetFull(ctx, fmt.Sprintf("key%d", i), &tmp)
+		tmp.Close()
+
+		pc.Put(ctx, fmt.Sprintf("key%d", i+3), gather.FromSlice(payload))
+	}
+
+	// The hard limit must cap the on-disk cache regardless of the reads above.
+	// 1000 bytes / ~332 per blob => at most ~3 retained blobs.
+	const maxRetained = 5
+
+	require.LessOrEqualf(t, len(data), maxRetained,
+		"content cache holds %d blobs, far above what the %d-byte hard limit allows: "+
+			"cache-hit size accounting was corrupted and the sweep stopped enforcing the limit",
+		len(data), limitBytes)
+
+	// The tracked size must stay consistent with the blobs actually on disk, so
+	// that a subsequent Put keeps enforcing the limit without needing a re-scan.
+	require.LessOrEqual(t, totalStoredBytes(ctx, t, cs), int64(limitBytes)+blobSize+int64(cacheprot.ChecksumProtection([]byte{1, 2, 3}).OverheadBytes()))
+}
+
+func totalStoredBytes(ctx context.Context, t *testing.T, cs cache.Storage) int64 {
+	t.Helper()
+
+	var total int64
+
+	require.NoError(t, cs.ListBlobs(ctx, "", func(bm blob.Metadata) error {
+		total += bm.Length
+
+		return nil
+	}))
+
+	return total
+}


### PR DESCRIPTION
## Problem

Fixes #5408. With only a hard cache limit configured

```
kopia cache set --content-cache-size-limit-mb=1000
kopia cache set --metadata-cache-size-limit-mb=1000
```

a sustained read-heavy session (a `kopia mount` + diff/restore in the report) lets `~/.cache/kopia/contents/` grow far past the limit — the reporter saw it reach ~6 GB against a 1000 MB hard limit, with every other subdir under 230 MB. Running `kopia cache info` immediately brings it back down, and the overflow is workload/duration dependent (a short run, or the same steps over a fresh connection, stays under the limit).

## Root cause

The persistent LRU cache sweeps on every `Put` and on the initial scan, using an in-memory running total `contentMetadataHeap.totalDataBytes` to decide whether it is above the soft/hard limit. On a cache **hit**, `getPartialCacheHit` refreshes the item's timestamp but also feeds the **request length** back into the heap as the item's tracked size:

```go
// persistent_lru_cache.go, getPartialCacheHit
c.listCache.AddOrUpdate(blob.Metadata{
    BlobID:    blob.ID(key),
    Length:    length,   // -1 for a full read, or a sub-range length for a partial read
    Timestamp: mtime,
})
```

For a full-blob read `length` is `-1` (`getFull` → `getPartial(..., -1, ...)`); for a partial read it is the sub-range, not the full blob size. `AddOrUpdate` applies the update whenever the timestamp is newer:

```go
h.totalDataBytes += bm.Length - h.data[i].Length   // += (-1) - realLength
```

so each qualifying hit subtracts the item's real size and records `-1` in its place. `totalDataBytes` drifts steadily below the real on-disk size, `aboveSoftLimit`/`aboveHardLimit` stop firing, and the sweep no longer enforces either limit — the directory grows unbounded until the next `initialScan` (a fresh `kopia cache info`, reconnect, or restart) recomputes the total from the actual blobs.

The timestamp gate explains the duration dependence: `TouchBlob` only advances an item's mtime once per `TouchThreshold` (default 10 min), so the corrupting update only lands on re-reads that cross that window — i.e. long-running mounts, not short commands.

## Fix

A read never changes a blob's on-disk size, so the hit path should refresh only the timestamp. Added `contentMetadataHeap.Touch`, which updates the timestamp of an already-tracked item and leaves its `Length` (and thus `totalDataBytes`) untouched, and switched `getPartialCacheHit` to use it.

## Test

`TestPersistentLRUCache_CacheHitsPreserveHardLimit` primes the cache to its hard limit, then interleaves full-blob cache hits with new fetches under a 1 ns touch threshold (so each re-read crosses the window). Before the fix the cache retains 33 blobs against a limit that holds ~3; after the fix the sweep keeps it bounded. The full `internal/cache` and `repo/content` suites stay green.
