### PR TITLE
docs(general): add SECURITY.md surfacing the existing security@kopia.io channel

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you find a security issue you would like to disclose privately, please email
+**security@kopia.io**. Please do **not** open a public GitHub issue for security
+vulnerabilities.
+
+This mirrors the private disclosure channel already documented in the project
+README, surfaced here so it also appears under GitHub's **Security policy** tab.


### PR DESCRIPTION
Hi, and thank you for Kopia.

The README documents a private security-disclosure channel (`security@kopia.io`), but there's no `SECURITY.md`, so GitHub's **Security policy** tab is empty and the community-health profile reports no policy. Reporters who look there — the standard place — don't find the channel.

This PR adds a short `SECURITY.md` that surfaces the **existing** channel (it doesn't invent a new one): report privately to `security@kopia.io`, don't open a public issue.

For transparency: I used AI assistance to spot and draft this; I verified the missing policy and the README channel myself.
