### PR TITLE
refactor(general): use structured logging in diff

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -81,7 +81,12 @@ func maybeOID(e fs.Entry) string {
 }
 
 func (c *Comparer) compareDirectories(ctx context.Context, dir1, dir2 fs.Directory, parent string) error {
-	log(ctx).Debugf("comparing directories %v (%v and %v)", parent, maybeOID(dir1), maybeOID(dir2))
+	log(ctx).Debugw(
+		"comparing directories",
+		"parent", parent,
+		"dir1", maybeOID(dir1),
+		"dir2", maybeOID(dir2),
+	)
 
 	var entries1, entries2 []fs.Entry
 
@@ -235,7 +240,7 @@ func compareMetadata(ctx context.Context, e1, e2 fs.Entry, path string, st *Entr
 	if changed {
 		st.SameContentButDifferentMetadata++
 
-		log(ctx).Debugf("content unchanged but metadata has been modified: %v", path)
+		log(ctx).Debugw("content unchanged but metadata has been modified", "path", path)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the remaining formatted debug logs in `internal/diff` with structured events
- expose the compared parent path, both directory object IDs, and the metadata-only change path as independent fields
- preserve comparison behavior and control flow

The existing `Debugf` calls encoded these values inside formatted message strings, which made them difficult to query as structured log data.

Refs #1478

## Validation

- `GOTOOLCHAIN=go1.25.12 go test ./internal/diff`
- `GOTOOLCHAIN=go1.25.12 go vet ./internal/diff`
- `GOTOOLCHAIN=go1.25.12 make lint`
- `GOTOOLCHAIN=go1.25.12 make ci-tests` — 6,449 tests passed, 109 skipped, 0 failed
- `gofmt -d internal/diff/diff.go`
- `git diff --check`

## AI assistance

OpenAI Codex assisted with implementation and validation. No human review is claimed.
