### PR TITLE
feat(cli): apply object-lock retention in repository sync-to

### DIFF
--- a/cli/command_repository_sync.go
+++ b/cli/command_repository_sync.go
@@ -30,6 +30,9 @@ type commandRepositorySyncTo struct {
 	repositorySyncParallelism          int
 	repositorySyncDestinationMustExist bool
 	repositorySyncTimes                bool
+	repositorySyncRetentionMode        string
+	repositorySyncRetentionPeriod      time.Duration
+	repositorySyncExtendObjectLocks    bool
 
 	lastSyncProgress  string
 	syncProgressMutex sync.Mutex
@@ -46,6 +49,9 @@ func (c *commandRepositorySyncTo) setup(svc advancedAppServices, parent commandP
 	cmd.Flag("parallel", "Copy parallelism.").Default("1").IntVar(&c.repositorySyncParallelism)
 	cmd.Flag("must-exist", "Fail if destination does not have repository format blob.").BoolVar(&c.repositorySyncDestinationMustExist)
 	cmd.Flag("times", "Synchronize blob times if supported.").BoolVar(&c.repositorySyncTimes)
+	cmd.Flag("retention-mode", "Apply object-lock retention mode to synchronized blobs on the destination (requires object-lock capable storage such as S3).").EnumVar(&c.repositorySyncRetentionMode, blob.Governance.String(), blob.Compliance.String())
+	cmd.Flag("retention-period", "Object-lock retention period for synchronized blobs (minimum 24h). Schedule syncs so locks are refreshed with a safety margin of at least 24h before expiry.").DurationVar(&c.repositorySyncRetentionPeriod)
+	cmd.Flag("extend-object-locks", "Extend object locks on destination blobs already in sync (one retention-update API request per locked blob per run).").Default("true").BoolVar(&c.repositorySyncExtendObjectLocks)
 
 	c.out.setup(svc)
 	c.progress = svc.getProgress()
@@ -91,21 +97,72 @@ func (c *commandRepositorySyncTo) runSyncWithStorage(ctx context.Context, src bl
 		log(ctx).Info("NOTE: By default no BLOBs are deleted, pass --delete to allow it.")
 	}
 
-	if err := c.ensureRepositoriesHaveSameFormatBlob(ctx, src, dst); err != nil {
+	dst, blobcfg, err := c.setupDestinationRetention(ctx, dst)
+	if err != nil {
 		return err
+	}
+
+	if err := c.ensureRepositoriesHaveSameFormatBlob(ctx, src, dst); err != nil {
+		return wrapObjectLockError(err)
 	}
 
 	log(ctx).Info("Looking for BLOBs to synchronize...")
 
+	extendLocks := c.extendLocksEnabled(blobcfg)
+
+	plan, err := c.computeSyncPlan(ctx, src, dst, extendLocks)
+	if err != nil {
+		return err
+	}
+
+	log(ctx).Infof(
+		"  Found %v BLOBs to delete (%v), %v in sync (%v)",
+		len(plan.blobsToDelete), units.BytesString(plan.totalDeleteBytes),
+		plan.inSyncBlobs, units.BytesString(plan.inSyncBytes),
+	)
+
+	if extendLocks {
+		log(ctx).Infof("  Found %v BLOBs to extend object locks on", len(plan.blobsToExtend))
+	}
+
+	if c.repositorySyncDryRun {
+		return nil
+	}
+
+	log(ctx).Info("Copying...")
+
+	c.beginSyncProgress()
+
+	finalErr := c.runSyncBlobs(ctx, src, dst, plan.blobsToCopy, plan.blobsToDelete, plan.totalCopyBytes)
+
+	c.finishSyncProcess()
+
+	if finalErr == nil {
+		finalErr = c.extendDestinationLocks(ctx, dst, plan.blobsToExtend, blobcfg)
+	}
+
+	return wrapObjectLockError(finalErr)
+}
+
+// syncPlan describes the work to be performed by a sync-to run.
+type syncPlan struct {
+	blobsToCopy    []blob.Metadata
+	totalCopyBytes int64
+
+	blobsToDelete    []blob.Metadata
+	totalDeleteBytes int64
+
+	blobsToExtend []blob.Metadata
+
+	inSyncBlobs int
+	inSyncBytes int64
+}
+
+// computeSyncPlan lists the source and destination blobs and classifies them
+// into blobs to copy, delete and extend object locks on.
+func (c *commandRepositorySyncTo) computeSyncPlan(ctx context.Context, src blob.Reader, dst blob.Storage, extendLocks bool) (*syncPlan, error) {
 	var (
-		inSyncBlobs int
-		inSyncBytes int64
-
-		blobsToCopy    []blob.Metadata
-		totalCopyBytes int64
-
-		blobsToDelete    []blob.Metadata
-		totalDeleteBytes int64
+		plan syncPlan
 
 		srcBlobs     int
 		totalSrcSize int64
@@ -113,7 +170,7 @@ func (c *commandRepositorySyncTo) runSyncWithStorage(ctx context.Context, src bl
 
 	dstMetadata, err := c.listDestinationBlobs(ctx, dst)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	c.beginSyncProgress()
@@ -126,22 +183,26 @@ func (c *commandRepositorySyncTo) runSyncWithStorage(ctx context.Context, src bl
 
 		switch {
 		case !exists:
-			blobsToCopy = append(blobsToCopy, srcmd)
-			totalCopyBytes += srcmd.Length
+			plan.blobsToCopy = append(plan.blobsToCopy, srcmd)
+			plan.totalCopyBytes += srcmd.Length
 		case srcmd.Timestamp.After(dstmd.Timestamp) && c.repositorySyncUpdate:
-			blobsToCopy = append(blobsToCopy, srcmd)
-			totalCopyBytes += srcmd.Length
+			plan.blobsToCopy = append(plan.blobsToCopy, srcmd)
+			plan.totalCopyBytes += srcmd.Length
 		default:
-			inSyncBlobs++
-			inSyncBytes += srcmd.Length
+			plan.inSyncBlobs++
+			plan.inSyncBytes += srcmd.Length
+
+			if shouldExtendObjectLock(extendLocks, srcmd.BlobID) {
+				plan.blobsToExtend = append(plan.blobsToExtend, srcmd)
+			}
 		}
 
 		srcBlobs++
-		c.outputSyncProgress(fmt.Sprintf("  Found %v BLOBs (%v) in the source repository, %v (%v) to copy", srcBlobs, units.BytesString(totalSrcSize), len(blobsToCopy), units.BytesString(totalCopyBytes)))
+		c.outputSyncProgress(fmt.Sprintf("  Found %v BLOBs (%v) in the source repository, %v (%v) to copy", srcBlobs, units.BytesString(totalSrcSize), len(plan.blobsToCopy), units.BytesString(plan.totalCopyBytes)))
 
 		return nil
 	}); err != nil {
-		return errors.Wrap(err, "error listing blobs")
+		return nil, errors.Wrap(err, "error listing blobs")
 	}
 
 	c.finishSyncProcess()
@@ -149,30 +210,68 @@ func (c *commandRepositorySyncTo) runSyncWithStorage(ctx context.Context, src bl
 	if c.repositorySyncDelete {
 		for _, dstmd := range dstMetadata {
 			// found in dst, not in src since we were deleting from dst as we found a match.
-			blobsToDelete = append(blobsToDelete, dstmd)
-			totalDeleteBytes += dstmd.Length
+			plan.blobsToDelete = append(plan.blobsToDelete, dstmd)
+			plan.totalDeleteBytes += dstmd.Length
 		}
 	}
 
-	log(ctx).Infof(
-		"  Found %v BLOBs to delete (%v), %v in sync (%v)",
-		len(blobsToDelete), units.BytesString(totalDeleteBytes),
-		inSyncBlobs, units.BytesString(inSyncBytes),
-	)
+	return &plan, nil
+}
 
-	if c.repositorySyncDryRun {
+// setupDestinationRetention validates the retention flags and, when retention
+// is enabled, wraps the destination storage so that locking-prefixed blobs are
+// written with the configured retention options.
+func (c *commandRepositorySyncTo) setupDestinationRetention(ctx context.Context, dst blob.Storage) (blob.Storage, format.BlobStorageConfiguration, error) {
+	blobcfg := format.BlobStorageConfiguration{
+		RetentionMode:   blob.RetentionMode(c.repositorySyncRetentionMode),
+		RetentionPeriod: c.repositorySyncRetentionPeriod,
+	}
+	if err := blobcfg.Validate(); err != nil {
+		return dst, blobcfg, errors.Wrap(err, "invalid retention flags")
+	}
+
+	if blobcfg.IsRetentionEnabled() {
+		dst = repo.WrapLockingStorage(dst, blobcfg)
+
+		if c.repositorySyncDelete {
+			log(ctx).Warn("--delete with object-lock retention may create delete markers; locked historical versions remain retained but point-in-time recovery may be required")
+		}
+	}
+
+	return dst, blobcfg, nil
+}
+
+// extendLocksEnabled returns whether object locks on in-sync destination blobs
+// should be extended during this run.
+func (c *commandRepositorySyncTo) extendLocksEnabled(blobcfg format.BlobStorageConfiguration) bool {
+	return blobcfg.IsRetentionEnabled() && c.repositorySyncExtendObjectLocks
+}
+
+// shouldExtendObjectLock returns whether the given in-sync blob is a candidate
+// for object-lock extension.
+func shouldExtendObjectLock(extendLocks bool, id blob.ID) bool {
+	return extendLocks && repo.IsLockingStorageBlobID(id)
+}
+
+// extendDestinationLocks extends object locks on destination blobs that were
+// already in sync and therefore not re-uploaded with fresh retention.
+func (c *commandRepositorySyncTo) extendDestinationLocks(ctx context.Context, dst blob.Storage, blobsToExtend []blob.Metadata, blobcfg format.BlobStorageConfiguration) error {
+	if len(blobsToExtend) == 0 {
 		return nil
 	}
 
-	log(ctx).Info("Copying...")
+	log(ctx).Info("Extending object locks...")
 
 	c.beginSyncProgress()
 
-	finalErr := c.runSyncBlobs(ctx, src, dst, blobsToCopy, blobsToDelete, totalCopyBytes)
+	err := c.runExtendBlobRetention(ctx, dst, blobsToExtend, blob.ExtendOptions{
+		RetentionMode:   blobcfg.RetentionMode,
+		RetentionPeriod: blobcfg.RetentionPeriod,
+	})
 
 	c.finishSyncProcess()
 
-	return finalErr
+	return err
 }
 
 func (c *commandRepositorySyncTo) listDestinationBlobs(ctx context.Context, dst blob.Storage) (map[blob.ID]blob.Metadata, error) {
@@ -349,6 +448,56 @@ func syncDeleteBlob(ctx context.Context, m blob.Metadata, dst blob.Storage) erro
 	}
 
 	return errors.Wrap(err, "error deleting blob")
+}
+
+func (c *commandRepositorySyncTo) runExtendBlobRetention(ctx context.Context, dst blob.Storage, blobsToExtend []blob.Metadata, opts blob.ExtendOptions) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	extendCh := sliceToChannel(ctx, blobsToExtend)
+
+	var totalExtended stats.CountSum
+
+	for workerID := range c.repositorySyncParallelism {
+		eg.Go(func() error {
+			for m := range extendCh {
+				log(ctx).Debugf("[%v] Extending object lock on %v...\n", workerID, m.BlobID)
+
+				if err := syncExtendBlobRetention(ctx, m, dst, opts); err != nil {
+					return errors.Wrapf(err, "error extending object lock on %v", m.BlobID)
+				}
+
+				numBlobs, _ := totalExtended.Add(m.Length)
+
+				c.outputSyncProgress(fmt.Sprintf("  Extended object locks on %v of %v BLOBs", numBlobs, len(blobsToExtend)))
+			}
+
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return errors.Wrap(err, "error extending object locks")
+	}
+
+	return nil
+}
+
+func syncExtendBlobRetention(ctx context.Context, m blob.Metadata, dst blob.Storage, opts blob.ExtendOptions) error {
+	err := dst.ExtendBlobRetention(ctx, m.BlobID, opts)
+
+	// tolerate blobs that disappeared between listing and extension, same as syncDeleteBlob.
+	if errors.Is(err, blob.ErrBlobNotFound) {
+		return nil
+	}
+
+	return wrapObjectLockError(errors.Wrap(err, "error extending blob retention"))
+}
+
+func wrapObjectLockError(err error) error {
+	if errors.Is(err, blob.ErrUnsupportedPutBlobOption) || errors.Is(err, blob.ErrUnsupportedObjectLock) {
+		return errors.Wrap(err, "destination storage does not support object-lock retention; remove --retention-mode/--retention-period or use an object-lock capable destination (e.g. s3)")
+	}
+
+	return err
 }
 
 func (c *commandRepositorySyncTo) ensureRepositoriesHaveSameFormatBlob(ctx context.Context, src blob.Reader, dst blob.Storage) error {

--- a/cli/command_repository_sync_retention_test.go
+++ b/cli/command_repository_sync_retention_test.go
@@ -1,0 +1,165 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/faketime"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/testutil"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/tests/testenv"
+)
+
+const testRetentionPeriod = 24 * time.Hour
+
+// listBlobRetention returns the retention info for all blobs in the given
+// storage, separated into locking-prefixed and non-locking blob IDs.
+func listBlobRetention(t *testing.T, st blobtesting.RetentionStorage) (locking, nonLocking map[blob.ID]time.Time) {
+	t.Helper()
+
+	ctx := testlogging.Context(t)
+
+	locking = map[blob.ID]time.Time{}
+	nonLocking = map[blob.ID]time.Time{}
+
+	require.NoError(t, st.ListBlobs(ctx, "", func(bm blob.Metadata) error {
+		mode, retainUntil, err := st.GetRetention(ctx, bm.BlobID)
+		require.NoError(t, err, "getting retention for %v", bm.BlobID)
+
+		if repo.IsLockingStorageBlobID(bm.BlobID) {
+			require.Equal(t, blob.Governance, mode, "unexpected retention mode on %v", bm.BlobID)
+			locking[bm.BlobID] = retainUntil
+		} else {
+			require.Empty(t, mode, "unexpected retention mode on non-locking blob %v", bm.BlobID)
+			nonLocking[bm.BlobID] = retainUntil
+		}
+
+		return nil
+	}))
+
+	return locking, nonLocking
+}
+
+func TestRepositorySyncRetention(t *testing.T) {
+	startTime := clock.Now()
+	ft := faketime.NewTimeAdvance(startTime)
+
+	runner := testenv.NewInProcRunner(t)
+	env := testenv.NewCLITest(t, []string{}, runner)
+
+	// source repository in reconnectable in-memory storage driven by the same
+	// fake clock as the destination, so blob timestamps are deterministic and
+	// unchanged blobs are classified as in-sync on subsequent runs.
+	srcSt := repotesting.NewReconnectableStorage(t, blobtesting.NewVersionedMapStorage(ft.NowFunc()))
+	srcOpt := testutil.EnsureType[*repotesting.ReconnectableStorageOptions](t, srcSt.ConnectionInfo().Config)
+
+	dstFake := blobtesting.NewVersionedMapStorage(ft.NowFunc())
+	dstSt := repotesting.NewReconnectableStorage(t, dstFake)
+	dstOpt := testutil.EnsureType[*repotesting.ReconnectableStorageOptions](t, dstSt.ConnectionInfo().Config)
+
+	env.RunAndExpectSuccess(t, "repo", "create", "in-memory", "--uuid", srcOpt.UUID)
+
+	srcDir := testutil.TempDirectory(t)
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("hello world"), 0o600))
+	env.RunAndExpectSuccess(t, "snapshot", "create", srcDir)
+
+	// invalid flag combinations
+	env.RunAndExpectFailure(t, "repo", "sync-to", "in-memory", "--uuid", dstOpt.UUID,
+		"--retention-mode", blob.Governance.String())
+	env.RunAndExpectFailure(t, "repo", "sync-to", "in-memory", "--uuid", dstOpt.UUID,
+		"--retention-mode", blob.Governance.String(), "--retention-period", "1h")
+	env.RunAndExpectFailure(t, "repo", "sync-to", "in-memory", "--uuid", dstOpt.UUID,
+		"--retention-mode", "invalid-mode", "--retention-period", "24h")
+
+	// initial sync with retention applies object locks to locking-prefixed
+	// blobs, including the initial kopia.repository write.
+	env.RunAndExpectSuccess(t, "repo", "sync-to", "in-memory", "--uuid", dstOpt.UUID,
+		"--retention-mode", blob.Governance.String(), "--retention-period", "24h")
+
+	locking, nonLocking := listBlobRetention(t, dstFake)
+	require.NotEmpty(t, locking)
+	require.Contains(t, locking, blob.ID("kopia.repository"))
+
+	for id, retainUntil := range locking {
+		require.Equal(t, startTime.Add(testRetentionPeriod), retainUntil, "unexpected retention time on %v", id)
+	}
+
+	for id, retainUntil := range nonLocking {
+		require.True(t, retainUntil.IsZero(), "unexpected retention on non-locking blob %v", id)
+	}
+
+	// re-running the sync later extends the object locks on in-sync blobs.
+	extendTime := ft.Advance(12 * time.Hour)
+
+	env.RunAndExpectSuccess(t, "repo", "sync-to", "in-memory", "--uuid", dstOpt.UUID,
+		"--retention-mode", blob.Governance.String(), "--retention-period", "24h")
+
+	locking, _ = listBlobRetention(t, dstFake)
+	require.NotEmpty(t, locking)
+
+	for id, retainUntil := range locking {
+		require.Equal(t, extendTime.Add(testRetentionPeriod), retainUntil, "lock not extended on %v", id)
+	}
+
+	// --no-extend-object-locks skips the extension phase.
+	ft.Advance(1 * time.Hour)
+	env.RunAndExpectSuccess(t, "repo", "sync-to", "in-memory", "--uuid", dstOpt.UUID,
+		"--retention-mode", blob.Governance.String(), "--retention-period", "24h",
+		"--no-extend-object-locks")
+
+	locking, _ = listBlobRetention(t, dstFake)
+	for id, retainUntil := range locking {
+		require.Equal(t, extendTime.Add(testRetentionPeriod), retainUntil, "lock unexpectedly extended on %v", id)
+	}
+
+	// --dry-run reports the extension candidates but does not extend.
+	_, stderr := env.RunAndExpectSuccessWithErrOut(t, "repo", "sync-to", "in-memory", "--uuid", dstOpt.UUID,
+		"--retention-mode", blob.Governance.String(), "--retention-period", "24h",
+		"--dry-run")
+	require.Contains(t, strings.Join(stderr, "\n"), "BLOBs to extend object locks on")
+
+	locking, _ = listBlobRetention(t, dstFake)
+	for id, retainUntil := range locking {
+		require.Equal(t, extendTime.Add(testRetentionPeriod), retainUntil, "lock unexpectedly extended on %v during dry-run", id)
+	}
+
+	// the synchronized copy is a fully working repository.
+	env.RunAndExpectSuccess(t, "repo", "disconnect")
+	env.RunAndExpectSuccess(t, "repo", "connect", "in-memory", "--uuid", dstOpt.UUID)
+	env.RunAndExpectSuccess(t, "snapshot", "list")
+	env.RunAndExpectSuccess(t, "repo", "disconnect")
+}
+
+func TestRepositorySyncRetentionUnsupportedDestination(t *testing.T) {
+	runner := testenv.NewInProcRunner(t)
+	env := testenv.NewCLITest(t, []string{}, runner)
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+
+	srcDir := testutil.TempDirectory(t)
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("hello world"), 0o600))
+	env.RunAndExpectSuccess(t, "snapshot", "create", srcDir)
+
+	// fresh destination: fails on the initial format blob write.
+	dstDir := testutil.TempDirectory(t)
+	_, stderr := env.RunAndExpectFailure(t, "repo", "sync-to", "filesystem", "--path", dstDir,
+		"--retention-mode", blob.Governance.String(), "--retention-period", "24h")
+	require.Contains(t, strings.Join(stderr, "\n"), "does not support object-lock retention")
+
+	// destination synced without retention, then an extension-only run also
+	// fails with the same actionable message.
+	env.RunAndExpectSuccess(t, "repo", "sync-to", "filesystem", "--path", dstDir)
+	_, stderr = env.RunAndExpectFailure(t, "repo", "sync-to", "filesystem", "--path", dstDir,
+		"--retention-mode", blob.Governance.String(), "--retention-period", "24h")
+	require.Contains(t, strings.Join(stderr, "\n"), "does not support object-lock retention")
+}

--- a/internal/blobtesting/object_locking_map.go
+++ b/internal/blobtesting/object_locking_map.go
@@ -214,10 +214,10 @@ func (s *objectLockingMap) ExtendBlobRetention(ctx context.Context, id blob.ID, 
 	// future. Note that we do not bump the existing time on the element `e.mtime`
 	// by the given delta because we'd like to align with the S3 storage's current
 	// time and the S3 storage code extends retention periods based off the
-	// current time, not object mod time.
-	if !e.retentionTime.IsZero() {
-		e.retentionTime = s.timeNow().Add(opts.RetentionPeriod)
-	}
+	// current time, not object mod time. Mirroring S3 PutObjectRetention, this
+	// also places retention on a version that previously had none.
+	e.retentionMode = opts.RetentionMode
+	e.retentionTime = s.timeNow().Add(opts.RetentionPeriod)
 
 	return nil
 }

--- a/repo/locking_storage.go
+++ b/repo/locking_storage.go
@@ -1,8 +1,12 @@
 package repo
 
 import (
+	"context"
+	"strings"
+
 	"github.com/kopia/kopia/internal/epoch"
 	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/blob/beforeop"
 	"github.com/kopia/kopia/repo/content"
 	"github.com/kopia/kopia/repo/content/indexblob"
 	"github.com/kopia/kopia/repo/format"
@@ -16,4 +20,30 @@ func GetLockingStoragePrefixes() []blob.ID {
 		blob.ID(format.KopiaRepositoryBlobID),
 		blob.ID(format.KopiaBlobCfgBlobID),
 	}, content.PackBlobIDPrefixes...)
+}
+
+// IsLockingStorageBlobID returns true when the given blob ID matches one of the
+// prefixes that may be maintained by Object Locking.
+func IsLockingStorageBlobID(id blob.ID) bool {
+	for _, prefix := range GetLockingStoragePrefixes() {
+		if strings.HasPrefix(string(id), string(prefix)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// WrapLockingStorage wraps the given storage so that PutBlob for blobs matching
+// GetLockingStoragePrefixes carries the retention options from the given
+// blob storage configuration.
+func WrapLockingStorage(st blob.Storage, r format.BlobStorageConfiguration) blob.Storage {
+	return beforeop.NewWrapper(st, nil, nil, nil, func(_ context.Context, id blob.ID, opts *blob.PutOptions) error {
+		if IsLockingStorageBlobID(id) {
+			opts.RetentionMode = r.RetentionMode
+			opts.RetentionPeriod = r.RetentionPeriod
+		}
+
+		return nil
+	})
 }

--- a/repo/locking_storage_test.go
+++ b/repo/locking_storage_test.go
@@ -1,0 +1,64 @@
+package repo_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/faketime"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/format"
+)
+
+func TestIsLockingStorageBlobID(t *testing.T) {
+	cases := []struct {
+		blobID blob.ID
+		want   bool
+	}{
+		{"p0123456789abcdef", true},
+		{"q0123456789abcdef", true},
+		{"n0123456789abcdef", true},
+		{"xn0123456789abcdef", true},
+		{"e0123456789abcdef", false},
+		{"kopia.repository", true},
+		{"kopia.blobcfg", true},
+		{"kopia.maintenance", false},
+		{"s01234567890abcdef", false},
+		{"_log0123456789abcdef", false},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, repo.IsLockingStorageBlobID(tc.blobID), "blob ID %v", tc.blobID)
+	}
+}
+
+func TestWrapLockingStorage(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	startTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	ft := faketime.NewTimeAdvance(startTime)
+	st := blobtesting.NewVersionedMapStorage(ft.NowFunc())
+
+	wrapped := repo.WrapLockingStorage(st, format.BlobStorageConfiguration{
+		RetentionMode:   blob.Governance,
+		RetentionPeriod: 24 * time.Hour,
+	})
+
+	require.NoError(t, wrapped.PutBlob(ctx, "p0123456789abcdef", gather.FromSlice([]byte("locked")), blob.PutOptions{}))
+	require.NoError(t, wrapped.PutBlob(ctx, "kopia.maintenance", gather.FromSlice([]byte("unlocked")), blob.PutOptions{}))
+
+	mode, retainUntil, err := st.GetRetention(ctx, "p0123456789abcdef")
+	require.NoError(t, err)
+	require.Equal(t, blob.Governance, mode)
+	require.Equal(t, startTime.Add(24*time.Hour), retainUntil)
+
+	mode, retainUntil, err = st.GetRetention(ctx, "kopia.maintenance")
+	require.NoError(t, err)
+	require.Empty(t, mode)
+	require.True(t, retainUntil.IsZero())
+}

--- a/repo/open.go
+++ b/repo/open.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -291,7 +290,7 @@ func openWithConfig(ctx context.Context, st blob.Storage, cliOpts ClientOptions,
 	}
 
 	if blobcfg.IsRetentionEnabled() {
-		st = wrapLockingStorage(st, blobcfg)
+		st = WrapLockingStorage(st, blobcfg)
 	}
 
 	_, err = retry.WithExponentialBackoffMaxRetries(ctx, -1, "wait for upgrade", func() (any, error) {
@@ -418,24 +417,6 @@ func handleMissingRequiredFeatures(ctx context.Context, fmgr *format.Manager, ig
 	}
 
 	return nil
-}
-
-func wrapLockingStorage(st blob.Storage, r format.BlobStorageConfiguration) blob.Storage {
-	// collect prefixes that need to be locked on put
-	prefixes := GetLockingStoragePrefixes()
-
-	return beforeop.NewWrapper(st, nil, nil, nil, func(_ context.Context, id blob.ID, opts *blob.PutOptions) error {
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(string(id), string(prefix)) {
-				opts.RetentionMode = r.RetentionMode
-				opts.RetentionPeriod = r.RetentionPeriod
-
-				break
-			}
-		}
-
-		return nil
-	})
 }
 
 func addThrottler(st blob.Storage, limits throttling.Limits) (blob.Storage, throttling.SettableThrottler, error) {

--- a/site/content/docs/Advanced/Ransomware Protection/_index.md
+++ b/site/content/docs/Advanced/Ransomware Protection/_index.md
@@ -100,6 +100,21 @@ An additional layer of protection is `Object Locking' that can be enabled in AWS
     * Run: `kopia maintenance set --extend-object-locks true`
       * Note that the `full-interval` must be at least 1 day shorter than the `retention-period` or Kopia will not allow you to enable Object Lock extension
 
+### How to maintain an immutable copy of a local repository (sync-to)
+
+If your primary repository lives on storage that does not support object locks (for example a local filesystem or SFTP server), you can still maintain an immutable third copy in object-locked storage using [Synchronization](../synchronization/):
+
+  * Create a new bucket with Object Locks (and versioning) enabled, as described above
+  * Synchronize regularly, applying retention to the destination:
+    * Run: `kopia repository sync-to s3 --bucket <bucket name> --access-key=<access key> --secret-access-key=<secret access key> --retention-mode COMPLIANCE --retention-period <retention time>`
+    * The retention flags only affect the destination; the source repository is unchanged
+  * Each run also extends the object locks on blobs that are already in sync, so protection does not lapse between runs.  This costs one retention-update API request per locked blob per run; on frequent syncs you can pass `--no-extend-object-locks` and refresh the locks on a less frequent schedule.  Always refresh with a safety margin of at least 24 hours before lock expiry (for example, 30d retention refreshed weekly)
+  * Grant the synchronization credentials only what is needed:
+    * AWS S3: `s3:PutObject`, `s3:GetObject`, `s3:ListBucket` and `s3:PutObjectRetention`; do **not** grant `s3:BypassGovernanceRetention`
+    * Backblaze B2 (S3-compatible keys): `listAllBucketNames`, `listFiles`, `readFiles`, `writeFiles` and `writeFileRetentions`; do **not** grant `deleteFiles` or governance-bypass capabilities
+  * Using `COMPLIANCE` mode is recommended, since the synchronization host necessarily holds credentials that can update retention
+  * Avoid `--delete` for immutable replicas: with object locks it creates delete markers — locked versions remain retained, but the current view of the repository may appear deleted and recovery requires point-in-time access
+
 ### How to restore a snapshot that was deleted by ransomware (or some other process)
   * If you have data that needs to be restored, make sure that either your retention time will not expire or your lifecycle data expiration is sufficient to ensure you can download your data before the cloud provider removes it
   * Disconnect the repo in Kopia

--- a/site/content/docs/Advanced/Synchronization/_index.md
+++ b/site/content/docs/Advanced/Synchronization/_index.md
@@ -31,6 +31,20 @@ When synchronizing to a filesystem location, it is important to check that the f
 $ kopia repository sync-to filesystem --path /dest/repository --must-exist
 ```
 
+### Synchronizing to object-locked storage (immutable replicas)
+
+When the destination supports object locking (for example an S3 bucket with Object Lock and versioning enabled), synchronization can apply object-lock retention to the copied repository blobs, creating an immutable replica of a repository whose primary storage does not support object locks (such as a local filesystem or SFTP):
+
+```
+$ kopia repository sync-to s3 --bucket my-bucket --retention-mode COMPLIANCE --retention-period 30d
+```
+
+The retention flags only affect the destination; the source repository is not modified. The destination bucket must be created with Object Lock (and versioning) enabled, and the destination storage must support object locking — otherwise the synchronization fails with an error. See [Ransomware Protection](../ransomware-protection/) for details, including the recommended retention mode and required permissions.
+
+Because blobs that are already in sync are not re-uploaded, each synchronization run also extends the object locks on the blobs already present in the destination, so that immutability protection does not lapse between runs. This extension performs one retention-update API request per locked blob on every run. When synchronizing frequently, pass `--no-extend-object-locks` on most runs and let a less frequent run (for example, weekly) refresh the locks — but always schedule the refreshing runs with a safety margin of at least 24 hours before lock expiry.
+
+Combining `--delete` with retention creates delete markers in the destination: locked historical versions remain retained, but recovering them requires version-aware (point-in-time) access. For immutable replicas, not passing `--delete` is recommended.
+
 ### Automation
 
 For automated synchronization tasks, progress output can be suppressed using the `--no-progress` flag to provide clean output suitable for cron jobs and scripts.

--- a/tests/end_to_end_test/repository_sync_test.go
+++ b/tests/end_to_end_test/repository_sync_test.go
@@ -1,7 +1,10 @@
 package endtoend_test
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/tests/clitestutil"
@@ -35,6 +38,12 @@ func TestRepositorySync(t *testing.T) {
 	// synchronizing to empty directory fails with --must-exist
 	dir3 := testutil.TempDirectory(t)
 	e.RunAndExpectFailure(t, "repo", "sync-to", "filesystem", "--path", dir3, "--must-exist")
+
+	// object-lock retention flags require an object-lock capable destination.
+	dir4 := testutil.TempDirectory(t)
+	_, stderr := e.RunAndExpectFailure(t, "repo", "sync-to", "filesystem", "--path", dir4,
+		"--retention-mode", "GOVERNANCE", "--retention-period", "24h")
+	require.Contains(t, strings.Join(stderr, "\n"), "does not support object-lock retention")
 
 	// now connect to the new repository in new location
 	e.RunAndExpectSuccess(t, "repo", "connect", "filesystem", "--path", dir2)


### PR DESCRIPTION
Fixes #3759

## Problem

As described in #3759, it is currently impossible to maintain an immutable copy of a repository whose primary storage does not support object locking (filesystem, SFTP, ...) by syncing it to object-lock capable storage:

- `repository sync-to` writes every blob with empty `PutOptions`, so nothing on the destination ever receives an object lock.
- Blobs already in sync are never re-uploaded, so even manually-applied locks would silently expire — and `maintenance --extend-object-locks` only runs against the connected (local) repository, whose backend rejects retention (`blob-retention: unsupported put-blob option`).

## Solution

Add destination-only retention support to `sync-to`, reusing the existing locking machinery:

```
kopia repository sync-to s3 --bucket my-bucket ... --retention-mode COMPLIANCE --retention-period 30d
```

- New `--retention-mode` / `--retention-period` flags (same names/values as `repository create`, validated by the existing `format.BlobStorageConfiguration.Validate()`). When set, the destination storage is wrapped with the same locking wrapper used by `repo/open.go`, so blobs matching the locking prefixes (packs, indexes, `kopia.repository`, `kopia.blobcfg`) are uploaded with retention. The source repository is not modified; no repository-format changes, no new persisted state.
- Each run also **extends object locks** on locking-prefixed blobs that are already in sync, so immutability does not lapse between syncs. This costs one retention-update API request per locked blob per run; `--no-extend-object-locks` skips it for frequent syncs (with a less frequent lock-refreshing run recommended, always with a ≥24h safety margin before lock expiry).
- Syncing with retention flags to a destination that does not support object locking fails fast with an actionable error instead of silently degrading.
- `wrapLockingStorage` is moved from `repo/open.go` to `repo/locking_storage.go` and exported (`WrapLockingStorage`, plus `IsLockingStorageBlobID`) so the CLI and the open path share one implementation of the prefix rules.
- The `blobtesting` fake's `ExtendBlobRetention` now matches S3 `PutObjectRetention` semantics (places retention on versions that previously had none and updates the mode), which also covers upgrading an existing unlocked mirror to a locked one.

## Testing

- Unit tests for `IsLockingStorageBlobID`/`WrapLockingStorage` (`repo/locking_storage_test.go`).
- CLI test (`cli/command_repository_sync_retention_test.go`) using the in-memory versioned storage and a movable fake clock: verifies retention on locking-prefixed blobs only (including the initial `kopia.repository` write), lock extension moving expiry forward on re-sync, `--no-extend-object-locks` and `--dry-run` not mutating locks, flag validation failures, the unsupported-destination error (both on fresh sync and extension-only runs), and that the synchronized copy is a fully working repository.
- e2e: `sync-to filesystem` with retention flags fails with the actionable message.
- Manually verified against minio with an object-locked bucket: locks applied (`X-Amz-Object-Lock-Mode`/`Retain-Until-Date`) on locking blobs only, re-sync advances the retain-until date, deletion of a locked version is rejected as WORM-protected.
- `make lint` and existing test suites pass.

## Docs

Updated `site/content/docs/Advanced/Synchronization/_index.md` and `site/content/docs/Advanced/Ransomware Protection/_index.md`: workflow, extension cost and scheduling guidance, recommended minimal credentials (no governance bypass), and `--delete` implications for immutable replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)