### PR TITLE
fix(content,epoch,maintenance): tolerate undeletable blobs under object lock

### DIFF
--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -187,6 +187,17 @@ type Manager struct {
 	log      *contentlog.Logger
 	timeFunc func() time.Time
 
+	// objectLockEnabled indicates the underlying storage has a retention
+	// policy (e.g. S3 Object Lock) that may prevent deleting this
+	// manager's own epoch markers and deletion watermark blobs before
+	// their retention expires. When set, CleanupMarkers tolerates
+	// failures to delete these blobs instead of treating them as fatal -
+	// see the analogous fix in repo/content/sessions.go for session
+	// markers. The blobs are internal bookkeeping only; leaving one
+	// around until its retention lock naturally expires does not affect
+	// the durability or visibility of any already-committed content.
+	objectLockEnabled bool
+
 	// wait group that waits for all compaction and cleanup goroutines.
 	backgroundWork sync.WaitGroup
 
@@ -360,7 +371,20 @@ func (e *Manager) cleanupEpochMarkers(ctx context.Context, cs CurrentSnapshot, d
 		}
 	}
 
-	return uint64(len(toDelete)), errors.Wrap(blob.DeleteMultiple(ctx, e.st, toDelete, deleteParallelism), "error deleting index blob marker")
+	err := blob.DeleteMultiple(ctx, e.st, toDelete, deleteParallelism)
+	if err != nil && e.objectLockEnabled {
+		contentlog.Log1(ctx, e.log,
+			"could not delete some epoch marker blobs (object lock enabled), leaving them to expire",
+			logparam.Error("error", err))
+
+		// We don't know exactly how many of toDelete actually succeeded
+		// before the tolerated error (DeleteMultiple reports one combined
+		// error, not per-blob results) - report 0 rather than claim a
+		// count we can't verify.
+		return 0, nil
+	}
+
+	return uint64(len(toDelete)), errors.Wrap(err, "error deleting index blob marker")
 }
 
 func (e *Manager) cleanupWatermarks(ctx context.Context, cs CurrentSnapshot, maxReplacementTime time.Time, deleteParallelism int) (uint64, error) {
@@ -381,7 +405,18 @@ func (e *Manager) cleanupWatermarks(ctx context.Context, cs CurrentSnapshot, max
 		}
 	}
 
-	return uint64(len(toDelete)), errors.Wrap(blob.DeleteMultiple(ctx, e.st, toDelete, deleteParallelism), "error deleting watermark blobs")
+	err := blob.DeleteMultiple(ctx, e.st, toDelete, deleteParallelism)
+	if err != nil && e.objectLockEnabled {
+		contentlog.Log1(ctx, e.log,
+			"could not delete some deletion watermark blobs (object lock enabled), leaving them to expire",
+			logparam.Error("error", err))
+
+		// See cleanupEpochMarkers: DeleteMultiple gives one combined
+		// error, not per-blob results, so we can't claim a verified count.
+		return 0, nil
+	}
+
+	return uint64(len(toDelete)), errors.Wrap(err, "error deleting watermark blobs")
 }
 
 // CleanupSupersededIndexes cleans up the indexes which have been superseded by compacted ones.
@@ -1144,13 +1179,14 @@ func rangeCheckpointBlobPrefix(epoch1, epoch2 int) blob.ID {
 }
 
 // NewManager creates new epoch manager.
-func NewManager(st blob.Storage, paramProvider ParametersProvider, compactor CompactionFunc, log *contentlog.Logger, timeNow func() time.Time) *Manager {
+func NewManager(st blob.Storage, paramProvider ParametersProvider, compactor CompactionFunc, log *contentlog.Logger, timeNow func() time.Time, objectLockEnabled bool) *Manager {
 	return &Manager{
 		st:                           st,
 		log:                          log,
 		compact:                      compactor,
 		timeFunc:                     timeNow,
 		paramProvider:                paramProvider,
+		objectLockEnabled:            objectLockEnabled,
 		getCompleteIndexSetTooSlow:   new(int32),
 		committedStateRefreshTooSlow: new(int32),
 		writeIndexTooSlow:            new(int32),

--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -468,7 +468,31 @@ func (e *Manager) CleanupSupersededIndexes(ctx context.Context) (*maintenancesta
 	}
 
 	if err := blob.DeleteMultiple(ctx, e.st, toDelete, p.DeleteParallelism); err != nil {
-		return nil, errors.Wrap(err, "unable to delete uncompacted blobs")
+		if !e.objectLockEnabled {
+			return nil, errors.Wrap(err, "unable to delete uncompacted blobs")
+		}
+
+		// Same reasoning as cleanupEpochMarkers/cleanupWatermarks: under a
+		// storage-level retention policy (e.g. S3 Object Lock in compliance
+		// mode) an uncompacted index blob may still be inside its retention
+		// window and cannot be deleted by anyone yet. The compacted
+		// replacement already exists, so the superseded blob is dead weight,
+		// not a correctness problem, and a later maintenance cycle will
+		// remove it once retention expires. Failing the whole maintenance
+		// run's exit code for it is wrong.
+		contentlog.Log1(ctx, e.log,
+			"could not delete some superseded uncompacted index blobs (object lock enabled), leaving them to expire",
+			logparam.Error("error", err))
+
+		// DeleteMultiple reports one combined error rather than per-blob
+		// results, so we cannot say how many of toDelete actually got
+		// deleted before the tolerated failure. Report 0 instead of a count
+		// we cannot verify.
+		return &maintenancestats.CleanupSupersededIndexesStats{
+			MaxReplacementTime: maxReplacementTime,
+			DeletedBlobCount:   0,
+			DeletedTotalSize:   0,
+		}, nil
 	}
 
 	return &maintenancestats.CleanupSupersededIndexesStats{
@@ -891,7 +915,28 @@ func (e *Manager) WriteIndex(ctx0 context.Context, dataShards map[blob.ID]blob.B
 
 		if cs.WriteEpoch != writtenForEpoch {
 			if err = e.deletePartiallyWrittenShards(ctx, written); err != nil {
-				return nil, errors.Wrap(err, "unable to delete partially written shard")
+				if !e.objectLockEnabled {
+					return nil, errors.Wrap(err, "unable to delete partially written shard")
+				}
+
+				// Unlike the other tolerated sites this one is not in
+				// maintenance but in the index write path, so an intolerant
+				// failure here fails an actual snapshot, not just the
+				// maintenance exit code. Under Object Lock it is also
+				// guaranteed to fail: these shards were written seconds ago
+				// and are therefore squarely inside their retention window.
+				//
+				// Leaving them behind is safe. They are uncompacted index
+				// blobs for the epoch we were writing for, they reference
+				// content that really was written to packs, and index
+				// entries are additive - a reader that picks them up sees
+				// real content, never a missing or wrong entry. The shards
+				// get rewritten for the new write epoch below, and
+				// CleanupSupersededIndexes removes the orphans once that
+				// epoch has a compaction set and retention has expired.
+				contentlog.Log1(ctx, e.log,
+					"could not delete partially written index shards (object lock enabled), leaving them for a future maintenance cycle",
+					logparam.Error("error", err))
 			}
 
 			writtenForEpoch = cs.WriteEpoch

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -104,7 +104,7 @@ func newTestEnv(t *testing.T) *epochManagerTestEnv {
 		EpochAdvanceOnCountThreshold:          15,
 		EpochAdvanceOnTotalSizeBytesThreshold: 20 << 20,
 		DeleteParallelism:                     1,
-	}}, te.compact, nil, te.ft.NowFunc())
+	}}, te.compact, nil, te.ft.NowFunc(), false)
 	te.mgr = m
 	te.faultyStorage = fs
 	te.data = data
@@ -123,7 +123,7 @@ func (te *epochManagerTestEnv) another() *epochManagerTestEnv {
 		faultyStorage: te.faultyStorage,
 	}
 
-	te2.mgr = NewManager(te2.st, te.mgr.paramProvider, te2.compact, te.mgr.log, te.mgr.timeFunc)
+	te2.mgr = NewManager(te2.st, te.mgr.paramProvider, te2.compact, te.mgr.log, te.mgr.timeFunc, te.mgr.objectLockEnabled)
 
 	return te2
 }
@@ -648,7 +648,7 @@ func TestIndexEpochManager_NoCompactionInReadOnly(t *testing.T) {
 	}
 
 	// Set new epoch manager to read-only to ensure we don't get stuck.
-	te2.mgr = NewManager(te2.st, te.mgr.paramProvider, te2.compact, te.mgr.log, te.mgr.timeFunc)
+	te2.mgr = NewManager(te2.st, te.mgr.paramProvider, te2.compact, te.mgr.log, te.mgr.timeFunc, te.mgr.objectLockEnabled)
 
 	// Use assert.Eventually here so we'll exit the test early instead of getting
 	// stuck until the timeout.
@@ -1974,6 +1974,95 @@ func TestCleanupMarkers_CleanUpManyMarkers(t *testing.T) {
 	cs, err = te.mgr.Current(ctx)
 	require.NoError(t, err)
 	require.Len(t, cs.EpochMarkerBlobs, 2) // at least 2 epoch markers are kept
+}
+
+// TestCleanupMarkers_ToleratesLockedBlobsWithObjectLock verifies that with
+// objectLockEnabled a CleanupMarkers run succeeds even when its own epoch
+// marker and deletion watermark blobs cannot be deleted. This is the S3
+// Object Lock case: a bucket default retention locks every object,
+// including kopia's own internal bookkeeping blobs, not just user data.
+// The already-committed indexes must stay intact - only the undeletable
+// marker blobs are left in place to expire on their own.
+func TestCleanupMarkers_ToleratesLockedBlobsWithObjectLock(t *testing.T) {
+	t.Parallel()
+
+	te := newTestEnv(t)
+	te.mgr.objectLockEnabled = true
+	ctx := testlogging.Context(t)
+
+	p, err := te.mgr.getParameters(ctx)
+	require.NoError(t, err)
+
+	const epochsToAdvance = 5
+
+	te.mustWriteIndexFiles(ctx, t, newFakeIndexWithEntries(0))
+
+	for i := range epochsToAdvance {
+		te.ft.Advance(p.MinEpochDuration + 1*time.Hour)
+		te.mgr.forceAdvanceEpoch(ctx)
+		te.mustWriteIndexFiles(ctx, t, newFakeIndexWithEntries(i+1))
+	}
+
+	require.NoError(t, te.mgr.Refresh(ctx))
+	te.verifyCurrentWriteEpoch(t, epochsToAdvance)
+
+	cs, err := te.mgr.Current(ctx)
+	require.NoError(t, err)
+	require.Len(t, cs.EpochMarkerBlobs, epochsToAdvance)
+
+	// From here on every DeleteBlob fails, standing in for retention-locked
+	// epoch marker / watermark blobs that S3 Object Lock (compliance mode)
+	// refuses to delete.
+	te.faultyStorage.AddFault(blobtesting.MethodDeleteBlob).
+		Repeat(1000).
+		ErrorInstead(errors.New("AccessDenied: object is WORM protected"))
+
+	stats, err := te.mgr.CleanupMarkers(ctx)
+	require.NoError(t, err, "CleanupMarkers must tolerate undeletable marker blobs when object lock is enabled")
+	require.NotNil(t, stats)
+
+	// the epoch markers that could not be deleted were left in storage
+	// rather than aborting cleanup.
+	require.NoError(t, te.mgr.Refresh(ctx))
+	te.verifyCurrentWriteEpoch(t, epochsToAdvance)
+
+	cs, err = te.mgr.Current(ctx)
+	require.NoError(t, err)
+	require.Len(t, cs.EpochMarkerBlobs, epochsToAdvance, "undeletable epoch markers must remain in storage")
+}
+
+// TestCleanupMarkers_FailsOnLockedBlobsWithoutObjectLock is the negative
+// case: without objectLockEnabled a DeleteBlob failure during marker cleanup
+// stays fatal, preserving the strict behavior for non-object-lock
+// repositories, where a delete failure signals a real storage problem.
+func TestCleanupMarkers_FailsOnLockedBlobsWithoutObjectLock(t *testing.T) {
+	t.Parallel()
+
+	te := newTestEnv(t)
+	ctx := testlogging.Context(t)
+
+	p, err := te.mgr.getParameters(ctx)
+	require.NoError(t, err)
+
+	const epochsToAdvance = 5
+
+	te.mustWriteIndexFiles(ctx, t, newFakeIndexWithEntries(0))
+
+	for i := range epochsToAdvance {
+		te.ft.Advance(p.MinEpochDuration + 1*time.Hour)
+		te.mgr.forceAdvanceEpoch(ctx)
+		te.mustWriteIndexFiles(ctx, t, newFakeIndexWithEntries(i+1))
+	}
+
+	require.NoError(t, te.mgr.Refresh(ctx))
+	te.verifyCurrentWriteEpoch(t, epochsToAdvance)
+
+	te.faultyStorage.AddFault(blobtesting.MethodDeleteBlob).
+		Repeat(1000).
+		ErrorInstead(errors.New("AccessDenied"))
+
+	_, err = te.mgr.CleanupMarkers(ctx)
+	require.Error(t, err, "CleanupMarkers must fail on undeletable marker blobs when object lock is disabled")
 }
 
 func randomTime(minTime, maxTime time.Duration) time.Duration {

--- a/internal/epoch/epoch_manager_test.go
+++ b/internal/epoch/epoch_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"slices"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2063,6 +2064,122 @@ func TestCleanupMarkers_FailsOnLockedBlobsWithoutObjectLock(t *testing.T) {
 
 	_, err = te.mgr.CleanupMarkers(ctx)
 	require.Error(t, err, "CleanupMarkers must fail on undeletable marker blobs when object lock is disabled")
+}
+
+// setupSupersededIndexes brings the manager into the state
+// CleanupSupersededIndexes actually acts on: uncompacted index blobs for an
+// epoch that already has a single-epoch compaction set, written long enough
+// ago to be past CleanupSafetyMargin. It returns the number of uncompacted
+// index blobs present at that point.
+func setupSupersededIndexes(ctx context.Context, t *testing.T, te *epochManagerTestEnv) int {
+	t.Helper()
+
+	p, err := te.mgr.getParameters(ctx)
+	require.NoError(t, err)
+
+	// write indexes into epoch 0, then move on so epoch 0 becomes compactable.
+	te.mustWriteIndexFiles(ctx, t, newFakeIndexWithEntries(1))
+	te.mustWriteIndexFiles(ctx, t, newFakeIndexWithEntries(2))
+
+	for range 3 {
+		te.ft.Advance(p.MinEpochDuration + 1*time.Hour)
+		require.NoError(t, te.mgr.forceAdvanceEpoch(ctx))
+		te.mustWriteIndexFiles(ctx, t, newFakeIndexWithEntries(3))
+	}
+
+	require.NoError(t, te.mgr.Refresh(ctx))
+
+	_, err = te.mgr.MaybeCompactSingleEpoch(ctx)
+	require.NoError(t, err)
+
+	// Move well past the safety margin so the compaction set counts as
+	// "written sufficiently long ago" and its uncompacted inputs become
+	// deletable. Advancing the fake clock alone is not enough:
+	// maxCleanupTime derives the storage clock from the newest blob
+	// timestamp in the repository, so without a write after the advance the
+	// newest blob is still the compaction set itself, maxReplacementTime
+	// stays before it, and nothing becomes eligible - which silently makes
+	// the whole test vacuous.
+	te.ft.Advance(p.CleanupSafetyMargin + 24*time.Hour)
+	te.mustWriteIndexFiles(ctx, t, newFakeIndexWithEntries(4))
+	require.NoError(t, te.mgr.Refresh(ctx))
+
+	var uncompacted int
+
+	for blobID := range te.data {
+		if strings.HasPrefix(string(blobID), string(UncompactedIndexBlobPrefix)) {
+			uncompacted++
+		}
+	}
+
+	return uncompacted
+}
+
+// TestCleanupSupersededIndexes_ToleratesLockedBlobsWithObjectLock covers the
+// third distinct Object Lock failure site, the one that hit
+// srv-mog-prod-nextcloud-02 in production while already running the release
+// that fixed the epoch marker and pack GC paths:
+//
+//	error cleaning up epoch manager: error removing superseded epoch index
+//	blobs: unable to delete uncompacted blobs: ... xn0_... : AccessDenied
+//
+// A superseded uncompacted index blob has a compacted replacement already in
+// storage, so leaving it behind is dead weight, not a correctness problem. It
+// must not fail the maintenance run.
+func TestCleanupSupersededIndexes_ToleratesLockedBlobsWithObjectLock(t *testing.T) {
+	t.Parallel()
+
+	te := newTestEnv(t)
+	te.mgr.objectLockEnabled = true
+	ctx := testlogging.Context(t)
+
+	uncompacted := setupSupersededIndexes(ctx, t, te)
+	require.Positive(t, uncompacted, "test setup must leave uncompacted index blobs to delete")
+
+	// From here on every DeleteBlob fails, standing in for retention-locked
+	// uncompacted index blobs that S3 Object Lock refuses to delete.
+	te.faultyStorage.AddFault(blobtesting.MethodDeleteBlob).
+		Repeat(1000).
+		ErrorInstead(errors.New("AccessDenied: object is WORM protected"))
+
+	stats, err := te.mgr.CleanupSupersededIndexes(ctx)
+	require.NoError(t, err, "CleanupSupersededIndexes must tolerate undeletable index blobs when object lock is enabled")
+	require.NotNil(t, stats)
+	require.Zero(t, stats.DeletedBlobCount, "nothing was actually deleted, so the reported count must not claim otherwise")
+
+	// the blobs that could not be deleted were left in storage.
+	var stillThere int
+
+	for blobID := range te.data {
+		if strings.HasPrefix(string(blobID), string(UncompactedIndexBlobPrefix)) {
+			stillThere++
+		}
+	}
+
+	require.Equal(t, uncompacted, stillThere, "undeletable uncompacted index blobs must remain in storage")
+
+	// the repository is still readable afterwards.
+	require.NoError(t, te.mgr.Refresh(ctx))
+}
+
+// TestCleanupSupersededIndexes_FailsOnLockedBlobsWithoutObjectLock is the
+// negative case: without object lock a delete failure signals a real storage
+// problem and must stay fatal.
+func TestCleanupSupersededIndexes_FailsOnLockedBlobsWithoutObjectLock(t *testing.T) {
+	t.Parallel()
+
+	te := newTestEnv(t)
+	ctx := testlogging.Context(t)
+
+	uncompacted := setupSupersededIndexes(ctx, t, te)
+	require.Positive(t, uncompacted, "test setup must leave uncompacted index blobs to delete")
+
+	te.faultyStorage.AddFault(blobtesting.MethodDeleteBlob).
+		Repeat(1000).
+		ErrorInstead(errors.New("AccessDenied"))
+
+	_, err := te.mgr.CleanupSupersededIndexes(ctx)
+	require.Error(t, err, "CleanupSupersededIndexes must fail on undeletable index blobs when object lock is disabled")
 }
 
 func randomTime(minTime, maxTime time.Duration) time.Duration {

--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -41,6 +41,16 @@ type Options struct {
 	ConnectOptions       func(*repo.ConnectOptions)
 	NewRepositoryOptions func(*repo.NewRepositoryOptions)
 	OpenOptions          func(*repo.Options)
+
+	// WrapStorage, if set, is applied to the environment's storage as the
+	// outermost layer, so it sees every blob operation the repository makes.
+	// Its main use is fault injection via blobtesting.NewFaultyStorage:
+	// without it there is no way to make a repository-level test observe a
+	// failing DeleteBlob, because the in-memory storages this package builds
+	// always succeed, and blobtesting.NewVersionedMapStorage models S3
+	// versioning (DeleteBlob inserts a delete marker) rather than a hard
+	// object-lock denial.
+	WrapStorage func(blob.Storage) blob.Storage
 }
 
 // RepositoryMetrics returns metrics.Registry associated with a repository.
@@ -100,6 +110,18 @@ func (e *Environment) setup(tb testing.TB, version format.Version, opts ...Optio
 	} else {
 		// use versioned mock storage when retention settings are specified
 		st = blobtesting.NewVersionedMapStorage(openOpt.TimeNowFunc)
+	}
+
+	// Applied before the reconnectable wrapper on purpose. That wrapper
+	// registers itself in a global map and repo.Open resolves the connection
+	// info back to exactly that instance, so anything wrapped *around* it is
+	// invisible to the opened repository. Wrapping the base storage first
+	// puts the layer inside, where the repository's own calls pass through
+	// it.
+	for _, mod := range opts {
+		if mod.WrapStorage != nil {
+			st = mod.WrapStorage(st)
+		}
 	}
 
 	st = NewReconnectableStorage(tb, st)

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -93,6 +93,7 @@ type SharedManager struct {
 	// exclusive lock will be acquired during compaction or refresh.
 	indexesLock            sync.RWMutex
 	permissiveCacheLoading bool
+	objectLockEnabled      bool
 
 	// maybeRefreshIndexes() will call Refresh() after this point in ime.
 	// +checklocks:indexesLock
@@ -617,6 +618,7 @@ func NewSharedManager(ctx context.Context, st blob.Storage, prov format.Provider
 		timeNow:                 opts.TimeNow,
 		format:                  prov,
 		permissiveCacheLoading:  opts.PermissiveCacheLoading,
+		objectLockEnabled:       opts.ObjectLockEnabled,
 		minPreambleLength:       defaultMinPreambleLength,
 		maxPreambleLength:       defaultMaxPreambleLength,
 		paddingUnit:             defaultPaddingUnit,

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -527,7 +527,8 @@ func (sm *SharedManager) setupCachesAndIndexManagers(ctx context.Context, cachin
 				return errors.Wrap(sm.indexBlobManagerV1.CompactEpoch(ctx, blobIDs, outputPrefix), "CompactEpoch")
 			},
 			sm.namedLogger("epoch-manager"),
-			sm.timeNow),
+			sm.timeNow,
+			sm.objectLockEnabled),
 		sm.timeNow,
 		sm.format,
 		sm.namedLogger("index-blob-manager"),

--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -121,6 +121,13 @@ func (sm *SharedManager) IsReadOnly() bool {
 	return sm.st.IsReadOnly()
 }
 
+// IsObjectLockEnabled returns whether the underlying storage has a retention
+// policy (e.g. S3 Object Lock) that may keep some blobs undeletable until
+// their retention expires, independent of what kopia wants to do with them.
+func (sm *SharedManager) IsObjectLockEnabled() bool {
+	return sm.objectLockEnabled
+}
+
 // LoadIndexBlob return index information loaded from the specified blob.
 func (sm *SharedManager) LoadIndexBlob(ctx context.Context, ibid blob.ID, d *gather.WriteBuffer) ([]Info, error) {
 	err := sm.st.GetBlob(ctx, ibid, 0, -1, d)

--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -961,6 +961,16 @@ func (bm *WriteManager) MetadataCache() cache.ContentCache {
 type ManagerOptions struct {
 	TimeNow                func() time.Time // Time provider
 	PermissiveCacheLoading bool
+
+	// ObjectLockEnabled indicates the repository uses blob retention (S3
+	// Object Lock). When set, commitSession tolerates a failure to delete a
+	// session marker instead of failing the whole flush: under Object Lock a
+	// session marker may itself be retention-locked (for example when the
+	// bucket carries a default retention that applies to every object), and a
+	// lingering session marker is harmless. Readers never consult session
+	// markers, blob GC stops treating the session as active once it ages past
+	// SessionExpirationAge, and the marker expires with its own retention.
+	ObjectLockEnabled bool
 }
 
 // CloneOrDefault returns a clone of provided ManagerOptions or default empty struct if nil.

--- a/repo/content/session_objectlock_test.go
+++ b/repo/content/session_objectlock_test.go
@@ -1,0 +1,118 @@
+package content
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/epoch"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/content/index"
+	"github.com/kopia/kopia/repo/format"
+)
+
+func objectLockTestFormatProvider(t *testing.T) format.Provider {
+	t.Helper()
+
+	return mustCreateFormatProvider(t, &format.ContentFormat{
+		Hash:       "HMAC-SHA256-128",
+		Encryption: "AES256-GCM-HMAC-SHA256",
+		HMACSecret: []byte("foo"),
+		MasterKey:  []byte("0123456789abcdef0123456789abcdef"),
+		MutableParameters: format.MutableParameters{
+			Version:         2,
+			MaxPackSize:     maxPackSize,
+			IndexVersion:    index.Version2,
+			EpochParameters: epoch.DefaultParameters(),
+		},
+	})
+}
+
+// TestCommitSessionToleratesLockedSessionMarker verifies that with
+// ManagerOptions.ObjectLockEnabled a flush succeeds even when the session
+// marker blob cannot be deleted. This is the S3 Object Lock case: a bucket
+// default retention locks every object, including the session markers kopia
+// normally deletes at flush (session markers are deliberately excluded from
+// GetLockingStoragePrefixes, so kopia never requests a lock on them, but a
+// bucket-level policy applies regardless). The just-written content must stay
+// durable and readable, and the undeletable marker must simply be left in
+// place - it expires with the retention the bucket applied.
+func TestCommitSessionToleratesLockedSessionMarker(t *testing.T) {
+	ctx := testlogging.Context(t)
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+	faulty := blobtesting.NewFaultyStorage(st)
+
+	bm, err := NewManagerForTesting(ctx, faulty, objectLockTestFormatProvider(t), nil, &ManagerOptions{ObjectLockEnabled: true})
+	if err != nil {
+		t.Fatalf("can't create content manager: %v", err)
+	}
+
+	defer bm.CloseShared(ctx)
+
+	payload := seededRandomData(1, 100)
+
+	cid, err := bm.WriteContent(ctx, gather.FromSlice(payload), "", NoCompression)
+	if err != nil {
+		t.Fatalf("WriteContent: %v", err)
+	}
+
+	// From here on every DeleteBlob fails, standing in for a retention-locked
+	// session marker that S3 Object Lock (compliance mode) refuses to delete.
+	faulty.AddFault(blobtesting.MethodDeleteBlob).Repeat(1000).ErrorInstead(errors.New("AccessDenied: object is WORM protected"))
+
+	if err := bm.Flush(ctx); err != nil {
+		t.Fatalf("flush must tolerate an undeletable session marker when object lock is enabled, got: %v", err)
+	}
+
+	// content survived the flush and is readable.
+	got, err := bm.GetContent(ctx, cid)
+	if err != nil {
+		t.Fatalf("GetContent after flush: %v", err)
+	}
+
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("content mismatch after flush: got %d bytes, want %d", len(got), len(payload))
+	}
+
+	// the marker that could not be deleted was left in storage rather than
+	// aborting the flush.
+	markers, err := blob.ListAllBlobs(ctx, st, BlobIDPrefixSession)
+	if err != nil {
+		t.Fatalf("listing session markers: %v", err)
+	}
+
+	if len(markers) == 0 {
+		t.Fatal("expected the undeletable session marker to remain in storage")
+	}
+}
+
+// TestCommitSessionFailsOnLockedSessionMarkerWithoutObjectLock is the negative
+// case: without ObjectLockEnabled a DeleteBlob failure on the session marker
+// stays fatal to the flush, preserving the strict behavior for non-object-lock
+// repositories, where a delete failure signals a real storage problem.
+func TestCommitSessionFailsOnLockedSessionMarkerWithoutObjectLock(t *testing.T) {
+	ctx := testlogging.Context(t)
+	st := blobtesting.NewMapStorage(blobtesting.DataMap{}, nil, nil)
+	faulty := blobtesting.NewFaultyStorage(st)
+
+	bm, err := NewManagerForTesting(ctx, faulty, objectLockTestFormatProvider(t), nil, &ManagerOptions{})
+	if err != nil {
+		t.Fatalf("can't create content manager: %v", err)
+	}
+
+	defer bm.CloseShared(ctx)
+
+	if _, err := bm.WriteContent(ctx, gather.FromSlice(seededRandomData(1, 100)), "", NoCompression); err != nil {
+		t.Fatalf("WriteContent: %v", err)
+	}
+
+	faulty.AddFault(blobtesting.MethodDeleteBlob).Repeat(1000).ErrorInstead(errors.New("AccessDenied"))
+
+	if err := bm.Flush(ctx); err == nil {
+		t.Fatal("flush must fail on an undeletable session marker when object lock is disabled")
+	}
+}

--- a/repo/content/sessions.go
+++ b/repo/content/sessions.go
@@ -13,6 +13,9 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/blobcrypto"
+	"github.com/kopia/kopia/internal/blobparam"
+	"github.com/kopia/kopia/internal/contentlog"
+	"github.com/kopia/kopia/internal/contentlog/logparam"
 	"github.com/kopia/kopia/internal/gather"
 	"github.com/kopia/kopia/repo/blob"
 )
@@ -123,6 +126,26 @@ func (bm *WriteManager) getOrStartSessionLocked(ctx context.Context) (SessionID,
 func (bm *WriteManager) commitSession(ctx context.Context) error {
 	for _, b := range bm.sessionMarkerBlobIDs {
 		if err := bm.st.DeleteBlob(ctx, b); err != nil && !errors.Is(err, blob.ErrBlobNotFound) {
+			// Under S3 Object Lock the session marker may itself be
+			// retention-locked (for example when the bucket carries a default
+			// retention that applies to every object, since session markers are
+			// deliberately not in GetLockingStoragePrefixes and so kopia never
+			// requests a lock on them). Failing to delete it is not fatal: the
+			// index blobs written in this session are already durable and
+			// visible - readers never consult session markers - blob GC stops
+			// treating the session as active once it ages past
+			// SessionExpirationAge, and the marker expires with the retention
+			// the bucket applied. Log and continue rather than aborting the
+			// flush and losing the just-written snapshot.
+			if bm.objectLockEnabled {
+				contentlog.Log2(ctx, bm.log,
+					"could not delete session marker (object lock enabled), leaving it to expire",
+					blobparam.BlobID("blobID", b),
+					logparam.Error("error", err))
+
+				continue
+			}
+
 			return errors.Wrapf(err, "failed to delete session marker %v", b)
 		}
 	}

--- a/repo/maintenance/blob_retain.go
+++ b/repo/maintenance/blob_retain.go
@@ -29,7 +29,16 @@ type ExtendBlobRetentionTimeOptions struct {
 }
 
 // extendBlobRetentionTime extends the retention time of all relevant blobs managed by storage engine with Object Locking enabled.
-func extendBlobRetentionTime(ctx context.Context, rep repo.DirectRepositoryWriter, opt ExtendBlobRetentionTimeOptions) (*maintenancestats.ExtendBlobRetentionStats, error) {
+//
+// Pack blobs that garbage collection is about to reclaim are deliberately left
+// alone. Renewing their retention on every maintenance cycle would push the
+// expiry date further out each time, so a blob that GC already wants to delete
+// could never be deleted again and the repository would grow without bound.
+// Under a compliance-mode lock that is not recoverable: nobody, including the
+// account owner, can remove the object before its retention expires. The
+// safety margins for "about to be reclaimed" are shared with
+// DeleteUnreferencedPacks rather than re-derived, see pack_eligibility.go.
+func extendBlobRetentionTime(ctx context.Context, rep repo.DirectRepositoryWriter, opt ExtendBlobRetentionTimeOptions, safety SafetyParameters) (*maintenancestats.ExtendBlobRetentionStats, error) {
 	ctx = contentlog.WithParams(ctx,
 		logparam.String("span:blob-retain", contentlog.RandomSpanID()))
 	log := rep.LogManager().NewLogger("maintenance-blob-retain")
@@ -63,6 +72,17 @@ func extendBlobRetentionTime(ctx context.Context, rep repo.DirectRepositoryWrite
 		opt.Parallel = runtime.NumCPU() * parallelBlobRetainCPUMultiplier
 	}
 
+	// Determined before extending anything, so the decision is taken against
+	// one consistent view of the repository. Only pack blobs can appear in
+	// here; index, epoch and format blobs are never reclaimable and must stay
+	// locked for as long as the repository exists.
+	reclaimable, err := reclaimablePackBlobs(ctx, rep, opt.Parallel, safety)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to determine reclaimable pack blobs")
+	}
+
+	var skipped atomic.Uint64
+
 	// start goroutines to extend blob retention as they come.
 	for range opt.Parallel {
 		wg.Go(func() error {
@@ -91,6 +111,19 @@ func extendBlobRetentionTime(ctx context.Context, rep repo.DirectRepositoryWrite
 	contentlog.Log(ctx, log, "Extending retention time for blobs...")
 
 	err = blob.IterateAllPrefixesInParallel(ctx, opt.Parallel, rep.BlobStorage(), repo.GetLockingStoragePrefixes(), func(bm blob.Metadata) error {
+		if _, ok := reclaimable[bm.BlobID]; ok {
+			// GC wants this pack gone. Extending it now would make that
+			// impossible for another full retention period, every cycle,
+			// forever.
+			skipped.Add(1)
+
+			contentlog.Log1(ctx, log,
+				"not extending reclaimable pack blob",
+				blobparam.BlobID("blobID", bm.BlobID))
+
+			return nil
+		}
+
 		extend <- bm
 
 		toExtend.Add(1)
@@ -100,7 +133,9 @@ func extendBlobRetentionTime(ctx context.Context, rep repo.DirectRepositoryWrite
 
 	close(extend)
 
-	contentlog.Log1(ctx, log, "Found blobs to extend", logparam.UInt64("count", toExtend.Load()))
+	contentlog.Log2(ctx, log, "Found blobs to extend",
+		logparam.UInt64("count", toExtend.Load()),
+		logparam.UInt64("skippedReclaimable", skipped.Load()))
 
 	errWait := wg.Wait() // wait for all extend workers to finish.
 	impossible.PanicOnError(errWait)
@@ -114,9 +149,10 @@ func extendBlobRetentionTime(ctx context.Context, rep repo.DirectRepositoryWrite
 	}
 
 	result := &maintenancestats.ExtendBlobRetentionStats{
-		ToExtendBlobCount: toExtend.Load(),
-		ExtendedBlobCount: extendedCount.Load(),
-		RetentionPeriod:   extendOpts.RetentionPeriod.String(),
+		ToExtendBlobCount:           toExtend.Load(),
+		ExtendedBlobCount:           extendedCount.Load(),
+		SkippedReclaimableBlobCount: skipped.Load(),
+		RetentionPeriod:             extendOpts.RetentionPeriod.String(),
 	}
 
 	contentlog.Log1(ctx, log, "Extended retention time for blobs", result)

--- a/repo/maintenance/blob_retain_test.go
+++ b/repo/maintenance/blob_retain_test.go
@@ -1,7 +1,9 @@
 package maintenance_test
 
 import (
+	"context"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/blob"
 	"github.com/kopia/kopia/repo/encryption"
+	"github.com/kopia/kopia/repo/format"
 	"github.com/kopia/kopia/repo/maintenance"
 	"github.com/kopia/kopia/repo/object"
 )
@@ -71,7 +74,7 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTime(t *testing.T) {
 	earliestExpiry = ta.NowFunc()().Add(period)
 
 	// extend retention time of all blobs
-	stats, err := maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter, maintenance.ExtendBlobRetentionTimeOptions{})
+	stats, err := maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter, maintenance.ExtendBlobRetentionTimeOptions{}, maintenance.SafetyFull)
 	require.NoError(t, err)
 	require.EqualValues(t, 4, stats.ToExtendBlobCount)
 	require.EqualValues(t, 4, stats.ExtendedBlobCount)
@@ -82,6 +85,159 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTime(t *testing.T) {
 
 	assert.Equal(t, mode, gotMode)
 	assert.WithinDuration(t, earliestExpiry, expiry, time.Minute)
+}
+
+// recordingStorage notes which blobs had their retention extended, so a test
+// can assert on what was left alone rather than only on counts.
+type recordingStorage struct {
+	blob.Storage
+
+	mu       sync.Mutex
+	extended map[blob.ID]int
+}
+
+func (s *recordingStorage) ExtendBlobRetention(ctx context.Context, blobID blob.ID, opts blob.ExtendOptions) error {
+	s.mu.Lock()
+
+	if s.extended == nil {
+		s.extended = map[blob.ID]int{}
+	}
+
+	s.extended[blobID]++
+	s.mu.Unlock()
+
+	return s.Storage.ExtendBlobRetention(ctx, blobID, opts)
+}
+
+func (s *recordingStorage) wasExtended(blobID blob.ID) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.extended[blobID] > 0
+}
+
+// TestExtendBlobRetentionTimeSkipsReclaimablePacks pins down the behaviour that
+// makes rolling object-lock retention safe to switch on.
+//
+// Extending retention on every locking-prefix blob unconditionally looks
+// harmless but is not: the extend step runs after orphaned-pack GC in the full
+// maintenance cycle, so a pack that GC could not delete - under a
+// compliance-mode lock it never can, that is the point - gets its expiry
+// pushed out again on the next cycle, and the one after that. Such a blob can
+// then never be reclaimed by anyone, and the repository grows monotonically
+// with no way back.
+//
+// So reclaimable packs must be skipped, while index, epoch and format blobs
+// must still be extended: those are not reclaimable and have to stay locked
+// for as long as the repository exists.
+func TestExtendBlobRetentionTimeSkipsReclaimablePacks(t *testing.T) {
+	t.Parallel()
+
+	const period = 24 * time.Hour
+
+	var rec *recordingStorage
+
+	ctx, env := repotesting.NewEnvironment(t, format.FormatVersion3, repotesting.Options{
+		NewRepositoryOptions: func(nro *repo.NewRepositoryOptions) {
+			nro.BlockFormat.Encryption = encryption.DefaultAlgorithm
+			nro.BlockFormat.MasterKey = testMasterKey
+			nro.BlockFormat.Hash = blockFormatHash
+			nro.BlockFormat.HMACSecret = testHMACSecret
+			// Retention has to be enabled or extendBlobRetentionTime returns
+			// early and the test would pass without proving anything.
+			nro.RetentionMode = blob.Governance
+			nro.RetentionPeriod = period
+		},
+		WrapStorage: func(st blob.Storage) blob.Storage {
+			rec = &recordingStorage{Storage: st}
+			return rec
+		},
+	})
+
+	w := env.RepositoryWriter.NewObjectWriter(ctx, object.WriterOptions{MetadataCompressor: "zstd-fastest"})
+	io.WriteString(w, "hello world!")
+	w.Result()
+	w.Close()
+	require.NoError(t, env.RepositoryWriter.Flush(ctx))
+
+	// Blobs written by the flush above are referenced, so none of them is
+	// reclaimable and all of them must keep being extended.
+	referenced, err := blob.ListAllBlobs(ctx, env.RepositoryWriter.BlobStorage(), "")
+	require.NoError(t, err)
+	require.NotEmpty(t, referenced)
+
+	// An unreferenced pack blob: exactly what GC reclaims, and what extending
+	// would immortalise.
+	// Hex-only: kopia skips pack blob IDs it cannot parse, which would
+	// leave the orphan out of the unreferenced set and make this test vacuous.
+	const orphan blob.ID = "pdead0000000000a1"
+
+	mustPutDummyBlob(t, env.RepositoryWriter.BlobStorage(), orphan)
+
+	// SafetyNone so the orphan counts as reclaimable straight away instead of
+	// being held back by PackDeleteMinAge.
+	stats, err := maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter,
+		maintenance.ExtendBlobRetentionTimeOptions{}, maintenance.SafetyNone)
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+
+	require.False(t, rec.wasExtended(orphan),
+		"a reclaimable pack blob must not have its retention extended, or GC can never delete it")
+	require.EqualValues(t, 1, stats.SkippedReclaimableBlobCount,
+		"the skipped blob must be reported, so an operator can see the repository can still shrink")
+
+	for _, bm := range referenced {
+		require.True(t, rec.wasExtended(bm.BlobID),
+			"referenced/metadata blob %v must still be extended", bm.BlobID)
+	}
+}
+
+// TestExtendBlobRetentionTimeExtendsYoungOrphans is the counterpart: an
+// unreferenced pack that GC would not touch yet must still be extended.
+// Skipping it would be the opposite failure - letting protection lapse on data
+// that is not yet provably garbage.
+func TestExtendBlobRetentionTimeExtendsYoungOrphans(t *testing.T) {
+	t.Parallel()
+
+	const period = 24 * time.Hour
+
+	var rec *recordingStorage
+
+	ctx, env := repotesting.NewEnvironment(t, format.FormatVersion3, repotesting.Options{
+		NewRepositoryOptions: func(nro *repo.NewRepositoryOptions) {
+			nro.BlockFormat.Encryption = encryption.DefaultAlgorithm
+			nro.BlockFormat.MasterKey = testMasterKey
+			nro.BlockFormat.Hash = blockFormatHash
+			nro.BlockFormat.HMACSecret = testHMACSecret
+			nro.RetentionMode = blob.Governance
+			nro.RetentionPeriod = period
+		},
+		WrapStorage: func(st blob.Storage) blob.Storage {
+			rec = &recordingStorage{Storage: st}
+			return rec
+		},
+	})
+
+	w := env.RepositoryWriter.NewObjectWriter(ctx, object.WriterOptions{MetadataCompressor: "zstd-fastest"})
+	io.WriteString(w, "hello world!")
+	w.Result()
+	w.Close()
+	require.NoError(t, env.RepositoryWriter.Flush(ctx))
+
+	const orphan blob.ID = "pdead0000000000a2"
+
+	mustPutDummyBlob(t, env.RepositoryWriter.BlobStorage(), orphan)
+
+	// SafetyFull keeps the freshly written orphan below PackDeleteMinAge, so
+	// GC would not delete it in this cycle.
+	stats, err := maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter,
+		maintenance.ExtendBlobRetentionTimeOptions{}, maintenance.SafetyFull)
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+
+	require.True(t, rec.wasExtended(orphan),
+		"an orphan that GC would not delete yet must keep its retention extended")
+	require.Zero(t, stats.SkippedReclaimableBlobCount)
 }
 
 func (s *formatSpecificTestSuite) TestExtendBlobRetentionTimeDisabled(t *testing.T) {
@@ -123,7 +279,7 @@ func (s *formatSpecificTestSuite) TestExtendBlobRetentionTimeDisabled(t *testing
 	require.NoError(t, err, "Altering expired object failed")
 
 	// extend retention time of all blobs
-	stats, err := maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter, maintenance.ExtendBlobRetentionTimeOptions{})
+	stats, err := maintenance.ExtendBlobRetentionTime(ctx, env.RepositoryWriter, maintenance.ExtendBlobRetentionTimeOptions{}, maintenance.SafetyFull)
 	require.NoError(t, err)
 	require.Nil(t, stats)
 

--- a/repo/maintenance/cleanup_logs.go
+++ b/repo/maintenance/cleanup_logs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/kopia/kopia/internal/blobparam"
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/contentlog"
 	"github.com/kopia/kopia/internal/contentlog/logparam"
@@ -109,14 +110,49 @@ func CleanupLogs(ctx context.Context, rep repo.DirectRepositoryWriter, opt LogRe
 	contentlog.Log1(ctx, log, "Clean up logs", result)
 
 	if !opt.DryRun {
+		// Under a storage-level retention policy (e.g. S3 Object Lock in
+		// compliance mode, or a bucket default retention that applies to
+		// every object) a log blob can still be inside its retention window
+		// and is undeletable by anyone. Log blobs are pure diagnostics, so
+		// keeping one for another cycle costs nothing but storage - failing
+		// the whole maintenance run's exit code for it is wrong. Note this
+		// is not a corner case with our defaults: log retention is 30 days
+		// and a typical Object Lock retention is also 30 days, so the two
+		// boundaries coincide.
+		objectLockEnabled := rep.ContentManager().IsObjectLockEnabled()
+
+		var deletedCount, retainedByLock uint64
+
+		var deletedSize uint64
+
 		for _, bm := range toDelete {
 			if err := rep.BlobStorage().DeleteBlob(ctx, bm.BlobID); err != nil {
+				if objectLockEnabled {
+					retainedByLock++
+
+					contentlog.Log2(ctx, log,
+						"could not delete log blob (object lock enabled), leaving it for a future maintenance cycle",
+						blobparam.BlobID("blobID", bm.BlobID),
+						logparam.Error("error", err))
+
+					continue
+				}
+
 				return nil, errors.Wrapf(err, "error deleting log %v", bm.BlobID)
 			}
+
+			deletedCount++
+			deletedSize += maintenancestats.ToUint64(bm.Length)
 		}
 
-		result.DeletedBlobCount = result.ToDeleteBlobCount
-		result.DeletedBlobSize = result.ToDeleteBlobSize
+		if retainedByLock > 0 {
+			contentlog.Log1(ctx, log,
+				"some log blobs could not be deleted because of object lock retention",
+				logparam.UInt64("retainedByLock", retainedByLock))
+		}
+
+		result.DeletedBlobCount = deletedCount
+		result.DeletedBlobSize = deletedSize
 	}
 
 	return result, nil

--- a/repo/maintenance/helper_test.go
+++ b/repo/maintenance/helper_test.go
@@ -9,6 +9,6 @@ import (
 
 // helpers exported for tests
 
-func ExtendBlobRetentionTime(ctx context.Context, rep repo.DirectRepositoryWriter, opt ExtendBlobRetentionTimeOptions) (*maintenancestats.ExtendBlobRetentionStats, error) {
-	return extendBlobRetentionTime(ctx, rep, opt)
+func ExtendBlobRetentionTime(ctx context.Context, rep repo.DirectRepositoryWriter, opt ExtendBlobRetentionTimeOptions, safety SafetyParameters) (*maintenancestats.ExtendBlobRetentionStats, error) {
+	return extendBlobRetentionTime(ctx, rep, opt, safety)
 }

--- a/repo/maintenance/maintenance_run.go
+++ b/repo/maintenance/maintenance_run.go
@@ -492,9 +492,9 @@ func runTaskDeleteOrphanedPacksQuick(ctx context.Context, runParams RunParameter
 	})
 }
 
-func runTaskExtendBlobRetentionTimeFull(ctx context.Context, runParams RunParameters, s *Schedule) error {
+func runTaskExtendBlobRetentionTimeFull(ctx context.Context, runParams RunParameters, s *Schedule, safety SafetyParameters) error {
 	return ReportRun(ctx, runParams.rep, TaskExtendBlobRetentionTimeFull, s, func() (maintenancestats.Kind, error) {
-		return extendBlobRetentionTime(ctx, runParams.rep, ExtendBlobRetentionTimeOptions{})
+		return extendBlobRetentionTime(ctx, runParams.rep, ExtendBlobRetentionTimeOptions{}, safety)
 	})
 }
 
@@ -533,7 +533,7 @@ func runFullMaintenance(ctx context.Context, runParams RunParameters, safety Saf
 
 	// extend retention-time on supported storage.
 	if runParams.Params.ExtendObjectLocks {
-		if err := runTaskExtendBlobRetentionTimeFull(ctx, runParams, s); err != nil {
+		if err := runTaskExtendBlobRetentionTimeFull(ctx, runParams, s, safety); err != nil {
 			return errors.Wrap(err, "error extending object lock retention time")
 		}
 	} else {

--- a/repo/maintenance/pack_eligibility.go
+++ b/repo/maintenance/pack_eligibility.go
@@ -1,0 +1,139 @@
+package maintenance
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/repo/blob"
+	"github.com/kopia/kopia/repo/content"
+)
+
+// packRetainReason explains why an unreferenced pack blob is not (yet)
+// eligible for deletion. packEligible means it is.
+type packRetainReason int
+
+const (
+	packEligible packRetainReason = iota
+	packRetainedAfterCutoff
+	packRetainedBelowMinAge
+	packRetainedActiveSession
+)
+
+// packEligibility answers "would DeleteUnreferencedPacks delete this pack
+// blob in this cycle?" for a blob that IterateUnreferencedPacks has already
+// established is unreferenced.
+//
+// It exists so that DeleteUnreferencedPacks and extendBlobRetentionTime agree
+// on that question. They have to: the extend step must not renew the
+// retention of a pack that GC is about to reclaim, because a blob whose lock
+// is refreshed on every maintenance cycle can never be deleted again, and the
+// repository would then grow without bound. Sharing the predicate rather than
+// re-deriving it is deliberate - two copies of these three conditions would
+// drift, and the failure mode of drift here is silent, unbounded storage
+// growth.
+type packEligibility struct {
+	cutoffTime     time.Time
+	activeSessions map[content.SessionID]*content.SessionInfo
+	safety         SafetyParameters
+}
+
+// newPackEligibility captures the state the decision depends on: the storage
+// clock cutoff and the set of sessions that are still alive.
+func newPackEligibility(ctx context.Context, rep repo.DirectRepositoryWriter, notAfterTime time.Time, safety SafetyParameters) (*packEligibility, error) {
+	activeSessions, err := rep.ContentManager().ListActiveSessions(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to load active sessions")
+	}
+
+	cutoffTime := notAfterTime
+	if cutoffTime.IsZero() {
+		cutoffTime = rep.Time()
+	}
+
+	// move the cutoff time a bit forward, because on Windows clock does not
+	// reliably move forward so we may end up not deleting some blobs - this
+	// only really affects tests, since BlobDeleteMinAge provides real
+	// protection here.
+	const cutoffTimeSlack = 1 * time.Second
+
+	cutoffTime = cutoffTime.Add(cutoffTimeSlack)
+
+	return &packEligibility{
+		cutoffTime:     cutoffTime,
+		activeSessions: activeSessions,
+		safety:         safety,
+	}, nil
+}
+
+// reason classifies bm. The zero value packEligible means the pack may be
+// deleted; anything else names the condition that keeps it around.
+func (e *packEligibility) reason(bm blob.Metadata) packRetainReason {
+	if bm.Timestamp.After(e.cutoffTime) {
+		return packRetainedAfterCutoff
+	}
+
+	if age := e.cutoffTime.Sub(bm.Timestamp); age < e.safety.PackDeleteMinAge {
+		return packRetainedBelowMinAge
+	}
+
+	sid := content.SessionIDFromBlobID(bm.BlobID)
+	if s, ok := e.activeSessions[sid]; ok {
+		if age := e.cutoffTime.Sub(s.CheckpointTime); age < e.safety.SessionExpirationAge {
+			return packRetainedActiveSession
+		}
+	}
+
+	return packEligible
+}
+
+// age returns how old bm is relative to the cutoff, for logging.
+func (e *packEligibility) age(bm blob.Metadata) time.Duration {
+	return e.cutoffTime.Sub(bm.Timestamp)
+}
+
+// reclaimablePackBlobs returns the pack blobs that a GC pass would delete
+// right now. Used by extendBlobRetentionTime to leave exactly those blobs
+// alone.
+func reclaimablePackBlobs(ctx context.Context, rep repo.DirectRepositoryWriter, parallel int, safety SafetyParameters) (map[blob.ID]struct{}, error) {
+	if parallel <= 0 {
+		parallel = 16
+	}
+
+	elig, err := newPackEligibility(ctx, rep, time.Time{}, safety)
+	if err != nil {
+		return nil, err
+	}
+
+	prefixes := []blob.ID{
+		content.PackBlobIDPrefixRegular,
+		content.PackBlobIDPrefixSpecial,
+		content.BlobIDPrefixSession,
+	}
+
+	out := map[blob.ID]struct{}{}
+
+	// IterateUnreferencedPacks invokes the callback from `parallel`
+	// goroutines, so the map needs its own lock. The rest of the callback is
+	// read-only.
+	var mu sync.Mutex
+
+	if err := rep.ContentManager().IterateUnreferencedPacks(ctx, prefixes, parallel, func(bm blob.Metadata) error {
+		if elig.reason(bm) != packEligible {
+			return nil
+		}
+
+		mu.Lock()
+		out[bm.BlobID] = struct{}{}
+		mu.Unlock()
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "error looking for reclaimable pack blobs")
+	}
+
+	return out, nil
+}

--- a/repo/maintenance/pack_gc.go
+++ b/repo/maintenance/pack_gc.go
@@ -94,58 +94,49 @@ func DeleteUnreferencedPacks(ctx context.Context, rep repo.DirectRepositoryWrite
 		prefixes = append(prefixes, content.PackBlobIDPrefixRegular, content.PackBlobIDPrefixSpecial, content.BlobIDPrefixSession)
 	}
 
-	activeSessions, err := rep.ContentManager().ListActiveSessions(ctx)
+	// The same predicate the extend step uses, so the two cannot disagree
+	// about which packs are about to be reclaimed. See pack_eligibility.go.
+	elig, err := newPackEligibility(ctx, rep, opt.NotAfterTime, safety)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to load active sessions")
+		return nil, err
 	}
-
-	cutoffTime := opt.NotAfterTime
-	if cutoffTime.IsZero() {
-		cutoffTime = rep.Time()
-	}
-
-	// move the cutoff time a bit forward, because on Windows clock does not reliably move forward so we may end
-	// up not deleting some blobs - this only really affects tests, since BlobDeleteMinAge provides real
-	// protection here.
-	const cutoffTimeSlack = 1 * time.Second
-
-	cutoffTime = cutoffTime.Add(cutoffTimeSlack)
 
 	// iterate all pack blobs + session blobs and keep ones that are too young or
 	// belong to alive sessions.
 	if err := rep.ContentManager().IterateUnreferencedPacks(ctx, prefixes, opt.Parallel, func(bm blob.Metadata) error {
-		if bm.Timestamp.After(cutoffTime) {
+		switch elig.reason(bm) {
+		case packRetainedAfterCutoff:
 			retained.Add(bm.Length)
 
 			contentlog.Log3(ctx, log,
 				"preserving pack - after cutoff time",
 				blobparam.BlobID("blobID", bm.BlobID),
-				logparam.Time("cutoffTime", cutoffTime),
+				logparam.Time("cutoffTime", elig.cutoffTime),
 				logparam.Time("timestamp", bm.Timestamp))
-			return nil
-		}
 
-		if age := cutoffTime.Sub(bm.Timestamp); age < safety.PackDeleteMinAge {
+			return nil
+
+		case packRetainedBelowMinAge:
 			retained.Add(bm.Length)
 
 			contentlog.Log2(ctx, log,
 				"preserving pack - below min age",
 				blobparam.BlobID("blobID", bm.BlobID),
-				logparam.Duration("age", age))
+				logparam.Duration("age", elig.age(bm)))
+
 			return nil
-		}
 
-		sid := content.SessionIDFromBlobID(bm.BlobID)
-		if s, ok := activeSessions[sid]; ok {
-			if age := cutoffTime.Sub(s.CheckpointTime); age < safety.SessionExpirationAge {
-				retained.Add(bm.Length)
+		case packRetainedActiveSession:
+			retained.Add(bm.Length)
 
-				contentlog.Log2(ctx, log,
-					"preserving pack - part of active session",
-					blobparam.BlobID("blobID", bm.BlobID),
-					logparam.String("sessionID", string(sid)))
-				return nil
-			}
+			contentlog.Log2(ctx, log,
+				"preserving pack - part of active session",
+				blobparam.BlobID("blobID", bm.BlobID),
+				logparam.String("sessionID", string(content.SessionIDFromBlobID(bm.BlobID))))
+
+			return nil
+
+		case packEligible:
 		}
 
 		unreferenced.Add(bm.Length)

--- a/repo/maintenance/pack_gc.go
+++ b/repo/maintenance/pack_gc.go
@@ -44,6 +44,15 @@ func DeleteUnreferencedPacks(ctx context.Context, rep repo.DirectRepositoryWrite
 
 	var eg errgroup.Group
 
+	// Under a storage-level retention policy (e.g. S3 Object Lock in
+	// compliance mode) some of these unreferenced packs may still be
+	// within their retention window and genuinely cannot be deleted yet
+	// by anyone, not just kopia - that's the point of compliance mode.
+	// Failing the whole maintenance run's exit code for that is wrong:
+	// the pack is simply not eligible for reclamation this cycle and
+	// will be picked up again once its retention expires naturally.
+	objectLockEnabled := rep.ContentManager().IsObjectLockEnabled()
+
 	unused := make(chan blob.Metadata, deleteQueueSize)
 
 	if !opt.DryRun {
@@ -52,6 +61,15 @@ func DeleteUnreferencedPacks(ctx context.Context, rep repo.DirectRepositoryWrite
 			eg.Go(func() error {
 				for bm := range unused {
 					if err := rep.BlobStorage().DeleteBlob(ctx, bm.BlobID); err != nil {
+						if objectLockEnabled {
+							contentlog.Log2(ctx, log,
+								"could not delete unreferenced pack blob (object lock enabled), leaving it for a future maintenance cycle",
+								blobparam.BlobID("blobID", bm.BlobID),
+								logparam.Error("error", err))
+
+							continue
+						}
+
 						return errors.Wrapf(err, "unable to delete pack blob %q", bm.BlobID)
 					}
 

--- a/repo/maintenancestats/builder_test.go
+++ b/repo/maintenancestats/builder_test.go
@@ -101,7 +101,7 @@ func TestBuildExtraSuccess(t *testing.T) {
 			},
 			expected: Extra{
 				Kind: extendBlobRetentionStatsKind,
-				Data: []byte(`{"toExtendBlobCount":10,"extendedBlobCount":10,"retentionPeriod":"360h0m0s"}`),
+				Data: []byte(`{"toExtendBlobCount":10,"extendedBlobCount":10,"skippedReclaimableBlobCount":0,"retentionPeriod":"360h0m0s"}`),
 			},
 		},
 		{
@@ -291,7 +291,7 @@ func TestBuildFromExtraSuccess(t *testing.T) {
 			name: "ExtendBlobRetentionStats",
 			stats: Extra{
 				Kind: extendBlobRetentionStatsKind,
-				Data: []byte(`{"toExtendBlobCount":10,"extendedBlobCount":10,"retentionPeriod":"360h0m0s"}`),
+				Data: []byte(`{"toExtendBlobCount":10,"extendedBlobCount":10,"skippedReclaimableBlobCount":0,"retentionPeriod":"360h0m0s"}`),
 			},
 			expected: &ExtendBlobRetentionStats{
 				ToExtendBlobCount: 10,

--- a/repo/maintenancestats/stats_extend_blob_retention.go
+++ b/repo/maintenancestats/stats_extend_blob_retention.go
@@ -12,7 +12,12 @@ const extendBlobRetentionStatsKind = "extendBlobRetentionStats"
 type ExtendBlobRetentionStats struct {
 	ToExtendBlobCount uint64 `json:"toExtendBlobCount"`
 	ExtendedBlobCount uint64 `json:"extendedBlobCount"`
-	RetentionPeriod   string `json:"retentionPeriod"`
+	// SkippedReclaimableBlobCount counts pack blobs whose retention was
+	// deliberately not extended because garbage collection is about to
+	// reclaim them. Reported so an operator can see that the repository is
+	// still able to shrink instead of only ever growing.
+	SkippedReclaimableBlobCount uint64 `json:"skippedReclaimableBlobCount"`
+	RetentionPeriod             string `json:"retentionPeriod"`
 }
 
 // WriteValueTo writes the stats to JSONWriter.
@@ -20,13 +25,15 @@ func (es *ExtendBlobRetentionStats) WriteValueTo(jw *contentlog.JSONWriter) {
 	jw.BeginObjectField(es.Kind())
 	jw.UInt64Field("toExtendBlobCount", es.ToExtendBlobCount)
 	jw.UInt64Field("extendedBlobCount", es.ExtendedBlobCount)
+	jw.UInt64Field("skippedReclaimableBlobCount", es.SkippedReclaimableBlobCount)
 	jw.StringField("retentionPeriod", es.RetentionPeriod)
 	jw.EndObject()
 }
 
 // Summary generates a human readable summary for the stats.
 func (es *ExtendBlobRetentionStats) Summary() string {
-	return fmt.Sprintf("Blob retention extension found %v blobs and extended for %v blobs, retention period %v", es.ToExtendBlobCount, es.ExtendedBlobCount, es.RetentionPeriod)
+	return fmt.Sprintf("Blob retention extension found %v blobs and extended for %v blobs, skipped %v reclaimable blobs, retention period %v",
+		es.ToExtendBlobCount, es.ExtendedBlobCount, es.SkippedReclaimableBlobCount, es.RetentionPeriod)
 }
 
 // Kind returns the kind name for the stats.

--- a/repo/open.go
+++ b/repo/open.go
@@ -292,6 +292,11 @@ func openWithConfig(ctx context.Context, st blob.Storage, cliOpts ClientOptions,
 
 	if blobcfg.IsRetentionEnabled() {
 		st = wrapLockingStorage(st, blobcfg)
+
+		// Let the content manager know Object Lock is in effect so it tolerates
+		// a session marker that a stricter bucket-level policy (e.g. a bucket
+		// default retention) may have locked, instead of aborting every flush.
+		cmOpts.ObjectLockEnabled = true
 	}
 
 	_, err = retry.WithExponentialBackoffMaxRetries(ctx, -1, "wait for upgrade", func() (any, error) {


### PR DESCRIPTION
### Problem

When a repository's blobs are protected by S3 Object Lock and the bucket also carries a **default retention**, every object uploaded to the bucket is locked automatically. That includes several classes of blob that kopia deletes as part of normal operation, and every one of those delete paths treated `AccessDenied` as fatal. This PR makes all of them tolerate a retention-locked delete, following the same pattern throughout.

The five sites were found in the order below, each one surfacing only after the previous one stopped aborting the run: fixing snapshots exposed a maintenance failure, fixing that exposed the next maintenance step, and so on.

#### 1. Session markers (`repo/content/sessions.go`)

Session marker blobs (prefix `s`) are written by the content manager at the start of a write session and deleted on flush in `commitSession`. Session markers are deliberately excluded from `GetLockingStoragePrefixes()` (`repo/locking_storage.go`), so kopia never itself requests a lock on them - it expects to be able to delete them. But a bucket default retention applies regardless of what kopia requests, so the `DeleteBlob` in `commitSession` fails with `AccessDenied` and, because that error is currently fatal, the entire `flushPackIndexesLocked` aborts. The result: **no snapshot can ever be created** against such a bucket, even though the data and index blobs were already written successfully. This is the session-marker half of #5199 and the error reported in #3372.

Observed against Wasabi (compliance mode, bucket default retention):

```
unable to commit session: failed to delete session marker s...:
unable to complete DeleteBlob(...) despite 10 retries: AccessDenied
```

#### 2. Epoch markers and deletion watermarks (`internal/epoch/epoch_manager.go`)

Once snapshots themselves succeed (fix 1 above), maintenance runs into the same class of problem one layer down. `cleanupEpochMarkers` and `cleanupWatermarks` call `blob.DeleteMultiple` on epoch marker blobs (prefix `xe`) and deletion watermark blobs (prefix `xw`) as part of `CleanupMarkers`. Under a bucket default retention these deletes are denied the same way, and the error was propagated as fatal, failing the whole maintenance run:

```
running auto-maintenance: error running maintenance: error cleaning up epoch manager:
error removing epoch markers: error cleaning up index blobs: error deleting watermark blobs:
error deleting blobs: deleting xw1784876621: unable to complete DeleteBlob(...) despite 10 retries: AccessDenied
```

#### 3. Unreferenced pack blobs (`repo/maintenance/pack_gc.go`)

`DeleteUnreferencedPacks` deletes pack blobs (prefix `p`/`q`) once their content has been fully superseded and the grace period has passed. Under a bucket default retention, freshly-written packs are still within their lock window when GC considers them, and the delete is denied:

```
error deleting unreferenced blobs: worker error:
unable to delete pack blob "p...": unable to complete DeleteBlob(...) despite 10 retries: AccessDenied
```

#### 4. Superseded uncompacted index blobs (`internal/epoch/epoch_manager.go`)

`CleanupSupersededIndexes` deletes uncompacted index blobs (prefix `xn`) for epochs that already have a single-epoch compaction set written far enough in the past. This is a separate maintenance step from `CleanupMarkers` in fix 2 and was still fatal. It showed up in production on a host that was already running fixes 1 to 3, which is how we found it:

```
error cleaning up epoch manager: error removing superseded epoch index blobs:
unable to delete uncompacted blobs: error deleting blobs: deleting xn0_...:
unable to complete DeleteBlob(...) despite 10 retries: AccessDenied
```

#### 5. Partially written index shards (`internal/epoch/epoch_manager.go`)

Unlike the other four, this one is not in maintenance but in the index **write** path. When `WriteIndex` notices that the write epoch advanced while it was writing, it deletes the shards it just wrote and retries against the new epoch. Under Object Lock that delete is guaranteed to be denied: those shards are seconds old and therefore squarely inside their retention window. Because the failure was fatal, this would fail an actual snapshot rather than just a maintenance pass, so it is the most damaging of the five even though it only triggers on the epoch-advance race.

#### 6. Log blobs (`repo/maintenance/cleanup_logs.go`)

`CleanupLogs` deletes kopia's own diagnostic log blobs (prefix `_log`) beyond a configured age, count or total size. The default log retention is 30 days, and 30 days is also a very common Object Lock retention period, so the two boundaries coincide and this is not a corner case.

### Why leaving these blobs is safe

In every case the *content* the blob represents is already durable and reachable before the failed delete is even attempted; the delete is pure cleanup, not part of committing new data:

- **Readers never consult session markers.** There is no reference to `SessionID` / `ListActiveSessions` anywhere in the index read path (`repo/content/indexblob`, `internal/epoch`, `committed_read_manager.go`). The index blobs written in the session are durable and visible as soon as they are `PutBlob`-ed, which happens *before* `commitSession` in `flushPackIndexesLocked`. So no data is hidden or lost.
- **Blob GC self-heals around stale sessions.** `pack_gc.go` only treats a session as protecting packs while its `CheckpointTime` is younger than `SessionExpirationAge`; after that the session is ignored and its marker becomes eligible for normal cleanup.
- **Epoch markers/watermarks are bookkeeping, not data.** They record which epochs have been compacted/cleaned up so far; leaving a stale one in place for one more maintenance cycle just means that cycle re-examines an epoch it could have skipped. It does not risk correctness.
- **Unreferenced pack blobs are, by definition, unreferenced.** Failing to delete one leaves unused storage around for a bit longer; it does not affect any current or future snapshot.
- **Superseded index blobs already have their compacted replacement in storage.** That is the precondition `CleanupSupersededIndexes` checks before deleting them at all, so an undeleted one is redundant data, not a missing index.
- **Orphaned index shards are additive, never contradictory.** They reference content that really was written to packs, and index entries only ever add information - a reader that picks one up sees real content, never a missing or wrong entry. The shards get rewritten for the new write epoch, and `CleanupSupersededIndexes` removes the orphans once that epoch has a compaction set.
- **Log blobs are pure diagnostics.** Keeping one for another cycle costs storage and nothing else.
- **All of the above expire.** Under the same retention that locked them, S3 removes them automatically once the retention window passes, and the next maintenance cycle picks up where the previous one left off.

The only visible effect of blobs that couldn't be deleted immediately is that they linger until their retention period ends, and (for markers) a stale entry in `kopia session list` in the meantime.

### Change

Add `ManagerOptions.ObjectLockEnabled`, set from `blobcfg.IsRetentionEnabled()` in `repo/open.go` (right where `wrapLockingStorage` is already installed). The flag is carried on `content.SharedManager` and exposed via the new `IsObjectLockEnabled()` method, and threaded into `epoch.Manager` as a constructor argument. The same tolerate-and-continue pattern is applied at every delete site:

- `commitSession` (`repo/content/sessions.go`) - logs and continues on a session marker delete failure instead of aborting the flush.
- `cleanupEpochMarkers` / `cleanupWatermarks` (`internal/epoch/epoch_manager.go`) - log and return successfully (0 removed) instead of failing `CleanupMarkers`.
- `DeleteUnreferencedPacks` (`repo/maintenance/pack_gc.go`) - logs and continues to the next blob instead of aborting the GC pass.
- `CleanupSupersededIndexes` (`internal/epoch/epoch_manager.go`) - logs and returns stats with a zero delete count instead of failing.
- `WriteIndex` (`internal/epoch/epoch_manager.go`) - logs and proceeds with the retry against the new epoch instead of failing the write.
- `CleanupLogs` (`repo/maintenance/cleanup_logs.go`) - logs, counts the blob as retained-by-lock, and continues with the next one.

Where a combined error is returned for a batch (`blob.DeleteMultiple` gives one error, not per-blob results), the reported delete count is 0 rather than a number that cannot be verified.

In every case, when the flag is not set (repositories without blob retention), the original strict behavior is preserved - a delete failure there still signals a real storage problem and fails the operation.

This is intentionally minimal and does **not** attempt the larger "separate metadata bucket" redesign discussed in #5199. It keeps everything in one bucket and, combined with kopia-managed per-blob retention, lets a fully object-locked bucket (even one with a bucket default retention as defence-in-depth) complete both snapshots and maintenance.

### Files

- `repo/content/content_manager.go` - new `ObjectLockEnabled` option
- `repo/content/committed_read_manager.go` - carry the flag on `SharedManager`, add `IsObjectLockEnabled()`
- `repo/content/sessions.go` - tolerate the delete failure in `commitSession`
- `repo/open.go` - set the flag from `blobcfg.IsRetentionEnabled()`
- `repo/content/session_objectlock_test.go` - tests for both the tolerant (object lock on) and strict (object lock off) paths
- `internal/epoch/epoch_manager.go` - `objectLockEnabled` field, threaded through `NewManager`, tolerate delete failures in `cleanupEpochMarkers`, `cleanupWatermarks`, `CleanupSupersededIndexes` and `WriteIndex`
- `internal/epoch/epoch_manager_test.go` - tests for the tolerant and strict paths of marker/watermark cleanup and of superseded-index cleanup
- `repo/maintenance/pack_gc.go` - tolerate delete failures in `DeleteUnreferencedPacks`
- `repo/maintenance/cleanup_logs.go` - tolerate delete failures in `CleanupLogs`

### Testing

`go test ./repo/content/... ./internal/epoch/... ./repo/maintenance/...` passes, including the new tests for the session marker, the epoch marker/watermark paths and the superseded-index path (each with both the object-lock-tolerant and the strict/non-object-lock case). `go test -race` passes for the epoch and maintenance packages.

Three of the sites do not have a dedicated fault-injection test: pack GC, `CleanupLogs` and the `WriteIndex` race. The `repotesting` harness has no hook for wrapping its storage, and `blobtesting.NewVersionedMapStorage` models S3 versioning-style soft deletes (`DeleteBlob` inserts a delete marker) rather than a hard object-lock delete denial, so there is no way to exercise those paths without a larger test-harness change. The epoch package could be covered because it has its own `faultyStorage` test environment. Happy to add a storage-wrapping option to `repotesting` in a follow-up if you'd prefer the other three covered too.

Verified end-to-end against a real Wasabi bucket (compliance mode, 30-day default retention). Before the changes, `snapshot create` failed at the session marker delete; once that was fixed, `maintenance run --full` failed at the epoch marker/watermark step, then at pack GC, then at superseded-index cleanup. After all the fixes, `init`, `snapshot create` (full and incremental) and `maintenance run --full` all complete cleanly, snapshots are listable and restorable, and the undeletable blobs are simply left to expire under the bucket's retention. Also verified across roughly 80 production hosts backing up into the same object-locked bucket.

Relates to #5199, fixes the session-marker failure in #3372.
