### PR TITLE
fix(maintenance): do not deadlock pack GC when deletes keep failing

### DIFF
--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -41,6 +41,16 @@ type Options struct {
 	ConnectOptions       func(*repo.ConnectOptions)
 	NewRepositoryOptions func(*repo.NewRepositoryOptions)
 	OpenOptions          func(*repo.Options)
+
+	// WrapStorage, if set, is applied to the environment's storage as the
+	// outermost layer, so it sees every blob operation the repository makes.
+	// Its main use is fault injection via blobtesting.NewFaultyStorage:
+	// without it there is no way to make a repository-level test observe a
+	// failing DeleteBlob, because the in-memory storages this package builds
+	// always succeed, and blobtesting.NewVersionedMapStorage models S3
+	// versioning (DeleteBlob inserts a delete marker) rather than a hard
+	// object-lock denial.
+	WrapStorage func(blob.Storage) blob.Storage
 }
 
 // RepositoryMetrics returns metrics.Registry associated with a repository.
@@ -100,6 +110,18 @@ func (e *Environment) setup(tb testing.TB, version format.Version, opts ...Optio
 	} else {
 		// use versioned mock storage when retention settings are specified
 		st = blobtesting.NewVersionedMapStorage(openOpt.TimeNowFunc)
+	}
+
+	// Applied before the reconnectable wrapper on purpose. That wrapper
+	// registers itself in a global map and repo.Open resolves the connection
+	// info back to exactly that instance, so anything wrapped *around* it is
+	// invisible to the opened repository. Wrapping the base storage first
+	// puts the layer inside, where the repository's own calls pass through
+	// it.
+	for _, mod := range opts {
+		if mod.WrapStorage != nil {
+			st = mod.WrapStorage(st)
+		}
 	}
 
 	st = NewReconnectableStorage(tb, st)

--- a/repo/maintenance/pack_gc.go
+++ b/repo/maintenance/pack_gc.go
@@ -42,7 +42,24 @@ func DeleteUnreferencedPacks(ctx context.Context, rep repo.DirectRepositoryWrite
 
 	var unreferenced, deleted, retained stats.CountSum
 
-	var eg errgroup.Group
+	// errgroup.WithContext, not a bare errgroup: the delete workers below
+	// leave their range loop as soon as one of them returns an error, and
+	// the producer keeps feeding a buffered channel. Once every worker is
+	// gone and the buffer is full, an unguarded `unused <- bm` blocks
+	// forever - close(unused) and eg.Wait() are never reached and the whole
+	// maintenance run hangs with no output and no CPU use. The cancelled
+	// context is what lets the producer notice that and stop.
+	//
+	// Observed in production against S3 Object Lock, where practically
+	// every delete is denied: runs sat wedged for 11 hours after their
+	// snapshot had already succeeded, and only SIGKILL cleared them
+	// (SIGTERM does not, since the goroutine is blocked on a channel send
+	// rather than on the context). The threshold is low - deleteQueueSize
+	// plus opt.Parallel unreferenced blobs, so ~116 with the defaults - and
+	// it has nothing to do with repository size. Object Lock is only the
+	// most reliable way to trigger it; any persistent DeleteBlob failure
+	// does the same.
+	eg, egCtx := errgroup.WithContext(ctx)
 
 	unused := make(chan blob.Metadata, deleteQueueSize)
 
@@ -95,7 +112,7 @@ func DeleteUnreferencedPacks(ctx context.Context, rep repo.DirectRepositoryWrite
 
 	// iterate all pack blobs + session blobs and keep ones that are too young or
 	// belong to alive sessions.
-	if err := rep.ContentManager().IterateUnreferencedPacks(ctx, prefixes, opt.Parallel, func(bm blob.Metadata) error {
+	iterErr := rep.ContentManager().IterateUnreferencedPacks(ctx, prefixes, opt.Parallel, func(bm blob.Metadata) error {
 		if bm.Timestamp.After(cutoffTime) {
 			retained.Add(bm.Length)
 
@@ -133,15 +150,32 @@ func DeleteUnreferencedPacks(ctx context.Context, rep repo.DirectRepositoryWrite
 		unreferenced.Add(bm.Length)
 
 		if !opt.DryRun {
-			unused <- bm
+			select {
+			case unused <- bm:
+			case <-egCtx.Done():
+				// Every delete worker has given up. Stop producing; the
+				// worker's error is reported below and is the real cause.
+				return egCtx.Err()
+			}
 		}
 
 		return nil
-	}); err != nil {
-		return nil, errors.Wrap(err, "error looking for unreferenced pack blobs")
+	})
+
+	// Close and drain before looking at either error, so no worker is left
+	// blocked on a channel that nobody will ever close.
+	close(unused)
+
+	// The workers' error takes precedence: when the producer aborted, it did
+	// so *because* the workers were gone, and their failure is the root
+	// cause rather than the cancellation it caused.
+	if werr := eg.Wait(); werr != nil {
+		return nil, errors.Wrap(werr, "worker error")
 	}
 
-	close(unused)
+	if iterErr != nil {
+		return nil, errors.Wrap(iterErr, "error looking for unreferenced pack blobs")
+	}
 
 	unreferencedCount, unreferencedSize := unreferenced.Approximate()
 	retainedCount, retainedSize := retained.Approximate()
@@ -156,11 +190,6 @@ func DeleteUnreferencedPacks(ctx context.Context, rep repo.DirectRepositoryWrite
 	}
 
 	contentlog.Log1(ctx, log, "Found unreferenced pack blobs to delete", result)
-
-	// wait for all delete workers to finish.
-	if err := eg.Wait(); err != nil {
-		return nil, errors.Wrap(err, "worker error")
-	}
 
 	if opt.DryRun {
 		return result, nil

--- a/repo/maintenance/pack_gc_test.go
+++ b/repo/maintenance/pack_gc_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kopia/kopia/internal/blobtesting"
 	"github.com/kopia/kopia/internal/clock"
 	"github.com/kopia/kopia/internal/faketime"
 	"github.com/kopia/kopia/internal/gather"
@@ -23,6 +25,7 @@ import (
 	"github.com/kopia/kopia/repo/encryption"
 	"github.com/kopia/kopia/repo/format"
 	"github.com/kopia/kopia/repo/maintenance"
+	"github.com/kopia/kopia/repo/maintenancestats"
 	"github.com/kopia/kopia/repo/object"
 )
 
@@ -147,6 +150,84 @@ func (s *formatSpecificTestSuite) TestDeleteUnreferencedPacks(t *testing.T) {
 
 	diff := cmp.Diff(blobsBefore, blobsAfter)
 	require.Empty(t, diff, "unexpected blobs")
+}
+
+// TestDeleteUnreferencedPacksDoesNotDeadlockOnPersistentDeleteFailure covers a
+// deadlock that is easy to hit and hard to diagnose. The delete workers leave
+// their range loop as soon as one of them returns an error, while the producer
+// keeps sending into a buffered channel. Once every worker is gone and the
+// buffer is full, the send blocks forever: close(unused) and eg.Wait() are
+// never reached, and the maintenance run sits there with no output and no CPU
+// use until it is killed. SIGTERM does not clear it either, because the
+// goroutine is parked on a channel send rather than on the context.
+//
+// The threshold is deleteQueueSize plus the worker count, so roughly 116 with
+// the defaults, and it is unrelated to repository size. S3 Object Lock is
+// simply the most reliable way to produce a persistent DeleteBlob failure;
+// any storage that keeps rejecting deletes does the same, which is why this
+// test runs without object lock enabled.
+func TestDeleteUnreferencedPacksDoesNotDeadlockOnPersistentDeleteFailure(t *testing.T) {
+	t.Parallel()
+
+	var faulty *blobtesting.FaultyStorage
+
+	ctx, env := repotesting.NewEnvironment(t, format.FormatVersion3, repotesting.Options{
+		WrapStorage: func(st blob.Storage) blob.Storage {
+			faulty = blobtesting.NewFaultyStorage(st)
+			return faulty
+		},
+	})
+
+	// Comfortably more than deleteQueueSize + parallelism, so the producer
+	// still has blobs to hand over after the last worker has given up.
+	const unreferencedBlobs = 250
+
+	// Hex-only IDs on purpose: kopia parses pack blob IDs, and a name with
+	// non-hex characters is skipped instead of being treated as an
+	// unreferenced pack, which would make this test silently vacuous.
+	for i := range unreferencedBlobs {
+		mustPutDummyBlob(t, env.RepositoryWriter.BlobStorage(), blob.ID(fmt.Sprintf("pbeef%08x", i)))
+	}
+
+	// Every delete from here on is refused, standing in for a storage-level
+	// retention policy or any other permanent denial.
+	faulty.AddFault(blobtesting.MethodDeleteBlob).
+		Repeat(10 * unreferencedBlobs).
+		ErrorInstead(errors.New("AccessDenied"))
+
+	type outcome struct {
+		stats *maintenancestats.DeleteUnreferencedPacksStats
+		err   error
+	}
+
+	done := make(chan outcome, 1)
+
+	go func() {
+		// SafetyNone so the blobs we just wrote are immediately eligible
+		// instead of being retained by PackDeleteMinAge.
+		s, err := maintenance.DeleteUnreferencedPacks(ctx, env.RepositoryWriter,
+			maintenance.DeleteUnreferencedPacksOptions{}, maintenance.SafetyNone)
+		done <- outcome{stats: s, err: err}
+	}()
+
+	select {
+	case res := <-done:
+		if res.err == nil && res.stats != nil {
+			// Guard against a vacuous pass: if the GC pass found nothing to
+			// delete, it never exercised the delete path at all and this
+			// test proves nothing.
+			require.Failf(t, "GC pass did not attempt any deletes",
+				"unreferenced=%d retained=%d deleted=%d - the seeded blobs were not treated as unreferenced packs",
+				res.stats.UnreferencedPackCount, res.stats.RetainedPackCount, res.stats.DeletedPackCount)
+		}
+
+		// Returning an error is the correct behaviour without object lock:
+		// a delete that keeps failing is a real storage problem. What must
+		// not happen is not returning at all.
+		require.Error(t, res.err, "a persistent delete failure must fail the GC pass, not succeed")
+	case <-time.After(30 * time.Second):
+		t.Fatal("DeleteUnreferencedPacks did not return - the producer is deadlocked on the delete queue")
+	}
 }
 
 func verifyBlobExists(t *testing.T, st blob.Storage, blobID blob.ID) {


### PR DESCRIPTION
### Problem

`DeleteUnreferencedPacks` deadlocks permanently as soon as `DeleteBlob` keeps failing.

The delete workers leave their `range unused` loop on their first error:

```go
for bm := range unused {
    if err := rep.BlobStorage().DeleteBlob(ctx, bm.BlobID); err != nil {
        return errors.Wrapf(err, "unable to delete pack blob %q", bm.BlobID)
    }
```

Meanwhile the producer keeps sending into the buffered channel:

```go
if !opt.DryRun {
    unused <- bm
}
```

Once every worker has returned and the 100-slot buffer is full, that send blocks forever. `close(unused)` and `eg.Wait()` are never reached, so the function never returns and the maintenance run hangs.

The threshold is low: `deleteQueueSize` plus the worker count, so about 116 unreferenced pack blobs with the defaults. It does not depend on repository size. A repository with fewer unreferenced packs than that finishes iterating first, the channel gets closed, and the workers report the error normally - which is why this looks intermittent rather than deterministic.

Symptoms when it does trigger:

- the process stays alive with no output and no measurable CPU use, indefinitely
- `SIGTERM` does not clear it, because the goroutine is parked on a channel send rather than on the context
- the snapshot itself has usually already succeeded, so the only visible sign is a job that never finishes

Observed in production on a fleet of ~80 hosts backing up to S3 with Object Lock enabled, where practically every pack delete is refused: eight runs sat wedged between 9 and 11 hours before they were killed. Object Lock is only the most reliable way to produce a persistent `DeleteBlob` failure - any storage or permission problem that keeps rejecting deletes does the same.

### Change

`errgroup.WithContext` instead of a bare `errgroup.Group`, so a worker returning an error cancels a context the producer can observe:

```go
select {
case unused <- bm:
case <-egCtx.Done():
    return egCtx.Err()
}
```

The error handling after the iteration is restructured so that the channel is always closed and the workers are always awaited. Previously an early `return` on the iteration error skipped `close(unused)` entirely, which would have left the remaining workers blocked on a channel nobody closes - a goroutine leak rather than a deadlock, but the same class of bug.

The workers' error takes precedence when reporting, because when the producer aborts it does so *because* the workers are gone; their failure is the root cause rather than the cancellation it caused.

Behaviour is otherwise unchanged: a persistent delete failure still fails the GC pass, it just fails instead of hanging.

### Tests

`TestDeleteUnreferencedPacksDoesNotDeadlockOnPersistentDeleteFailure` seeds 250 unreferenced pack blobs, makes every `DeleteBlob` fail, and requires the call to return within 30 seconds.

Verified that it actually catches the bug: against the unpatched code it fails with

```
pack_gc_test.go:229: DeleteUnreferencedPacks did not return - the producer is deadlocked on the delete queue
--- FAIL (30.46s)
```

and passes in well under a second with the fix. It also guards against becoming vacuous: if the GC pass finds nothing to delete, the test fails with the observed stats rather than passing, since it would then never have exercised the delete path at all.

The first commit adds `repotesting.Options.WrapStorage`, which the test needs. There was previously no way to make a repository-level test observe a failing `DeleteBlob`: the in-memory storages that `repotesting` builds always succeed, and `blobtesting.NewVersionedMapStorage` models S3 versioning (`DeleteBlob` inserts a delete marker) rather than a hard denial. The wrapper is applied *before* `NewReconnectableStorage`, because that wrapper registers itself in a global map and `repo.Open` resolves the connection info back to exactly that instance - anything wrapped around it is invisible to the opened repository.

`go build ./...`, `go vet` and `go test -race ./repo/maintenance/ ./internal/repotesting/` pass.

### Relationship to #5509

Found while working on #5509 (Object Lock tolerance), but independent of it: this bug needs no Object Lock and no retention policy, only a `DeleteBlob` that keeps failing. Split out so it can be reviewed and merged on its own.

The `repotesting.WrapStorage` commit also appears in #5509, where its tests need the same hook. Whichever merges first, the other needs a trivial rebase.
