### PR TITLE
Fix user password env

### DIFF
--- a/cli/command_user_add_set.go
+++ b/cli/command_user_add_set.go
@@ -33,7 +33,7 @@ func (c *commandServerUserAddSet) setup(svc appServices, parent commandParent, i
 	}
 
 	cmd.Flag("ask-password", "Ask for user password").BoolVar(&c.userAskPassword)
-	cmd.Flag("user-password", "Password").StringVar(&c.userSetPassword)
+	cmd.Flag("user-password", "Password").Envar(svc.EnvName("KOPIA_USER_PASSWORD")).StringVar(&c.userSetPassword)
 	cmd.Flag("user-password-hash", "Password hash").StringVar(&c.userSetPasswordHash)
 	cmd.Arg("username", "Username").Required().StringVar(&c.userSetName)
 	cmd.Action(svc.repositoryWriterAction(c.runServerUserAddSet))

--- a/cli/command_user_hash_password.go
+++ b/cli/command_user_hash_password.go
@@ -18,7 +18,7 @@ type commandServerUserHashPassword struct {
 func (c *commandServerUserHashPassword) setup(svc appServices, parent commandParent) {
 	cmd := parent.Command("hash-password", "Hash a user password that can be passed to the 'server user add/set' command").Alias("hash")
 
-	cmd.Flag("user-password", "Password").StringVar(&c.password)
+	cmd.Flag("user-password", "Password").Envar(svc.EnvName("KOPIA_USER_PASSWORD")).StringVar(&c.password)
 
 	cmd.Action(svc.repositoryWriterAction(c.runServerUserHashPassword))
 

--- a/cli/password.go
+++ b/cli/password.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -98,6 +99,15 @@ func askPass(out io.Writer, prompt string) (string, error) {
 	fd, err := intFd(os.Stdin)
 	if err != nil {
 		return "", errors.Wrap(err, "password input error")
+	}
+
+	if !term.IsTerminal(fd) {
+		reader := bufio.NewReader(os.Stdin)
+		pwd, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return "", err
+		}
+		return strings.TrimRight(pwd, "\r\n"), nil
 	}
 
 	for range 5 {


### PR DESCRIPTION
Support supplying user password via env variable or stdin in `user add`/`set`/`hash-password`.