### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.19.1
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.14.1
-	github.com/kopia/htmluibuild v0.0.1-0.20260722043300-c772f5bec708
+	github.com/kopia/htmluibuild v0.0.1-0.20260804002937-29e3e25473e0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/minio/minio-go/v7 v7.2.1

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.14.1 h1:swE9kzyWXD/wVG+l5Pe8bWnQ0giIY7D1GjCBKk3kG2U=
 github.com/klauspost/reedsolomon v1.14.1/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
-github.com/kopia/htmluibuild v0.0.1-0.20260722043300-c772f5bec708 h1:S/AQz11wHOplISS6AR30HdqAnIk/BYBOYdr1x9teNos=
-github.com/kopia/htmluibuild v0.0.1-0.20260722043300-c772f5bec708/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260804002937-29e3e25473e0 h1:K1wXXSB9Wz0wQG53vfvr4Xd9zRaVcJ/wpQNrZjTOrfg=
+github.com/kopia/htmluibuild v0.0.1-0.20260804002937-29e3e25473e0/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/794f12677e68a8ed26c18945d4c9e755d3cd7191...553ca95fc08f7990e569a2ee11330c200de56f69

* Mon 16:31 -0700 https://github.com/kopia/htmlui/commit/3a06333 Jarek Kowalski build(deps): upgrade to react-router v8 and React 19.2.8
* Mon 16:34 -0700 https://github.com/kopia/htmlui/commit/4dc16ab dependabot[bot] build(deps): bump brace-expansion
* Mon 16:35 -0700 https://github.com/kopia/htmlui/commit/a805bf2 dependabot[bot] build(deps): bump postcss from 8.5.15 to 8.5.25
* Mon 16:39 -0700 https://github.com/kopia/htmlui/commit/6edd400 dependabot[bot] build(deps): bump @fortawesome/fontawesome-svg-core from 6.7.2 to 7.3.1
* Mon 16:47 -0700 https://github.com/kopia/htmlui/commit/a7a9178 dependabot[bot] build(deps): bump @fortawesome/free-regular-svg-icons
* Mon 16:50 -0700 https://github.com/kopia/htmlui/commit/f18926a dependabot[bot] build(deps): bump http-proxy-middleware from 3.0.7 to 4.2.0
* Mon 17:02 -0700 https://github.com/kopia/htmlui/commit/c8c426e dependabot[bot] build(deps): bump @fortawesome/react-fontawesome from 0.2.2 to 3.5.0
* Mon 17:05 -0700 https://github.com/kopia/htmlui/commit/1000177 Jarek Kowalski build(deps-dev): migrate to @eslint-react/eslint-plugin for ESLint 10
* Mon 17:19 -0700 https://github.com/kopia/htmlui/commit/553ca95 Julio López build(deps): bump @fortawesome/free-solid-svg-icons from 6.7.2 to 7.1.0

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Tue Aug  4 00:31:23 UTC 2026*
