### PR TITLE
fix(server): Retry failed scheduled snapshots

### DIFF
--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -131,13 +131,6 @@ func (s *sourceManager) setCurrentTaskID(taskID string) {
 	s.currentTask = taskID
 }
 
-func (s *sourceManager) setNextSnapshotTime(t time.Time) {
-	s.sourceMutex.Lock()
-	defer s.sourceMutex.Unlock()
-
-	s.nextSnapshotTime = &t
-}
-
 func (s *sourceManager) currentUploader() *upload.Uploader {
 	s.sourceMutex.RLock()
 	defer s.sourceMutex.RUnlock()
@@ -214,11 +207,15 @@ func (s *sourceManager) runLocal(ctx context.Context) {
 }
 
 func (s *sourceManager) backoffBeforeNextSnapshot() {
-	if _, ok := s.getNextSnapshotTime(); !ok {
+	s.sourceMutex.Lock()
+	defer s.sourceMutex.Unlock()
+
+	if s.paused || s.findClosestNextSnapshotTimeReadLocked() == nil {
 		return
 	}
 
-	s.setNextSnapshotTime(clock.Now().Add(failedSnapshotRetryInterval))
+	t := clock.Now().Add(failedSnapshotRetryInterval)
+	s.nextSnapshotTime = &t
 }
 
 func (s *sourceManager) isRunningReadOnly() bool {

--- a/internal/server/source_manager_test.go
+++ b/internal/server/source_manager_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/snapshot/policy"
+)
+
+func TestSourceManagerBackoffAfterFailedScheduledSnapshot(t *testing.T) {
+	sm := &sourceManager{
+		pol: policy.SchedulingPolicy{
+			IntervalSeconds: int64(time.Hour.Seconds()),
+		},
+		snapshotRequests: make(chan struct{}, 1),
+	}
+
+	initialSnapshotTime := clock.Now().Add(time.Minute)
+	sm.nextSnapshotTime = &initialSnapshotTime
+	sm.scheduleSnapshotNow()
+
+	_, ok := sm.getNextSnapshotTime()
+	require.False(t, ok, "queued snapshot should clear the next snapshot time")
+
+	beforeBackoff := clock.Now()
+
+	sm.backoffBeforeNextSnapshot()
+
+	nextSnapshotTime, ok := sm.getNextSnapshotTime()
+	require.True(t, ok, "failed scheduled snapshot should be retried")
+	require.WithinDuration(t, beforeBackoff.Add(failedSnapshotRetryInterval), nextSnapshotTime, time.Second)
+}
+
+func TestSourceManagerBackoffAfterFailedManualSnapshot(t *testing.T) {
+	sm := &sourceManager{
+		pol: policy.SchedulingPolicy{
+			Manual: true,
+		},
+		snapshotRequests: make(chan struct{}, 1),
+	}
+
+	initialSnapshotTime := clock.Now().Add(time.Minute)
+	sm.nextSnapshotTime = &initialSnapshotTime
+	sm.scheduleSnapshotNow()
+	sm.backoffBeforeNextSnapshot()
+
+	_, ok := sm.getNextSnapshotTime()
+	require.False(t, ok, "manual snapshot should not be retried")
+}


### PR DESCRIPTION
## Summary

- determine retry eligibility from the cached scheduling policy instead of the cleared next-snapshot timestamp
- restore the five-minute retry after a failed scheduled snapshot, including while the repository is unavailable
- keep manual-only policies unscheduled and add regression coverage for both cases

Fixes #5521

## Testing

- `go test ./internal/server -run '^TestSourceManagerBackoffAfterFailed(Scheduled|Manual)Snapshot$' -count=10`
- `go test ./internal/server -count=1`
- `go test -race ./internal/server -count=1`
- `go vet ./internal/server`
- `make check-locks`
- `tools/.tools/golangci-lint-2.6.1/golangci-lint --timeout 1200s run ./internal/server/...`
- `git diff --check`
