### PR TITLE
publish container images to ghcr as well

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -131,7 +131,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -127,6 +127,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name != 'pull_request' && github.repository == 'kopia/kopia'
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up QEMU
@@ -184,6 +190,8 @@ jobs:
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        GHCR_USERNAME: ${{ github.actor }}
+        GHCR_TOKEN: ${{ github.token }}
     - name: Bump Homebrew formula
       uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
       # only bump formula for tags which don't contain '-'

--- a/Makefile
+++ b/Makefile
@@ -503,12 +503,7 @@ publish-scoop:
 	$(CURDIR)/tools/scoop-publish.sh $(RELEASE_STAGING_DIR) $(KOPIA_VERSION_NO_PREFIX)
 
 publish-docker:
-ifneq ($(DOCKERHUB_TOKEN),)
-	@echo $(DOCKERHUB_TOKEN) | docker login --username $(DOCKERHUB_USERNAME) --password-stdin
 	$(CURDIR)/tools/docker-publish.sh $(CURDIR)/dist_binaries
-else
-	@echo DOCKERHUB_TOKEN is not set.
-endif
 
 PERF_BENCHMARK_INSTANCE=kopia-perf
 PERF_BENCHMARK_INSTANCE_ZONE=us-west1-a

--- a/tools/docker-publish.sh
+++ b/tools/docker-publish.sh
@@ -5,6 +5,25 @@ DOCKER_BUILD_DIR=tools/docker
 if [ "$DOCKERHUB_REPO" == "" ]; then
     DOCKERHUB_REPO=kopia/kopia
 fi
+if [ "$GHCR_REPO" == "" ]; then
+    GHCR_REPO=ghcr.io/kopia/kopia
+fi
+
+if [ "$DOCKERHUB_USERNAME" == "" ]; then
+    echo "DOCKERHUB_USERNAME is not set."
+fi
+if [ "$DOCKERHUB_TOKEN" == "" ]; then
+    echo "DOCKERHUB_TOKEN is not set."
+fi
+echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+
+if [ "$GHCR_USERNAME" == "" ]; then
+    echo "GHCR_USERNAME is not set."
+fi
+if [ "$GHCR_TOKEN" == "" ]; then
+    echo "GHCR_TOKEN is not set."
+fi
+echo "$GHCR_TOKEN" | docker login ghcr.io --username "$GHCR_USERNAME" --password-stdin
 
 cp -r "$DIST_DIR/kopia_linux_amd64/" "$DOCKER_BUILD_DIR/bin-amd64/"
 chmod 0755 "$DOCKER_BUILD_DIR/bin-amd64/kopia"
@@ -40,11 +59,12 @@ if [[ "$KOPIA_VERSION_NO_PREFIX" =~ 20[0-9]+\.[0-9]+\.[0-9]+ ]]; then
     extra_tags="unstable"
 fi
 
-versioned_image=$DOCKERHUB_REPO:$KOPIA_VERSION_NO_PREFIX
-tags="-t $versioned_image"
+dockerhub_versioned_image=$DOCKERHUB_REPO:$KOPIA_VERSION_NO_PREFIX
+ghcr_versioned_image=$GHCR_REPO:$KOPIA_VERSION_NO_PREFIX
+tags="-t $dockerhub_versioned_image -t $ghcr_versioned_image"
 for t in $extra_tags; do
     if [ "$t" != "0" ]; then
-        tags="$tags -t $DOCKERHUB_REPO:$t"
+        tags="$tags -t $DOCKERHUB_REPO:$t -t $GHCR_REPO:$t"
     fi
 done
 

--- a/tools/docker-publish.sh
+++ b/tools/docker-publish.sh
@@ -68,5 +68,5 @@ for t in $extra_tags; do
     fi
 done
 
-echo Building $versioned_image with tags [$tags]...
+echo Building kopia container image with tags [$tags]...
 docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 $tags --push $DOCKER_BUILD_DIR


### PR DESCRIPTION
I have a slight preference for using ghcr images when possible, because they're easier to discover without needing to leave github, and it's easier to see that the image is controlled by the same person/set of people as the codebase itself. I'm sure there are others feel the same. :)

so, I propose a small tweak to the scripts involved to publish future image tags to ghcr, in addition to the current docker hub image