### PR TITLE
build(deps): upgrade Go to 1.25.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kopia/kopia
 
 go 1.25.8
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	cloud.google.com/go/storage v1.64.0


### PR DESCRIPTION
- https://go.dev/doc/devel/release#go1.25.minor
- https://github.com/golang/go/issues?q=milestone%3AGo1.25.13+label%3ACherryPickApproved