### PR TITLE
feat(server): Report restore task progress

### DIFF
--- a/internal/server/api_object_get.go
+++ b/internal/server/api_object_get.go
@@ -7,9 +7,88 @@ import (
 	"time"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/timetrack"
+	"github.com/kopia/kopia/internal/uitask"
 	"github.com/kopia/kopia/repo/object"
+	"github.com/kopia/kopia/snapshot/restore"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
+
+const downloadProgressUpdateInterval = 250 * time.Millisecond
+
+type downloadProgressReader struct {
+	object.Reader
+	ctx    context.Context
+	onRead func(int64)
+}
+
+func (r *downloadProgressReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	n, err := r.Reader.Read(p)
+	if n > 0 {
+		r.onRead(int64(n))
+	}
+
+	return n, err //nolint:wrapcheck
+}
+
+func serveObjectDownload(
+	ctx context.Context,
+	tasks *uitask.Manager,
+	w http.ResponseWriter,
+	req *http.Request,
+	fname string,
+	mtime time.Time,
+	obj object.Reader,
+) {
+	// The response must remain synchronous so the browser can save the streamed
+	// file. Running it as a task still makes long downloads observable in the UI.
+	_ = tasks.Run(ctx, "Restore", "File: "+fname, func(ctx context.Context, ctrl uitask.Controller) error {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		ctrl.OnCancel(cancel)
+
+		var (
+			downloaded int64
+			throttle   timetrack.Throttle
+		)
+
+		progress := newRestoreTaskProgress()
+		stats := restore.Stats{
+			EnqueuedFileCount:     1,
+			EnqueuedTotalFileSize: obj.Length(),
+		}
+		progress.report(ctrl, stats)
+
+		reader := &downloadProgressReader{
+			Reader: obj,
+			ctx:    ctx,
+			onRead: func(n int64) {
+				downloaded += n
+				stats.RestoredTotalFileSize = downloaded
+				if throttle.ShouldOutput(downloadProgressUpdateInterval) {
+					progress.report(ctrl, stats)
+				}
+			},
+		}
+
+		http.ServeContent(w, req, fname, mtime, reader)
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		stats.RestoredFileCount = 1
+		stats.RestoredTotalFileSize = downloaded
+		progress.report(ctrl, stats)
+
+		return nil
+	})
+}
 
 func handleObjectGet(ctx context.Context, rc requestContext) {
 	oidstr := rc.muxVar("objectID")
@@ -30,8 +109,14 @@ func handleObjectGet(ctx context.Context, rc requestContext) {
 		http.Error(rc.w, "object not found", http.StatusNotFound)
 		return
 	}
+	if err != nil {
+		http.Error(rc.w, "unable to open object", http.StatusInternalServerError)
+		return
+	}
+	defer obj.Close() //nolint:errcheck
 
-	if snapshotfs.IsDirectoryID(oid) {
+	isDirectory := snapshotfs.IsDirectoryID(oid)
+	if isDirectory {
 		rc.w.Header().Set("Content-Type", "application/json")
 	}
 
@@ -47,6 +132,11 @@ func handleObjectGet(ctx context.Context, rc requestContext) {
 		if m, err := time.Parse(time.RFC3339Nano, p); err == nil {
 			mtime = m
 		}
+	}
+
+	if !isDirectory && rc.queryParam("fname") != "" {
+		serveObjectDownload(ctx, rc.srv.taskManager(), rc.w, rc.req, fname, mtime, obj)
+		return
 	}
 
 	http.ServeContent(rc.w, rc.req, fname, mtime, obj)

--- a/internal/server/api_object_get_test.go
+++ b/internal/server/api_object_get_test.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/uitask"
+)
+
+type testObjectReader struct {
+	*bytes.Reader
+}
+
+func (r testObjectReader) Close() error {
+	return nil
+}
+
+func (r testObjectReader) Length() int64 {
+	return int64(r.Size())
+}
+
+func TestServeObjectDownloadCreatesRestoreTask(t *testing.T) {
+	contents := bytes.Repeat([]byte("test data"), 1000)
+	obj := testObjectReader{bytes.NewReader(contents)}
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/download", nil)
+	tasks := uitask.NewManager(false)
+
+	serveObjectDownload(req.Context(), tasks, recorder, req, "sample.bin", time.Time{}, obj)
+
+	result := recorder.Result()
+	t.Cleanup(func() { require.NoError(t, result.Body.Close()) })
+
+	got, err := io.ReadAll(result.Body)
+	require.NoError(t, err)
+	require.Equal(t, contents, got)
+	require.Equal(t, 200, result.StatusCode)
+
+	taskList := tasks.ListTasks()
+	require.Len(t, taskList, 1)
+
+	task := taskList[0]
+	require.Equal(t, "Restore", task.Kind)
+	require.Equal(t, "File: sample.bin", task.Description)
+	require.Equal(t, uitask.StatusSuccess, task.Status)
+	require.Equal(t, uitask.SimpleCounter(1), task.Counters["Restored Files"])
+	require.Equal(t, uitask.BytesCounter(int64(len(contents))), task.Counters["Restored Bytes"])
+}

--- a/internal/server/api_restore.go
+++ b/internal/server/api_restore.go
@@ -4,12 +4,15 @@ import (
 	"archive/zip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/internal/uitask"
+	"github.com/kopia/kopia/internal/units"
 	"github.com/kopia/kopia/snapshot/restore"
 	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
@@ -24,6 +27,64 @@ func restoreCounters(s restore.Stats) map[string]uitask.CounterValue {
 		"Skipped Files":        uitask.SimpleCounter(int64(s.SkippedCount)),
 		"Skipped Bytes":        uitask.BytesCounter(s.SkippedTotalFileSize),
 	}
+}
+
+type restoreTaskProgress struct {
+	estimator timetrack.Estimator
+}
+
+func newRestoreTaskProgress() *restoreTaskProgress {
+	return &restoreTaskProgress{estimator: timetrack.Start()}
+}
+
+func (p *restoreTaskProgress) report(ctrl uitask.Controller, s restore.Stats) {
+	ctrl.ReportCounters(restoreCounters(s))
+	ctrl.ReportProgressInfo(p.progressInfo(s))
+}
+
+func (p *restoreTaskProgress) progressInfo(s restore.Stats) string {
+	processedCount := s.RestoredFileCount + s.RestoredDirCount + s.RestoredSymlinkCount + s.SkippedCount
+	totalCount := s.EnqueuedFileCount + s.EnqueuedDirCount + s.EnqueuedSymlinkCount
+	processedSize := s.RestoredTotalFileSize + s.SkippedTotalFileSize
+	totalSize := s.EnqueuedTotalFileSize
+
+	// The root entry is processed directly rather than enqueued. Keep the item
+	// counts intuitive for single-file restores and at the end of directory restores.
+	if processedCount > totalCount {
+		totalCount = processedCount
+	}
+
+	line := fmt.Sprintf("Processed %v of %v items (%v of %v)",
+		processedCount, totalCount, units.BytesString(processedSize), units.BytesString(totalSize))
+
+	completed, total := float64(processedSize), float64(totalSize)
+	usingItemCounts := totalSize == 0
+	if totalSize == 0 {
+		completed, total = float64(processedCount), float64(totalCount)
+	}
+
+	if total > 0 {
+		line += fmt.Sprintf(" (%.1f%%)", min(100*completed/total, 100))
+	}
+
+	if est, ok := p.estimator.Estimate(completed, total); ok {
+		speed := units.BytesPerSecondsString(est.SpeedPerSecond)
+		if usingItemCounts {
+			speed = fmt.Sprintf("%.1f items/s", est.SpeedPerSecond)
+		}
+
+		line += fmt.Sprintf(", %v, remaining %v", speed, est.Remaining)
+	}
+
+	if s.SkippedCount > 0 {
+		line += fmt.Sprintf(", skipped %v (%v)", s.SkippedCount, units.BytesString(s.SkippedTotalFileSize))
+	}
+
+	if s.IgnoredErrorCount > 0 {
+		line += fmt.Sprintf(", ignored %v errors", s.IgnoredErrorCount)
+	}
+
+	return line
 }
 
 func handleRestore(ctx context.Context, rc requestContext) (any, *apiError) {
@@ -94,9 +155,10 @@ func handleRestore(ctx context.Context, rc requestContext) (any, *apiError) {
 		taskIDChan <- ctrl.CurrentTaskID()
 
 		opt := req.Options
+		progress := newRestoreTaskProgress()
 
 		opt.ProgressCallback = func(_ context.Context, s restore.Stats) {
-			ctrl.ReportCounters(restoreCounters(s))
+			progress.report(ctrl, s)
 		}
 
 		cancelChan := make(chan struct{})
@@ -108,7 +170,7 @@ func handleRestore(ctx context.Context, rc requestContext) (any, *apiError) {
 
 		st, err := restore.Entry(ctx, rep, out, rootEntry, opt)
 		if err == nil {
-			ctrl.ReportCounters(restoreCounters(st))
+			progress.report(ctrl, st)
 		}
 
 		return errors.Wrap(err, "error restoring")

--- a/internal/server/api_restore_internal_test.go
+++ b/internal/server/api_restore_internal_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/snapshot/restore"
+)
+
+func TestRestoreProgressInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		stats    restore.Stats
+		contains []string
+	}{
+		{
+			name: "bytes",
+			stats: restore.Stats{
+				RestoredFileCount:     1,
+				EnqueuedFileCount:     2,
+				RestoredTotalFileSize: 250,
+				EnqueuedTotalFileSize: 1000,
+			},
+			contains: []string{"Processed 1 of 2 items", "25.0%"},
+		},
+		{
+			name: "zero-byte-items",
+			stats: restore.Stats{
+				RestoredFileCount: 1,
+				EnqueuedFileCount: 4,
+			},
+			contains: []string{"Processed 1 of 4 items", "25.0%"},
+		},
+		{
+			name: "skipped",
+			stats: restore.Stats{
+				SkippedCount:          2,
+				EnqueuedFileCount:     4,
+				SkippedTotalFileSize:  500,
+				EnqueuedTotalFileSize: 1000,
+			},
+			contains: []string{"Processed 2 of 4 items", "50.0%", "skipped 2"},
+		},
+		{
+			name: "root-entry",
+			stats: restore.Stats{
+				RestoredFileCount:     1,
+				RestoredTotalFileSize: 1000,
+			},
+			contains: []string{"Processed 1 of 1 items", "100.0%"},
+		},
+		{
+			name: "clamps-percentage-and-reports-errors",
+			stats: restore.Stats{
+				RestoredFileCount:     2,
+				EnqueuedFileCount:     1,
+				RestoredTotalFileSize: 2000,
+				EnqueuedTotalFileSize: 1000,
+				IgnoredErrorCount:     1,
+			},
+			contains: []string{"Processed 2 of 2 items", "100.0%", "ignored 1 errors"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := newRestoreTaskProgress().progressInfo(tc.stats)
+			for _, want := range tc.contains {
+				require.Contains(t, got, want)
+			}
+		})
+	}
+}

--- a/site/content/docs/Getting started/_index.md
+++ b/site/content/docs/Getting started/_index.md
@@ -62,6 +62,8 @@ When you want to restore your files/directories from a snapshot, you can do so f
 
 You can restore files/directories using either of these options.
 
+Restore operations, including individual file downloads, appear on the `Tasks` page while they are running. The task status shows the completion percentage and can be used to cancel the restore.
+
 #### Video Tutorial
 
 Here is a video tutorial on how to use `KopiaUI` (note that the video is of an older version of `KopiaUI` and the interface is different in the current version of `KopiaUI`, but the main principles of how to use `KopiaUI` are the same):


### PR DESCRIPTION
## Summary

- report item and byte progress for restores started through the server API
- include completion percentage, transfer speed, estimated remaining time, skipped data, and ignored errors
- register individual file downloads as cancellable Restore tasks
- handle byte-based, zero-byte, skipped, and root-entry progress consistently
- document restore progress in the KopiaUI getting-started guide
- add server tests for progress calculation and streamed object downloads

## Why

Restore operations in KopiaUI previously provided no useful indication of how much work had completed. Individual file downloads also bypassed the restore endpoint entirely, so they did not appear on the Tasks page.

This change uses the restore statistics already produced by Kopia's restore implementation and reports them through the existing task controller. Individual downloads are streamed synchronously as before while also being represented by a Restore task.

Closes #3609.

Companion HTML UI PR: [kopia/htmlui#468](https://github.com/kopia/htmlui/pull/468)

## Validation

- `go test ./internal/server ./snapshot/restore`
- `git diff --check`
- end-to-end testing in a locally built macOS ARM64 KopiaUI application
- verified directory restores and individual file downloads appear in Tasks with an incrementing percentage
