### PR TITLE
fix(kopiaui): fix status-poll socket leak in KopiaUI

### DIFF
--- a/app/public/server.js
+++ b/app/public/server.js
@@ -117,11 +117,15 @@ function newServerForRepo(repoID) {
               });
             } else {
               log.warn("error fetching status", resp.statusMessage);
+              resp.resume();
             }
           },
         );
         req.on("error", (e) => {
           log.info("error fetching status", e);
+        });
+        req.on("timeout", () => {
+          req.destroy(new Error("status poll timed out"));
         });
         req.end();
       }


### PR DESCRIPTION
Found this while debugging a growing number of ephemeral ports held open
by kopia on my machine, traced back to the KopiaUI status-poll loop.

`pollOnce()` in `app/public/server.js` never drains the response body on a
non-200 status, and never handles the `timeout` event on the request (the
`timeout` option added in #3055 only emits an event, it doesn't abort
anything on its own). Both leave the underlying socket open instead of
being freed, one leaked connection per affected 3-second poll for as long
as the app runs.

This adds handling for both cases so the socket is released every time.