### PR TITLE
fix(general): increment `attempt` to correctly log index write retries

### DIFF
--- a/internal/epoch/epoch_manager.go
+++ b/internal/epoch/epoch_manager.go
@@ -842,6 +842,8 @@ func (e *Manager) WriteIndex(ctx0 context.Context, dataShards map[blob.ID]blob.B
 		ctx := contentlog.WithParams(ctx0,
 			logparam.String("span:writeEpochIndex", fmt.Sprintf("attempt-%v", attempt)))
 
+		attempt++
+
 		p, err := e.getParameters(ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fix: increment `attempt` to correctly log index write retries

