### PR TITLE
fix(cli): preserve storage stats across snapshot list filters

### DIFF
--- a/cli/command_snapshot_list.go
+++ b/cli/command_snapshot_list.go
@@ -155,12 +155,6 @@ func (c *commandSnapshotList) outputJSON(ctx context.Context, rep repo.Repositor
 	defer jl.end()
 
 	for _, snapshotGroup := range snapshot.GroupBySource(manifests) {
-		snapshotGroup = snapshot.SortByTime(snapshotGroup, c.reverseSort)
-
-		if c.maxResultsPerPath > 0 && len(snapshotGroup) > c.maxResultsPerPath {
-			snapshotGroup = snapshotGroup[len(snapshotGroup)-c.maxResultsPerPath:]
-		}
-
 		if c.snapshotListShowRetentionReasons {
 			src := snapshotGroup[0].Source
 			// compute retention reason
@@ -252,8 +246,14 @@ type snapshotListRow struct {
 
 func (c *commandSnapshotList) iterateSnapshotsMaybeWithStorageStats(ctx context.Context, rep repo.Repository, manifests []*snapshot.Manifest, callback func(m *snapshot.Manifest) error) error {
 	if c.storageStats {
-		//nolint:wrapcheck
-		return snapshotfs.CalculateStorageStats(ctx, rep, manifests, callback)
+		if err := snapshotfs.CalculateStorageStats(ctx, rep, snapshot.SortByTime(manifests, false), func(*snapshot.Manifest) error { return nil }); err != nil {
+			return err //nolint:wrapcheck
+		}
+	}
+
+	manifests = snapshot.SortByTime(manifests, c.reverseSort)
+	if c.maxResultsPerPath > 0 && len(manifests) > c.maxResultsPerPath {
+		manifests = manifests[len(manifests)-c.maxResultsPerPath:]
 	}
 
 	for _, m := range manifests {
@@ -267,11 +267,6 @@ func (c *commandSnapshotList) iterateSnapshotsMaybeWithStorageStats(ctx context.
 
 func (c *commandSnapshotList) outputManifestFromSingleSource(ctx context.Context, rep repo.Repository, manifests []*snapshot.Manifest, parts []string) error {
 	var lastTotalFileSize int64
-
-	manifests = snapshot.SortByTime(manifests, c.reverseSort)
-	if c.maxResultsPerPath > 0 && len(manifests) > c.maxResultsPerPath {
-		manifests = manifests[len(manifests)-c.maxResultsPerPath:]
-	}
 
 	var rows []*snapshotListRow
 

--- a/cli/command_snapshot_storage_stats_test.go
+++ b/cli/command_snapshot_storage_stats_test.go
@@ -75,47 +75,18 @@ func TestSnapshotStorageStats(t *testing.T) {
 		},
 	}, manifests[1].StorageStats)
 
+	firstStats := *manifests[0].StorageStats
+	latestStats := *manifests[1].StorageStats
+
 	// same but in reverse order
 	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(t, "snapshot", "ls", "--storage-stats", dir1, "--reverse", "--json"), &manifests)
 	require.Len(t, manifests, 2)
+	require.Equal(t, &latestStats, manifests[0].StorageStats)
+	require.Equal(t, &firstStats, manifests[1].StorageStats)
 
-	require.Equal(t, &snapshot.StorageStats{
-		NewData: snapshot.StorageUsageDetails{
-			ObjectBytes:          23,
-			OriginalContentBytes: 23,
-			PackedContentBytes:   135,
-			FileObjectCount:      4,
-			DirObjectCount:       2,
-			ContentCount:         6,
-		},
-		RunningTotal: snapshot.StorageUsageDetails{
-			ObjectBytes:          23,
-			OriginalContentBytes: 23,
-			PackedContentBytes:   135,
-			FileObjectCount:      4,
-			DirObjectCount:       2,
-			ContentCount:         6,
-		},
-	}, manifests[0].StorageStats)
-
-	require.Equal(t, &snapshot.StorageStats{
-		NewData: snapshot.StorageUsageDetails{
-			ObjectBytes:          0, // all file data was already present
-			OriginalContentBytes: 0,
-			PackedContentBytes:   0,
-			FileObjectCount:      0,
-			DirObjectCount:       2, // new directories only
-			ContentCount:         2,
-		},
-		RunningTotal: snapshot.StorageUsageDetails{
-			ObjectBytes:          23,
-			OriginalContentBytes: 23,
-			PackedContentBytes:   135,
-			FileObjectCount:      4,
-			DirObjectCount:       4,
-			ContentCount:         8,
-		},
-	}, manifests[1].StorageStats)
+	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(t, "snapshot", "ls", "--storage-stats", dir1, "--max-results=1", "--json"), &manifests)
+	require.Len(t, manifests, 1)
+	require.Equal(t, &latestStats, manifests[0].StorageStats)
 
 	out := env.RunAndExpectSuccess(t, "snapshot", "ls", "--storage-stats")
 	require.Len(t, out, 3)
@@ -128,10 +99,14 @@ func TestSnapshotStorageStats(t *testing.T) {
 
 	out = env.RunAndExpectSuccess(t, "snapshot", "ls", "--storage-stats", "--reverse")
 	require.Len(t, out, 3)
-	require.Contains(t, out[1], "new-data:135 B ")
-	require.Contains(t, out[1], "new-files:4 ")
+	require.Contains(t, out[1], "new-data:36 B ")
+	require.Contains(t, out[1], "new-files:1 ")
 	require.Contains(t, out[1], "new-dirs:2 ")
-	require.Contains(t, out[2], "new-data:0 B ")
-	require.Contains(t, out[2], "new-files:0 ")
+	require.Contains(t, out[2], "new-data:99 B ")
+	require.Contains(t, out[2], "new-files:3 ")
 	require.Contains(t, out[2], "new-dirs:2 ")
+
+	out = env.RunAndExpectSuccess(t, "snapshot", "ls", "--storage-stats", "--max-results=1")
+	require.Len(t, out, 2)
+	require.Contains(t, out[1], "new-data:36 B ")
 }


### PR DESCRIPTION
## Context

`snapshot list --storage-stats` calculated deltas after applying `--max-results` or `--reverse`, so the same snapshot could report different `new-data` values depending on display options.

## Changes

Calculate storage statistics from the complete chronological snapshot history before applying output ordering and limits. Extend the existing CLI regression test across JSON and text output.

## User impact

Storage deltas remain stable when snapshot lists are limited or reversed.

## Verification

- `go test ./cli -count=1` — passed
- `go vet -all ./cli` — passed
- golangci-lint v2.6.1 formatter and static-analysis checks — passed
- `make -j4 test` — `cli` passed; the full suite retained 16 Windows-host failures that reproduce on `master` (symlink privileges, log-link behavior, and local-time assumptions)

Fixes #5581
Fixes #3296