### PR TITLE
Preserve file attributes when restoring by filesystem path

### DIFF
--- a/cli/command_restore.go
+++ b/cli/command_restore.go
@@ -519,7 +519,9 @@ func (c *commandRestore) tryToConvertPathToID(ctx context.Context, rep repo.Repo
 		"   Relative path: %v\n"+
 		"   Object ID: %v", m.Source, formatTimestamp(m.StartTime.ToTime()), relPath, ohid)
 
-	return ohid.String(), nil
+	// The object holds only the content; mode, mtime and ownership live in the parent
+	// directory entry, so the caller has to descend to it from the snapshot root.
+	return filepath.Join(string(m.ID), relPath), nil
 }
 
 func createSnapshotTimeFilter(timespec string) (func(*snapshot.Manifest, int, int) bool, error) {

--- a/tests/end_to_end_test/restore_test.go
+++ b/tests/end_to_end_test/restore_test.go
@@ -937,6 +937,37 @@ func TestSnapshotRestoreByPath(t *testing.T) {
 	compareDirs(t, source, restoreDir)
 }
 
+func TestRestoreSingleFileByPathPreservesAttributes(t *testing.T) {
+	t.Parallel()
+
+	runner := testenv.NewInProcRunner(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir)
+
+	sourceDir := testutil.TempDirectory(t)
+	sourceFile := filepath.Join(sourceDir, "single-file")
+
+	require.NoError(t, os.WriteFile(sourceFile, []byte("some-data"), 0o600))
+	require.NoError(t, os.Chmod(sourceFile, 0o653))
+
+	modTime := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	require.NoError(t, os.Chtimes(sourceFile, modTime, modTime))
+
+	e.RunAndExpectSuccess(t, "snapshot", "create", sourceDir)
+
+	restoredFile := filepath.Join(testutil.TempDirectory(t), "restored-file")
+	e.RunAndExpectSuccess(t, "snapshot", "restore", sourceFile, restoredFile, "--snapshot-time=latest")
+
+	verifyFileMode(t, restoredFile, os.FileMode(0o653))
+
+	s, err := os.Stat(restoredFile)
+	require.NoError(t, err)
+	require.True(t, modTime.Equal(s.ModTime()), "invalid mtime on %v: %v, want %v", restoredFile, s.ModTime(), modTime)
+}
+
 func TestRestoreByPathWithoutTarget(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #5564

### Context

`kopia snapshot restore <filesystem-path> <target>` writes the file with mode `0644` and an epoch mtime. Restoring the same file as `<snapshot-id>/<subpath>` writes it correctly, so the metadata is lost during source resolution, not while setting attributes.

`tryToConvertPathToID` resolves the path down to the file's content object ID. That object holds only the bytes; mode, mtime, uid and gid live in the parent directory entry, and nothing in this path ever reads it. `FilesystemEntryFromIDWithPath` then calls `AutoDetectEntryFromObjectID` with no parent, producing default attributes.

The failure is silent, and the default mode is more permissive than the one that was backed up.

### Changes

Return the manifest ID joined with the relative path rather than the bare object ID. `FilesystemEntryFromIDWithPath` already handles that form: it loads the manifest, starts at the snapshot root and walks down, so the entry arrives with the attributes stored alongside it. That is the same resolution the working `<snapshot-id>/<subpath>` syntax uses.

Picking a specific manifest also makes the result unambiguous, so `--consistent-attributes` no longer has anything to disambiguate on this path — the snapshot was already chosen by `--snapshot-time`.

### User impact

Files and directories restored by path keep the mode and modification time they were snapshotted with, instead of silently getting `0644` and `1970-01-01`.

### Verification

- New `TestRestoreSingleFileByPathPreservesAttributes` fails on master with `invalid mtime ...: 1970-01-01 ...` and passes with the change.
- `TestSnapshotRestoreByPath`, `TestRestoreByPathWithoutTarget` and `TestRestoreSnapshotOfSingleFile` pass.
- `go test ./cli/... -count=1`, `go vet ./cli/...`, `gofmt` and `golangci-lint run ./cli/... ./tests/end_to_end_test/...` are clean.