### PR TITLE
Fix SMTP notification timeouts

### DIFF
--- a/notification/sender/email/email_sender.go
+++ b/notification/sender/email/email_sender.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/smtp"
+	"os"
 	"strings"
 	"time"
 
@@ -20,7 +21,9 @@ const ProviderType = "email"
 
 const defaultSMTPPort = 587
 
-const smtpSendTimeout = 10 * time.Second
+// smtpSendTimeout bounds the whole SMTP exchange, from dialing through QUIT.
+// It is a variable so that tests can shorten it.
+var smtpSendTimeout = 10 * time.Second
 
 type emailProvider struct {
 	opt Options
@@ -54,41 +57,57 @@ func (p *emailProvider) Send(ctx context.Context, msg *sender.Message) error {
 
 	msgPayload = []byte(strings.Join(headers, "\r\n") + "\r\n\r\n" + msg.Body)
 
-	ctx, cancel := context.WithTimeout(ctx, smtpSendTimeout)
-	defer cancel()
-
 	return sendMail(ctx, fmt.Sprintf("%v:%d", p.opt.SMTPServer, p.opt.SMTPPort), auth, p.opt.From, strings.Split(p.opt.To, ","), msgPayload)
 }
 
+// sendMail delivers msg over SMTP. The exchange is bounded by smtpSendTimeout, or by
+// any earlier deadline or cancellation already carried by ctx.
 func sendMail(ctx context.Context, addr string, auth smtp.Auth, from string, to []string, msg []byte) error {
+	ctx, cancel := context.WithTimeout(ctx, smtpSendTimeout)
+	defer cancel()
+
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "invalid SMTP server address")
 	}
 
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
 	if err != nil {
-		return err
+		return contextError(ctx, errors.Wrap(err, "unable to connect to SMTP server"))
 	}
+
 	defer conn.Close() //nolint:errcheck
 
-	deadline, _ := ctx.Deadline()
-	if err := conn.SetDeadline(deadline); err != nil {
-		return err
+	// A connection deadline is an absolute instant and never observes ctx.Done(), so
+	// closing the connection is what unblocks an in-flight read when the caller cancels.
+	defer context.AfterFunc(ctx, func() {
+		conn.Close() //nolint:errcheck
+	})()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			return errors.Wrap(err, "unable to set connection deadline")
+		}
 	}
 
+	return sendMailOnConn(ctx, conn, host, auth, from, to, msg)
+}
+
+func sendMailOnConn(ctx context.Context, conn net.Conn, host string, auth smtp.Auth, from string, to []string, msg []byte) error {
 	c, err := smtp.NewClient(conn, host)
 	if err != nil {
-		return contextError(ctx, err)
+		return contextError(ctx, errors.Wrap(err, "unable to start SMTP session"))
 	}
+
 	defer c.Close() //nolint:errcheck
 
 	if err := c.Hello("localhost"); err != nil {
-		return contextError(ctx, err)
+		return contextError(ctx, errors.Wrap(err, "SMTP greeting failed"))
 	}
+
 	if ok, _ := c.Extension("STARTTLS"); ok {
 		if err := c.StartTLS(&tls.Config{MinVersion: tls.VersionTLS12, ServerName: host}); err != nil {
-			return contextError(ctx, err)
+			return contextError(ctx, errors.Wrap(err, "STARTTLS failed"))
 		}
 	}
 
@@ -96,42 +115,63 @@ func sendMail(ctx context.Context, addr string, auth smtp.Auth, from string, to 
 		if ok, _ := c.Extension("AUTH"); !ok {
 			return errors.New("smtp: server doesn't support AUTH")
 		}
+
 		if err := c.Auth(auth); err != nil {
-			return contextError(ctx, err)
+			return contextError(ctx, errors.Wrap(err, "SMTP authentication failed"))
 		}
 	}
 
+	return writeMessage(ctx, c, from, to, msg)
+}
+
+func writeMessage(ctx context.Context, c *smtp.Client, from string, to []string, msg []byte) error {
 	if err := c.Mail(from); err != nil {
-		return contextError(ctx, err)
+		return contextError(ctx, errors.Wrap(err, "SMTP MAIL command failed"))
 	}
-	for _, addr := range to {
-		if err := c.Rcpt(addr); err != nil {
-			return contextError(ctx, err)
+
+	for _, rcpt := range to {
+		if err := c.Rcpt(rcpt); err != nil {
+			return contextError(ctx, errors.Wrap(err, "SMTP RCPT command failed"))
 		}
 	}
 
 	w, err := c.Data()
 	if err != nil {
-		return contextError(ctx, err)
+		return contextError(ctx, errors.Wrap(err, "SMTP DATA command failed"))
 	}
+
 	if _, err := w.Write(msg); err != nil {
-		return contextError(ctx, err)
+		return contextError(ctx, errors.Wrap(err, "unable to write message body"))
 	}
+
 	if err := w.Close(); err != nil {
-		return contextError(ctx, err)
+		return contextError(ctx, errors.Wrap(err, "unable to finish message body"))
 	}
 
 	if err := c.Quit(); err != nil {
-		return contextError(ctx, err)
+		return contextError(ctx, errors.Wrap(err, "SMTP QUIT failed"))
 	}
 
 	return nil
 }
 
+// contextError reports the context's own error when the exchange was stopped by the
+// deadline or by cancellation, keeping err in the chain for diagnostics. The connection
+// deadline is armed from the context deadline, so os.ErrDeadlineExceeded describes the
+// same expiry even when the context's own timer has not fired yet.
 func contextError(ctx context.Context, err error) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
+	if err == nil {
+		return nil
 	}
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("%w: %w", ctxErr, err)
+	}
+
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return fmt.Errorf("%w: %w", context.DeadlineExceeded, err)
+	}
+
 	return err
 }
 

--- a/notification/sender/email/email_sender.go
+++ b/notification/sender/email/email_sender.go
@@ -4,8 +4,10 @@ package email
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/smtp"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -17,11 +19,13 @@ const ProviderType = "email"
 
 const defaultSMTPPort = 587
 
+const smtpSendTimeout = 10 * time.Second
+
 type emailProvider struct {
 	opt Options
 }
 
-func (p *emailProvider) Send(_ context.Context, msg *sender.Message) error {
+func (p *emailProvider) Send(ctx context.Context, msg *sender.Message) error {
 	var auth smtp.Auth
 
 	if p.opt.SMTPUsername != "" {
@@ -49,13 +53,80 @@ func (p *emailProvider) Send(_ context.Context, msg *sender.Message) error {
 
 	msgPayload = []byte(strings.Join(headers, "\r\n") + "\r\n\r\n" + msg.Body)
 
-	//nolint:wrapcheck
-	return smtp.SendMail(
-		fmt.Sprintf("%v:%d", p.opt.SMTPServer, p.opt.SMTPPort),
-		auth,
-		p.opt.From,
-		strings.Split(p.opt.To, ","),
-		msgPayload)
+	ctx, cancel := context.WithTimeout(ctx, smtpSendTimeout)
+	defer cancel()
+
+	return sendMail(ctx, fmt.Sprintf("%v:%d", p.opt.SMTPServer, p.opt.SMTPPort), auth, p.opt.From, strings.Split(p.opt.To, ","), msgPayload)
+}
+
+func sendMail(ctx context.Context, addr string, auth smtp.Auth, from string, to []string, msg []byte) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return err
+	}
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close() //nolint:errcheck
+
+	deadline, _ := ctx.Deadline()
+	if err := conn.SetDeadline(deadline); err != nil {
+		return err
+	}
+
+	c, err := smtp.NewClient(conn, host)
+	if err != nil {
+		return contextError(ctx, err)
+	}
+	defer c.Close() //nolint:errcheck
+
+	if err := c.Hello("localhost"); err != nil {
+		return contextError(ctx, err)
+	}
+
+	if auth != nil {
+		if ok, _ := c.Extension("AUTH"); !ok {
+			return errors.New("smtp: server doesn't support AUTH")
+		}
+		if err := c.Auth(auth); err != nil {
+			return contextError(ctx, err)
+		}
+	}
+
+	if err := c.Mail(from); err != nil {
+		return contextError(ctx, err)
+	}
+	for _, addr := range to {
+		if err := c.Rcpt(addr); err != nil {
+			return contextError(ctx, err)
+		}
+	}
+
+	w, err := c.Data()
+	if err != nil {
+		return contextError(ctx, err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return contextError(ctx, err)
+	}
+	if err := w.Close(); err != nil {
+		return contextError(ctx, err)
+	}
+
+	if err := c.Quit(); err != nil {
+		return contextError(ctx, err)
+	}
+
+	return nil
+}
+
+func contextError(ctx context.Context, err error) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
 }
 
 func (p *emailProvider) Summary() string {

--- a/notification/sender/email/email_sender.go
+++ b/notification/sender/email/email_sender.go
@@ -3,6 +3,7 @@ package email
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/smtp"
@@ -84,6 +85,11 @@ func sendMail(ctx context.Context, addr string, auth smtp.Auth, from string, to 
 
 	if err := c.Hello("localhost"); err != nil {
 		return contextError(ctx, err)
+	}
+	if ok, _ := c.Extension("STARTTLS"); ok {
+		if err := c.StartTLS(&tls.Config{MinVersion: tls.VersionTLS12, ServerName: host}); err != nil {
+			return contextError(ctx, err)
+		}
 	}
 
 	if auth != nil {

--- a/notification/sender/email/email_sender_test.go
+++ b/notification/sender/email/email_sender_test.go
@@ -2,6 +2,7 @@ package email_test
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -164,6 +165,47 @@ func TestEmailProvider_AUTH(t *testing.T) {
 	require.ErrorContains(t,
 		p2.Send(ctx, &sender.Message{Subject: "Test", Body: "test"}),
 		"smtp: server doesn't support AUTH")
+}
+
+func TestEmailProviderHonorsContextDeadline(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	serverDone := make(chan struct{})
+	defer close(serverDone)
+
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		<-serverDone
+	}()
+
+	p, err := sender.GetSender(testlogging.Context(t), "my-profile", "email", &email.Options{
+		SMTPServer: "127.0.0.1",
+		SMTPPort:   listener.Addr().(*net.TCPAddr).Port,
+		From:       "some-user@example.com",
+		To:         "another-user@example.com",
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- p.Send(ctx, &sender.Message{Subject: "Test", Body: "test"})
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("email send did not honor its context deadline")
+	}
 }
 
 func TestEmailProvider_Invalid(t *testing.T) {

--- a/notification/sender/email/email_sender_test.go
+++ b/notification/sender/email/email_sender_test.go
@@ -167,45 +167,108 @@ func TestEmailProvider_AUTH(t *testing.T) {
 		"smtp: server doesn't support AUTH")
 }
 
-func TestEmailProviderHonorsContextDeadline(t *testing.T) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer listener.Close()
+// stalledSMTPServer accepts TCP connections and then never speaks, which is how a
+// wedged SMTP server behaves: the connection succeeds and the greeting never arrives.
+func stalledSMTPServer(t *testing.T) (host string, port int) {
+	t.Helper()
 
-	serverDone := make(chan struct{})
-	defer close(serverDone)
+	var lc net.ListenConfig
+
+	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	done := make(chan struct{})
 
 	go func() {
-		conn, acceptErr := listener.Accept()
-		if acceptErr != nil {
-			return
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+
+			go func() {
+				<-done
+
+				conn.Close() //nolint:errcheck
+			}()
 		}
-		defer conn.Close()
-		<-serverDone
 	}()
 
+	t.Cleanup(func() {
+		close(done)
+		listener.Close() //nolint:errcheck
+	})
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	return addr.IP.String(), addr.Port
+}
+
+// sendToStalledServer sends a notification to a server that never answers and returns
+// the resulting error, failing the test if the send does not give up on its own.
+func sendToStalledServer(ctx context.Context, t *testing.T, giveUpAfter time.Duration) error {
+	t.Helper()
+
+	host, port := stalledSMTPServer(t)
+
 	p, err := sender.GetSender(testlogging.Context(t), "my-profile", "email", &email.Options{
-		SMTPServer: "127.0.0.1",
-		SMTPPort:   listener.Addr().(*net.TCPAddr).Port,
+		SMTPServer: host,
+		SMTPPort:   port,
 		From:       "some-user@example.com",
 		To:         "another-user@example.com",
 	})
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-
 	errCh := make(chan error, 1)
+
 	go func() {
 		errCh <- p.Send(ctx, &sender.Message{Subject: "Test", Body: "test"})
 	}()
 
 	select {
-	case err := <-errCh:
-		require.ErrorIs(t, err, context.DeadlineExceeded)
-	case <-time.After(time.Second):
-		t.Fatal("email send did not honor its context deadline")
+	case sendErr := <-errCh:
+		return sendErr
+	case <-time.After(giveUpAfter):
+		t.Fatal("email send did not give up on its own")
+
+		return nil
 	}
+}
+
+// TestEmailProvider_SendTimeout covers the failure in #5563: the caller's context has no
+// deadline of its own, so the provider's own timeout is the only thing that ends the send.
+func TestEmailProvider_SendTimeout(t *testing.T) {
+	defer email.TestingSetSendTimeout(200 * time.Millisecond)()
+
+	require.ErrorIs(t, sendToStalledServer(context.Background(), t, 30*time.Second), context.DeadlineExceeded)
+}
+
+// TestEmailProvider_ContextDeadline covers a caller deadline shorter than the provider's
+// own timeout, which must win.
+func TestEmailProvider_ContextDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	require.ErrorIs(t, sendToStalledServer(ctx, t, 30*time.Second), context.DeadlineExceeded)
+}
+
+// TestEmailProvider_Cancellation covers cancellation while the connection is already
+// established, which a connection deadline alone does not observe.
+func TestEmailProvider_Cancellation(t *testing.T) {
+	// A send timeout far longer than the guard below, so that only the cancellation can
+	// end the send in time. A connection deadline alone would run to the full timeout.
+	defer email.TestingSetSendTimeout(60 * time.Second)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	require.ErrorIs(t, sendToStalledServer(ctx, t, 10*time.Second), context.Canceled)
 }
 
 func TestEmailProvider_Invalid(t *testing.T) {

--- a/notification/sender/email/export_test.go
+++ b/notification/sender/email/export_test.go
@@ -1,0 +1,12 @@
+package email
+
+import "time"
+
+// TestingSetSendTimeout overrides the SMTP send timeout and returns a function that
+// restores the previous value.
+func TestingSetSendTimeout(d time.Duration) func() {
+	old := smtpSendTimeout
+	smtpSendTimeout = d
+
+	return func() { smtpSendTimeout = old }
+}


### PR DESCRIPTION
## Problem

An unreachable SMTP server could leave `smtp.SendMail` blocked forever. Repository-server clients then waited for the synchronous notification RPC even after their snapshot had completed.

## Fix

Replace the context-free SMTP helper with the equivalent client sequence over a context-aware dialer, including the existing STARTTLS and AUTH behavior. A 10-second deadline now bounds the connection and every SMTP protocol operation; an earlier caller deadline still wins. No asynchronous delivery or new configuration was added.

Fixes #5563.

## User impact

A broken or blackholed SMTP notification endpoint now fails the notification after a bounded interval instead of wedging snapshot completion indefinitely.

## Verification

- Added a deterministic local-listener regression: it accepts TCP but never sends the SMTP greeting. The test fails on clean `master` at its one-second guard and passes with this change, returning `context.DeadlineExceeded`.
- `go test ./notification/... -count=1`
- `go vet ./notification/...`
- `git diff --check`