### PR TITLE
feat(splitter):  integration of rollinghash v4.3.1: 2.3x speed in splitting, 1.6x speed overall

### DIFF
--- a/cli/command_benchmark_splitters.go
+++ b/cli/command_benchmark_splitters.go
@@ -40,7 +40,53 @@ func (c *commandBenchmarkSplitters) setup(svc appServices, parent commandParent)
 	c.out.setup(svc)
 }
 
-func (c *commandBenchmarkSplitters) run(ctx context.Context) error { //nolint:funlen
+// benchmarkSplitterFeedSize mirrors objectWriter's feed granularity so the
+// benchmark measures splitting the way snapshots actually drive it.
+const benchmarkSplitterFeedSize = 256 << 10
+
+// appendSegmentLengths splits d with the named algorithm and appends the
+// length of every produced segment. It uses the push-based ChunkSplitter
+// when the algorithm has one (as the object writer does), otherwise the
+// byte-at-a-time Splitter.
+func appendSegmentLengths(dst []int, algo string, d []byte) []int {
+	if cf := splitter.GetChunkFactory(algo); cf != nil {
+		s := cf()
+		defer s.Reset()
+
+		drain := func() {
+			for s.Next() {
+				dst = append(dst, len(s.Bytes()))
+			}
+		}
+
+		for off := 0; off < len(d); off += benchmarkSplitterFeedSize {
+			s.Write(d[off:min(off+benchmarkSplitterFeedSize, len(d))]) //nolint:errcheck
+			drain()
+		}
+
+		s.Close() //nolint:errcheck
+		drain()
+
+		return dst
+	}
+
+	s := splitter.GetFactory(algo)()
+	defer s.Close()
+
+	for len(d) > 0 {
+		n := s.NextSplitPoint(d)
+		if n < 0 {
+			return append(dst, len(d))
+		}
+
+		dst = append(dst, n)
+		d = d[n:]
+	}
+
+	return dst
+}
+
+func (c *commandBenchmarkSplitters) run(ctx context.Context) error {
 	type benchResult struct {
 		splitter       string
 		duration       time.Duration
@@ -81,23 +127,10 @@ func (c *commandBenchmarkSplitters) run(ctx context.Context) error { //nolint:fu
 		tt := timetrack.Start()
 
 		segmentLengths := runInParallelNoInput(c.parallel, func() []int {
-			fact := splitter.GetFactory(sp)
-
 			var segmentLengths []int
 
 			for _, d := range dataBlocks {
-				s := fact()
-
-				for len(d) > 0 {
-					n := s.NextSplitPoint(d)
-					if n < 0 {
-						segmentLengths = append(segmentLengths, len(d))
-						break
-					}
-
-					segmentLengths = append(segmentLengths, n)
-					d = d[n:]
-				}
+				segmentLengths = appendSegmentLengths(segmentLengths, sp, d)
 			}
 
 			return segmentLengths

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b
-	github.com/chmduquesne/rollinghash/v4 v4.3.1
+	github.com/chmduquesne/rollinghash/v4 v4.3.3
 	github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327
 	github.com/chromedp/chromedp v0.14.2
 	github.com/coreos/go-systemd/v22 v22.7.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b
-	github.com/chmduquesne/rollinghash v4.0.0+incompatible
+	github.com/chmduquesne/rollinghash/v4 v4.3.1
 	github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327
 	github.com/chromedp/chromedp v0.14.2
 	github.com/coreos/go-systemd/v22 v22.7.0

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chmduquesne/rollinghash/v4 v4.3.1 h1:v93k4fwRgIpC5KGMjJR2ZNjKFWM5JvJFkU6vepe4x/8=
-github.com/chmduquesne/rollinghash/v4 v4.3.1/go.mod h1:o5VzflIjb5D1s4aExhSmacmg9fA4v1Am0g/KNw56/e0=
+github.com/chmduquesne/rollinghash/v4 v4.3.3 h1:qVRh+IyQRaJZ7RqOH4M3gKdmc/sOroJIO20kYhTnPE4=
+github.com/chmduquesne/rollinghash/v4 v4.3.3/go.mod h1:o5VzflIjb5D1s4aExhSmacmg9fA4v1Am0g/KNw56/e0=
 github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327 h1:UQ4AU+BGti3Sy/aLU8KVseYKNALcX9UXY6DfpwQ6J8E=
 github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327/go.mod h1:NItd7aLkcfOA/dcMXvl8p1u+lQqioRMq/SqDp71Pb/k=
 github.com/chromedp/chromedp v0.14.2 h1:r3b/WtwM50RsBZHMUm9fsNhhzRStTHrKdr2zmwbZSzM=

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chmduquesne/rollinghash v4.0.0+incompatible h1:hnREQO+DXjqIw3rUTzWN7/+Dpw+N5Um8zpKV0JOEgbo=
-github.com/chmduquesne/rollinghash v4.0.0+incompatible/go.mod h1:Uc2I36RRfTAf7Dge82bi3RU0OQUmXT9iweIcPqvr8A0=
+github.com/chmduquesne/rollinghash/v4 v4.3.1 h1:v93k4fwRgIpC5KGMjJR2ZNjKFWM5JvJFkU6vepe4x/8=
+github.com/chmduquesne/rollinghash/v4 v4.3.1/go.mod h1:o5VzflIjb5D1s4aExhSmacmg9fA4v1Am0g/KNw56/e0=
 github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327 h1:UQ4AU+BGti3Sy/aLU8KVseYKNALcX9UXY6DfpwQ6J8E=
 github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327/go.mod h1:NItd7aLkcfOA/dcMXvl8p1u+lQqioRMq/SqDp71Pb/k=
 github.com/chromedp/chromedp v0.14.2 h1:r3b/WtwM50RsBZHMUm9fsNhhzRStTHrKdr2zmwbZSzM=

--- a/repo/object/object_manager.go
+++ b/repo/object/object_manager.go
@@ -44,9 +44,10 @@ type contentManager interface {
 type Manager struct {
 	Format format.ObjectFormat
 
-	contentMgr         contentManager
-	newDefaultSplitter splitter.Factory
-	writerPool         sync.Pool
+	contentMgr              contentManager
+	newDefaultSplitter      splitter.Factory
+	newDefaultChunkSplitter splitter.ChunkFactory
+	writerPool              sync.Pool
 }
 
 // NewWriter creates an ObjectWriter for writing to the repository.
@@ -55,17 +56,22 @@ func (om *Manager) NewWriter(ctx context.Context, opt WriterOptions) Writer {
 	w.ctx = ctx
 	w.om = om
 
-	var splitFactory splitter.Factory
+	splitFactory := om.newDefaultSplitter
+	chunkFactory := om.newDefaultChunkSplitter
 
 	if opt.Splitter != "" {
-		splitFactory = splitter.GetFactory(opt.Splitter)
+		if cf := splitter.GetChunkFactory(opt.Splitter); cf != nil {
+			splitFactory, chunkFactory = nil, cf
+		} else if sf := splitter.GetFactory(opt.Splitter); sf != nil {
+			splitFactory, chunkFactory = sf, nil
+		}
 	}
 
-	if splitFactory == nil {
-		splitFactory = om.newDefaultSplitter
+	if chunkFactory != nil {
+		w.splitter, w.chunkSplitter = nil, chunkFactory()
+	} else {
+		w.splitter, w.chunkSplitter = splitFactory(), nil
 	}
-
-	w.splitter = splitFactory()
 
 	w.description = opt.Description
 	w.prefix = opt.Prefix
@@ -239,6 +245,7 @@ func NewObjectManager(_ context.Context, bm contentManager, f format.ObjectForma
 	}
 
 	om.newDefaultSplitter = os
+	om.newDefaultChunkSplitter = splitter.GetChunkFactory(splitterID)
 
 	return om, nil
 }

--- a/repo/object/object_manager_test.go
+++ b/repo/object/object_manager_test.go
@@ -434,6 +434,213 @@ func verifyNoError(t *testing.T, err error) {
 	require.NoError(t, err)
 }
 
+// TestChunkSplitterObjectWriter checks that the rolling-hash splitters
+// drive the object writer to the same result regardless of how the input
+// is broken up across Write calls, and that the data round-trips.
+func TestChunkSplitterObjectWriter(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	r := rand.New(rand.NewSource(42))
+	data := make([]byte, 5<<20)
+	_, err := r.Read(data)
+	require.NoError(t, err)
+
+	for _, splitterName := range []string{"DYNAMIC-256K-BUZHASH", "DYNAMIC-4M-BUZHASH", "DYNAMIC-256K-RABINKARP"} {
+		for _, async := range []int{0, 4} {
+			t.Run(fmt.Sprintf("%s/async-%d", splitterName, async), func(t *testing.T) {
+				_, _, om := setupTest(t, nil)
+
+				write := func(pieceSize int) ID {
+					w := om.NewWriter(ctx, WriterOptions{Splitter: splitterName, AsyncWrites: async})
+					defer w.Close() //nolint:errcheck
+
+					for off := 0; off < len(data); off += pieceSize {
+						end := min(off+pieceSize, len(data))
+						_, werr := w.Write(data[off:end])
+						require.NoError(t, werr)
+					}
+
+					oid, rerr := w.Result()
+					require.NoError(t, rerr)
+
+					return oid
+				}
+
+				oid := write(len(data))
+				verifyFull(ctx, t, om, oid, data)
+
+				for _, pieceSize := range []int{1, 100, 4096, 1 << 20} {
+					require.Equal(t, oid, write(pieceSize), "object id depends on Write chunking for piece size %d", pieceSize)
+				}
+
+				// the push-based splitter must produce the same object id as
+				// the byte-at-a-time splitter for the same algorithm, so that
+				// deduplication against existing repositories is preserved.
+				pull := om.NewWriter(ctx, WriterOptions{Splitter: splitterName, AsyncWrites: async})
+				ow := testutil.EnsureType[*objectWriter](t, pull)
+				ow.splitter, ow.chunkSplitter = splitter.GetFactory(splitterName)(), nil
+
+				_, werr := pull.Write(data)
+				require.NoError(t, werr)
+
+				pullOID, rerr := pull.Result()
+				require.NoError(t, rerr)
+				require.NoError(t, pull.Close())
+				require.Equal(t, pullOID, oid, "push and pull splitter produced different object ids")
+			})
+		}
+	}
+}
+
+func TestChunkSplitterObjectWriterShortInputs(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	_, _, om := setupTest(t, nil)
+
+	for _, size := range []int{0, 1, 63, 64, 65, 1000} {
+		data := make([]byte, size)
+		for i := range data {
+			data[i] = byte(i)
+		}
+
+		w := om.NewWriter(ctx, WriterOptions{Splitter: "DYNAMIC-256K-BUZHASH"})
+
+		_, err := w.Write(data)
+		require.NoError(t, err)
+
+		oid, err := w.Result()
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		verifyFull(ctx, t, om, oid, data)
+	}
+}
+
+// TestChunkSplitterCheckpointing exercises Checkpoint mid-stream on the
+// push-based splitter path: every checkpoint must be a verifiable object
+// and the final result must round-trip.
+func TestChunkSplitterCheckpointing(t *testing.T) {
+	ctx := testlogging.Context(t)
+	_, _, om := setupTest(t, nil)
+
+	r := rand.New(rand.NewSource(7))
+	data := make([]byte, 6<<20)
+	_, err := r.Read(data)
+	require.NoError(t, err)
+
+	w := om.NewWriter(ctx, WriterOptions{Splitter: "DYNAMIC-256K-BUZHASH"})
+	defer w.Close() //nolint:errcheck
+
+	written := 0
+
+	for _, piece := range []int{40, 1 << 20, 33, 3 << 20, len(data) - 40 - (1 << 20) - 33 - (3 << 20)} {
+		_, werr := w.Write(data[written : written+piece])
+		require.NoError(t, werr)
+
+		written += piece
+
+		cp, cerr := w.Checkpoint()
+		require.NoError(t, cerr)
+
+		if cp != EmptyID {
+			_, verr := VerifyObject(ctx, om.contentMgr, cp)
+			require.NoError(t, verr)
+		}
+	}
+
+	require.Equal(t, len(data), written)
+
+	oid, err := w.Result()
+	require.NoError(t, err)
+	verifyFull(ctx, t, om, oid, data)
+}
+
+// TestChunkSplitterConcatenate checks Concatenate over objects written
+// through the push-based splitter path.
+func TestChunkSplitterConcatenate(t *testing.T) {
+	ctx := testlogging.Context(t)
+	_, _, om := setupTest(t, nil)
+
+	mkObject := func(seed int64, size int) (ID, []byte) {
+		r := rand.New(rand.NewSource(seed))
+		buf := make([]byte, size)
+		_, err := r.Read(buf)
+		require.NoError(t, err)
+
+		w := om.NewWriter(ctx, WriterOptions{Splitter: "DYNAMIC-256K-RABINKARP"})
+		defer w.Close() //nolint:errcheck
+
+		_, err = w.Write(buf)
+		require.NoError(t, err)
+
+		oid, err := w.Result()
+		require.NoError(t, err)
+
+		return oid, buf
+	}
+
+	a, aData := mkObject(1, 3<<20)
+	b, bData := mkObject(2, 5<<20)
+
+	concatenated, err := om.Concatenate(ctx, []ID{a, b, a}, "")
+	require.NoError(t, err)
+
+	verifyFull(ctx, t, om, concatenated, slices.Concat(aData, bData, aData))
+}
+
+// BenchmarkObjectWriterSplitting compares object-writer throughput with
+// the byte-at-a-time splitter (pull) against the rollinghash.ChunkWriter
+// splitter (push) for the same algorithm, feeding data in iocopy-sized
+// pieces.
+func BenchmarkObjectWriterSplitting(b *testing.B) {
+	ctx := testlogging.Context(b)
+
+	r := rand.New(rand.NewSource(5))
+	data := make([]byte, 64<<20)
+	_, err := r.Read(data)
+	require.NoError(b, err)
+
+	const pieceSize = 64 << 10
+
+	run := func(b *testing.B, splitterName string, pull bool) {
+		b.Helper()
+
+		fcm := &fakeContentManager{data: map[content.ID][]byte{}}
+
+		om, err := NewObjectManager(ctx, fcm, format.ObjectFormat{Splitter: splitterName}, nil)
+		require.NoError(b, err)
+
+		b.SetBytes(int64(len(data)))
+		b.ReportAllocs()
+
+		for b.Loop() {
+			w := om.NewWriter(ctx, WriterOptions{})
+
+			if pull {
+				ow := testutil.EnsureType[*objectWriter](b, w)
+				ow.splitter, ow.chunkSplitter = splitter.GetFactory(splitterName)(), nil
+			}
+
+			for off := 0; off < len(data); off += pieceSize {
+				if _, err := w.Write(data[off:min(off+pieceSize, len(data))]); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			if _, err := w.Result(); err != nil {
+				b.Fatal(err)
+			}
+
+			w.Close() //nolint:errcheck
+		}
+	}
+
+	for _, splitterName := range []string{"DYNAMIC-4M-BUZHASH", "DYNAMIC-2M-RABINKARP"} {
+		b.Run(splitterName+"/before-pull", func(b *testing.B) { run(b, splitterName, true) })
+		b.Run(splitterName+"/after-push", func(b *testing.B) { run(b, splitterName, false) })
+	}
+}
+
 func verifyIndirectBlock(ctx context.Context, t *testing.T, om *Manager, oid ID, expectedComp compression.HeaderID) {
 	t.Helper()
 

--- a/repo/object/object_writer.go
+++ b/repo/object/object_writer.go
@@ -83,7 +83,11 @@ type objectWriter struct {
 
 	description string
 
-	splitter splitter.Splitter
+	// exactly one of splitter and chunkSplitter is non-nil: chunkSplitter
+	// for the rolling-hash algorithms that support push-based splitting,
+	// splitter for the FIXED family and as a fallback.
+	splitter      splitter.Splitter
+	chunkSplitter splitter.ChunkSplitter
 
 	// provides mutual exclusion of all public APIs (Write, Result, Checkpoint)
 	mu sync.Mutex
@@ -103,6 +107,12 @@ func (w *objectWriter) Close() error {
 		w.splitter.Close()
 	}
 
+	if w.chunkSplitter != nil {
+		w.chunkSplitter.Close() //nolint:errcheck
+		w.chunkSplitter.Reset() // return the splitter to its pool
+		w.chunkSplitter = nil
+	}
+
 	w.buffer.Close()
 
 	w.om.closedWriter(w)
@@ -116,6 +126,14 @@ func (w *objectWriter) Write(data []byte) (n int, err error) {
 
 	dataLen := len(data)
 	w.totalLength += int64(dataLen)
+
+	if w.chunkSplitter != nil {
+		if err := w.writeChunkedLocked(data); err != nil {
+			return 0, err
+		}
+
+		return dataLen, nil
+	}
 
 	for len(data) > 0 {
 		n := w.splitter.NextSplitPoint(data)
@@ -139,8 +157,52 @@ func (w *objectWriter) Write(data []byte) (n int, err error) {
 }
 
 // +checklocks:w.mu
+func (w *objectWriter) writeChunkedLocked(data []byte) error {
+	// Feed the splitter in bounded slices, draining completed chunks
+	// between them, so that an unusually large Write does not make the
+	// splitter buffer the whole slice before any chunk is emitted. Most
+	// callers already Write in iocopy.BufSize (64 KiB) pieces; this only
+	// caps the outliers.
+	const feedSize = 256 << 10
+
+	for len(data) > 0 {
+		n := min(len(data), feedSize)
+
+		if _, err := w.chunkSplitter.Write(data[:n]); err != nil {
+			return errors.Wrap(err, "splitter error")
+		}
+
+		if err := w.drainChunksLocked(); err != nil {
+			return err
+		}
+
+		data = data[n:]
+	}
+
+	return nil
+}
+
+// +checklocks:w.mu
+func (w *objectWriter) drainChunksLocked() error {
+	for w.chunkSplitter.Next() {
+		if err := w.flushChunkLocked(gather.FromSlice(w.chunkSplitter.Bytes())); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// +checklocks:w.mu
 func (w *objectWriter) flushBufferLocked() error {
-	length := w.buffer.Length()
+	defer w.buffer.Reset()
+
+	return w.flushChunkLocked(w.buffer.Bytes())
+}
+
+// +checklocks:w.mu
+func (w *objectWriter) flushChunkLocked(data gather.Bytes) error {
+	length := data.Length()
 
 	// hold a lock as we may grow the index
 	w.indirectIndexGrowMutex.Lock()
@@ -151,10 +213,8 @@ func (w *objectWriter) flushBufferLocked() error {
 	w.currentPosition += int64(length)
 	w.indirectIndexGrowMutex.Unlock()
 
-	defer w.buffer.Reset()
-
 	if w.asyncWritesSemaphore == nil {
-		return w.saveError(w.prepareAndWriteContentChunk(chunkID, w.buffer.Bytes()))
+		return w.saveError(w.prepareAndWriteContentChunk(chunkID, data))
 	}
 
 	// acquire write semaphore
@@ -163,7 +223,7 @@ func (w *objectWriter) flushBufferLocked() error {
 	w.asyncWritesWG.Add(1)
 
 	asyncBuf := gather.NewWriteBuffer()
-	w.buffer.Bytes().WriteTo(asyncBuf) //nolint:errcheck
+	data.WriteTo(asyncBuf) //nolint:errcheck
 
 	go func() {
 		defer func() {
@@ -267,6 +327,14 @@ func (w *objectWriter) Result() (ID, error) {
 
 	// no need to hold a lock on w.indirectIndexGrowMutex, since growing index only happens synchronously
 	// and never in parallel with calling Result()
+	if w.chunkSplitter != nil {
+		if err := w.flushFinalChunksLocked(); err != nil {
+			return EmptyID, err
+		}
+
+		return w.checkpointLocked()
+	}
+
 	if w.buffer.Length() > 0 || len(w.indirectIndex) == 0 {
 		if err := w.flushBufferLocked(); err != nil {
 			return EmptyID, err
@@ -274,6 +342,25 @@ func (w *objectWriter) Result() (ID, error) {
 	}
 
 	return w.checkpointLocked()
+}
+
+// +checklocks:w.mu
+func (w *objectWriter) flushFinalChunksLocked() error {
+	if err := w.chunkSplitter.Close(); err != nil {
+		return errors.Wrap(err, "splitter error")
+	}
+
+	if err := w.drainChunksLocked(); err != nil {
+		return err
+	}
+
+	if len(w.indirectIndex) == 0 {
+		// nothing was written: emit a single empty content, same as the
+		// byte-at-a-time path flushing an empty buffer.
+		return w.flushChunkLocked(gather.Bytes{})
+	}
+
+	return nil
 }
 
 // Checkpoint returns object ID which represents portion of the object that has already been written.

--- a/repo/splitter/splitter_buzhash32.go
+++ b/repo/splitter/splitter_buzhash32.go
@@ -1,7 +1,7 @@
 package splitter
 
 import (
-	"github.com/chmduquesne/rollinghash/buzhash32"
+	"github.com/chmduquesne/rollinghash/v4/buzhash32"
 )
 
 type buzhash32Splitter struct {

--- a/repo/splitter/splitter_chunk.go
+++ b/repo/splitter/splitter_chunk.go
@@ -86,56 +86,31 @@ func GetChunkFactory(name string) ChunkFactory {
 }
 
 // rollingHashChunkSplitter adapts rollinghash.ChunkWriter to ChunkSplitter.
+//
+// A stream shorter than the rolling window yields no boundary; since
+// rollinghash v4.3.3 the ChunkWriter still emits those trailing bytes as a
+// single final chunk (a truly empty stream yields nothing), so no
+// short-stream fallback is needed here.
 type rollingHashChunkSplitter struct {
 	cw      rollinghash.ChunkWriter
 	maxSize int
-
-	// head keeps the first up-to-window bytes of the stream. A stream
-	// shorter than the rolling window never produces a boundary and
-	// rollinghash.ChunkWriter does not emit it as a chunk, so we emit it
-	// from here instead.
-	head   []byte
-	total  int
-	closed bool
-	tiny   bool // the short-stream fallback chunk in head is being served
 }
 
 func (s *rollingHashChunkSplitter) Write(p []byte) (int, error) {
-	if s.total < splitterSlidingWindowSize {
-		s.head = append(s.head, p[:min(len(p), splitterSlidingWindowSize-s.total)]...)
-	}
-
-	s.total += len(p)
-
 	//nolint:wrapcheck
 	return s.cw.Write(p)
 }
 
 func (s *rollingHashChunkSplitter) Close() error {
-	s.closed = true
-
 	//nolint:wrapcheck
 	return s.cw.Close()
 }
 
 func (s *rollingHashChunkSplitter) Next() bool {
-	if s.cw.Next() {
-		return true
-	}
-
-	if s.closed && !s.tiny && s.total > 0 && s.total < splitterSlidingWindowSize {
-		s.tiny = true
-		return true
-	}
-
-	return false
+	return s.cw.Next()
 }
 
 func (s *rollingHashChunkSplitter) Bytes() []byte {
-	if s.tiny {
-		return s.head
-	}
-
 	return s.cw.Bytes()
 }
 
@@ -145,10 +120,6 @@ func (s *rollingHashChunkSplitter) MaxSegmentSize() int {
 
 func (s *rollingHashChunkSplitter) Reset() {
 	s.cw.Reset()
-	s.head = s.head[:0]
-	s.total = 0
-	s.closed = false
-	s.tiny = false
 }
 
 // recyclableChunkSplitter returns its wrapped splitter to a pool when

--- a/repo/splitter/splitter_chunk.go
+++ b/repo/splitter/splitter_chunk.go
@@ -1,0 +1,205 @@
+package splitter
+
+import (
+	"io"
+	"sync"
+
+	"github.com/chmduquesne/rollinghash/v4"
+	"github.com/chmduquesne/rollinghash/v4/buzhash32"
+	"github.com/chmduquesne/rollinghash/v4/rabinkarp64"
+)
+
+// ChunkSplitter splits a byte stream into content-defined chunks. Where
+// Splitter is handed a buffer and returns the offset at which the caller
+// should cut it, ChunkSplitter owns the chunk accumulator: the caller
+// feeds the stream through Write, drains completed chunks through Next and
+// Bytes, then calls Close to release the final, possibly short, chunk.
+//
+// This inversion lets the rolling-hash splitters find boundaries with
+// rollinghash.ChunkWriter, which scans buffers with BatchBoundaries and
+// skips the sub-minimum-size prefix of every chunk instead of hashing one
+// byte at a time. Measured at 2-3x the throughput of the equivalent
+// Splitter (BenchmarkSplitter, BenchmarkObjectWriterSplitting).
+//
+// For a given algorithm and average size the boundaries are identical to
+// the equivalent Splitter for every chunk at least splitterSlidingWindowSize
+// bytes long, which covers every production splitter (minimum chunk size
+// 64 KiB and up); see TestChunkSplitterMatchesSplitter.
+type ChunkSplitter interface {
+	// Write feeds stream bytes. It consumes all of p and returns no error
+	// before Close.
+	io.Writer
+
+	// Close signals the end of the stream so that Next can yield the
+	// final, possibly short, chunk. Write must not be called afterwards.
+	io.Closer
+
+	// Next reports whether another completed chunk is available. Bytes
+	// returns the current one, valid only until the next call to Write,
+	// Next or Close.
+	Next() bool
+	Bytes() []byte
+
+	// MaxSegmentSize returns the largest chunk the splitter will emit.
+	MaxSegmentSize() int
+
+	// Reset returns the splitter to its initial state, ready for a new
+	// stream and re-enabling Write after Close. Any chunk not yet drained
+	// is discarded.
+	Reset()
+}
+
+// ChunkFactory creates ChunkSplitter instances.
+type ChunkFactory func() ChunkSplitter
+
+// chunkSplitterFactories maps algorithm names to a ChunkFactory, for the
+// subset of SupportedAlgorithms backed by a rolling hash. Names absent
+// here (the FIXED family) have no push-based implementation and are only
+// available through GetFactory.
+//
+//nolint:gochecknoglobals
+var chunkSplitterFactories = map[string]ChunkFactory{
+	"DYNAMIC-128K-BUZHASH": newBuzHash32ChunkFactory(splitterSize128KB),
+	"DYNAMIC-256K-BUZHASH": newBuzHash32ChunkFactory(splitterSize256KB),
+	"DYNAMIC-512K-BUZHASH": newBuzHash32ChunkFactory(splitterSize512KB),
+	"DYNAMIC-1M-BUZHASH":   newBuzHash32ChunkFactory(splitterSize1MB),
+	"DYNAMIC-2M-BUZHASH":   newBuzHash32ChunkFactory(splitterSize2MB),
+	"DYNAMIC-4M-BUZHASH":   newBuzHash32ChunkFactory(splitterSize4MB),
+	"DYNAMIC-8M-BUZHASH":   newBuzHash32ChunkFactory(splitterSize8MB),
+
+	"DYNAMIC-128K-RABINKARP": newRabinKarp64ChunkFactory(splitterSize128KB),
+	"DYNAMIC-256K-RABINKARP": newRabinKarp64ChunkFactory(splitterSize256KB),
+	"DYNAMIC-512K-RABINKARP": newRabinKarp64ChunkFactory(splitterSize512KB),
+	"DYNAMIC-1M-RABINKARP":   newRabinKarp64ChunkFactory(splitterSize1MB),
+	"DYNAMIC-2M-RABINKARP":   newRabinKarp64ChunkFactory(splitterSize2MB),
+	"DYNAMIC-4M-RABINKARP":   newRabinKarp64ChunkFactory(splitterSize4MB),
+	"DYNAMIC-8M-RABINKARP":   newRabinKarp64ChunkFactory(splitterSize8MB),
+
+	"DYNAMIC": newBuzHash32ChunkFactory(splitterSize4MB),
+}
+
+// GetChunkFactory returns the ChunkFactory for the named algorithm, or nil
+// if the algorithm has no push-based implementation (in which case
+// GetFactory still returns a byte-at-a-time Splitter).
+func GetChunkFactory(name string) ChunkFactory {
+	return chunkSplitterFactories[name]
+}
+
+// rollingHashChunkSplitter adapts rollinghash.ChunkWriter to ChunkSplitter.
+type rollingHashChunkSplitter struct {
+	cw      rollinghash.ChunkWriter
+	maxSize int
+
+	// head keeps the first up-to-window bytes of the stream. A stream
+	// shorter than the rolling window never produces a boundary and
+	// rollinghash.ChunkWriter does not emit it as a chunk, so we emit it
+	// from here instead.
+	head   []byte
+	total  int
+	closed bool
+	tiny   bool // the short-stream fallback chunk in head is being served
+}
+
+func (s *rollingHashChunkSplitter) Write(p []byte) (int, error) {
+	if s.total < splitterSlidingWindowSize {
+		s.head = append(s.head, p[:min(len(p), splitterSlidingWindowSize-s.total)]...)
+	}
+
+	s.total += len(p)
+
+	//nolint:wrapcheck
+	return s.cw.Write(p)
+}
+
+func (s *rollingHashChunkSplitter) Close() error {
+	s.closed = true
+
+	//nolint:wrapcheck
+	return s.cw.Close()
+}
+
+func (s *rollingHashChunkSplitter) Next() bool {
+	if s.cw.Next() {
+		return true
+	}
+
+	if s.closed && !s.tiny && s.total > 0 && s.total < splitterSlidingWindowSize {
+		s.tiny = true
+		return true
+	}
+
+	return false
+}
+
+func (s *rollingHashChunkSplitter) Bytes() []byte {
+	if s.tiny {
+		return s.head
+	}
+
+	return s.cw.Bytes()
+}
+
+func (s *rollingHashChunkSplitter) MaxSegmentSize() int {
+	return s.maxSize
+}
+
+func (s *rollingHashChunkSplitter) Reset() {
+	s.cw.Reset()
+	s.head = s.head[:0]
+	s.total = 0
+	s.closed = false
+	s.tiny = false
+}
+
+// recyclableChunkSplitter returns its wrapped splitter to a pool when
+// Reset is called, so that the sizeable rolling-hash chunk buffer is
+// reused across object writers.
+type recyclableChunkSplitter struct {
+	*rollingHashChunkSplitter
+
+	pool *sync.Pool
+}
+
+func (s *recyclableChunkSplitter) Reset() {
+	s.rollingHashChunkSplitter.Reset()
+	s.pool.Put(s.rollingHashChunkSplitter)
+}
+
+func pooledChunk(newSplitter func() *rollingHashChunkSplitter) ChunkFactory {
+	pool := &sync.Pool{}
+
+	return func() ChunkSplitter {
+		s, ok := pool.Get().(*rollingHashChunkSplitter)
+		if !ok {
+			s = newSplitter()
+		}
+
+		return &recyclableChunkSplitter{s, pool}
+	}
+}
+
+func newBuzHash32ChunkFactory(avgSize int) ChunkFactory {
+	mask := uint64(uint32(avgSize - 1))      //nolint:gosec
+	minSize, maxSize := avgSize/2, avgSize*2 //nolint:mnd
+
+	return pooledChunk(func() *rollingHashChunkSplitter {
+		return &rollingHashChunkSplitter{
+			cw: rollinghash.NewChunkWriter(buzhash32.New(), splitterSlidingWindowSize, mask,
+				rollinghash.WithBoundaries(minSize, maxSize)),
+			maxSize: maxSize,
+		}
+	})
+}
+
+func newRabinKarp64ChunkFactory(avgSize int) ChunkFactory {
+	mask := uint64(avgSize - 1)              //nolint:gosec
+	minSize, maxSize := avgSize/2, avgSize*2 //nolint:mnd
+
+	return pooledChunk(func() *rollingHashChunkSplitter {
+		return &rollingHashChunkSplitter{
+			cw: rollinghash.NewChunkWriter(rabinkarp64.New(), splitterSlidingWindowSize, mask,
+				rollinghash.WithBoundaries(minSize, maxSize)),
+			maxSize: maxSize,
+		}
+	})
+}

--- a/repo/splitter/splitter_chunk_test.go
+++ b/repo/splitter/splitter_chunk_test.go
@@ -1,0 +1,211 @@
+package splitter
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// splitOffsets returns the absolute cut offsets produced by feeding all of
+// data to a byte-at-a-time Splitter.
+func splitOffsets(data []byte, s Splitter) []int {
+	var offsets []int
+
+	total := len(data)
+	pos := 0
+
+	for len(data) > 0 {
+		n := s.NextSplitPoint(data)
+		if n < 0 {
+			break
+		}
+
+		pos += n
+		offsets = append(offsets, pos)
+		data = data[n:]
+	}
+
+	// the trailing bytes after the last boundary are a final chunk that
+	// NextSplitPoint never reports (its caller flushes them itself).
+	if pos < total {
+		offsets = append(offsets, total)
+	}
+
+	return offsets
+}
+
+// chunkOffsets returns the absolute cut offsets produced by feeding data to
+// a ChunkSplitter in pieces of the given size (0 means one Write), plus the
+// concatenation of every emitted chunk.
+func chunkOffsets(tb testing.TB, data []byte, s ChunkSplitter, pieceSize int) (offsets []int, assembled []byte) {
+	tb.Helper()
+
+	if pieceSize <= 0 {
+		pieceSize = len(data)
+	}
+
+	pos := 0
+
+	drain := func() {
+		for s.Next() {
+			b := s.Bytes()
+			pos += len(b)
+			offsets = append(offsets, pos)
+			assembled = append(assembled, b...)
+		}
+	}
+
+	for off := 0; off < len(data); off += pieceSize {
+		end := min(off+pieceSize, len(data))
+
+		if _, err := s.Write(data[off:end]); err != nil {
+			tb.Fatalf("write: %v", err)
+		}
+
+		drain()
+	}
+
+	if err := s.Close(); err != nil {
+		tb.Fatalf("close: %v", err)
+	}
+
+	drain()
+
+	return offsets, assembled
+}
+
+// TestChunkSplitterMatchesSplitter verifies that the push-based rolling-hash
+// splitters cut a stream at exactly the same offsets as the equivalent
+// byte-at-a-time Splitter, for every average size whose minimum chunk
+// length is at least the rolling window. All production splitters
+// (minimum 64 KiB) are in this range; the byte-at-a-time splitters prime
+// the window with zeros, which only changes boundaries in the first
+// splitterSlidingWindowSize bytes, below any real minimum chunk size.
+func TestChunkSplitterMatchesSplitter(t *testing.T) {
+	r := rand.New(rand.NewSource(5))
+
+	data := make([]byte, 5000000)
+	if _, err := r.Read(data); err != nil {
+		t.Fatalf("cannot initialize random data: %v", err)
+	}
+
+	avgSizes := []int{
+		1024, 2048, 32768, 65536,
+		splitterSize128KB, splitterSize256KB, splitterSize512KB,
+		splitterSize1MB, splitterSize2MB,
+	}
+
+	pieceSizes := []int{0, 1, 100, 4096, 65537}
+
+	algos := []struct {
+		name string
+		pull func(int) Factory
+		push func(int) ChunkFactory
+	}{
+		{"buzhash32", newBuzHash32SplitterFactory, newBuzHash32ChunkFactory},
+		{"rabinkarp64", newRabinKarp64SplitterFactory, newRabinKarp64ChunkFactory},
+	}
+
+	for _, algo := range algos {
+		for _, avg := range avgSizes {
+			want := splitOffsets(data, algo.pull(avg)())
+
+			for _, piece := range pieceSizes {
+				t.Run(fmt.Sprintf("%s/%d/piece-%d", algo.name, avg, piece), func(t *testing.T) {
+					t.Parallel()
+
+					got, assembled := chunkOffsets(t, data, algo.push(avg)(), piece)
+
+					require.Equal(t, want, got, "cut offsets differ")
+					require.True(t, bytes.Equal(data, assembled), "assembled stream differs from input")
+				})
+			}
+		}
+	}
+}
+
+func TestChunkSplitterShortStreams(t *testing.T) {
+	for _, size := range []int{0, 1, 63, 64, 65, 1000} {
+		t.Run(fmt.Sprintf("size-%d", size), func(t *testing.T) {
+			data := make([]byte, size)
+			for i := range data {
+				data[i] = byte(i)
+			}
+
+			_, assembled := chunkOffsets(t, data, newBuzHash32ChunkFactory(splitterSize128KB)(), 0)
+
+			require.True(t, bytes.Equal(data, assembled), "assembled stream differs from input")
+		})
+	}
+}
+
+func TestChunkSplitterMaxSegmentSize(t *testing.T) {
+	require.Equal(t, splitterSize1MB*2, newBuzHash32ChunkFactory(splitterSize1MB)().MaxSegmentSize())
+	require.Equal(t, splitterSize1MB*2, newRabinKarp64ChunkFactory(splitterSize1MB)().MaxSegmentSize())
+}
+
+func BenchmarkSplitter(b *testing.B) {
+	r := rand.New(rand.NewSource(5))
+
+	// feed the splitters the same way the object writer does: 64 KiB
+	// pieces, draining completed chunks between them.
+	const pieceSize = 64 << 10
+
+	data := make([]byte, 64<<20)
+	if _, err := r.Read(data); err != nil {
+		b.Fatalf("cannot initialize random data: %v", err)
+	}
+
+	for _, algo := range []string{"DYNAMIC-4M-BUZHASH", "DYNAMIC-2M-RABINKARP"} {
+		b.Run(algo+"/splitter", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+
+			for b.Loop() {
+				s := GetFactory(algo)()
+
+				for off := 0; off < len(data); off += pieceSize {
+					buf := data[off:min(off+pieceSize, len(data))]
+					for len(buf) > 0 {
+						n := s.NextSplitPoint(buf)
+						if n < 0 {
+							break
+						}
+
+						buf = buf[n:]
+					}
+				}
+
+				s.Close()
+			}
+		})
+
+		b.Run(algo+"/chunksplitter", func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+
+			for b.Loop() {
+				s := GetChunkFactory(algo)()
+
+				for off := 0; off < len(data); off += pieceSize {
+					if _, err := s.Write(data[off:min(off+pieceSize, len(data))]); err != nil {
+						b.Fatalf("write: %v", err)
+					}
+
+					for s.Next() { //nolint:revive
+					}
+				}
+
+				if err := s.Close(); err != nil {
+					b.Fatalf("close: %v", err)
+				}
+
+				for s.Next() { //nolint:revive
+				}
+
+				s.Reset()
+			}
+		})
+	}
+}

--- a/repo/splitter/splitter_rabinkarp64.go
+++ b/repo/splitter/splitter_rabinkarp64.go
@@ -1,7 +1,7 @@
 package splitter
 
 import (
-	"github.com/chmduquesne/rollinghash/rabinkarp64"
+	"github.com/chmduquesne/rollinghash/v4/rabinkarp64"
 )
 
 type rabinKarp64Splitter struct {


### PR DESCRIPTION
Hi there,

Disclaimer: This pull request is for illustrative purposes only. Do not integrate it blindly. The code was entirely AI-generated and although I reviewed it, I am not familiar enough with this project to guarantee its quality. I am not a kopia user.

Context: I recently improved the rollinghash library with the addition of the ChunkWriter interface. This interface was designed with kopia in mind. It leverages [instruction level parallelism](https://en.wikipedia.org/wiki/Instruction-level_parallelism) to achieve about twice the previous throughput. This means that you can get identical chunks in roughly half the time. I was interested in knowing how much performance kopia would get out of this code. The answer is that splitting becomes 2.35 times faster, and that performance through the full object writer becomes 1.6 times faster.

Code changes: This branch reimplements the DYNAMIC-* rolling-hash splitters on rollinghash v4.3.1's ChunkWriter. It required the addition of a new splitter.ChunkSplitter interface, used by the object writer for these algorithms; FIXED keeps the existing Splitter.

Dedup is preserved: boundaries are byte-identical to the old splitter. TestChunkSplitterMatchesSplitter and TestChunkSplitterObjectWriter assert identical cut offsets / object IDs against the old path directly.

You may use this code, rewrite it entirely, or ignore this PR completely. I just wanted to let you know that significant speed improvements are possible at the cost of a small refactoring 🙂

Cheers,
Christophe-Marie Duquesne