### PR TITLE
fix(kopiaui): prevent status poll socket leaks

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -77,7 +77,10 @@ dev: node_modules/.up-to-date
 run:
 	$(npm) $(npm_flags) run start-electron-prebuilt
 
-e2e-test:
+test: $(npm)
+	$(npm) $(npm_flags) test
+
+e2e-test: test
 	$(npm) $(npm_flags) run e2e
 
 build-electron: ../dist/kopia-ui/.up-to-date

--- a/app/package.json
+++ b/app/package.json
@@ -140,6 +140,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build-html": "react-scripts build",
+    "test": "node --test tests/*.test.js",
     "e2e": "playwright test",
     "eject": "react-scripts eject",
     "start-electron": "electron .",

--- a/app/public/request-poller.js
+++ b/app/public/request-poller.js
@@ -1,0 +1,120 @@
+// Creates a polling loop that never has more than one request in flight.
+export function createRequestPoller({
+  interval,
+  request,
+  getRequestOptions,
+  onResponse,
+  onError,
+}) {
+  let activeRequest = null;
+  let pollTimer = null;
+  let stopped = true;
+
+  function scheduleNextPoll() {
+    if (!stopped) {
+      pollTimer = setTimeout(pollOnce, interval);
+    }
+  }
+
+  function finishRequest(req, callback) {
+    if (activeRequest !== req) {
+      return;
+    }
+
+    activeRequest = null;
+
+    try {
+      callback?.();
+    } finally {
+      scheduleNextPoll();
+    }
+  }
+
+  function pollOnce() {
+    pollTimer = null;
+
+    if (stopped) {
+      return;
+    }
+
+    const options = getRequestOptions();
+    if (!options) {
+      scheduleNextPoll();
+      return;
+    }
+
+    let req;
+
+    try {
+      req = request(options, (resp) => {
+        const chunks = [];
+
+        resp.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        resp.once("end", () => {
+          finishRequest(req, () => onResponse(resp, Buffer.concat(chunks)));
+        });
+        resp.once("aborted", () => {
+          finishRequest(req, () => onError(new Error("response aborted")));
+        });
+        resp.once("error", (err) => {
+          finishRequest(req, () => onError(err));
+        });
+      });
+    } catch (err) {
+      try {
+        onError(err);
+      } finally {
+        scheduleNextPoll();
+      }
+
+      return;
+    }
+
+    activeRequest = req;
+
+    req.once("timeout", () => {
+      if (activeRequest !== req) {
+        return;
+      }
+
+      // A ClientRequest timeout is only a notification. Explicitly destroy the
+      // request so its socket is not retained while the next poll is scheduled.
+      req.destroy();
+      finishRequest(req);
+    });
+    req.once("error", (err) => {
+      finishRequest(req, () => onError(err));
+    });
+
+    try {
+      req.end();
+    } catch (err) {
+      req.destroy();
+      finishRequest(req, () => onError(err));
+    }
+  }
+
+  return {
+    start() {
+      if (!stopped) {
+        return;
+      }
+
+      stopped = false;
+      scheduleNextPoll();
+    },
+
+    stop() {
+      stopped = true;
+
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+        pollTimer = null;
+      }
+
+      const req = activeRequest;
+      activeRequest = null;
+      req?.destroy();
+    },
+  };
+}

--- a/app/public/server.js
+++ b/app/public/server.js
@@ -3,6 +3,7 @@ const path = await import("path");
 const https = await import("https");
 
 import { defaultServerBinary } from "./utils.js";
+import { createRequestPoller } from "./request-poller.js";
 import { spawn } from "child_process";
 import log from "electron-log";
 import { configDir, isPortableConfig } from "./config.js";
@@ -11,6 +12,7 @@ let servers = {};
 
 function newServerForRepo(repoID) {
   let runningServerProcess = null;
+  let runningStatusPoller = null;
   let runningServerCertSHA256 = "";
   let runningServerPassword = "";
   let runningServerControlPassword = "";
@@ -73,18 +75,20 @@ function newServerForRepo(repoID) {
 
       const pollInterval = 3000;
 
-      function pollOnce() {
-        if (
-          !runningServerAddress ||
-          !runningServerCertificate ||
-          !runningServerPassword ||
-          !runningServerControlPassword
-        ) {
-          return;
-        }
+      const statusPoller = createRequestPoller({
+        interval: pollInterval,
+        request: https.request,
+        getRequestOptions: () => {
+          if (
+            !runningServerAddress ||
+            !runningServerCertificate ||
+            !runningServerPassword ||
+            !runningServerControlPassword
+          ) {
+            return null;
+          }
 
-        const req = https.request(
-          {
+          return {
             ca: [runningServerCertificate],
             host: "127.0.0.1",
             port: parseInt(new URL(runningServerAddress).port),
@@ -98,43 +102,45 @@ function newServerForRepo(repoID) {
                   "server-control" + ":" + runningServerControlPassword,
                 ).toString("base64"),
             },
-          },
-          (resp) => {
-            if (resp.statusCode === 200) {
-              resp.on("data", (x) => {
-                try {
-                  const newDetails = JSON.parse(x);
-                  if (
-                    JSON.stringify(newDetails) !=
-                    JSON.stringify(runningServerStatusDetails)
-                  ) {
-                    runningServerStatusDetails = newDetails;
-                    statusUpdated();
-                  }
-                } catch (e) {
-                  log.warn("unable to parse status JSON", e);
-                }
-              });
-            } else {
-              log.warn("error fetching status", resp.statusMessage);
+          };
+        },
+        onResponse: (resp, body) => {
+          if (resp.statusCode === 200) {
+            try {
+              const newDetails = JSON.parse(body.toString());
+              if (
+                JSON.stringify(newDetails) !=
+                JSON.stringify(runningServerStatusDetails)
+              ) {
+                runningServerStatusDetails = newDetails;
+                statusUpdated();
+              }
+            } catch (e) {
+              log.warn("unable to parse status JSON", e);
             }
-          },
-        );
-        req.on("error", (e) => {
+          } else {
+            log.warn("error fetching status", resp.statusMessage);
+          }
+        },
+        onError: (e) => {
           log.info("error fetching status", e);
-        });
-        req.end();
-      }
+        },
+      });
 
-      const statusPollInterval = setInterval(pollOnce, pollInterval);
+      runningStatusPoller = statusPoller;
+      statusPoller.start();
 
       runningServerProcess.on("close", (code, signal) => {
         this.appendToLog(
           `child process exited with code ${code} and signal ${signal}`,
         );
-        if (runningServerProcess === p) {
-          clearInterval(statusPollInterval);
 
+        statusPoller.stop();
+        if (runningStatusPoller === statusPoller) {
+          runningStatusPoller = null;
+        }
+
+        if (runningServerProcess === p) {
           runningServerAddress = "";
           runningServerPassword = "";
           runningServerControlPassword = "";
@@ -210,6 +216,9 @@ function newServerForRepo(repoID) {
     },
 
     stopServer() {
+      runningStatusPoller?.stop();
+      runningStatusPoller = null;
+
       if (!runningServerProcess) {
         log.info("stopServer: server not started");
         return;

--- a/app/tests/request-poller.test.js
+++ b/app/tests/request-poller.test.js
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { createRequestPoller } from "../public/request-poller.js";
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(promise) {
+  let timeout;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timeout = setTimeout(() => reject(new Error("timed out")), 1000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+test("timed-out polls are destroyed and never overlap", async () => {
+  let activeRequests = 0;
+  let destroyedRequests = 0;
+  let maxActiveRequests = 0;
+  let requestCount = 0;
+  let enoughRequestsResolve;
+  const enoughRequests = new Promise((resolve) => {
+    enoughRequestsResolve = resolve;
+  });
+
+  const poller = createRequestPoller({
+    interval: 5,
+    getRequestOptions: () => ({ timeout: 5 }),
+    request: (options) => {
+      const req = new EventEmitter();
+      let destroyed = false;
+
+      requestCount++;
+      if (requestCount === 3) {
+        enoughRequestsResolve();
+      }
+
+      activeRequests++;
+      maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+
+      req.end = () => {
+        setTimeout(() => req.emit("timeout"), options.timeout);
+      };
+      req.destroy = () => {
+        if (!destroyed) {
+          destroyed = true;
+          destroyedRequests++;
+          activeRequests--;
+        }
+      };
+
+      return req;
+    },
+    onResponse: () => assert.fail("unexpected response"),
+    onError: (err) => assert.fail(err),
+  });
+
+  poller.start();
+  await waitFor(enoughRequests);
+  poller.stop();
+
+  assert.equal(requestCount, 3);
+  assert.equal(maxActiveRequests, 1);
+  assert.equal(destroyedRequests, requestCount);
+  assert.equal(activeRequests, 0);
+});
+
+test("stopping destroys a hung poll and prevents another poll", async () => {
+  let requestCount = 0;
+  let destroyedRequests = 0;
+  let requestStartedResolve;
+  const requestStarted = new Promise((resolve) => {
+    requestStartedResolve = resolve;
+  });
+
+  const poller = createRequestPoller({
+    interval: 5,
+    getRequestOptions: () => ({ timeout: 60_000 }),
+    request: () => {
+      const req = new EventEmitter();
+
+      requestCount++;
+      requestStartedResolve();
+      req.end = () => {};
+      req.destroy = () => destroyedRequests++;
+
+      return req;
+    },
+    onResponse: () => assert.fail("unexpected response"),
+    onError: (err) => assert.fail(err),
+  });
+
+  poller.start();
+  await waitFor(requestStarted);
+  poller.stop();
+  await delay(15);
+
+  assert.equal(requestCount, 1);
+  assert.equal(destroyedRequests, 1);
+});
+
+test("response bodies are collected before the next poll", async () => {
+  let requestCount = 0;
+  let receivedBody;
+  let poller;
+  let responseReceivedResolve;
+  const responseReceived = new Promise((resolve) => {
+    responseReceivedResolve = resolve;
+  });
+
+  poller = createRequestPoller({
+    interval: 5,
+    getRequestOptions: () => ({}),
+    request: (_options, handleResponse) => {
+      const req = new EventEmitter();
+
+      requestCount++;
+      req.end = () => {
+        queueMicrotask(() => {
+          const resp = new EventEmitter();
+          resp.statusCode = 200;
+          handleResponse(resp);
+          resp.emit("data", Buffer.from('{"connected":'));
+          resp.emit("data", Buffer.from("false}"));
+          resp.emit("end");
+        });
+      };
+      req.destroy = () => {};
+
+      return req;
+    },
+    onResponse: (_resp, body) => {
+      receivedBody = body.toString();
+      poller.stop();
+      responseReceivedResolve();
+    },
+    onError: (err) => assert.fail(err),
+  });
+
+  poller.start();
+  await waitFor(responseReceived);
+
+  assert.equal(requestCount, 1);
+  assert.equal(receivedBody, '{"connected":false}');
+});


### PR DESCRIPTION
Fixes #5595.

Tested locally and confirmed that with 0.23.1 new sockets accumulated every 3s retry, and after the fix only a single persistent remained.

Disclaimer: code generated with gpt-5.6-sol high, reviewed by me and seems reasonable.