### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.19.2
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.14.2
-	github.com/kopia/htmluibuild v0.0.1-0.20260804002937-29e3e25473e0
+	github.com/kopia/htmluibuild v0.0.1-0.20260902000125-afc29e78fce1
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/minio/minio-go/v7 v7.3.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.14.2 h1:SafJYwpBBQBI6amHUygcjxZjXeN2HpiENHQDwuPWCCQ=
 github.com/klauspost/reedsolomon v1.14.2/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
-github.com/kopia/htmluibuild v0.0.1-0.20260804002937-29e3e25473e0 h1:K1wXXSB9Wz0wQG53vfvr4Xd9zRaVcJ/wpQNrZjTOrfg=
-github.com/kopia/htmluibuild v0.0.1-0.20260804002937-29e3e25473e0/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260902000125-afc29e78fce1 h1:NMiAmjW5twIC+Spri/Gf/Oav5ETdJE2A6l1rxqmI24c=
+github.com/kopia/htmluibuild v0.0.1-0.20260902000125-afc29e78fce1/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/553ca95fc08f7990e569a2ee11330c200de56f69...4868e7a91350161bd9da3b08c4555977595e4b4a

* Tue 16:39 -0700 https://github.com/kopia/htmlui/commit/e1f6e1e dependabot[bot] build(deps-dev): bump @testing-library/user-event from 14.6.1 to 14.6.6
* Tue 16:40 -0700 https://github.com/kopia/htmlui/commit/ebfe4d7 dependabot[bot] build(deps-dev): bump typescript-eslint from 8.66.0 to 8.68.0
* Tue 16:56 -0700 https://github.com/kopia/htmlui/commit/4868e7a dependabot[bot] build(deps-dev): bump jsdom from 27.0.1 to 30.0.1

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Wed Sep  2 00:02:53 UTC 2026*
