### PR TITLE
fix(cli): make remove-files --filename patterns match full paths

### DIFF
--- a/cli/command_snapshot_fix_remove_files.go
+++ b/cli/command_snapshot_fix_remove_files.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path"
 	"slices"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -35,8 +36,12 @@ func (c *commandSnapshotFixRemoveFiles) rewriteEntry(ctx context.Context, pathFr
 		return nil, nil
 	}
 
+	// pathFromRoot is already the entry's full path relative to the snapshot root.
 	for _, n := range c.removeFilesByName {
-		matched, err := path.Match(n, ent.Name)
+		matched, err := matchPathPattern(n, pathFromRoot)
+		if !matched && err == nil {
+			matched, err = path.Match(n, ent.Name)
+		}
 		if err != nil {
 			return nil, errors.Wrap(err, "invalid wildcard")
 		}
@@ -49,6 +54,47 @@ func (c *commandSnapshotFixRemoveFiles) rewriteEntry(ctx context.Context, pathFr
 	}
 
 	return ent, nil
+}
+
+// matchPathPattern reports whether glob pattern matches the full path.
+//
+// The pattern must match a suffix of the path: it may start at any depth, but
+// from there each pattern segment must match exactly one consecutive path
+// segment using path.Match wildcards. Pattern segments may not be skipped and
+// a "*" spans exactly one path segment.
+//
+// A single-segment pattern such as ".vscode" matches by basename at any depth,
+// preserving the original behavior, while patterns such as "Users/liquid/.vscode"
+// or "*/.vscode" match by anchored path suffix.
+func matchPathPattern(pattern, full string) (bool, error) {
+	patternSegments := strings.Split(pattern, "/")
+	pathSegments := strings.Split(full, "/")
+
+	// the pattern can only match if it is no longer than the path
+	if len(patternSegments) > len(pathSegments) {
+		return false, nil
+	}
+
+	for start := 0; start <= len(pathSegments)-len(patternSegments); start++ {
+		matchedAll := true
+
+		for i, seg := range patternSegments {
+			ok, err := path.Match(seg, pathSegments[start+i])
+			if err != nil {
+				return false, errors.Wrap(err, "invalid wildcard")
+			}
+			if !ok {
+				matchedAll = false
+				break
+			}
+		}
+
+		if matchedAll {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (c *commandSnapshotFixRemoveFiles) run(ctx context.Context, rep repo.RepositoryWriter) error {


### PR DESCRIPTION
snapshot fix remove-files --filename previously matched patterns only against the entry basename (ent.Name), so any pattern containing "/" (e.g. "Users/liquid/.vscode", "*/.vscode") could never match anything.

The pattern is now matched against the entry's full path relative to the snapshot root using a new matchPathPattern() helper with strict suffix semantics:

- The pattern may start at any depth, but from there each segment must match one consecutive path segment; no segments may be skipped and "*" spans exactly one path segment (no globstar; "**" == "*").
- Single-segment patterns (e.g. ".vscode") still match by basename at any depth — the original path.Match(ent.Name) call is kept unchanged as a fallback, so the change is fully backward-compatible.
- Invalid wildcards still return the original "invalid wildcard" error.

Note: the pathFromRoot passed into rewriteEntry is already the entry's full path relative to the snapshot root (it is NOT the parent's path), so no additional joining is done.

Verified by dry-runs against a live repo: ".vscode", "*/.vscode", "Users/liquid/.vscode", "liquid/.vscode", and "Users/**/.vscode" all behave as documented; go test ./cli/ -run TestSnapshotFix passes.