### PR TITLE
fix(maintenance): Truncate timestamp precision in S3 putBlob and ExtendBlobRetention

### DIFF
--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -166,7 +166,7 @@ func (s *s3Storage) putBlob(ctx context.Context, b blob.ID, data blob.Bytes, opt
 			return versionMetadata{}, errors.Errorf("invalid retention mode: %q", opts.RetentionMode)
 		}
 
-		retainUntilDate = clock.Now().Add(opts.RetentionPeriod).UTC()
+		retainUntilDate = clock.Now().Add(opts.RetentionPeriod).UTC().Truncate(time.Millisecond)
 	}
 
 	uploadInfo, err := s.cli.PutObject(ctx, s.BucketName, s.getObjectNameString(b), data.Reader(), int64(data.Length()), minio.PutObjectOptions{
@@ -234,7 +234,7 @@ func (s *s3Storage) ExtendBlobRetention(ctx context.Context, b blob.ID, opts blo
 		return errors.Errorf("invalid retention mode: %q", opts.RetentionMode)
 	}
 
-	retainUntilDate := clock.Now().Add(opts.RetentionPeriod).UTC()
+	retainUntilDate := clock.Now().Add(opts.RetentionPeriod).UTC().Truncate(time.Millisecond)
 
 	err := s.cli.PutObjectRetention(ctx, s.BucketName, s.getObjectNameString(b), minio.PutObjectRetentionOptions{
 		RetainUntilDate: &retainUntilDate,


### PR DESCRIPTION
The S3 Object Lock API expects the RetainUntilDate field to conform to ISO 8601 with millisecond precision at most. Go's time.Time, however, carries nanosecond precision. This leads to errors such as "error extending object lock retention time: Failed to extend n blobs" during full maintenance when using S3 providers that adhere strictly to this specification (NetApp Storagegrid is one example). This patch truncates the field to milliseconds. I successfully tested it on a NetApp Storagegrid.

This may fix [#5590](https://github.com/kopia/kopia/issues/5590), though I'm not certain it's the same problem.