### PR TITLE
docs(site): add Windows kopiaignore path guidance

### DIFF
--- a/site/content/docs/Advanced/Kopiaignore/_index.md
+++ b/site/content/docs/Advanced/Kopiaignore/_index.md
@@ -13,6 +13,8 @@ If such a file is placed within a directory, `Kopia` omits files and folders `ma
 
 >NOTE The default file is called `.kopiaignore`. However, ignore rules can be specified within the global or snapshot-specific `policy` - either directly or by providing a path to file containing such rules.   
 
+>NOTE On Windows, use forward slashes (`/`) as path separators in ignore rules, including rules entered directly in a policy or loaded from a `.kopiaignore` file. Backslashes (`\`) copied from Windows paths are not supported. For example, use `Documents/cache/*` instead of `Documents\cache\*`.
+
 In the following, we explain different rules and provide examples to create `.kopiaignore` files.
 
 ### Kopiaignore Files

--- a/site/content/docs/Advanced/Kopiaignore/_index.md
+++ b/site/content/docs/Advanced/Kopiaignore/_index.md
@@ -11,9 +11,9 @@ Users may want to exclude folders and files not to be saved within the repositor
 Kopia uses `pattern-based` ignore rules to omit folders and files from snapshots. While scanning directories and their content, Kopia looks explicitly for files that contain such rules. 
 If such a file is placed within a directory, `Kopia` omits files and folders `matching` the rules.
 
->NOTE The default file is called `.kopiaignore`. However, ignore rules can be specified within the global or snapshot-specific `policy` - either directly or by providing a path to file containing such rules.   
+>NOTE The default file is called `.kopiaignore`. However, ignore rules can be specified within the global or snapshot-specific `policy` - either directly or by providing a path to a file containing such rules.
 
->NOTE On Windows, use forward slashes (`/`) as path separators in ignore rules, including rules entered directly in a policy or loaded from a `.kopiaignore` file. Backslashes (`\`) copied from Windows paths are not supported. For example, use `Documents/cache/*` instead of `Documents\cache\*`.
+>NOTE On Windows, use forward slashes (`/`) as path separators in ignore rules, including rules entered directly in a `policy` or loaded from a `.kopiaignore` file. Backslashes (`\`) copied from Windows paths are not supported. For example, use `Documents/cache/*` instead of `Documents\cache\*`.
 
 In the following, we explain different rules and provide examples to create `.kopiaignore` files.
 


### PR DESCRIPTION
## Summary

Document the Windows path separator requirement for snapshot ignore rules.

Windows users must use forward slashes in `.kopiaignore` files and policy rules. The documentation now shows the equivalent forward-slash form and explains that backslashes copied from Windows paths are not supported by the ignore matcher.

Fixes #5582

## Tests

- `git diff --check` passed.
- `go test ./internal/wcmatch ./fs/ignorefs` passed.
- Hugo site build was not run locally because Hugo is not installed.

## AI Disclosure

OpenCode using the gpt-5.6-sol model assisted with repository research and prepared the initial documentation patch. The human submitter reviewed the wording and validation details before submission.