### PR TITLE
fix(content): don't panic when flushing delete marker after transient storage failure

### DIFF
--- a/repo/content/content_manager.go
+++ b/repo/content/content_manager.go
@@ -405,9 +405,11 @@ func (bm *WriteManager) verifyPackIndexBuilderLocked(mp format.MutableParameters
 	for k, cpi := range bm.packIndexBuilder {
 		assertInvariant(cpi.ContentID == k, "content ID entry has invalid key: %v %v", cpi.ContentID, k)
 
-		if cpi.Deleted {
-			assertInvariant(cpi.PackBlobID == "", "content can't be both deleted and have a pack content: %v", cpi.ContentID)
-		} else {
+		// deleted entries legitimately keep their original pack location so
+		// that deleted contents remain readable; they are moved into a new
+		// index rather than being written to a pack, so only non-deleted
+		// entries carry the assertions below.
+		if !cpi.Deleted {
 			assertInvariant(cpi.PackBlobID != "", "content that's not deleted must have a pack content: %+v", cpi)
 			assertInvariant(format.Version(cpi.FormatVersion) == mp.Version, "content that's not deleted must have a valid format version: %+v", cpi)
 		}

--- a/repo/content/delete_marker_flush_test.go
+++ b/repo/content/delete_marker_flush_test.go
@@ -1,0 +1,68 @@
+package content
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/gather"
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/repo/format"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteMarkerFlushTransientFailure verifies that deleting a committed
+// content and hitting a transient storage failure during the subsequent
+// Flush surfaces the storage error (instead of panicking on the
+// packIndexBuilder invariant), and that retrying the flush after the
+// transient failure persists the deletion marker: after reopening, the
+// content is reported deleted while remaining readable (tombstone keeps
+// the original pack location).
+func TestDeleteMarkerFlushTransientFailure(t *testing.T) {
+	ctx := testlogging.Context(t)
+
+	data := blobtesting.DataMap{}
+	st := blobtesting.NewMapStorage(data, nil, nil)
+	faulty := blobtesting.NewFaultyStorage(st)
+
+	s := &contentManagerSuite{mutableParameters: format.MutableParameters{
+		Version:      1,
+		IndexVersion: 1,
+		MaxPackSize:  maxPackSize,
+	}}
+
+	bm := s.newTestContentManager(t, faulty)
+	payload := seededRandomData(9, 100)
+
+	id, err := bm.WriteContent(ctx, gather.FromSlice(payload), "", NoCompression)
+	require.NoError(t, err)
+	require.NoError(t, bm.Flush(ctx))
+	require.NoError(t, bm.CloseShared(ctx))
+
+	// reopen so the content only exists in the committed index.
+	bm = s.newTestContentManager(t, faulty)
+
+	require.NoError(t, bm.DeleteContent(ctx, id))
+
+	errFlush := errors.New("transient put failure")
+	faulty.AddFault(blobtesting.MethodPutBlob).ErrorInstead(errFlush)
+
+	// transient failure must surface as an error, not a panic.
+	require.ErrorIs(t, bm.Flush(ctx), errFlush)
+	faulty.VerifyAllFaultsExercised(t)
+
+	// with the fault consumed, the retry persists the deleted marker.
+	require.NoError(t, bm.Flush(ctx))
+	require.NoError(t, bm.CloseShared(ctx))
+
+	// a fresh manager reflects the persisted deletion marker and the
+	// deleted content remains readable (tombstone keeps pack location).
+	bm = s.newTestContentManager(t, faulty)
+	defer bm.CloseShared(ctx)
+
+	ci, err := bm.ContentInfo(ctx, id)
+	require.NoError(t, err)
+	require.True(t, ci.Deleted)
+
+	verifyContent(ctx, t, bm, id, payload)
+}


### PR DESCRIPTION
## Summary

`DeleteContent` of a committed content followed by a `Flush()` that hits a
transient `PutBlob` failure (e.g. S3 5xx during index blob upload) panics
instead of returning the storage error:

```
panic: content can't be both deleted and have a pack content: <ID>
```

## Root cause

`verifyPackIndexBuilderLocked` asserts deleted entries must have an empty `PackBlobID`, but deletion markers deliberately keep the original pack location so deleted contents remain readable (`deletedInfo()` preserves pack fields; `preparePackDataContent()` moves them into the new index without writing pack data). The assertion went unnoticed because a successful flush clears the builder before the invariant check at unlock — on a transient index-write failure the valid tombstone is still in the builder and the process panics before the error reaches the caller.

## Fix

Apply the pack/format assertions only to non-deleted entries.

## Testing

- New `TestDeleteMarkerFlushTransientFailure`: transient failure surfaces as an error, retry persists the marker, deleted content stays readable after reopen.
- `go test ./repo/content/` — 313 passed.