### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.19.2
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.14.2
-	github.com/kopia/htmluibuild v0.0.1-0.20260902000125-afc29e78fce1
+	github.com/kopia/htmluibuild v0.0.1-0.20260905194626-d0bf838bed90
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/minio/minio-go/v7 v7.3.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.14.2 h1:SafJYwpBBQBI6amHUygcjxZjXeN2HpiENHQDwuPWCCQ=
 github.com/klauspost/reedsolomon v1.14.2/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
-github.com/kopia/htmluibuild v0.0.1-0.20260902000125-afc29e78fce1 h1:NMiAmjW5twIC+Spri/Gf/Oav5ETdJE2A6l1rxqmI24c=
-github.com/kopia/htmluibuild v0.0.1-0.20260902000125-afc29e78fce1/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260905194626-d0bf838bed90 h1:bNrRPtxvLPitGTU/K1DrD160GGWtASMJHH6Dmt1INGw=
+github.com/kopia/htmluibuild v0.0.1-0.20260905194626-d0bf838bed90/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/4868e7a91350161bd9da3b08c4555977595e4b4a...77c38c48f85f0d2b4c6e0e598f5d058611491a24

* 83 seconds ago https://github.com/kopia/htmlui/commit/77c38c4 dependabot[bot] build(deps-dev): bump @humanfs/node from 0.16.6 to 0.16.8

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Sat Sep  5 19:46:50 UTC 2026*
