### PR TITLE
refactor(repository): make index v1 key length check consistent

### DIFF
--- a/repo/content/index/index_v1.go
+++ b/repo/content/index/index_v1.go
@@ -284,7 +284,7 @@ func buildV1(allContents []*Info, output io.Writer) error {
 
 	if b1.keyLength == -1 {
 		b1.keyLength = unknownKeySize
-	} else if b1.keyLength < 1 || b1.keyLength > maxContentIDSize {
+	} else if b1.keyLength <= 1 || b1.keyLength > maxContentIDSize {
 		return errors.Wrapf(errInvalidKeySize, "key length=%d", b1.keyLength)
 	}
 


### PR DESCRIPTION
This makes the index-build-time keyLength check consistent with the corresponding index read check. This is also consistent with the checks performed in index v2.

Ref:

- #5247
- [automated review comment](https://github.com/kopia/kopia/pull/5247/changes/BASE..7522595ee2a7869ae9c780e092a188fa5a875610#r3927619716)