### PR TITLE
refactor(repository): cleanup content ID internal `const` definitions

### DIFF
--- a/repo/content/index/content_id_to_bytes.go
+++ b/repo/content/index/content_id_to_bytes.go
@@ -10,7 +10,7 @@ func bytesToContentID(b []byte) ID {
 		return ID{}
 	}
 
-	if len(b) > maxIDLength+1 {
+	if len(b) > maxContentIDSize {
 		panic(fmt.Sprintf("Content ID byte slice is longer than the maximum supported ID: %d", len(b)))
 	}
 

--- a/repo/content/index/id.go
+++ b/repo/content/index/id.go
@@ -30,7 +30,10 @@ func (p IDPrefix) ValidateSingle() error {
 }
 
 const (
-	maxIDDataLength = hashing.MaxHashSize
+	maxIDDataLength  = hashing.MaxHashSize
+	maxContentIDSize = maxIDDataLength + 1
+
+	unknownKeySize = 255
 
 	maxUInt8 = 255
 

--- a/repo/content/index/id.go
+++ b/repo/content/index/id.go
@@ -35,19 +35,20 @@ const (
 
 	unknownKeySize = 255
 
-	maxUInt8 = 255
+	// ensure maxContentIDSize < unknownKeySize.
+	_ uint8 = unknownKeySize - maxContentIDSize - 1
 
-	// maxIDLength needs to be less or equal than maxUInt8 and at least 8 bytes.
-	_ uint = maxUInt8 - maxIDDataLength
+	maxUInt8 = 255
+	// keep maxUInt8 untyped int and ensure it fits in uint8.
+	_ uint8 = maxUInt8
 )
 
 func _() {
 	var (
 		id ID
 
-		// verify len(ID.data) <= maxUInt8 and > 0
-		_ = uint(len(id.data))
-		_ = uint(maxUInt8 - len(id.data))
+		// verify len(ID.data) + 1 < 255 (unkownKeySize)
+		_ = uint8(unknownKeySize - 2 - len(id.data))
 	)
 }
 

--- a/repo/content/index/id.go
+++ b/repo/content/index/id.go
@@ -30,12 +30,12 @@ func (p IDPrefix) ValidateSingle() error {
 }
 
 const (
-	maxIDLength = hashing.MaxHashSize
+	maxIDDataLength = hashing.MaxHashSize
 
 	maxUInt8 = 255
 
 	// maxIDLength needs to be less or equal than maxUInt8 and at least 8 bytes.
-	_ uint = maxUInt8 - maxIDLength
+	_ uint = maxUInt8 - maxIDDataLength
 )
 
 func _() {
@@ -52,7 +52,7 @@ func _() {
 //
 //nolint:recvcheck
 type ID struct {
-	data [maxIDLength]byte
+	data [maxIDDataLength]byte
 
 	// those 2 could be packed into one byte, but that seems like overkill
 	prefix byte

--- a/repo/content/index/id.go
+++ b/repo/content/index/id.go
@@ -47,7 +47,7 @@ func _() {
 	var (
 		id ID
 
-		// verify len(ID.data) + 1 < 255 (unkownKeySize)
+		// verify len(ID.data) + 1 < 255 (unknownKeySize)
 		_ = uint8(unknownKeySize - 2 - len(id.data))
 	)
 }

--- a/repo/content/index/index.go
+++ b/repo/content/index/index.go
@@ -5,13 +5,6 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
-
-	"github.com/kopia/kopia/repo/hashing"
-)
-
-const (
-	maxContentIDSize = hashing.MaxHashSize + 1
-	unknownKeySize   = 255
 )
 
 // Index is a read-only index of packed contents.


### PR DESCRIPTION
- nit: use `maxContenIDSize` instead of `maxIDLength+1`
- nit: rename const to `maxIDDataLength`
- nit: group `const` definitions
- simplify and tighten id length assertions