### PR TITLE
fix(snapshots): Run snapshot-root actions for single files

### DIFF
--- a/snapshot/upload/upload.go
+++ b/snapshot/upload/upload.go
@@ -496,6 +496,33 @@ func (u *Uploader) uploadFileWithCheckpointing(ctx context.Context, relativePath
 	cancelCheckpointer := u.periodicallyCheckpoint(ctx, &cp, prototypeManifest)
 	defer cancelCheckpointer()
 
+	var hc actionContext
+	defer cleanupActionContext(ctx, &hc)
+
+	localFilePathOrEmpty := file.LocalFilesystemPath()
+
+	overrideFile, err := u.executeBeforeFileAction(ctx, pol.Actions.BeforeSnapshotRoot, file, &hc)
+	if err != nil {
+		return nil, errors.Wrap(err, "error executing before-snapshot-root action")
+	}
+
+	defer u.executeAfterFolderAction(ctx, "after-snapshot-root", pol.Actions.AfterSnapshotRoot, localFilePathOrEmpty, &hc)
+
+	if overrideFile != nil {
+		file = overrideFile
+		defer file.Close()
+	} else if hc.ActionsEnabled && pol.Actions.BeforeSnapshotRoot != nil && pol.Actions.BeforeSnapshotRoot.Mode != "async" {
+		refreshedFile, err := refreshFileEntry(ctx, file)
+		if err != nil {
+			return nil, err
+		}
+
+		if refreshedFile != nil {
+			file = refreshedFile
+			defer file.Close()
+		}
+	}
+
 	res, err := u.uploadFileInternal(ctx, &cp, relativePath, file, pol)
 	if err != nil {
 		return nil, err

--- a/snapshot/upload/upload_actions.go
+++ b/snapshot/upload/upload_actions.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/repo"
+	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
 )
 
@@ -195,16 +196,81 @@ func parseCaptures(v []byte, captures map[string]string) error {
 }
 
 func (u *Uploader) executeBeforeFolderAction(ctx context.Context, actionType string, h *policy.ActionCommand, dirPathOrEmpty string, hc *actionContext) (fs.Directory, error) {
-	if h == nil {
-		return nil, nil
+	p, err := u.executeBeforeAction(ctx, actionType, h, dirPathOrEmpty, hc)
+	if err != nil || p == "" {
+		return nil, err
 	}
 
-	if err := hc.ensureInitialized(ctx, actionType, dirPathOrEmpty, u.EnableActions); err != nil {
-		return nil, errors.Wrap(err, "error initializing action context")
+	d, err := localfs.Directory(p)
+
+	return d, errors.Wrap(err, "error getting local directory specified in KOPIA_SNAPSHOT_PATH")
+}
+
+func (u *Uploader) executeBeforeFileAction(ctx context.Context, h *policy.ActionCommand, file fs.File, hc *actionContext) (fs.File, error) {
+	p, err := u.executeBeforeAction(ctx, "before-snapshot-root", h, file.LocalFilesystemPath(), hc)
+	if err != nil || p == "" {
+		return nil, err
+	}
+
+	e, err := localfs.NewEntry(p)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting local file specified in KOPIA_SNAPSHOT_PATH")
+	}
+
+	f, ok := e.(fs.File)
+	if !ok {
+		e.Close()
+
+		return nil, errors.Errorf("not a file specified in KOPIA_SNAPSHOT_PATH: %v", p)
+	}
+
+	return f, nil
+}
+
+func refreshFileEntry(ctx context.Context, file fs.File) (fs.File, error) {
+	if pf, ok := file.(snapshot.HasDirEntryOrNil); ok {
+		de, err := pf.DirEntryOrNil(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "can't read placeholder")
+		}
+
+		if de != nil {
+			return nil, nil
+		}
+	}
+
+	r, err := file.Open(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to open file after before-snapshot-root action")
+	}
+	defer r.Close() //nolint:errcheck
+
+	e, err := r.Entry()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to refresh file after before-snapshot-root action")
+	}
+
+	f, ok := e.(fs.File)
+	if !ok {
+		e.Close()
+
+		return nil, errors.New("not a file after before-snapshot-root action")
+	}
+
+	return f, nil
+}
+
+func (u *Uploader) executeBeforeAction(ctx context.Context, actionType string, h *policy.ActionCommand, pathOrEmpty string, hc *actionContext) (string, error) {
+	if h == nil {
+		return "", nil
+	}
+
+	if err := hc.ensureInitialized(ctx, actionType, pathOrEmpty, u.EnableActions); err != nil {
+		return "", errors.Wrap(err, "error initializing action context")
 	}
 
 	if !hc.ActionsEnabled {
-		return nil, nil
+		return "", nil
 	}
 
 	uploadLog(ctx).Debugf("running action %v on %v %#v", actionType, hc.SourcePath, *h)
@@ -214,17 +280,16 @@ func (u *Uploader) executeBeforeFolderAction(ctx context.Context, actionType str
 	}
 
 	if err := runActionCommand(ctx, actionType, h, hc.envars(actionType), captures, hc.WorkDir); err != nil {
-		return nil, errors.Wrapf(err, "error running '%v' action", actionType)
+		return "", errors.Wrapf(err, "error running '%v' action", actionType)
 	}
 
 	if p := captures["KOPIA_SNAPSHOT_PATH"]; p != "" {
 		hc.SnapshotPath = p
-		d, err := localfs.Directory(hc.SnapshotPath)
 
-		return d, errors.Wrap(err, "error getting local directory specified in KOPIA_SNAPSHOT_PATH")
+		return p, nil
 	}
 
-	return nil, nil
+	return "", nil
 }
 
 func (u *Uploader) executeAfterFolderAction(ctx context.Context, actionType string, h *policy.ActionCommand, dirPathOrEmpty string, hc *actionContext) {

--- a/snapshot/upload/upload_test.go
+++ b/snapshot/upload/upload_test.go
@@ -196,6 +196,31 @@ type entry struct {
 	objectID object.ID
 }
 
+func TestUpload_SingleFileActionsNonLocal(t *testing.T) {
+	t.Parallel()
+
+	ctx := testlogging.Context(t)
+	th := newUploadTestHarness(ctx, t)
+	t.Cleanup(th.cleanup)
+
+	u := NewUploader(th.repo)
+	u.EnableActions = true
+
+	action := &policy.ActionCommand{
+		Command: filepath.Join(testutil.TempDirectory(t), "missing-command"),
+		Mode:    "essential",
+	}
+	pol := *policy.DefaultPolicy
+	pol.Actions.BeforeSnapshotRoot = action
+	pol.Actions.AfterSnapshotRoot = action
+	source := mockfs.NewFile("source", []byte("snapshot contents"), defaultPermissions)
+	require.Empty(t, source.LocalFilesystemPath())
+
+	man, err := u.Upload(ctx, source, policy.BuildTree(nil, &pol), snapshot.SourceInfo{})
+	require.NoError(t, err)
+	require.EqualValues(t, len("snapshot contents"), man.RootEntry.FileSize)
+}
+
 // findAllEntries recursively iterates over all the dirs and returns list of file entries.
 func findAllEntries(t *testing.T, ctx context.Context, dir fs.Directory) []entry {
 	t.Helper()

--- a/tests/end_to_end_test/snapshot_actions_test.go
+++ b/tests/end_to_end_test/snapshot_actions_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/kopia/kopia/fs/localfs"
 	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/internal/timetrack"
 	"github.com/kopia/kopia/snapshot"
@@ -161,6 +162,246 @@ func TestSnapshotActionsBeforeSnapshotRoot(t *testing.T) {
 	if got, want := snaps1[len(snaps1)-1].ObjectID, snaps1[0].ObjectID; got != want {
 		t.Fatalf("invalid snapshot ID after async action %v, wanted %v", got, want)
 	}
+}
+
+func TestSnapshotActionsSingleFile(t *testing.T) {
+	t.Parallel()
+
+	th := skipUnlessTestAction(t)
+	logsDir := testutil.TempLogDirectory(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--enable-actions")
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	sourceFile := tmpfileWithContents(t, "original contents")
+	beforeFile := tmpfileWithContents(t, "before snapshot")
+	afterFile := tmpfileWithContents(t, "after snapshot")
+	beforeEnvFile := filepath.Join(logsDir, "before-env.txt")
+	afterEnvFile := filepath.Join(logsDir, "after-env.txt")
+	sessionFile := filepath.Join(logsDir, "session.txt")
+	beforeCopy := tmpfileWithContents(t, beforeFile+" => $KOPIA_SOURCE_PATH\n")
+	afterCopy := tmpfileWithContents(t, afterFile+" => $KOPIA_SOURCE_PATH\nsession => "+sessionFile+"\n")
+
+	e.RunAndExpectSuccess(t, "policy", "set", "--global",
+		"--before-snapshot-root-action", th+" --copy-files="+beforeCopy+" --save-env="+beforeEnvFile+" --create-file=session")
+	e.RunAndExpectSuccess(t, "policy", "set", sourceFile,
+		"--after-snapshot-root-action", th+" --copy-files="+afterCopy+" --save-env="+afterEnvFile)
+
+	var previousSnapshotID string
+
+	for range 2 {
+		oldTime := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+		require.NoError(t, os.Chtimes(sourceFile, oldTime, oldTime))
+
+		var man snapshot.Manifest
+
+		testutil.MustParseJSONLines(t, e.RunAndExpectSuccess(t, "snapshot", "create", sourceFile, "--json"), &man)
+		require.Equal(t, []string{"before snapshot"}, e.RunAndExpectSuccess(t, "show", man.RootObjectID().String()))
+		require.EqualValues(t, len("before snapshot"), man.RootEntry.FileSize)
+		require.True(t, man.RootEntry.ModTime.ToTime().After(oldTime))
+
+		contents, err := os.ReadFile(sourceFile)
+		require.NoError(t, err)
+		require.Equal(t, "after snapshot", string(contents))
+		verifyFileExists(t, sessionFile)
+
+		beforeEnv := mustReadEnvFile(t, beforeEnvFile)
+		afterEnv := mustReadEnvFile(t, afterEnvFile)
+		require.Equal(t, "before-snapshot-root", beforeEnv["KOPIA_ACTION"])
+		require.Equal(t, "after-snapshot-root", afterEnv["KOPIA_ACTION"])
+		require.NotEmpty(t, beforeEnv["KOPIA_SNAPSHOT_ID"])
+		require.NotEqual(t, previousSnapshotID, beforeEnv["KOPIA_SNAPSHOT_ID"])
+
+		for _, name := range []string{"KOPIA_SNAPSHOT_ID", "KOPIA_SOURCE_PATH", "KOPIA_SNAPSHOT_PATH", "KOPIA_VERSION"} {
+			require.Equal(t, beforeEnv[name], afterEnv[name], name)
+		}
+
+		require.Equal(t, sourceFile, beforeEnv["KOPIA_SOURCE_PATH"])
+		require.Equal(t, sourceFile, beforeEnv["KOPIA_SNAPSHOT_PATH"])
+		require.NotEmpty(t, beforeEnv["KOPIA_VERSION"])
+
+		previousSnapshotID = beforeEnv["KOPIA_SNAPSHOT_ID"]
+	}
+}
+
+func TestSnapshotActionsSingleFileFailures(t *testing.T) {
+	t.Parallel()
+
+	th := skipUnlessTestAction(t)
+
+	for _, tc := range []struct {
+		name          string
+		beforeMode    string
+		beforeExit    string
+		afterExit     string
+		actions       bool
+		wantFailure   bool
+		wantBeforeRun bool
+		wantAfterRun  bool
+	}{
+		{"essential before", "essential", "3", "0", true, true, true, false},
+		{"optional before", "optional", "3", "0", true, false, true, true},
+		{"essential after", "essential", "0", "3", true, false, true, true},
+		{"after only", "", "0", "0", true, false, false, true},
+		{"disabled", "essential", "3", "3", false, false, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logsDir := testutil.TempLogDirectory(t)
+			e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+			flags := []string{"repo", "create", "filesystem", "--path", e.RepoDir}
+			if tc.actions {
+				flags = append(flags, "--enable-actions")
+			}
+
+			e.RunAndExpectSuccess(t, flags...)
+			defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+			sourceFile := tmpfileWithContents(t, "snapshot contents")
+			beforeEnvFile := filepath.Join(logsDir, "before-env.txt")
+			afterEnvFile := filepath.Join(logsDir, "after-env.txt")
+
+			if tc.beforeMode != "" {
+				e.RunAndExpectSuccess(t, "policy", "set", sourceFile,
+					"--before-snapshot-root-action", th+" --exit-code="+tc.beforeExit+" --save-env="+beforeEnvFile,
+					"--action-command-mode="+tc.beforeMode)
+			}
+
+			e.RunAndExpectSuccess(t, "policy", "set", sourceFile,
+				"--after-snapshot-root-action", th+" --exit-code="+tc.afterExit+" --save-env="+afterEnvFile)
+
+			if tc.wantFailure {
+				e.RunAndExpectFailure(t, "snapshot", "create", sourceFile)
+				require.Empty(t, clitestutil.ListSnapshotsAndExpectSuccess(t, e, sourceFile))
+			} else {
+				e.RunAndExpectSuccess(t, "snapshot", "create", sourceFile)
+			}
+
+			for envFile, wantRun := range map[string]bool{beforeEnvFile: tc.wantBeforeRun, afterEnvFile: tc.wantAfterRun} {
+				if wantRun {
+					verifyFileExists(t, envFile)
+				} else {
+					require.NoFileExists(t, envFile)
+				}
+			}
+		})
+	}
+}
+
+func TestSnapshotActionsSingleFileRedirection(t *testing.T) {
+	t.Parallel()
+
+	th := skipUnlessTestAction(t)
+
+	for _, tc := range []struct {
+		name        string
+		target      string
+		wantFailure bool
+	}{
+		{"file", tmpfileWithContents(t, "redirected contents"), false},
+		{"directory", testutil.TempDirectory(t), true},
+		{"missing", filepath.Join(testutil.TempDirectory(t), "missing"), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logsDir := testutil.TempLogDirectory(t)
+			e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+			e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--enable-actions")
+			defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+			sourceFile := tmpfileWithContents(t, "original contents")
+			redirectFile := tmpfileWithContents(t, "KOPIA_SNAPSHOT_PATH="+tc.target+"\n")
+			afterEnvFile := filepath.Join(logsDir, "after-env.txt")
+
+			e.RunAndExpectSuccess(t, "policy", "set", sourceFile,
+				"--before-snapshot-root-action", th+" --stdout-file="+redirectFile)
+			e.RunAndExpectSuccess(t, "policy", "set", sourceFile,
+				"--after-snapshot-root-action", th+" --save-env="+afterEnvFile)
+
+			if tc.wantFailure {
+				e.RunAndExpectFailure(t, "snapshot", "create", sourceFile)
+				require.Empty(t, clitestutil.ListSnapshotsAndExpectSuccess(t, e, sourceFile))
+				require.NoFileExists(t, afterEnvFile)
+
+				return
+			}
+
+			var man snapshot.Manifest
+
+			testutil.MustParseJSONLines(t, e.RunAndExpectSuccess(t, "snapshot", "create", sourceFile, "--json"), &man)
+			require.Equal(t, []string{"redirected contents"}, e.RunAndExpectSuccess(t, "show", man.RootObjectID().String()))
+			require.EqualValues(t, len("redirected contents"), man.RootEntry.FileSize)
+			require.Equal(t, sourceFile, man.Source.Path)
+
+			afterEnv := mustReadEnvFile(t, afterEnvFile)
+			require.Equal(t, sourceFile, afterEnv["KOPIA_SOURCE_PATH"])
+			require.Equal(t, tc.target, afterEnv["KOPIA_SNAPSHOT_PATH"])
+		})
+	}
+}
+
+func TestSnapshotActionsSingleFileUploadFailure(t *testing.T) {
+	t.Parallel()
+
+	th := skipUnlessTestAction(t)
+	logsDir := testutil.TempLogDirectory(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--enable-actions")
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	sourceFile := tmpfileWithContents(t, "snapshot contents")
+	afterEnvFile := filepath.Join(logsDir, "after-env.txt")
+
+	removeScript := `rm "$KOPIA_SOURCE_PATH"`
+	if runtime.GOOS == windowsOSName {
+		removeScript = `del "%KOPIA_SOURCE_PATH%"`
+	}
+
+	e.RunAndExpectSuccess(t, "policy", "set", sourceFile,
+		"--before-snapshot-root-action", tmpfileWithContents(t, removeScript), "--persist-action-script")
+	e.RunAndExpectSuccess(t, "policy", "set", sourceFile,
+		"--after-snapshot-root-action", th+" --save-env="+afterEnvFile)
+
+	e.RunAndExpectFailure(t, "snapshot", "create", sourceFile)
+	require.NoFileExists(t, sourceFile)
+	require.Empty(t, clitestutil.ListSnapshotsAndExpectSuccess(t, e, sourceFile))
+	require.Equal(t, sourceFile, mustReadEnvFile(t, afterEnvFile)["KOPIA_SOURCE_PATH"])
+}
+
+func TestSnapshotActionsSingleFileShallow(t *testing.T) {
+	t.Parallel()
+
+	th := skipUnlessTestAction(t)
+	logsDir := testutil.TempLogDirectory(t)
+	e := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
+
+	e.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", e.RepoDir, "--enable-actions")
+	defer e.RunAndExpectSuccess(t, "repo", "disconnect")
+
+	var original snapshot.Manifest
+
+	testutil.MustParseJSONLines(t, e.RunAndExpectSuccess(t, "snapshot", "create", tmpfileWithContents(t, "snapshot contents"), "--json"), &original)
+	placeholder, err := localfs.WriteShallowPlaceholder(filepath.Join(testutil.TempDirectory(t), "placeholder"), original.RootEntry)
+	require.NoError(t, err)
+
+	beforeEnvFile := filepath.Join(logsDir, "before-env.txt")
+	afterEnvFile := filepath.Join(logsDir, "after-env.txt")
+	e.RunAndExpectSuccess(t, "policy", "set", "--global",
+		"--before-snapshot-root-action", th+" --save-env="+beforeEnvFile,
+		"--after-snapshot-root-action", th+" --save-env="+afterEnvFile)
+
+	var man snapshot.Manifest
+
+	testutil.MustParseJSONLines(t, e.RunAndExpectSuccess(t, "snapshot", "create", placeholder, "--json"), &man)
+	require.Equal(t, original.RootObjectID(), man.RootObjectID())
+	verifyFileExists(t, beforeEnvFile)
+	verifyFileExists(t, afterEnvFile)
 }
 
 func TestSnapshotActionsBeforeAfterFolder(t *testing.T) {


### PR DESCRIPTION
When a snapshot source is a single file, its before/after snapshot-root actions are skipped. Run these actions around file uploads with the same policy, environment, and error handling used for directory snapshots. Keep directory traversal and filesystem snapshot behavior unchanged.

Support file redirection through `KOPIA_SNAPSHOT_PATH` and refresh file metadata after synchronous before-actions, preserving local read options and shallow placeholders. Add regression coverage for action ordering, inherited policies, shared action sessions, changed contents and metadata, redirection, failures, and disabled or nonlocal actions.

Fixes #3250.

Validation on macOS arm64 with Go 1.26.8:

- New regression fails before the fix: the snapshot contains the original contents instead of the contents written by the before-action.
- All snapshot-action end-to-end tests and the nonlocal-file unit regression pass.
- `make -j4 test`: 6474 tests, 109 skipped; all test packages passed.
- `make test UNIT_TEST_RACE_FLAGS=-race UNIT_TESTS_TIMEOUT=1200s`: 5490 tests, 109 skipped; all test packages passed with the race detector.
- `make lint`: no issues.
- `make install-noui`, CLI `--help`, `make vet check-locks`, and `make license-check` pass.
- Both affected test packages compile for Windows amd64; Windows execution is left to upstream CI.
