### PR TITLE
refactor(server): avoid indenting JSON payload in responses

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -388,7 +388,6 @@ func (s *Server) handleRequestPossiblyNotConnected(isAuthorized isAuthorizedFunc
 		rc.w.Header().Set("Content-Type", "application/json")
 
 		e := json.NewEncoder(rc.w)
-		e.SetIndent("", "  ")
 
 		var (
 			v   any


### PR DESCRIPTION
This can, and should, be done on the client-side when needed for troubleshooting.