### PR TITLE
refactor(general): propagate `TLSConfigTrustingSingleCertificate` error

### DIFF
--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -207,13 +207,16 @@ type Options struct {
 
 // NewKopiaAPIClient creates a client for connecting to Kopia HTTP API.
 func NewKopiaAPIClient(options Options) (*KopiaAPIClient, error) {
-	var transport http.RoundTripper
+	transport := http.DefaultTransport
 
 	// override transport which trusts only one certificate
 	if f := options.TrustedServerCertificateFingerprint; f != "" {
-		transport = tlsutil.TransportTrustingSingleCertificate(f)
-	} else {
-		transport = http.DefaultTransport
+		tr, err := tlsutil.TransportTrustingSingleCertificate(f)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create transport")
+		}
+
+		transport = tr
 	}
 
 	uri := options.BaseURL

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -129,34 +129,35 @@ func WriteCertificateToFile(fname string, cert *x509.Certificate) (err error) {
 
 // TLSConfigTrustingSingleCertificate return tls.Config which trusts exactly one TLS certificate with
 // provided SHA256 fingerprint.
-func TLSConfigTrustingSingleCertificate(sha256Fingerprint string) *tls.Config {
+func TLSConfigTrustingSingleCertificate(sha256Fingerprint string) (*tls.Config, error) {
+	if len(sha256Fingerprint) != sha256.Size*2 {
+		return nil, errors.Errorf("invalid SHA256 fingerprint %q", sha256Fingerprint)
+	}
+
 	sha256FingerprintBytes, err := hex.DecodeString(sha256Fingerprint)
-	if err != nil || len(sha256FingerprintBytes) < sha256.Size {
-		return &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			VerifyPeerCertificate: func(_ [][]byte, _ [][]*x509.Certificate) error {
-				return errors.Errorf("invalid SHA256 fingerprint %q", sha256Fingerprint)
-			},
-			VerifyConnection: func(tls.ConnectionState) error {
-				return errors.Errorf("invalid SHA256 fingerprint %q", sha256Fingerprint)
-			},
-		}
+	if err != nil {
+		return nil, errors.Errorf("invalid SHA256 fingerprint %q", sha256Fingerprint)
 	}
 
 	return &tls.Config{
 		InsecureSkipVerify:    true, //nolint:gosec
 		VerifyPeerCertificate: verifyPeerCertificateFunction(sha256FingerprintBytes),
 		VerifyConnection:      verifyConnectionFunction(sha256FingerprintBytes),
-	}
+	}, nil
 }
 
 // TransportTrustingSingleCertificate return http.RoundTripper which trusts exactly one TLS certificate with
 // provided SHA256 fingerprint.
-func TransportTrustingSingleCertificate(sha256Fingerprint string) http.RoundTripper {
-	t2 := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert
-	t2.TLSClientConfig = TLSConfigTrustingSingleCertificate(sha256Fingerprint)
+func TransportTrustingSingleCertificate(sha256Fingerprint string) (http.RoundTripper, error) {
+	c, err := TLSConfigTrustingSingleCertificate(sha256Fingerprint)
+	if err != nil {
+		return nil, err
+	}
 
-	return t2
+	t2 := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert
+	t2.TLSClientConfig = c
+
+	return t2, nil
 }
 
 func verifyPeerCertificateFunction(sha256FingerprintBytes []byte) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -72,13 +72,15 @@ func TestTransportTrustingSingleCertificate(t *testing.T) {
 }
 
 func TestTransportTrustingSingleCertificate_BadFingerprint(t *testing.T) {
+	const coffee = "coffee"
+
 	cases := []struct {
 		name        string
 		fingerprint string
 	}{
 		{
 			name:        "OddLength",
-			fingerprint: strings.Repeat("a", 33),
+			fingerprint: strings.Repeat("a", 65),
 		},
 		{
 			name:        "TooShort",
@@ -86,11 +88,11 @@ func TestTransportTrustingSingleCertificate_BadFingerprint(t *testing.T) {
 		},
 		{
 			name:        "TooLong",
-			fingerprint: strings.Repeat("a", 42),
+			fingerprint: strings.Repeat("a", 66),
 		},
 		{
 			name:        "NotHex",
-			fingerprint: "coffee",
+			fingerprint: coffee + strings.Repeat("a", 64-len(coffee)),
 		},
 	}
 

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -47,7 +47,8 @@ func TestTransportTrustingSingleCertificate(t *testing.T) {
 	h := sha256.Sum256(cert.Raw)
 	fingerprint := hex.EncodeToString(h[:])
 
-	transport := tlsutil.TransportTrustingSingleCertificate(fingerprint)
+	transport, err := tlsutil.TransportTrustingSingleCertificate(fingerprint)
+	require.NoError(t, err)
 	require.NotNil(t, transport)
 
 	// Testing the VerifyPeerCertificate function
@@ -71,13 +72,6 @@ func TestTransportTrustingSingleCertificate(t *testing.T) {
 }
 
 func TestTransportTrustingSingleCertificate_BadFingerprint(t *testing.T) {
-	ctx := t.Context()
-	certValid := 24 * time.Hour
-	names := []string{"127.0.0.1", "localhost"}
-
-	cert, _, err := tlsutil.GenerateServerCertificate(ctx, 2048, certValid, names)
-	require.NoError(t, err, "generating server cert")
-
 	cases := []struct {
 		name        string
 		fingerprint string
@@ -102,15 +96,10 @@ func TestTransportTrustingSingleCertificate_BadFingerprint(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			transport := tlsutil.TransportTrustingSingleCertificate(testCase.fingerprint)
-			require.NotNil(t, transport)
-
-			verifyPeerCertificate := transport.(*http.Transport).TLSClientConfig.VerifyPeerCertificate //nolint:forcetypeassert
-
-			rawCerts := [][]byte{cert.Raw}
-			err := verifyPeerCertificate(rawCerts, nil)
+			transport, err := tlsutil.TransportTrustingSingleCertificate(testCase.fingerprint)
 			require.Error(t, err)
 			require.ErrorContains(t, err, "invalid SHA256 fingerprint")
+			require.Nil(t, transport)
 		})
 	}
 }
@@ -140,13 +129,19 @@ func TestTransportTrustingSingleClientCertificate_TestClientFlow(t *testing.T) {
 		{
 			name: "NoResume",
 			getTransport: func() *http.Transport {
-				return tlsutil.TransportTrustingSingleCertificate(fingerprint).(*http.Transport) //nolint:forcetypeassert
+				tr, err := tlsutil.TransportTrustingSingleCertificate(fingerprint)
+				require.NoError(t, err)
+
+				return tr.(*http.Transport) //nolint:forcetypeassert
 			},
 		},
 		{
 			name: "Resume",
 			getTransport: func() *http.Transport {
-				transport := tlsutil.TransportTrustingSingleCertificate(fingerprint).(*http.Transport) //nolint:forcetypeassert
+				tr, err := tlsutil.TransportTrustingSingleCertificate(fingerprint)
+				require.NoError(t, err)
+
+				transport := tr.(*http.Transport) //nolint:forcetypeassert
 				transport.TLSClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(0)
 
 				return transport

--- a/repo/blob/rclone/rclone_storage.go
+++ b/repo/blob/rclone/rclone_storage.go
@@ -364,13 +364,14 @@ func New(ctx context.Context, opt *Options, isCreate bool) (blob.Storage, error)
 	fingerprintBytes := sha256.Sum256(cert.Raw)
 	fingerprintHexString := hex.EncodeToString(fingerprintBytes[:])
 
-	var cli http.Client
-
-	cli.Transport = &http.Transport{
-		TLSClientConfig: tlsutil.TLSConfigTrustingSingleCertificate(fingerprintHexString),
+	tc, err := tlsutil.TLSConfigTrustingSingleCertificate(fingerprintHexString)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating TLS config")
 	}
 
-	r.remoteControlHTTPClient = &cli
+	r.remoteControlHTTPClient = &http.Client{
+		Transport: &http.Transport{TLSClientConfig: tc},
+	}
 	r.remoteControlUsername = webdavUsername
 	r.remoteControlPassword = webdavPassword
 	r.remoteControlAddr = rcloneUrls.remoteControlAddr

--- a/repo/blob/webdav/webdav_storage.go
+++ b/repo/blob/webdav/webdav_storage.go
@@ -266,7 +266,12 @@ func New(_ context.Context, opts *Options, isCreate bool) (blob.Storage, error) 
 	cli.SetHeader("Accept-Encoding", "identity")
 
 	if opts.TrustedServerCertificateFingerprint != "" {
-		cli.SetTransport(tlsutil.TransportTrustingSingleCertificate(opts.TrustedServerCertificateFingerprint))
+		tr, err := tlsutil.TransportTrustingSingleCertificate(opts.TrustedServerCertificateFingerprint)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating HTTP transport")
+		}
+
+		cli.SetTransport(tr)
 	}
 
 	s := retrying.NewWrapper(&davStorage{

--- a/repo/grpc_repository_client.go
+++ b/repo/grpc_repository_client.go
@@ -893,7 +893,12 @@ func openGRPCAPIRepository(ctx context.Context, si *APIServerInfo, password stri
 	var transportCreds credentials.TransportCredentials
 
 	if si.TrustedServerCertificateFingerprint != "" {
-		transportCreds = credentials.NewTLS(tlsutil.TLSConfigTrustingSingleCertificate(si.TrustedServerCertificateFingerprint))
+		c, err := tlsutil.TLSConfigTrustingSingleCertificate(si.TrustedServerCertificateFingerprint)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating TLS config")
+		}
+
+		transportCreds = credentials.NewTLS(c)
 	} else {
 		transportCreds = credentials.NewClientTLSFromCert(nil, "")
 	}


### PR DESCRIPTION
Improves failure mode by explicitly making returning an error when the provided cert fingerprint is invalid.  The previously existing behavior of creating a transport that fails all connection verification, is often hard to troubleshoot.

Ref:
- #5540
- #5610