### PR TITLE
feat(ui): upgraded htmlui to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/klauspost/compress v1.20.0
 	github.com/klauspost/pgzip v1.2.6
 	github.com/klauspost/reedsolomon v1.14.2
-	github.com/kopia/htmluibuild v0.0.1-0.20260905194626-d0bf838bed90
+	github.com/kopia/htmluibuild v0.0.1-0.20260909034805-ec6d819a7882
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mattn/go-colorable v0.1.15
 	github.com/minio/minio-go/v7 v7.3.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.14.2 h1:SafJYwpBBQBI6amHUygcjxZjXeN2HpiENHQDwuPWCCQ=
 github.com/klauspost/reedsolomon v1.14.2/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
-github.com/kopia/htmluibuild v0.0.1-0.20260905194626-d0bf838bed90 h1:bNrRPtxvLPitGTU/K1DrD160GGWtASMJHH6Dmt1INGw=
-github.com/kopia/htmluibuild v0.0.1-0.20260905194626-d0bf838bed90/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
+github.com/kopia/htmluibuild v0.0.1-0.20260909034805-ec6d819a7882 h1:Rz+6/7t1asb+bi8VZ0dW7likPVxE+rE9ocdIham9ljI=
+github.com/kopia/htmluibuild v0.0.1-0.20260909034805-ec6d819a7882/go.mod h1:h53A5JM3t2qiwxqxusBe+PFgGcgZdS+DWCQvG5PTlto=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=


### PR DESCRIPTION
## Changes

Compare: https://github.com/kopia/htmlui/compare/77c38c48f85f0d2b4c6e0e598f5d058611491a24...047971b3a2e80839ba6ff93bfce63c2430a7157f

* Tue 16:37 -0700 https://github.com/kopia/htmlui/commit/9a53a80 dependabot[bot] build(deps): bump nanoid from 3.3.17 to 3.3.18
* Tue 16:40 -0700 https://github.com/kopia/htmlui/commit/82870e5 dependabot[bot] build(deps): bump @vitest/mocker, @vitest/coverage-v8 and vitest
* Tue 20:19 -0700 https://github.com/kopia/htmlui/commit/d1ea973 dependabot[bot] build(deps-dev): bump typescript from 5.9.3 to 6.0.3
* Tue 20:46 -0700 https://github.com/kopia/htmlui/commit/047971b dependabot[bot] build(deps): bump @fortawesome/fontawesome-svg-core from 6.7.2 to 7.3.1

*This PR description was [auto-generated](https://github.com/kopia/htmluibuild/blob/main/.github/workflows/after-push.yaml) at Wed Sep  9 03:48:27 UTC 2026*
