### PR TITLE
feat(cli): add --path to snapshot fix remove-files

### DIFF
--- a/cli/command_snapshot_fix_remove_files.go
+++ b/cli/command_snapshot_fix_remove_files.go
@@ -50,6 +50,11 @@ func (c *commandSnapshotFixRemoveFiles) rewriteEntry(ctx context.Context, pathFr
 		}
 	}
 
+	// the root's path is ".", which "*" matches; path wildcards apply to the entries below it
+	if pathFromRoot == "." {
+		return ent, nil
+	}
+
 	for _, p := range c.removeFilesByPath {
 		matched, err := path.Match(p, pathFromRoot)
 		if err != nil {
@@ -71,5 +76,25 @@ func (c *commandSnapshotFixRemoveFiles) run(ctx context.Context, rep repo.Reposi
 		return errors.New("must specify files to remove")
 	}
 
+	if err := validateWildcards(c.removeFilesByName); err != nil {
+		return err
+	}
+
+	if err := validateWildcards(c.removeFilesByPath); err != nil {
+		return err
+	}
+
 	return c.common.rewriteMatchingSnapshots(ctx, rep, c.rewriteEntry)
+}
+
+// validateWildcards fails on a malformed pattern before any snapshot is read,
+// since rewriting only reports it when an entry is matched against it.
+func validateWildcards(patterns []string) error {
+	for _, p := range patterns {
+		if _, err := path.Match(p, ""); err != nil {
+			return errors.Wrapf(err, "invalid wildcard %q", p)
+		}
+	}
+
+	return nil
 }

--- a/cli/command_snapshot_fix_remove_files.go
+++ b/cli/command_snapshot_fix_remove_files.go
@@ -16,6 +16,7 @@ type commandSnapshotFixRemoveFiles struct {
 
 	removeObjectIDs   []string
 	removeFilesByName []string
+	removeFilesByPath []string
 }
 
 func (c *commandSnapshotFixRemoveFiles) setup(svc appServices, parent commandParent) {
@@ -24,6 +25,7 @@ func (c *commandSnapshotFixRemoveFiles) setup(svc appServices, parent commandPar
 
 	cmd.Flag("object-id", "Remove files by their object ID").StringsVar(&c.removeObjectIDs)
 	cmd.Flag("filename", "Remove files by filename (wildcards are supported)").StringsVar(&c.removeFilesByName)
+	cmd.Flag("path", "Remove files by path relative to the snapshot root (wildcards are supported)").StringsVar(&c.removeFilesByPath)
 
 	cmd.Action(svc.repositoryWriterActionWithMaintenance(c.run))
 }
@@ -48,11 +50,24 @@ func (c *commandSnapshotFixRemoveFiles) rewriteEntry(ctx context.Context, pathFr
 		}
 	}
 
+	for _, p := range c.removeFilesByPath {
+		matched, err := path.Match(p, pathFromRoot)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid wildcard")
+		}
+
+		if matched {
+			log(ctx).Infof("will remove file %v", pathFromRoot)
+
+			return nil, nil
+		}
+	}
+
 	return ent, nil
 }
 
 func (c *commandSnapshotFixRemoveFiles) run(ctx context.Context, rep repo.RepositoryWriter) error {
-	if len(c.removeObjectIDs)+len(c.removeFilesByName) == 0 {
+	if len(c.removeObjectIDs)+len(c.removeFilesByName)+len(c.removeFilesByPath) == 0 {
 		return errors.New("must specify files to remove")
 	}
 

--- a/cli/command_snapshot_fix_test.go
+++ b/cli/command_snapshot_fix_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -269,6 +270,22 @@ func TestSnapshotFix(t *testing.T) {
 			},
 		},
 		{
+			name:                    "FixRemoveFiles_ByPath",
+			modifyRepoAfterSnapshot: func(env *testenv.CLITest, man *snapshot.Manifest, fileMap map[string]*snapshot.DirEntry) {},
+			flags:                   []string{"remove-files", "--path=dir1", "--path=dir2/small-*", "--path=large-file1"},
+			wantRecoveredFiles: []string{
+				"dir2",
+				"dir2/large-file1",
+				"dir2/large-file1-dup",
+				"dir2/large-file2",
+				"large-file1-dup",
+				"large-file2",
+				"small-file1",
+				"small-file1-dup",
+				"small-file2",
+			},
+		},
+		{
 			name:                    "FixRemoveFiles_ByWildcard",
 			modifyRepoAfterSnapshot: func(env *testenv.CLITest, man *snapshot.Manifest, fileMap map[string]*snapshot.DirEntry) {},
 			flags:                   []string{"remove-files", "--filename=small-*", "--filename=*-dup"},
@@ -360,6 +377,62 @@ func TestSnapshotFix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSnapshotFixRemoveFiles_ByPathIdenticalEntries(t *testing.T) {
+	if testutil.ShouldReduceTestComplexity() {
+		return
+	}
+
+	srcDir := testutil.TempDirectory(t)
+	mtime := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	// same name, contents and modification time, so the two entries differ by path only
+	for _, dir := range []string{"keep", "remove"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(srcDir, dir), 0o700))
+
+		fname := filepath.Join(srcDir, dir, "file")
+		mustWriteFileWithRepeatedData(t, fname, 1, []byte{1, 2, 3})
+		require.NoError(t, os.Chtimes(fname, mtime, mtime))
+	}
+
+	runner := testenv.NewInProcRunner(t)
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+	env.RunAndExpectSuccess(t, "snapshot", "create", srcDir)
+
+	// with one worker the entries are rewritten in order, so the kept entry is
+	// in the rewriter's cache before the entry to remove is looked at
+	env.RunAndExpectSuccess(t, "snapshot", "fix", "remove-files", "--path=remove/file", "--parallel=1", "--commit")
+	env.RunAndExpectSuccess(t, "snapshot", "verify")
+
+	var manifests []cli.SnapshotManifest
+
+	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(t, "snapshot", "list", "--json"), &manifests)
+	require.Len(t, manifests, 1)
+
+	var remainingFiles []string
+
+	for f := range mustGetFileMap(t, env, manifests[0].RootObjectID()) {
+		remainingFiles = append(remainingFiles, f)
+	}
+
+	sort.Strings(remainingFiles)
+	require.Equal(t, []string{"keep", "keep/file", "remove"}, remainingFiles)
+}
+
+func TestSnapshotFixRemoveFiles_ByPathInvalidWildcard(t *testing.T) {
+	srcDir := testutil.TempDirectory(t)
+	mustWriteFileWithRepeatedData(t, filepath.Join(srcDir, "file"), 1, []byte{1, 2, 3})
+
+	runner := testenv.NewInProcRunner(t)
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+	env.RunAndExpectSuccess(t, "snapshot", "create", srcDir)
+
+	env.RunAndExpectFailure(t, "snapshot", "fix", "remove-files", "--path=[", "--parallel=1")
 }
 
 // forgetContents rewrites contents into a new blob and deletes the blob

--- a/cli/command_snapshot_fix_test.go
+++ b/cli/command_snapshot_fix_test.go
@@ -422,9 +422,16 @@ func TestSnapshotFixRemoveFiles_ByPathIdenticalEntries(t *testing.T) {
 	require.Equal(t, []string{"keep", "keep/file", "remove"}, remainingFiles)
 }
 
-func TestSnapshotFixRemoveFiles_ByPathInvalidWildcard(t *testing.T) {
+func TestSnapshotFixRemoveFiles_ByPathRootWildcard(t *testing.T) {
+	if testutil.ShouldReduceTestComplexity() {
+		return
+	}
+
 	srcDir := testutil.TempDirectory(t)
-	mustWriteFileWithRepeatedData(t, filepath.Join(srcDir, "file"), 1, []byte{1, 2, 3})
+
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "dir"), 0o700))
+	mustWriteFileWithRepeatedData(t, filepath.Join(srcDir, "dir", "file"), 1, []byte{1, 2, 3})
+	mustWriteFileWithRepeatedData(t, filepath.Join(srcDir, "top"), 1, []byte{1, 2, 3})
 
 	runner := testenv.NewInProcRunner(t)
 	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
@@ -432,7 +439,27 @@ func TestSnapshotFixRemoveFiles_ByPathInvalidWildcard(t *testing.T) {
 	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
 	env.RunAndExpectSuccess(t, "snapshot", "create", srcDir)
 
-	env.RunAndExpectFailure(t, "snapshot", "fix", "remove-files", "--path=[", "--parallel=1")
+	// "*" must not match the root itself, which would be replaced by a stub (or fail here)
+	env.RunAndExpectSuccess(t, "snapshot", "fix", "remove-files", "--path=*", "--invalid-directory-handling=fail", "--commit")
+	env.RunAndExpectSuccess(t, "snapshot", "verify")
+
+	var manifests []cli.SnapshotManifest
+
+	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(t, "snapshot", "list", "--json"), &manifests)
+	require.Len(t, manifests, 1)
+	require.Equal(t, snapshot.EntryTypeDirectory, manifests[0].RootEntry.Type)
+	require.Empty(t, mustGetFileMap(t, env, manifests[0].RootObjectID()))
+}
+
+func TestSnapshotFixRemoveFiles_InvalidWildcard(t *testing.T) {
+	runner := testenv.NewInProcRunner(t)
+	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, runner)
+
+	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
+
+	// no snapshot to match against, so the pattern must be rejected before rewriting
+	env.RunAndExpectFailure(t, "snapshot", "fix", "remove-files", "--path=[")
+	env.RunAndExpectFailure(t, "snapshot", "fix", "remove-files", "--filename=[")
 }
 
 // forgetContents rewrites contents into a new blob and deletes the blob

--- a/snapshot/snapshotfs/dir_rewriter.go
+++ b/snapshot/snapshotfs/dir_rewriter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/json"
+	"io"
 	"path"
 	"runtime"
 
@@ -75,9 +76,14 @@ func (rw *DirRewriter) processRequest(pool *workshare.Pool[*dirRewriterRequest],
 	req.result, req.err = rw.getCachedReplacement(req.ctx, req.parentPath, req.input, req.metadataCompression)
 }
 
-func (rw *DirRewriter) getCacheKey(input *snapshot.DirEntry) dirRewriterCacheKey {
-	// cache key = SHA1 hash of the input as JSON (20 bytes)
+func (rw *DirRewriter) getCacheKey(parentPath string, input *snapshot.DirEntry) dirRewriterCacheKey {
+	// cache key = SHA1 hash of the path and the input as JSON (20 bytes); the
+	// path is part of the key because a rewriter may decide by path.
 	h := sha1.New()
+
+	if _, err := io.WriteString(h, parentPath+"\x00"); err != nil {
+		impossible.PanicOnError(err)
+	}
 
 	if err := json.NewEncoder(h).Encode(input); err != nil {
 		impossible.PanicOnError(err)
@@ -91,7 +97,7 @@ func (rw *DirRewriter) getCacheKey(input *snapshot.DirEntry) dirRewriterCacheKey
 }
 
 func (rw *DirRewriter) getCachedReplacement(ctx context.Context, parentPath string, input *snapshot.DirEntry, metadataComp compression.Name) (*snapshot.DirEntry, error) {
-	key := rw.getCacheKey(input)
+	key := rw.getCacheKey(parentPath, input)
 
 	// see if we already processed this exact directory entry
 	cached, ok, err := rw.cache.Get(ctx, nil, key[:])
@@ -219,7 +225,7 @@ func (rw *DirRewriter) equalEntries(e1, e2 *snapshot.DirEntry) bool {
 		return false
 	}
 
-	return rw.getCacheKey(e1) == rw.getCacheKey(e2)
+	return rw.getCacheKey("", e1) == rw.getCacheKey("", e2)
 }
 
 // RewriteSnapshotManifest rewrites the directory tree starting at a given manifest.


### PR DESCRIPTION
`snapshot fix remove-files --filename` matches the wildcard against the entry's name only. There is no way to remove one file or directory by where it sits in the snapshot: `--filename acme` removes every entry named `acme`, and `--filename 'acme-*'` every file whose name starts with `acme-`, even when only `repos/acme` and `debug/tarballs/acme-*` should go.

`--path` matches the wildcard against the entry's path relative to the snapshot root, the same path the `will remove file` log line prints. It is checked after `--object-id` and `--filename`. `path.Match` rules apply, so `*` doesn't cross `/`, and removing a directory removes everything under it. The snapshot root itself (path `.`) is never matched, so `--path='*'` empties the root instead of turning it into a stub. Malformed patterns for `--path` and `--filename` are rejected before any snapshot is read; until now a bad pattern only surfaced when an entry was matched against it, so it passed on a repository without snapshots.

The directory rewriter caches its decision per entry, keyed by the entry's JSON. Two identical entries (same name, contents and modification time) in different directories shared one cached result, so once the first had been kept, a `--path` removal of the second was skipped. The cache key now includes the entry's path. `equalEntries` still compares entries with an empty path.

Tests: a `FixRemoveFiles_ByPath` case in `TestSnapshotFix` where `--path=large-file1` removes the root file and leaves `dir2/large-file1` in place, a test with identical entries in two directories that runs with `--parallel=1` so the kept entry is cached before the other one is rewritten (it fails without the cache key change), a test that `--path='*'` leaves an empty root directory, and a test that a malformed wildcard fails on a repository without snapshots.
