### PR TITLE
fix(testing): prevent panic in Azure versioned storage test

### DIFF
--- a/repo/blob/azure/azure_immu_test.go
+++ b/repo/blob/azure/azure_immu_test.go
@@ -2,7 +2,6 @@ package azure_test
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 	"testing"
 	"time"
@@ -30,14 +29,11 @@ func TestAzureStorageImmutabilityProtection(t *testing.T) {
 	storageAccount := getEnvOrSkip(t, testImmutableStorageAccountEnv)
 	storageKey := getEnvOrSkip(t, testImmutableStorageKeyEnv)
 
-	data := make([]byte, 8)
-	rand.Read(data)
-
 	ctx := testlogging.Context(t)
 
 	// use context that gets canceled after opening storage to ensure it's not used beyond New().
 	newctx, cancel := context.WithCancel(ctx)
-	prefix := fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data)
+	prefix := storagePrefixForTest()
 	st, err := azure.New(newctx, &azure.Options{
 		Container:      container,
 		StorageAccount: storageAccount,

--- a/repo/blob/azure/azure_storage_test.go
+++ b/repo/blob/azure/azure_storage_test.go
@@ -104,9 +104,6 @@ func TestAzureStorage(t *testing.T) {
 	// create container if does not exist
 	createContainer(t, container, storageAccount, storageKey)
 
-	data := make([]byte, 8)
-	rand.Read(data)
-
 	ctx := testlogging.Context(t)
 
 	// use context that gets canceled after opening storage to ensure it's not used beyond New().
@@ -115,7 +112,7 @@ func TestAzureStorage(t *testing.T) {
 		Container:      container,
 		StorageAccount: storageAccount,
 		StorageKey:     storageKey,
-		Prefix:         fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data),
+		Prefix:         storagePrefixForTest(),
 	}, false)
 
 	cancel()
@@ -136,9 +133,6 @@ func TestAzureStorageSASToken(t *testing.T) {
 	storageAccount := getEnvOrSkip(t, testStorageAccountEnv)
 	sasToken := getEnvOrSkip(t, testStorageSASTokenEnv)
 
-	data := make([]byte, 8)
-	rand.Read(data)
-
 	ctx := testlogging.Context(t)
 
 	// use context that gets canceled after storage is initialize,
@@ -148,7 +142,7 @@ func TestAzureStorageSASToken(t *testing.T) {
 		Container:      container,
 		StorageAccount: storageAccount,
 		SASToken:       sasToken,
-		Prefix:         fmt.Sprintf("sastest-%v-%x/", clock.Now().Unix(), data),
+		Prefix:         storagePrefixForTest(),
 	}, false)
 
 	require.NoError(t, err)
@@ -176,9 +170,6 @@ func TestAzureStorageClientSecret(t *testing.T) {
 	clientID := getEnvOrSkip(t, testStorageClientIDEnv)
 	clientSecret := getEnvOrSkip(t, testStorageClientSecretEnv)
 
-	data := make([]byte, 8)
-	rand.Read(data)
-
 	ctx := testlogging.Context(t)
 
 	// use context that gets canceled after storage is initialize,
@@ -190,7 +181,7 @@ func TestAzureStorageClientSecret(t *testing.T) {
 		TenantID:       tenantID,
 		ClientID:       clientID,
 		ClientSecret:   clientSecret,
-		Prefix:         fmt.Sprintf("sastest-%v-%x/", clock.Now().Unix(), data),
+		Prefix:         storagePrefixForTest(),
 	}, false)
 
 	require.NoError(t, err)
@@ -218,9 +209,6 @@ func TestAzureStorageClientCertificate(t *testing.T) {
 	clientID := getEnvOrSkip(t, testStorageClientIDEnv)
 	clientCert := getEnvOrSkip(t, testStorageClientCertEnv)
 
-	data := make([]byte, 8)
-	rand.Read(data)
-
 	ctx := testlogging.Context(t)
 
 	// use context that gets canceled after storage is initialize,
@@ -232,7 +220,7 @@ func TestAzureStorageClientCertificate(t *testing.T) {
 		TenantID:          tenantID,
 		ClientID:          clientID,
 		ClientCertificate: clientCert,
-		Prefix:            fmt.Sprintf("sastest-%v-%x/", clock.Now().Unix(), data),
+		Prefix:            storagePrefixForTest(),
 	}, false)
 
 	require.NoError(t, err)
@@ -260,9 +248,6 @@ func TestAzureFederatedIdentity(t *testing.T) {
 	clientID := getEnvOrSkip(t, testStorageClientIDEnv)
 	azureFederatedTokenFilePath := getEnvOrSkip(t, testAzureFederatedIdentityFilePathEnv)
 
-	data := make([]byte, 8)
-	rand.Read(data)
-
 	ctx := testlogging.Context(t)
 
 	// use context that gets canceled after storage is initialize,
@@ -274,7 +259,7 @@ func TestAzureFederatedIdentity(t *testing.T) {
 		TenantID:                tenantID,
 		ClientID:                clientID,
 		AzureFederatedTokenFile: azureFederatedTokenFilePath,
-		Prefix:                  fmt.Sprintf("sastest-%v-%x/", clock.Now().Unix(), data),
+		Prefix:                  storagePrefixForTest(),
 	}, false)
 
 	require.NoError(t, err)
@@ -366,4 +351,12 @@ func getBlobCount(ctx context.Context, t *testing.T, st blob.Storage, prefix blo
 	require.NoError(t, err)
 
 	return count
+}
+
+func storagePrefixForTest() string {
+	var data [4]byte
+
+	rand.Read(data[:])
+
+	return fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data)
 }

--- a/repo/blob/azure/azure_storage_test.go
+++ b/repo/blob/azure/azure_storage_test.go
@@ -86,9 +86,7 @@ func TestCleanupOldData(t *testing.T) {
 
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		st.Close(testlogging.ContextForCleanup(t))
-	})
+	t.Cleanup(func() { st.Close(testlogging.ContextForCleanup(t)) })
 
 	blobtesting.CleanupOldData(ctx, t, st, blobtesting.MinCleanupAge)
 }
@@ -118,7 +116,7 @@ func TestAzureStorage(t *testing.T) {
 	cancel()
 	require.NoError(t, err)
 
-	defer st.Close(ctx)
+	t.Cleanup(func() { cleanupTestDataAndClose(t, st) })
 
 	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
@@ -148,12 +146,7 @@ func TestAzureStorageSASToken(t *testing.T) {
 	require.NoError(t, err)
 	cancel()
 
-	t.Cleanup(func() {
-		ctx := testlogging.ContextForCleanup(t)
-
-		blobtesting.CleanupOldData(ctx, t, st, 0)
-		st.Close(ctx)
-	})
+	t.Cleanup(func() { cleanupTestDataAndClose(t, st) })
 
 	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
@@ -187,12 +180,7 @@ func TestAzureStorageClientSecret(t *testing.T) {
 	require.NoError(t, err)
 	cancel()
 
-	t.Cleanup(func() {
-		ctx := testlogging.ContextForCleanup(t)
-
-		blobtesting.CleanupOldData(ctx, t, st, 0)
-		st.Close(ctx)
-	})
+	t.Cleanup(func() { cleanupTestDataAndClose(t, st) })
 
 	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
@@ -226,12 +214,7 @@ func TestAzureStorageClientCertificate(t *testing.T) {
 	require.NoError(t, err)
 	cancel()
 
-	t.Cleanup(func() {
-		ctx := testlogging.ContextForCleanup(t)
-
-		blobtesting.CleanupOldData(ctx, t, st, 0)
-		st.Close(ctx)
-	})
+	t.Cleanup(func() { cleanupTestDataAndClose(t, st) })
 
 	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
@@ -265,12 +248,7 @@ func TestAzureFederatedIdentity(t *testing.T) {
 	require.NoError(t, err)
 	cancel()
 
-	t.Cleanup(func() {
-		ctx := testlogging.ContextForCleanup(t)
-
-		blobtesting.CleanupOldData(ctx, t, st, 0)
-		st.Close(ctx)
-	})
+	t.Cleanup(func() { cleanupTestDataAndClose(t, st) })
 
 	blobtesting.VerifyStorage(ctx, t, st, blob.PutOptions{})
 	blobtesting.AssertConnectionInfoRoundTrips(ctx, t, st)
@@ -359,4 +337,14 @@ func storagePrefixForTest() string {
 	rand.Read(data[:])
 
 	return fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data)
+}
+
+func cleanupTestDataAndClose(tb testing.TB, st blob.Storage) {
+	tb.Helper()
+
+	ctx := testlogging.ContextForCleanup(tb)
+
+	blobtesting.CleanupOldData(ctx, tb, st, 0)
+
+	require.NoError(tb, st.Close(ctx))
 }

--- a/repo/blob/azure/azure_versioned_test.go
+++ b/repo/blob/azure/azure_versioned_test.go
@@ -29,7 +29,6 @@ func TestGetBlobVersionsFailsWhenVersioningDisabled(t *testing.T) {
 	ctx := testlogging.Context(t)
 	// use context that gets canceled after opening storage to ensure it's not used beyond New().
 	newctx, cancel := context.WithCancel(ctx)
-	t.Cleanup(cancel)
 
 	opts := &azure.Options{
 		Container:      container,
@@ -39,6 +38,8 @@ func TestGetBlobVersionsFailsWhenVersioningDisabled(t *testing.T) {
 	}
 	st, err := azure.New(newctx, opts, false)
 	require.NoError(t, err)
+
+	cancel()
 
 	t.Cleanup(func() { st.Close(testlogging.ContextForCleanup(t)) })
 
@@ -66,7 +67,6 @@ func TestGetBlobVersions(t *testing.T) {
 	ctx := testlogging.Context(t)
 	// use context that gets canceled after opening storage to ensure it's not used beyond New().
 	newctx, cancel := context.WithCancel(ctx)
-	t.Cleanup(cancel)
 
 	opts := &azure.Options{
 		Container:      container,
@@ -76,6 +76,8 @@ func TestGetBlobVersions(t *testing.T) {
 	}
 	st, err := azure.New(newctx, opts, false)
 	require.NoError(t, err)
+
+	cancel()
 
 	cSt := st // grab reference to prevent clobbering that results in SIGSEV during t.Cleanup
 
@@ -174,7 +176,6 @@ func TestGetBlobVersionsWithDeletion(t *testing.T) {
 	ctx := testlogging.Context(t)
 	// use context that gets canceled after opening storage to ensure it's not used beyond New().
 	newctx, cancel := context.WithCancel(ctx)
-	t.Cleanup(cancel)
 
 	opts := &azure.Options{
 		Container:      container,
@@ -184,6 +185,8 @@ func TestGetBlobVersionsWithDeletion(t *testing.T) {
 	}
 	st, err := azure.New(newctx, opts, false)
 	require.NoError(t, err)
+
+	cancel()
 
 	t.Cleanup(func() { st.Close(testlogging.ContextForCleanup(t)) })
 

--- a/repo/blob/azure/azure_versioned_test.go
+++ b/repo/blob/azure/azure_versioned_test.go
@@ -2,8 +2,6 @@ package azure_test
 
 import (
 	"context"
-	"crypto/rand"
-	"fmt"
 	"testing"
 	"time"
 
@@ -29,18 +27,15 @@ func TestGetBlobVersionsFailsWhenVersioningDisabled(t *testing.T) {
 	storageKey := getEnvOrSkip(t, testStorageKeyEnv)
 
 	ctx := testlogging.Context(t)
-	data := make([]byte, 8)
-	rand.Read(data)
 	// use context that gets canceled after opening storage to ensure it's not used beyond New().
 	newctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
-	prefix := fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data)
 	opts := &azure.Options{
 		Container:      container,
 		StorageAccount: storageAccount,
 		StorageKey:     storageKey,
-		Prefix:         prefix,
+		Prefix:         storagePrefixForTest(),
 	}
 	st, err := azure.New(newctx, opts, false)
 	require.NoError(t, err)
@@ -69,18 +64,15 @@ func TestGetBlobVersions(t *testing.T) {
 	createContainer(t, container, storageAccount, storageKey)
 
 	ctx := testlogging.Context(t)
-	data := make([]byte, 8)
-	rand.Read(data)
 	// use context that gets canceled after opening storage to ensure it's not used beyond New().
 	newctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
-	prefix := fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data)
 	opts := &azure.Options{
 		Container:      container,
 		StorageAccount: storageAccount,
 		StorageKey:     storageKey,
-		Prefix:         prefix,
+		Prefix:         storagePrefixForTest(),
 	}
 	st, err := azure.New(newctx, opts, false)
 	require.NoError(t, err)
@@ -99,9 +91,7 @@ func TestGetBlobVersions(t *testing.T) {
 		latestData   = "latest version"
 	)
 
-	const blobName = "TestGetBlobVersions"
-
-	blobID := blob.ID(blobName)
+	blobID := blob.ID(t.Name())
 	dataBlobs := []string{originalData, updatedData, latestData}
 	dataTimestamps, err := putBlobs(ctx, st, blobID, dataBlobs)
 
@@ -179,18 +169,15 @@ func TestGetBlobVersionsWithDeletion(t *testing.T) {
 	createContainer(t, container, storageAccount, storageKey)
 
 	ctx := testlogging.Context(t)
-	data := make([]byte, 8)
-	rand.Read(data)
 	// use context that gets canceled after opening storage to ensure it's not used beyond New().
 	newctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
-	prefix := fmt.Sprintf("test-%v-%x/", clock.Now().Unix(), data)
 	opts := &azure.Options{
 		Container:      container,
 		StorageAccount: storageAccount,
 		StorageKey:     storageKey,
-		Prefix:         prefix,
+		Prefix:         storagePrefixForTest(),
 	}
 	st, err := azure.New(newctx, opts, false)
 	require.NoError(t, err)

--- a/repo/blob/azure/azure_versioned_test.go
+++ b/repo/blob/azure/azure_versioned_test.go
@@ -148,12 +148,12 @@ func TestGetBlobVersions(t *testing.T) {
 	} {
 		t.Run(tt.testName, func(t *testing.T) {
 			opts.PointInTime = tt.pointInTime
-			st, err = azure.New(ctx, opts, false)
+			pitSt, err := azure.New(ctx, opts, false)
 			require.NoError(t, err)
 
 			var tmp gather.WriteBuffer
 
-			err = st.GetBlob(ctx, blobID, 0, -1, &tmp)
+			err = pitSt.GetBlob(ctx, blobID, 0, -1, &tmp)
 			require.ErrorIs(t, err, tt.expectedError)
 			require.Equal(t, tt.expectedBlobData, string(tmp.ToByteSlice()))
 		})

--- a/repo/blob/azure/azure_versioned_test.go
+++ b/repo/blob/azure/azure_versioned_test.go
@@ -106,6 +106,7 @@ func TestGetBlobVersions(t *testing.T) {
 	dataTimestamps, err := putBlobs(ctx, st, blobID, dataBlobs)
 
 	require.NoError(t, err)
+	require.Len(t, dataTimestamps, 3)
 
 	pastPIT := dataTimestamps[0].Add(-1 * time.Second)
 	futurePIT := dataTimestamps[2].Add(1 * time.Second)

--- a/repo/blob/azure/azure_versioned_test.go
+++ b/repo/blob/azure/azure_versioned_test.go
@@ -146,16 +146,17 @@ func TestGetBlobVersions(t *testing.T) {
 			expectedError:    nil,
 		},
 	} {
-		fmt.Printf("Running test: %s\n", tt.testName)
-		opts.PointInTime = tt.pointInTime
-		st, err = azure.New(ctx, opts, false)
-		require.NoError(t, err)
+		t.Run(tt.testName, func(t *testing.T) {
+			opts.PointInTime = tt.pointInTime
+			st, err = azure.New(ctx, opts, false)
+			require.NoError(t, err)
 
-		var tmp gather.WriteBuffer
+			var tmp gather.WriteBuffer
 
-		err = st.GetBlob(ctx, blobID, 0, -1, &tmp)
-		require.ErrorIs(t, err, tt.expectedError)
-		require.Equal(t, tt.expectedBlobData, string(tmp.ToByteSlice()))
+			err = st.GetBlob(ctx, blobID, 0, -1, &tmp)
+			require.ErrorIs(t, err, tt.expectedError)
+			require.Equal(t, tt.expectedBlobData, string(tmp.ToByteSlice()))
+		})
 	}
 }
 

--- a/repo/blob/azure/azure_versioned_test.go
+++ b/repo/blob/azure/azure_versioned_test.go
@@ -77,7 +77,9 @@ func TestGetBlobVersions(t *testing.T) {
 	st, err := azure.New(newctx, opts, false)
 	require.NoError(t, err)
 
-	t.Cleanup(func() { st.Close(testlogging.ContextForCleanup(t)) })
+	cSt := st // grab reference to prevent clobbering that results in SIGSEV during t.Cleanup
+
+	t.Cleanup(func() { cSt.Close(testlogging.ContextForCleanup(t)) })
 
 	// required for PIT versioning check
 	err = st.PutBlob(ctx, format.KopiaRepositoryBlobID, gather.FromSlice([]byte(nil)), blob.PutOptions{})


### PR DESCRIPTION
Avoids clobbering the reference to the storage (interface) used during `t.Cleanup()`

Also:
- add length check for returned timestamps
- `cleanupTestDataAndClose()` helper
- `storagePrefixForTest()` helper
- `cancel()` context after creating store as in other tests.