### PR TITLE
fix(testing): avoid clobbering storage used in `t.Cleanup`

### DIFF
--- a/repo/blob/azure/azure_versioned_test.go
+++ b/repo/blob/azure/azure_versioned_test.go
@@ -188,7 +188,9 @@ func TestGetBlobVersionsWithDeletion(t *testing.T) {
 
 	cancel()
 
-	t.Cleanup(func() { st.Close(testlogging.ContextForCleanup(t)) })
+	cSt := st // grab reference to prevent clobbering that results in SIGSEV during t.Cleanup
+
+	t.Cleanup(func() { cSt.Close(testlogging.ContextForCleanup(t)) })
 
 	// required for PIT versioning check
 	err = st.PutBlob(ctx, format.KopiaRepositoryBlobID, gather.FromSlice([]byte(nil)), blob.PutOptions{})


### PR DESCRIPTION
- Followup #5635
- https://github.com/kopia/kopia/pull/5635#discussion_r3980311454