### PR TITLE
refactor(server): remove `tls.Config.VerifyPeerCertificate`

### DIFF
--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -140,9 +140,8 @@ func TLSConfigTrustingSingleCertificate(sha256Fingerprint string) (*tls.Config, 
 	}
 
 	return &tls.Config{
-		InsecureSkipVerify:    true, //nolint:gosec
-		VerifyPeerCertificate: verifyPeerCertificateFunction(sha256FingerprintBytes),
-		VerifyConnection:      verifyConnectionFunction(sha256FingerprintBytes),
+		InsecureSkipVerify: true, //nolint:gosec
+		VerifyConnection:   verifyConnectionFunction(sha256FingerprintBytes),
 	}, nil
 }
 
@@ -158,30 +157,6 @@ func TransportTrustingSingleCertificate(sha256Fingerprint string) (http.RoundTri
 	t2.TLSClientConfig = c
 
 	return t2, nil
-}
-
-func verifyPeerCertificateFunction(sha256FingerprintBytes []byte) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		_ = verifiedChains
-
-		return verifyPeerCertificate(sha256FingerprintBytes, rawCerts)
-	}
-}
-
-func verifyPeerCertificate(sha256FingerprintBytes []byte, rawCerts [][]byte) error {
-	var serverCerts [][]byte
-
-	for _, c := range rawCerts {
-		serverCertFingerPrint := sha256.Sum256(c)
-
-		if bytes.Equal(serverCertFingerPrint[:], sha256FingerprintBytes) {
-			return nil
-		}
-
-		serverCerts = append(serverCerts, serverCertFingerPrint[:])
-	}
-
-	return errors.Errorf("can't find certificate matching SHA256 fingerprint %x (server had %x)", sha256FingerprintBytes, serverCerts)
 }
 
 func verifyConnectionFunction(sha256FingerprintBytes []byte) func(s tls.ConnectionState) error {

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -133,7 +133,7 @@ func TestTransportTrustingSingleClientCertificate_TestClientFlow(t *testing.T) {
 				tr, err := tlsutil.TransportTrustingSingleCertificate(fingerprint)
 				require.NoError(t, err)
 
-				return tr.(*http.Transport) //nolint:forcetypeassert
+				return testutil.EnsureType[*http.Transport](t, tr)
 			},
 		},
 		{
@@ -142,7 +142,7 @@ func TestTransportTrustingSingleClientCertificate_TestClientFlow(t *testing.T) {
 				tr, err := tlsutil.TransportTrustingSingleCertificate(fingerprint)
 				require.NoError(t, err)
 
-				transport := tr.(*http.Transport) //nolint:forcetypeassert
+				transport := testutil.EnsureType[*http.Transport](t, tr)
 				transport.TLSClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(0)
 
 				return transport

--- a/internal/tlsutil/tlsutil_test.go
+++ b/internal/tlsutil/tlsutil_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kopia/kopia/internal/clock"
+	"github.com/kopia/kopia/internal/testutil"
 	"github.com/kopia/kopia/internal/tlsutil"
 )
 
@@ -51,12 +53,10 @@ func TestTransportTrustingSingleCertificate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, transport)
 
-	// Testing the VerifyPeerCertificate function
-	verifyPeerCertificate := transport.(*http.Transport).TLSClientConfig.VerifyPeerCertificate //nolint:forcetypeassert
+	verifyConnection := testutil.EnsureType[*http.Transport](t, transport).TLSClientConfig.VerifyConnection
 
 	t.Run("Test with the correct certificate", func(t *testing.T) {
-		rawCerts := [][]byte{cert.Raw}
-		err := verifyPeerCertificate(rawCerts, nil)
+		err := verifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}})
 		require.NoError(t, err)
 	})
 
@@ -64,8 +64,7 @@ func TestTransportTrustingSingleCertificate(t *testing.T) {
 		invalidCert, _, err := tlsutil.GenerateServerCertificate(ctx, 2048, certValid, names)
 		require.NoError(t, err)
 
-		rawCerts := [][]byte{invalidCert.Raw}
-		err = verifyPeerCertificate(rawCerts, nil)
+		err = verifyConnection(tls.ConnectionState{PeerCertificates: []*x509.Certificate{invalidCert}})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "can't find certificate matching SHA256 fingerprint")
 	})


### PR DESCRIPTION
Instead rely on `VerifyConnection` and avoid duplicate validation on first connection.

Ref:
- #5540
- #5610
- #5628