### PR TITLE
fix(providers): time out SFTP connections that stop responding

### DIFF
--- a/repo/blob/sftp/sftp_storage.go
+++ b/repo/blob/sftp/sftp_storage.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/pkg/sftp"
@@ -37,6 +38,24 @@ const (
 	tempFileRandomSuffixLen = 8
 
 	packetSize = 1 << 15
+
+	keepaliveRequestType = "keepalive@openssh.com"
+)
+
+// The SFTP client waits for replies without a deadline, so a server or network
+// path that stops responding without closing the connection would block
+// requests forever. These bound how long a silent connection is trusted.
+var (
+	// connectTimeout bounds establishing the TCP connection to the server.
+	connectTimeout = 30 * time.Second
+
+	// keepaliveInterval is how often a keepalive request is sent, so an idle
+	// but healthy connection keeps receiving data from the server.
+	keepaliveInterval = 15 * time.Second
+
+	// readIdleTimeout is how long the connection may receive nothing from the
+	// server before it is closed, turning the hang into a connection error.
+	readIdleTimeout = 60 * time.Second
 )
 
 // sftpStorage implements blob.Storage on top of sftp.
@@ -522,7 +541,7 @@ func getSFTPClient(ctx context.Context, opt *Options) (*sftpConnection, error) {
 
 	addr := fmt.Sprintf("%s:%d", opt.Host, opt.Port)
 
-	conn, err := ssh.Dial("tcp", addr, config)
+	conn, err := dialSSH(ctx, addr, config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to dial [%s]: %#v", addr, config)
 	}
@@ -541,6 +560,58 @@ func getSFTPClient(ctx context.Context, opt *Options) (*sftpConnection, error) {
 		currentClient: c,
 		closeFunc:     conn.Close,
 	}, nil
+}
+
+// dialSSH connects to the SSH server at addr. Reads from the returned client's
+// connection fail after readIdleTimeout without data from the server, and
+// keepalives make a healthy server send data at least every keepaliveInterval.
+func dialSSH(ctx context.Context, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
+	d := net.Dialer{Timeout: connectTimeout}
+
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, errors.Wrap(err, "error connecting to SSH server")
+	}
+
+	c, chans, reqs, err := ssh.NewClientConn(&idleTimeoutConn{Conn: conn, timeout: readIdleTimeout}, addr, config)
+	if err != nil {
+		return nil, errors.Wrap(err, "error establishing SSH connection")
+	}
+
+	client := ssh.NewClient(c, chans, reqs)
+
+	go sendKeepalives(client, keepaliveInterval)
+
+	return client, nil
+}
+
+// sendKeepalives periodically sends a request the server must reply to, until
+// the connection is closed.
+func sendKeepalives(client *ssh.Client, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		if _, _, err := client.SendRequest(keepaliveRequestType, true, nil); err != nil {
+			return
+		}
+	}
+}
+
+// idleTimeoutConn fails a Read when nothing is received for the timeout.
+type idleTimeoutConn struct {
+	net.Conn
+
+	timeout time.Duration
+}
+
+func (c *idleTimeoutConn) Read(b []byte) (int, error) {
+	//nolint:forbidigo // network deadlines are based on the real wall clock
+	if err := c.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
+		return 0, errors.Wrap(err, "error setting read deadline")
+	}
+
+	return c.Conn.Read(b) //nolint:wrapcheck
 }
 
 // New creates new ssh-backed storage in a specified host.

--- a/repo/blob/sftp/sftp_timeout_test.go
+++ b/repo/blob/sftp/sftp_timeout_test.go
@@ -1,0 +1,256 @@
+//go:build !no_extra_providers
+
+package sftp
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+
+	"github.com/kopia/kopia/internal/testlogging"
+	"github.com/kopia/kopia/internal/timetrack"
+)
+
+// silenceableServer is an in-process SSH server with the SFTP subsystem that
+// can be silenced: it then keeps connections open but neither reads nor writes,
+// like a server or network path that hangs without closing the connection.
+type silenceableServer struct {
+	host           string
+	port           int
+	knownHostsFile string
+
+	silenced   atomic.Bool
+	shutdown   chan struct{}
+	connsMutex sync.Mutex
+	conns      []net.Conn
+}
+
+func (s *silenceableServer) silence() {
+	s.silenced.Store(true)
+}
+
+func (s *silenceableServer) options(t *testing.T) *Options {
+	t.Helper()
+
+	return &Options{
+		Path:           t.TempDir(),
+		Host:           s.host,
+		Port:           s.port,
+		Username:       "user",
+		Password:       "password",
+		KnownHostsFile: s.knownHostsFile,
+	}
+}
+
+// gatedConn stops passing data in either direction once the server is silenced.
+type gatedConn struct {
+	net.Conn
+
+	s *silenceableServer
+}
+
+func (c gatedConn) Read(b []byte) (int, error) {
+	n, err := c.Conn.Read(b)
+	if c.s.silenced.Load() {
+		<-c.s.shutdown
+		return 0, net.ErrClosed
+	}
+
+	return n, err
+}
+
+func (c gatedConn) Write(b []byte) (int, error) {
+	if c.s.silenced.Load() {
+		<-c.s.shutdown
+		return 0, net.ErrClosed
+	}
+
+	return c.Conn.Write(b)
+}
+
+func startSilenceableServer(t *testing.T) *silenceableServer {
+	t.Helper()
+
+	_, hostPrivateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	hostKey, err := ssh.NewSignerFromKey(hostPrivateKey)
+	require.NoError(t, err)
+
+	config := &ssh.ServerConfig{
+		PasswordCallback: func(ssh.ConnMetadata, []byte) (*ssh.Permissions, error) {
+			return &ssh.Permissions{}, nil
+		},
+	}
+	config.AddHostKey(hostKey)
+
+	l, err := (&net.ListenConfig{}).Listen(testlogging.Context(t), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := l.Addr().(*net.TCPAddr) //nolint:forcetypeassert
+
+	s := &silenceableServer{
+		host:           addr.IP.String(),
+		port:           addr.Port,
+		knownHostsFile: filepath.Join(t.TempDir(), "known_hosts"),
+		shutdown:       make(chan struct{}),
+	}
+
+	knownHostsLine := knownhosts.Line([]string{knownhosts.Normalize(l.Addr().String())}, hostKey.PublicKey())
+	require.NoError(t, os.WriteFile(s.knownHostsFile, []byte(knownHostsLine+"\n"), 0o600))
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+
+			s.connsMutex.Lock()
+			s.conns = append(s.conns, conn)
+			s.connsMutex.Unlock()
+
+			go serveSSH(gatedConn{conn, s}, config)
+		}
+	}()
+
+	t.Cleanup(func() {
+		close(s.shutdown)
+		l.Close()
+
+		s.connsMutex.Lock()
+		defer s.connsMutex.Unlock()
+
+		for _, c := range s.conns {
+			c.Close()
+		}
+	})
+
+	return s
+}
+
+func serveSSH(conn net.Conn, config *ssh.ServerConfig) {
+	sconn, chans, reqs, err := ssh.NewServerConn(conn, config)
+	if err != nil {
+		return
+	}
+
+	defer sconn.Close()
+
+	// replies to keepalive requests
+	go ssh.DiscardRequests(reqs)
+
+	for newChannel := range chans {
+		if newChannel.ChannelType() != "session" {
+			newChannel.Reject(ssh.UnknownChannelType, "unsupported channel type")
+			continue
+		}
+
+		channel, requests, err := newChannel.Accept()
+		if err != nil {
+			return
+		}
+
+		go func() {
+			for req := range requests {
+				isSFTP := req.Type == "subsystem" && len(req.Payload) > 4 && string(req.Payload[4:]) == "sftp"
+				req.Reply(isSFTP, nil)
+
+				if isSFTP {
+					go func() {
+						srv, err := sftp.NewServer(channel)
+						if err != nil {
+							return
+						}
+
+						srv.Serve()
+						srv.Close()
+					}()
+				}
+			}
+		}()
+	}
+}
+
+func useShortTimeouts(t *testing.T) {
+	t.Helper()
+
+	oldConnect, oldKeepalive, oldIdle := connectTimeout, keepaliveInterval, readIdleTimeout
+
+	connectTimeout = 5 * time.Second
+	keepaliveInterval = 200 * time.Millisecond
+	readIdleTimeout = 2 * time.Second
+
+	t.Cleanup(func() {
+		connectTimeout, keepaliveInterval, readIdleTimeout = oldConnect, oldKeepalive, oldIdle
+	})
+}
+
+// Not parallel: tests in this file change the package-level timeouts.
+
+func Test_getSFTPClient_silentServerFailsConnect(t *testing.T) {
+	useShortTimeouts(t)
+
+	s := startSilenceableServer(t)
+	s.silence()
+
+	timer := timetrack.StartTimer()
+
+	_, err := getSFTPClient(testlogging.Context(t), s.options(t))
+	require.Error(t, err)
+	require.Less(t, timer.Elapsed(), 10*time.Second)
+}
+
+func Test_getSFTPClient_silentConnectionFailsRequest(t *testing.T) {
+	useShortTimeouts(t)
+
+	s := startSilenceableServer(t)
+	opt := s.options(t)
+
+	conn, err := getSFTPClient(testlogging.Context(t), opt)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { conn.Close() })
+
+	_, err = conn.currentClient.Stat(opt.Path)
+	require.NoError(t, err)
+
+	s.silence()
+
+	timer := timetrack.StartTimer()
+
+	_, err = conn.currentClient.Stat(opt.Path)
+	require.Error(t, err)
+	require.Less(t, timer.Elapsed(), 10*time.Second)
+
+	// the error must trigger reconnecting and retrying
+	require.True(t, (&sftpImpl{}).IsConnectionClosedError(err), "unexpected error: %v", err)
+}
+
+func Test_getSFTPClient_idleConnectionIsKeptAlive(t *testing.T) {
+	useShortTimeouts(t)
+
+	s := startSilenceableServer(t)
+	opt := s.options(t)
+
+	conn, err := getSFTPClient(testlogging.Context(t), opt)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { conn.Close() })
+
+	time.Sleep(2 * readIdleTimeout)
+
+	_, err = conn.currentClient.Stat(opt.Path)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Problem

With the internal SSH client, nothing in the SFTP storage stack has a deadline: `ssh.Dial` is called without a timeout, and `pkg/sftp` waits for replies using `context.Background()`. If the server or the network path stops responding without closing the TCP connection (dropped NAT/firewall state, a hung server), every SFTP request waits forever. The reconnect logic in `internal/connection` and the retrying wrapper only react to errors, so they never engage.

We hit this with KopiaUI 0.23.1 and an SFTP repository on a Hetzner Storage Box: a request hung, and backups and maintenance stopped silently. The companion PR #5639 keeps the server's API responsive when a storage call hangs anyway.

## Change

- Dial with `net.Dialer{Timeout: 30s}` and run the SSH handshake with `ssh.NewClientConn`.
- Wrap the connection so each read sets a read deadline: a connection that receives nothing from the server for 60s fails.
- Send `keepalive@openssh.com` global requests with `want_reply` every 15s, so a healthy idle server always sends something back (RFC 4254 section 4 requires a reply, even to unknown requests). This is the same idea as OpenSSH's `ServerAliveInterval`. Like it, any data from the server counts, so long transfers on slow links are not affected.
- When the deadline kills a connection, pending requests fail with `sftp.ErrSSHFxConnectionLost`. `IsConnectionClosedError` already treats that error as a signal to reconnect and retry.

This detects a dead connection or an unresponsive sshd. It does not detect an SFTP server subprocess that is stuck while sshd still answers keepalives, for example on a hung disk. That is deliberate: it is also why long server-side operations do not cause false disconnects.

External SSH mode (`ExternalSSH: true`) is unchanged. Users of that mode can pass `-o ServerAliveInterval=...` through `SSHArguments`.

The timeouts are package-level defaults. I can expose them in `Options` if you prefer them to be configurable.

## Testing

The new `sftp_timeout_test.go` runs an in-process SSH/SFTP server (`x/crypto/ssh` plus the `pkg/sftp` server) that can be silenced: it keeps connections open but stops reading and writing.

The tests shorten the timeouts to a 2s idle timeout and 200ms keepalives.

- `Test_getSFTPClient_silentServerFailsConnect`: connecting to a silent server fails within the idle timeout.
- `Test_getSFTPClient_silentConnectionFailsRequest`: a request on an established connection that goes silent fails within the idle timeout. The error is one that `IsConnectionClosedError` recognizes, so the existing reconnect logic takes over.
- `Test_getSFTPClient_idleConnectionIsKeptAlive`: an idle connection is still usable after twice the idle timeout. This proves that keepalives prevent false disconnects.

Against the unmodified code, the first two tests hang until the test binary's timeout. With this change, each one fails fast as expected.

Commands I ran locally:
- `go test -race ./repo/blob/sftp/` (Go 1.27) and `go test ./repo/blob/sftp/` (Go 1.26.8). Both pass.
- `golangci-lint run ./repo/blob/sftp/...` (v2.11.4). Clean.

I did not run the Docker-based `TestSFTPStorageValid` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
