### PR TITLE
fix(server): avoid holding server lock during repository refresh I/O

### DIFF
--- a/internal/repotesting/repotesting.go
+++ b/internal/repotesting/repotesting.go
@@ -44,6 +44,9 @@ type Options struct {
 	// A non-zero StorageLimitBytes option limits the capacity of the underlying storage,
 	// otherwise it is unlimited.
 	StorageLimitBytes uint64
+	// WrapStorage, if set, wraps the underlying storage before the repository is created,
+	// for example to inject faults. RootStorage() returns the wrapped storage.
+	WrapStorage func(blob.Storage) blob.Storage
 }
 
 // RepositoryMetrics returns metrics.Registry associated with a repository.
@@ -53,8 +56,8 @@ func (e *Environment) RepositoryMetrics() *metrics.Registry {
 	}).Metrics()
 }
 
-// RootStorage returns the base storage map that implements the base in-memory
-// map at the base of all storage wrappers on top.
+// RootStorage returns the storage at the base of all storage wrappers on top:
+// the in-memory map, or the result of Options.WrapStorage when it is set.
 func (e *Environment) RootStorage() blob.Storage {
 	return e.st.(reconnectableStorage).Storage //nolint:forcetypeassert
 }
@@ -112,6 +115,12 @@ func (e *Environment) setup(tb testing.TB, version format.Version, opts ...Optio
 	} else {
 		// use versioned mock storage when retention settings are specified
 		st = blobtesting.NewVersionedMapStorage(openOpt.TimeNowFunc)
+	}
+
+	for _, mod := range opts {
+		if mod.WrapStorage != nil {
+			st = mod.WrapStorage(st)
+		}
 	}
 
 	st = NewReconnectableStorage(tb, st)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,6 +78,10 @@ type Server struct {
 
 	serverMutex sync.RWMutex
 
+	// refreshMutex serializes Refresh() calls. Request handlers never take it, so a refresh
+	// that is stuck on storage I/O does not block the API.
+	refreshMutex sync.Mutex
+
 	parallelSnapshotsMutex sync.Mutex
 
 	// +checklocks:parallelSnapshotsMutex
@@ -443,17 +447,26 @@ func (s *Server) refreshAsync() {
 
 // Refresh refreshes the state of the server in response to external signal (e.g. SIGHUP).
 func (s *Server) Refresh() {
-	s.serverMutex.Lock()
-	defer s.serverMutex.Unlock()
+	s.refreshMutex.Lock()
+	defer s.refreshMutex.Unlock()
 
-	if err := s.refreshLocked(s.rootctx); err != nil {
+	if err := s.refresh(s.rootctx); err != nil {
 		userLog(s.rootctx).Warnw("refresh error", "err", err)
 	}
 }
 
-// +checklocks:s.serverMutex
-func (s *Server) refreshLocked(ctx context.Context) error {
-	if s.rep == nil {
+// refresh reads the repository state without holding serverMutex, which is needed by every
+// API request, so that slow or unresponsive storage does not block unrelated requests.
+// serverMutex is only held to apply the result.
+//
+// +checklocks:s.refreshMutex
+func (s *Server) refresh(ctx context.Context) error {
+	s.serverMutex.RLock()
+	rep := s.rep
+	sourceManagersBefore := maps.Clone(s.sourceManagers)
+	s.serverMutex.RUnlock()
+
+	if rep == nil {
 		return nil
 	}
 
@@ -461,7 +474,7 @@ func (s *Server) refreshLocked(ctx context.Context) error {
 	s.nextRefreshTime = clock.Now().Add(s.options.RefreshInterval)
 	s.nextRefreshTimeLock.Unlock()
 
-	if err := s.rep.Refresh(ctx); err != nil {
+	if err := rep.Refresh(ctx); err != nil {
 		return errors.Wrap(err, "unable to refresh repository")
 	}
 
@@ -477,12 +490,29 @@ func (s *Server) refreshLocked(ctx context.Context) error {
 		}
 	}
 
-	if err := s.syncSourcesLocked(ctx); err != nil {
+	sources, maxParallelSnapshots, err := listSources(ctx, rep)
+	if err != nil {
 		return errors.Wrap(err, "unable to sync sources")
 	}
 
-	if s.maint != nil {
-		s.maint.refresh(ctx, false)
+	s.serverMutex.Lock()
+
+	if s.rep != rep {
+		// the repository was replaced by SetRepository() in the meantime, discard the result.
+		s.serverMutex.Unlock()
+
+		return nil
+	}
+
+	changes := s.updateSourceManagersLocked(sources, maxParallelSnapshots, sourceManagersBefore)
+	maint := s.maint
+
+	s.serverMutex.Unlock()
+
+	s.applySourceManagerChanges(ctx, changes)
+
+	if maint != nil {
+		maint.refresh(ctx, false)
 	}
 
 	return nil
@@ -679,72 +709,128 @@ func (s *Server) stopAllSourceManagersLocked(ctx context.Context) {
 
 // +checklocks:s.serverMutex
 func (s *Server) syncSourcesLocked(ctx context.Context) error {
+	sources, maxParallelSnapshots, err := listSources(ctx, s.rep)
+	if err != nil {
+		return err
+	}
+
+	changes := s.updateSourceManagersLocked(sources, maxParallelSnapshots, maps.Clone(s.sourceManagers))
+	s.applySourceManagerChanges(ctx, changes)
+
+	return nil
+}
+
+// listSources returns the sources that have snapshots or policies in the repository and
+// the maximum number of parallel snapshots for the repository user.
+func listSources(ctx context.Context, rep repo.Repository) (map[snapshot.SourceInfo]bool, int, error) {
+	snapshotSources, err := snapshot.ListSources(ctx, rep)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "unable to list sources")
+	}
+
+	policies, err := policy.ListPolicies(ctx, rep)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "unable to list sources")
+	}
+
+	// user@host policy
+	userhostPol, _, _, err := policy.GetEffectivePolicy(ctx, rep, snapshot.SourceInfo{
+		UserName: rep.ClientOptions().Username,
+		Host:     rep.ClientOptions().Hostname,
+	})
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "unable to get user policy")
+	}
+
 	sources := map[snapshot.SourceInfo]bool{}
 
-	if s.rep != nil {
-		snapshotSources, err := snapshot.ListSources(ctx, s.rep)
-		if err != nil {
-			return errors.Wrap(err, "unable to list sources")
-		}
+	for _, ss := range snapshotSources {
+		sources[ss] = true
+	}
 
-		policies, err := policy.ListPolicies(ctx, s.rep)
-		if err != nil {
-			return errors.Wrap(err, "unable to list sources")
-		}
-
-		// user@host policy
-		userhostPol, _, _, err := policy.GetEffectivePolicy(ctx, s.rep, snapshot.SourceInfo{
-			UserName: s.rep.ClientOptions().Username,
-			Host:     s.rep.ClientOptions().Hostname,
-		})
-		if err != nil {
-			return errors.Wrap(err, "unable to get user policy")
-		}
-
-		s.setMaxParallelSnapshotsLocked(userhostPol.UploadPolicy.MaxParallelSnapshots.OrDefault(1))
-
-		for _, ss := range snapshotSources {
-			sources[ss] = true
-		}
-
-		for _, pol := range policies {
-			if pol.Target().Path != "" && pol.Target().Host != "" && pol.Target().UserName != "" {
-				sources[pol.Target()] = true
-			}
+	for _, pol := range policies {
+		if pol.Target().Path != "" && pol.Target().Host != "" && pol.Target().UserName != "" {
+			sources[pol.Target()] = true
 		}
 	}
 
-	// copy existing sources to a map, from which we will remove sources that are found
-	// in the repository
-	oldSourceManagers := maps.Clone(s.sourceManagers)
+	return sources, userhostPol.UploadPolicy.MaxParallelSnapshots.OrDefault(1), nil
+}
+
+// sourceManagerChanges holds the source managers affected by updateSourceManagersLocked().
+type sourceManagerChanges struct {
+	added   map[*sourceManager]bool // new managers to start, the value indicates whether the source is local
+	kept    []*sourceManager        // existing managers whose status needs a refresh
+	removed []*sourceManager        // managers to stop
+}
+
+// updateSourceManagersLocked creates and removes source managers to match the provided
+// sources without performing storage I/O. Since the sources may have been listed without
+// holding serverMutex, managers created or deleted by other callers after 'before' was
+// captured are left as they are; the next refresh reconciles them.
+//
+// +checklocks:s.serverMutex
+func (s *Server) updateSourceManagersLocked(sources map[snapshot.SourceInfo]bool, maxParallelSnapshots int, before map[snapshot.SourceInfo]*sourceManager) sourceManagerChanges {
+	s.setMaxParallelSnapshotsLocked(maxParallelSnapshots)
+
+	changes := sourceManagerChanges{added: map[*sourceManager]bool{}}
 
 	for src := range sources {
-		if sm, ok := oldSourceManagers[src]; ok {
-			// pre-existing source, already has a manager
-			delete(oldSourceManagers, src)
-			sm.refreshStatus(ctx)
-		} else {
-			sm := newSourceManager(src, s, s.rep)
-			s.sourceManagers[src] = sm
+		if sm, ok := s.sourceManagers[src]; ok {
+			changes.kept = append(changes.kept, sm)
+			continue
+		}
 
-			sm.start(ctx, s.isLocal(src))
+		if _, ok := before[src]; ok {
+			// deleted in the meantime
+			continue
+		}
+
+		sm := newSourceManager(src, s, s.rep)
+		s.sourceManagers[src] = sm
+		changes.added[sm] = s.isLocal(src)
+	}
+
+	for src, sm := range s.sourceManagers {
+		if sources[src] || before[src] != sm {
+			// still in the repository or created in the meantime
+			continue
+		}
+
+		delete(s.sourceManagers, src)
+
+		changes.removed = append(changes.removed, sm)
+	}
+
+	return changes
+}
+
+// applySourceManagerChanges starts, refreshes and stops the source managers returned by
+// updateSourceManagersLocked(). It performs storage I/O and does not require serverMutex.
+func (s *Server) applySourceManagerChanges(ctx context.Context, changes sourceManagerChanges) {
+	// skip managers stopped in the meantime by SetRepository() or deleteSourceManager(),
+	// whose repository may already be closed.
+	for sm, isLocal := range changes.added {
+		if !sm.isStopped() {
+			sm.start(ctx, isLocal)
 		}
 	}
 
-	// whatever is left in oldSourceManagers are managers for sources that don't exist anymore.
-	// stop source manager for sources no longer in the repo.
-	for _, sm := range oldSourceManagers {
+	for _, sm := range changes.kept {
+		if !sm.isStopped() {
+			sm.refreshStatus(ctx)
+		}
+	}
+
+	for _, sm := range changes.removed {
 		sm.stop(ctx)
 	}
 
-	for src, sm := range oldSourceManagers {
+	for _, sm := range changes.removed {
 		sm.waitUntilStopped()
-		delete(s.sourceManagers, src)
 	}
 
 	s.refreshScheduler("sources refreshed")
-
-	return nil
 }
 
 func (s *Server) isKnownUIRoute(path string) bool {
@@ -1020,17 +1106,23 @@ func (s *Server) isLocal(src snapshot.SourceInfo) bool {
 
 func (s *Server) getOrCreateSourceManager(ctx context.Context, src snapshot.SourceInfo) *sourceManager {
 	s.serverMutex.Lock()
-	defer s.serverMutex.Unlock()
 
-	if s.sourceManagers[src] == nil {
-		userLog(ctx).Debugf("creating source manager for %v", src)
-		sm := newSourceManager(src, s, s.rep)
-		s.sourceManagers[src] = sm
-
-		sm.start(ctx, s.isLocal(src))
+	if sm := s.sourceManagers[src]; sm != nil {
+		s.serverMutex.Unlock()
+		return sm
 	}
 
-	return s.sourceManagers[src]
+	userLog(ctx).Debugf("creating source manager for %v", src)
+	sm := newSourceManager(src, s, s.rep)
+	s.sourceManagers[src] = sm
+	isLocal := s.isLocal(src)
+
+	s.serverMutex.Unlock()
+
+	// start without holding serverMutex, because it reads from the repository.
+	sm.start(ctx, isLocal)
+
+	return sm
 }
 
 func (s *Server) deleteSourceManager(ctx context.Context, src snapshot.SourceInfo) bool {

--- a/internal/server/server_maintenance.go
+++ b/internal/server/server_maintenance.go
@@ -80,27 +80,21 @@ func (s *srvMaintenance) refresh(ctx context.Context, notify bool) {
 		defer s.srv.refreshScheduler("maintenance schedule changed")
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if err := s.refreshLocked(ctx); err != nil {
-		userLog(ctx).Debugw("unable to refresh maintenance manager", "err", err)
-	}
-}
-
-func (s *srvMaintenance) refreshLocked(ctx context.Context) error {
+	// read the schedule without holding s.mu, which the scheduler needs while holding the server lock.
 	nmt, err := maintenance.TimeToAttemptNextMaintenance(ctx, s.dr)
 	if err != nil {
-		return errors.Wrap(err, "unable to get next maintenance time")
+		userLog(ctx).Debugw("unable to refresh maintenance manager", "err", errors.Wrap(err, "unable to get next maintenance time"))
+		return
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if nmt.Before(s.nextMaintenanceNoEarlierThan) {
 		nmt = s.nextMaintenanceNoEarlierThan
 	}
 
 	s.cachedNextMaintenanceTime = nmt
-
-	return nil
 }
 
 func (s *srvMaintenance) nextMaintenanceTime() time.Time {

--- a/internal/server/server_refresh_test.go
+++ b/internal/server/server_refresh_test.go
@@ -1,0 +1,82 @@
+package server_test
+
+import (
+	"context"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kopia/kopia/internal/apiclient"
+	"github.com/kopia/kopia/internal/blobtesting"
+	"github.com/kopia/kopia/internal/repotesting"
+	"github.com/kopia/kopia/internal/serverapi"
+	"github.com/kopia/kopia/internal/servertesting"
+	"github.com/kopia/kopia/repo/blob"
+)
+
+func TestServer_RepoStatusWhileRefreshIsBlocked(t *testing.T) {
+	var fst *blobtesting.FaultyStorage
+
+	ctx, env := repotesting.NewEnvironment(t, repotesting.FormatNotImportant, repotesting.Options{
+		WrapStorage: func(st blob.Storage) blob.Storage {
+			fst = blobtesting.NewFaultyStorage(st)
+			return fst
+		},
+	})
+	srvInfo := servertesting.StartServer(t, env, false)
+
+	cli, err := apiclient.NewKopiaAPIClient(apiclient.Options{
+		BaseURL:  srvInfo.BaseURL,
+		Username: servertesting.TestUIUsername,
+		Password: servertesting.TestUIPassword,
+	})
+	require.NoError(t, err)
+	require.NoError(t, cli.FetchCSRFTokenForTesting(ctx))
+
+	listBlocked := make(chan struct{})
+	release := make(chan struct{})
+
+	var blockedOnce, releaseOnce sync.Once
+
+	releaseStorage := func() { releaseOnce.Do(func() { close(release) }) }
+
+	// registered after StartServer() so that storage is released before the server shuts down.
+	t.Cleanup(releaseStorage)
+
+	// simulate a storage connection that stops responding: all listings hang until released.
+	fst.AddFault(blobtesting.MethodListBlobs).Repeat(math.MaxInt32).Before(func() {
+		blockedOnce.Do(func() { close(listBlocked) })
+		<-release
+	})
+
+	syncDone := make(chan error, 1)
+
+	go func() {
+		syncDone <- cli.Post(ctx, "repo/sync", &serverapi.Empty{}, &serverapi.Empty{})
+	}()
+
+	select {
+	case <-listBlocked:
+	case <-time.After(10 * time.Second):
+		t.Fatal("refresh did not reach the storage")
+	}
+
+	statusCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	st, err := serverapi.RepoStatus(statusCtx, cli)
+	require.NoError(t, err, "repository status must not wait for a blocked refresh")
+	require.True(t, st.Connected)
+
+	releaseStorage()
+
+	select {
+	case err := <-syncDone:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("refresh did not finish after the storage was released")
+	}
+}

--- a/internal/server/source_manager.go
+++ b/internal/server/source_manager.go
@@ -155,6 +155,9 @@ func (s *sourceManager) setUploader(u *upload.Uploader) {
 func (s *sourceManager) start(ctx context.Context, isLocal bool) {
 	s.refreshStatus(ctx)
 
+	// counted before the goroutine starts, so that waitUntilStopped() waits for it.
+	s.wg.Add(1)
+
 	go s.run(ctx, isLocal)
 }
 
@@ -165,7 +168,6 @@ func (s *sourceManager) run(ctx context.Context, isLocal bool) {
 	s.setStatus("INITIALIZING")
 	defer s.setStatus("STOPPED")
 
-	s.wg.Add(1)
 	defer s.wg.Done()
 
 	if isLocal {
@@ -309,6 +311,15 @@ func (s *sourceManager) stop(ctx context.Context) {
 
 func (s *sourceManager) waitUntilStopped() {
 	s.wg.Wait()
+}
+
+func (s *sourceManager) isStopped() bool {
+	select {
+	case <-s.closed:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *sourceManager) snapshotInternal(ctx context.Context, ctrl uitask.Controller, result *notifydata.ManifestWithError) error {


### PR DESCRIPTION
This PR stops the whole API server from wedging when a single storage call hangs during a refresh. Companion to #5638, which adds SFTP timeouts and keepalives. This PR makes the server itself resilient to any hung storage call.

### Incident

A KopiaUI 0.23.1 server with an SFTP repository lost its SFTP connection silently: no error and no replies. A storage call made by `Server.Refresh()` hung forever. `Refresh()` holds `serverMutex` for writing across all of its storage I/O, and every HTTP handler takes `serverMutex.RLock()` in `captureRequestContext()`. As a result, every API request blocked, including `/api/v1/repo/status`. KopiaUI polls that endpoint every few seconds, and it piled up about 16k hung localhost connections.

### What changed

- A dedicated `refreshMutex` serializes `Refresh()`. Request handlers never take it.
- The repository is captured under a brief read lock. `rep.Refresh`, the authenticator and authorizer refreshes, listing sources and policies, and reading the user@host policy all run without `serverMutex`.
- `serverMutex` is taken only to apply the result to the source manager map, with no I/O under the lock. The result is applied only if `SetRepository()` has not replaced the repository in the meantime. Otherwise it is discarded.
- Starting new source managers, refreshing the status of existing ones, and stopping and waiting for removed ones now happen after the lock is released. Stopping a manager can block on an in-flight upload.
- Managers that are created or deleted through the API while the sources are being listed are left alone, and the next refresh reconciles them. This prevents a stale listing from undoing a user's action.
- `getOrCreateSourceManager()`, used when a source is created through the API, now adds the manager to the map under `serverMutex` and starts it after releasing the lock. Before, adding a source while storage was hung wedged the server in the same way.
- `sourceManager.start()` now calls `wg.Add(1)` before starting its goroutine instead of inside it, so `waitUntilStopped()` no longer misses a manager whose goroutine is about to start. A refresh skips managers that were already stopped when it reaches them instead of starting or refreshing them.
- `srvMaintenance.refresh()` no longer holds its mutex while it reads the maintenance schedule. The scheduler takes that mutex while holding `serverMutex`, so a hung read there would wedge the server in the same way. At worst this causes one extra maintenance check, which auto mode skips when maintenance is not due.
- `repotesting.Options` gets a `WrapStorage` field, so tests can inject storage faults.

### How tested

- New `TestServer_RepoStatusWhileRefreshIsBlocked`: wraps the storage in `blobtesting.FaultyStorage`, blocks all `ListBlobs` calls, and triggers `repo/sync`. While the refresh is stuck, it requires `/api/v1/repo/status` to respond within 5s. Before this change it fails with `context deadline exceeded` (3 of 3 runs). After this change it passes in under 1s.
- `go test ./internal/server/... ./internal/repotesting/...`, also with `-race`.
- `make check-locks`.
- Full-repo `make lint`.

### Known remaining cases

- `SetRepository()` still does I/O under `serverMutex`: it closes the previous repository and syncs sources. Its locking is unchanged here.
- A refresh or source creation that overlaps a concurrent `SetRepository()` can still run storage reads, including the maintenance schedule read, against the repository being closed. The stopped-manager check is best-effort. Those reads return errors, as in-flight HTTP handlers already can, and a refresh's result is discarded.
- Requests that read from the hung storage themselves, such as listing snapshots, still hang. This change keeps unrelated requests working.
- `epoch.Manager.refreshLocked()` retries failing storage calls forever, with a sleep that cannot be interrupted, when its context is never cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
