### PR TITLE
feat(cli): Add new cli/env option to ignore .storageconfig

### DIFF
--- a/cli/storage_s3.go
+++ b/cli/storage_s3.go
@@ -29,6 +29,7 @@ func (c *storageS3Flags) Setup(svc StorageProviderServices, cmd *kingpin.CmdClau
 	cmd.Flag("prefix", "Prefix to use for objects in the bucket. Put trailing slash (/) if you want to use prefix as directory. e.g my-backup-dir/ would put repository contents inside my-backup-dir directory").StringVar(&c.s3options.Prefix)
 	cmd.Flag("disable-tls", "Disable TLS security (HTTPS)").BoolVar(&c.s3options.DoNotUseTLS)
 	cmd.Flag("disable-tls-verification", "Disable TLS (HTTPS) certificate verification").BoolVar(&c.s3options.DoNotVerifyTLS)
+	cmd.Flag("disable-storage-config", "Disable retrieving .storageconfig from the bucket").BoolVar(&c.s3options.DisableStorageConfig)
 
 	commonThrottlingFlags(cmd, &c.s3options.Limits)
 

--- a/repo/blob/s3/s3_options.go
+++ b/repo/blob/s3/s3_options.go
@@ -43,4 +43,8 @@ type Options struct {
 
 	// PointInTime specifies a view of the (versioned) store at that time
 	PointInTime *time.Time `json:"pointInTime,omitempty"`
+
+	// DisableStorageConfig disables retrieving the .storageconfig file from the bucket.
+	DisableStorageConfig bool `json:"disableStorageConfig,omitempty"`
+
 }

--- a/repo/blob/s3/s3_storage.go
+++ b/repo/blob/s3/s3_storage.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"strconv"
 	"time"
 
 	"github.com/minio/minio-go/v7"
@@ -456,6 +457,14 @@ func newStorageWithCredentials(ctx context.Context, creds *credentials.Credentia
 		Options:       *opt,
 		cli:           cli,
 		storageConfig: &StorageConfig{},
+	}
+
+	
+
+
+	disableStorageConfig, _ := strconv.ParseBool(os.Getenv("KOPIA_DISABLE_STORAGECONFIG"))
+	if opt.DisableStorageConfig || disableStorageConfig {
+		return &s, nil
 	}
 
 	var scOutput gather.WriteBuffer


### PR DESCRIPTION
Needed for certain storage providers where storage tiers are not implemented/used. The main concern is that container logs are polluted with ".storageconfig not found".

Tested locally:

* make ci-tests 
DONE 6486 tests, 108 skipped in 123.379s

* make lint-all
GOOS=windows GOARCH=amd64 /home/rgherta/kopia/tools/.tools/golangci-lint-2.11.4/golangci-lint --timeout 1200s run 
GOOS=darwin GOARCH=amd64 /home/rgherta/kopia/tools/.tools/golangci-lint-2.11.4/golangci-lint --timeout 1200s run 
GOOS=darwin GOARCH=arm64 /home/rgherta/kopia/tools/.tools/golangci-lint-2.11.4/golangci-lint --timeout 1200s run 
GOOS=linux GOARCH=amd64 /home/rgherta/kopia/tools/.tools/golangci-lint-2.11.4/golangci-lint --timeout 1200s run 
GOOS=linux GOARCH=arm64 /home/rgherta/kopia/tools/.tools/golangci-lint-2.11.4/golangci-lint --timeout 1200s run 
GOOS=linux GOARCH=arm /home/rgherta/kopia/tools/.tools/golangci-lint-2.11.4/golangci-lint --timeout 1200s run 
GOOS=openbsd GOARCH=amd64 /home/rgherta/kopia/tools/.tools/golangci-lint-2.11.4/golangci-lint --timeout 1200s run 
GOOS=freebsd GOARCH=amd64 /home/rgherta/kopia/tools/.tools/golangci-lint-2.11.4/golangci-lint --timeout 1200s run

* make goreleaser
release succeeded after 112.02s