### PR TITLE
fix(testing): TestServerControlSocketActivated flake

### DIFF
--- a/tests/socketactivation_test/socketactivation_test.go
+++ b/tests/socketactivation_test/socketactivation_test.go
@@ -52,7 +52,7 @@ func TestServerControlSocketActivated(t *testing.T) {
 	l1File, err := testutil.EnsureType[*net.TCPListener](t, l1).File()
 	require.NoError(t, err, "failed to get filehandle for socket")
 
-	serverStopped := make(chan error)
+serverStopped := make(chan error, 1)
 
 	var sp testutil.ServerParameters
 
@@ -161,8 +161,8 @@ func TestServerControlSocketActivatedTooManyFDs(t *testing.T) {
 		t.Fatal("server did not exit in time")
 	}
 
-	// gotExpectedErrorMessage may be read before stderrAsyncCallback sets it above.
-	// Prevent flaky tests failure by avoid potential race where stderrAsyncCallback may
-	// be still processing the server's output, even after wait() has returned.
+// gotExpectedErrorMessage may be read before stderrAsyncCallback sets it above.
+// Prevent flaky test failures by avoiding a potential race where stderrAsyncCallback
+// may still be processing the server's output even after wait() has returned.
 	require.Eventually(t, gotExpectedErrorMessage.Load, 15*time.Second, time.Second, "expected server's stderr to contain a line along the lines of 'Too many activated sockets ...'")
 }

--- a/tests/socketactivation_test/socketactivation_test.go
+++ b/tests/socketactivation_test/socketactivation_test.go
@@ -60,6 +60,7 @@ func TestServerControlSocketActivated(t *testing.T) {
 	runner.ExtraFiles = append(runner.ExtraFiles, l1File)
 	wait, kill := env.RunAndProcessStderr(t, sp.ProcessOutput,
 		"server", "start", "--insecure", "--random-server-control-password", "--address=127.0.0.1:0")
+	runner.ExtraFiles = nil
 
 	t.Cleanup(func() { kill(); wait() })
 

--- a/tests/socketactivation_test/socketactivation_test.go
+++ b/tests/socketactivation_test/socketactivation_test.go
@@ -57,9 +57,10 @@ func TestServerControlSocketActivated(t *testing.T) {
 	var sp testutil.ServerParameters
 
 	runner.ExtraFiles = append(runner.ExtraFiles, l1File)
-	wait, _ := env.RunAndProcessStderr(t, sp.ProcessOutput,
+	wait, kill := env.RunAndProcessStderr(t, sp.ProcessOutput,
 		"server", "start", "--insecure", "--random-server-control-password", "--address=127.0.0.1:0")
 
+	t.Cleanup(func() { kill(); wait() })
 	l1File.Close()
 
 	require.NotEmpty(t, sp.BaseURL, "Failed to start server")

--- a/tests/socketactivation_test/socketactivation_test.go
+++ b/tests/socketactivation_test/socketactivation_test.go
@@ -52,33 +52,17 @@ func TestServerControlSocketActivated(t *testing.T) {
 	l1File, err := testutil.EnsureType[*net.TCPListener](t, l1).File()
 	require.NoError(t, err, "failed to get filehandle for socket")
 
-	serverStarted := make(chan struct{})
-	serverStopped := make(chan struct{})
+	serverStopped := make(chan error)
 
 	var sp testutil.ServerParameters
 
-	go func() {
-		runner.ExtraFiles = append(runner.ExtraFiles, l1File)
-		wait, _ := env.RunAndProcessStderr(t, sp.ProcessOutput,
-			"server", "start", "--insecure", "--random-server-control-password", "--address=127.0.0.1:0")
+	runner.ExtraFiles = append(runner.ExtraFiles, l1File)
+	wait, _ := env.RunAndProcessStderr(t, sp.ProcessOutput,
+		"server", "start", "--insecure", "--random-server-control-password", "--address=127.0.0.1:0")
 
-		l1File.Close()
-		close(serverStarted)
+	l1File.Close()
 
-		wait()
-
-		close(serverStopped)
-	}()
-
-	select {
-	case <-serverStarted:
-		require.NotEmpty(t, sp.BaseURL, "Failed to start server")
-		t.Logf("server started on %v", sp.BaseURL)
-
-	case <-time.After(15 * time.Second):
-		t.Fatal("server did not start in time")
-	}
-
+	require.NotEmpty(t, sp.BaseURL, "Failed to start server")
 	require.Contains(t, sp.BaseURL, ":"+strconv.Itoa(port))
 
 	checkServerStatusFn := func(collect *assert.CollectT) {
@@ -91,8 +75,15 @@ func TestServerControlSocketActivated(t *testing.T) {
 
 	env.RunAndExpectSuccess(t, "server", "shutdown", "--address", sp.BaseURL, "--server-control-password", sp.ServerControlPassword)
 
+	go func() {
+		serverStopped <- wait()
+
+		close(serverStopped)
+	}()
+
 	select {
-	case <-serverStopped:
+	case err := <-serverStopped:
+		require.NoError(t, err, "server exited with error")
 		t.Log("server shut down")
 
 	case <-time.After(15 * time.Second):

--- a/tests/socketactivation_test/socketactivation_test.go
+++ b/tests/socketactivation_test/socketactivation_test.go
@@ -5,6 +5,7 @@ package socketactivation_test
 import (
 	"net"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -61,7 +62,10 @@ serverStopped := make(chan error, 1)
 		"server", "start", "--insecure", "--random-server-control-password", "--address=127.0.0.1:0")
 
 	t.Cleanup(func() { kill(); wait() })
-	l1File.Close()
+
+	if runtime.GOOS == "darwin" {
+		l1File.Close()
+	}
 
 	require.NotEmpty(t, sp.BaseURL, "Failed to start server")
 	require.Contains(t, sp.BaseURL, ":"+strconv.Itoa(port))

--- a/tests/socketactivation_test/socketactivation_test.go
+++ b/tests/socketactivation_test/socketactivation_test.go
@@ -169,5 +169,8 @@ func TestServerControlSocketActivatedTooManyFDs(t *testing.T) {
 		t.Fatal("server did not exit in time")
 	}
 
-	require.True(t, gotExpectedErrorMessage.Load(), "expected server's stderr to contain a line along the lines of 'Too many activated sockets ...'")
+	// gotExpectedErrorMessage may be read before stderrAsyncCallback sets it above.
+	// Prevent flaky tests failure by avoid potential race where stderrAsyncCallback may
+	// be still processing the server's output, even after wait() has returned.
+	require.Eventually(t, gotExpectedErrorMessage.Load, 15*time.Second, time.Second, "expected server's stderr to contain a line along the lines of 'Too many activated sockets ...'")
 }

--- a/tests/socketactivation_test/socketactivation_test.go
+++ b/tests/socketactivation_test/socketactivation_test.go
@@ -53,7 +53,7 @@ func TestServerControlSocketActivated(t *testing.T) {
 	l1File, err := testutil.EnsureType[*net.TCPListener](t, l1).File()
 	require.NoError(t, err, "failed to get filehandle for socket")
 
-serverStopped := make(chan error, 1)
+	serverStopped := make(chan error, 1)
 
 	var sp testutil.ServerParameters
 
@@ -165,8 +165,8 @@ func TestServerControlSocketActivatedTooManyFDs(t *testing.T) {
 		t.Fatal("server did not exit in time")
 	}
 
-// gotExpectedErrorMessage may be read before stderrAsyncCallback sets it above.
-// Prevent flaky test failures by avoiding a potential race where stderrAsyncCallback
-// may still be processing the server's output even after wait() has returned.
+	// gotExpectedErrorMessage may be read before stderrAsyncCallback sets it above.
+	// Prevent flaky test failures by avoiding a potential race where stderrAsyncCallback
+	// may still be processing the server's output even after wait() has returned.
 	require.Eventually(t, gotExpectedErrorMessage.Load, 15*time.Second, time.Second, "expected server's stderr to contain a line along the lines of 'Too many activated sockets ...'")
 }


### PR DESCRIPTION
Fix `TestServerControlSocketActivated` flake.
Clear `runner.ExtraFiles` before calling running other commands. This appears to be the primary source of the spurious test failures.

Refactor `TestServerControlSocketActivated` to:
- start server from the test (go)routine instead of a background one;
- process server's output synchronously in the test goroutine;
- fix race: close the listener file descriptor synchronously in the test goroutine instead of async, which ensures the descriptor is closed before sending the first request to the (status) server, otherwise, shutdown hangs (when the listener close is delayed);
- check and assert server's exit status;
- ensure servers exits when tests fail.

Also, address potential race in `TestServerControlSocketActivatedTooManyFDs`

Ref:
- #3313
- #5626